### PR TITLE
Add LV2 plugin hosting and ChowCentaur model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,6 +836,7 @@ dependencies = [
  "block-core",
  "domain",
  "log",
+ "lv2",
  "nam",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,10 +129,12 @@ dependencies = [
  "anyhow",
  "application",
  "block-core",
+ "block-thumbnails",
  "cpal",
  "domain",
  "engine",
  "env_logger",
+ "image",
  "infra-cpal",
  "infra-filesystem",
  "infra-yaml",
@@ -892,6 +894,10 @@ dependencies = [
 
 [[package]]
 name = "block-routing"
+version = "0.1.0"
+
+[[package]]
+name = "block-thumbnails"
 version = "0.1.0"
 
 [[package]]
@@ -2849,6 +2855,7 @@ name = "infra-cpal"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "block-util",
  "cpal",
  "domain",
  "engine",
@@ -3223,6 +3230,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
 dependencies = [
  "imgref",
+]
+
+[[package]]
+name = "lv2"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "block-core",
+ "libloading",
+ "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
   "crates/block-full-rig",
   "crates/block-cab",
   "crates/block-body",
+  "crates/lv2",
   "crates/ir",
   "crates/block-ir",
   "crates/block-wah",

--- a/crates/block-gain/Cargo.toml
+++ b/crates/block-gain/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 anyhow.workspace = true
 asset-runtime = { path = "../asset-runtime" }
 nam = { path = "../nam" }
+lv2 = { path = "../lv2" }
 block-core = { path = "../block-core" }
 log.workspace = true
 

--- a/crates/block-gain/src/lib.rs
+++ b/crates/block-gain/src/lib.rs
@@ -11,6 +11,7 @@ pub enum GainBackendKind {
     Native,
     Nam,
     Ir,
+    Lv2,
 }
 
 pub fn supported_models() -> &'static [&'static str] {
@@ -25,6 +26,7 @@ pub fn gain_model_visual(model_id: &str) -> Option<ModelVisualData> {
             GainBackendKind::Native => "NATIVE",
             GainBackendKind::Nam => "NAM",
             GainBackendKind::Ir => "IR",
+            GainBackendKind::Lv2 => "LV2",
         },
         supported_instruments: def.supported_instruments,
         knob_layout: def.knob_layout,

--- a/crates/block-gain/src/lv2_chowcentaur.rs
+++ b/crates/block-gain/src/lv2_chowcentaur.rs
@@ -1,0 +1,195 @@
+use crate::registry::GainModelDefinition;
+use crate::GainBackendKind;
+use anyhow::Result;
+use block_core::param::{
+    enum_parameter, float_parameter, required_f32, required_string,
+    ModelParameterSchema, ParameterSet, ParameterUnit,
+};
+use block_core::{AudioChannelLayout, BlockProcessor, ModelAudioMode};
+
+pub const MODEL_ID: &str = "chowcentaur";
+pub const DISPLAY_NAME: &str = "Centaur";
+const BRAND: &str = "chowdsp";
+
+const PLUGIN_URI: &str = "https://github.com/jatinchowdhury18/KlonCentaur";
+const PLUGIN_DIR: &str = "ChowCentaur.lv2";
+
+#[cfg(target_os = "macos")]
+const PLUGIN_BINARY: &str = "ChowCentaur.dylib";
+#[cfg(target_os = "linux")]
+const PLUGIN_BINARY: &str = "ChowCentaur.so";
+#[cfg(target_os = "windows")]
+const PLUGIN_BINARY: &str = "ChowCentaur.dll";
+
+// LV2 port indices (from TTL)
+const PORT_FREEWHEEL: usize = 0;
+const PORT_AUDIO_IN: usize = 1;
+const PORT_AUDIO_OUT: usize = 2;
+const PORT_GAIN: usize = 3;
+const PORT_TREBLE: usize = 4;
+const PORT_LEVEL: usize = 5;
+const PORT_MODE: usize = 6;
+const PORT_ENABLED: usize = 7;
+const PORT_MONO: usize = 8;
+
+pub fn model_schema() -> ModelParameterSchema {
+    ModelParameterSchema {
+        effect_type: block_core::EFFECT_TYPE_GAIN.into(),
+        model: MODEL_ID.into(),
+        display_name: DISPLAY_NAME.into(),
+        audio_mode: ModelAudioMode::MonoOnly,
+        parameters: vec![
+            float_parameter(
+                "gain",
+                "Gain",
+                None,
+                Some(50.0),
+                0.0,
+                100.0,
+                1.0,
+                ParameterUnit::Percent,
+            ),
+            float_parameter(
+                "treble",
+                "Treble",
+                None,
+                Some(50.0),
+                0.0,
+                100.0,
+                1.0,
+                ParameterUnit::Percent,
+            ),
+            float_parameter(
+                "level",
+                "Level",
+                None,
+                Some(50.0),
+                0.0,
+                100.0,
+                1.0,
+                ParameterUnit::Percent,
+            ),
+            enum_parameter(
+                "mode",
+                "Mode",
+                None,
+                Some("traditional"),
+                &[
+                    ("traditional", "Traditional"),
+                    ("neural", "Neural"),
+                ],
+            ),
+        ],
+    }
+}
+
+fn validate_params(params: &ParameterSet) -> Result<()> {
+    let _ = required_f32(params, "gain").map_err(anyhow::Error::msg)?;
+    let _ = required_f32(params, "treble").map_err(anyhow::Error::msg)?;
+    let _ = required_f32(params, "level").map_err(anyhow::Error::msg)?;
+    let _ = required_string(params, "mode").map_err(anyhow::Error::msg)?;
+    Ok(())
+}
+
+fn asset_summary(_params: &ParameterSet) -> Result<String> {
+    Ok(format!("lv2='{}'", MODEL_ID))
+}
+
+fn resolve_lib_path() -> Result<String> {
+    let exe_dir = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.parent().map(|p| p.to_path_buf()));
+
+    // Try relative to executable first, then relative to CWD
+    let candidates = [
+        exe_dir.as_ref().map(|d| d.join("../../").join(lv2::default_lv2_lib_dir()).join(PLUGIN_BINARY)),
+        Some(std::path::PathBuf::from(lv2::default_lv2_lib_dir()).join(PLUGIN_BINARY)),
+    ];
+
+    for candidate in candidates.iter().flatten() {
+        if candidate.exists() {
+            return Ok(candidate.to_string_lossy().to_string());
+        }
+    }
+
+    anyhow::bail!(
+        "LV2 binary '{}' not found in '{}'",
+        PLUGIN_BINARY,
+        lv2::default_lv2_lib_dir()
+    )
+}
+
+fn resolve_bundle_path() -> Result<String> {
+    let exe_dir = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.parent().map(|p| p.to_path_buf()));
+
+    let candidates = [
+        exe_dir.as_ref().map(|d| d.join("../../plugins").join(PLUGIN_DIR)),
+        Some(std::path::PathBuf::from("plugins").join(PLUGIN_DIR)),
+    ];
+
+    for candidate in candidates.iter().flatten() {
+        if candidate.exists() {
+            return Ok(candidate.to_string_lossy().to_string());
+        }
+    }
+
+    anyhow::bail!("LV2 bundle '{}' not found in plugins/", PLUGIN_DIR)
+}
+
+fn build(
+    params: &ParameterSet,
+    sample_rate: f32,
+    layout: AudioChannelLayout,
+) -> Result<BlockProcessor> {
+    if layout != AudioChannelLayout::Mono {
+        anyhow::bail!("ChowCentaur is mono-only");
+    }
+
+    let gain = required_f32(params, "gain").map_err(anyhow::Error::msg)? / 100.0;
+    let treble = required_f32(params, "treble").map_err(anyhow::Error::msg)? / 100.0;
+    let level = required_f32(params, "level").map_err(anyhow::Error::msg)? / 100.0;
+    let mode_str = required_string(params, "mode").map_err(anyhow::Error::msg)?;
+    let mode: f32 = if mode_str == "neural" { 1.0 } else { 0.0 };
+
+    let lib_path = resolve_lib_path()?;
+    let bundle_path = resolve_bundle_path()?;
+
+    let processor = lv2::build_lv2_processor(
+        &lib_path,
+        PLUGIN_URI,
+        sample_rate as f64,
+        &bundle_path,
+        &[PORT_AUDIO_IN],
+        &[PORT_AUDIO_OUT],
+        &[
+            (PORT_FREEWHEEL, 0.0),
+            (PORT_GAIN, gain),
+            (PORT_TREBLE, treble),
+            (PORT_LEVEL, level),
+            (PORT_MODE, mode),
+            (PORT_ENABLED, 1.0),
+            (PORT_MONO, 1.0),
+        ],
+    )?;
+
+    Ok(BlockProcessor::Mono(Box::new(processor)))
+}
+
+fn schema() -> Result<ModelParameterSchema> {
+    Ok(model_schema())
+}
+
+pub const MODEL_DEFINITION: GainModelDefinition = GainModelDefinition {
+    id: MODEL_ID,
+    display_name: DISPLAY_NAME,
+    brand: BRAND,
+    backend_kind: GainBackendKind::Lv2,
+    schema,
+    validate: validate_params,
+    asset_summary,
+    build,
+    supported_instruments: block_core::GUITAR_BASS,
+    knob_layout: &[],
+};

--- a/crates/lv2/Cargo.toml
+++ b/crates/lv2/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "lv2"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+block-core = { path = "../block-core" }
+anyhow.workspace = true
+log.workspace = true
+libloading = "0.8"

--- a/crates/lv2/src/host.rs
+++ b/crates/lv2/src/host.rs
@@ -1,0 +1,262 @@
+use anyhow::{bail, Context, Result};
+use std::ffi::{c_char, c_void, CStr, CString};
+use std::ptr;
+
+// ---------------------------------------------------------------------------
+// LV2 C ABI types (repr(C))
+// ---------------------------------------------------------------------------
+
+pub type LV2Handle = *mut c_void;
+
+#[repr(C)]
+pub struct LV2Descriptor {
+    pub uri: *const c_char,
+    pub instantiate: Option<
+        unsafe extern "C" fn(
+            descriptor: *const LV2Descriptor,
+            sample_rate: f64,
+            bundle_path: *const c_char,
+            features: *const *const LV2Feature,
+        ) -> LV2Handle,
+    >,
+    pub connect_port:
+        Option<unsafe extern "C" fn(instance: LV2Handle, port: u32, data_location: *mut c_void)>,
+    pub activate: Option<unsafe extern "C" fn(instance: LV2Handle)>,
+    pub run: Option<unsafe extern "C" fn(instance: LV2Handle, n_samples: u32)>,
+    pub deactivate: Option<unsafe extern "C" fn(instance: LV2Handle)>,
+    pub cleanup: Option<unsafe extern "C" fn(instance: LV2Handle)>,
+    pub extension_data: Option<unsafe extern "C" fn(uri: *const c_char) -> *const c_void>,
+}
+
+#[repr(C)]
+pub struct LV2Feature {
+    pub uri: *const c_char,
+    pub data: *mut c_void,
+}
+
+#[repr(C)]
+pub struct LV2UridMap {
+    pub handle: *mut c_void,
+    pub map: Option<unsafe extern "C" fn(handle: *mut c_void, uri: *const c_char) -> u32>,
+}
+
+// ---------------------------------------------------------------------------
+// Minimal URID map
+// ---------------------------------------------------------------------------
+
+const LV2_URID_MAP_URI: &str = "http://lv2plug.in/ns/ext/urid#map";
+const LV2_BUF_SIZE_BOUNDED_URI: &str = "http://lv2plug.in/ns/ext/buf-size#boundedBlockLength";
+
+struct UridMap {
+    uris: Vec<String>,
+}
+
+impl UridMap {
+    fn new() -> Self {
+        Self { uris: Vec::new() }
+    }
+
+    fn map(&mut self, uri: &str) -> u32 {
+        if let Some(pos) = self.uris.iter().position(|u| u == uri) {
+            return (pos + 1) as u32;
+        }
+        self.uris.push(uri.to_string());
+        self.uris.len() as u32
+    }
+}
+
+unsafe extern "C" fn urid_map_callback(handle: *mut c_void, uri: *const c_char) -> u32 {
+    let map = unsafe { &mut *(handle as *mut UridMap) };
+    let uri_str = unsafe { CStr::from_ptr(uri) }
+        .to_str()
+        .unwrap_or("");
+    map.map(uri_str)
+}
+
+// ---------------------------------------------------------------------------
+// Port metadata (filled by the caller)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Lv2PortKind {
+    AudioIn,
+    AudioOut,
+    ControlIn,
+    ControlOut,
+}
+
+#[derive(Debug, Clone)]
+pub struct Lv2PortInfo {
+    pub index: usize,
+    pub kind: Lv2PortKind,
+    pub name: String,
+    pub default_value: f32,
+}
+
+// ---------------------------------------------------------------------------
+// Lv2Plugin — owns the loaded library and instance
+// ---------------------------------------------------------------------------
+
+pub struct Lv2Plugin {
+    _library: libloading::Library,
+    descriptor: *const LV2Descriptor,
+    handle: LV2Handle,
+    // These must outlive the plugin instance:
+    _urid_map: Box<UridMap>,
+    _lv2_urid_map_struct: Box<LV2UridMap>,
+    _features: Vec<LV2Feature>,
+    _feature_ptrs: Vec<*const LV2Feature>,
+    // Keep CStrings alive for the lifetime of the plugin
+    _urid_map_uri_cstr: CString,
+    _buf_size_uri_cstr: CString,
+    _bundle_path_cstr: CString,
+}
+
+// The processor runs on a single audio thread; the plugin pointer is not
+// shared across threads, so we assert Send. LV2 plugins are inherently
+// single-threaded in their `run` path.
+unsafe impl Send for Lv2Plugin {}
+unsafe impl Sync for Lv2Plugin {}
+
+impl Lv2Plugin {
+    /// Load an LV2 plugin from a shared library.
+    ///
+    /// - `lib_path`: path to the `.dylib` / `.so` / `.dll`
+    /// - `uri`: the LV2 plugin URI to look up in the descriptor list
+    /// - `sample_rate`: audio sample rate
+    /// - `bundle_path`: path to the `.lv2` bundle directory (TTL metadata)
+    pub fn load(
+        lib_path: &str,
+        uri: &str,
+        sample_rate: f64,
+        bundle_path: &str,
+    ) -> Result<Self> {
+        // 1. dlopen
+        let library = unsafe { libloading::Library::new(lib_path) }
+            .with_context(|| format!("failed to load LV2 library: {lib_path}"))?;
+
+        // 2. Get lv2_descriptor symbol
+        let lv2_descriptor_fn: libloading::Symbol<
+            unsafe extern "C" fn(index: u32) -> *const LV2Descriptor,
+        > = unsafe { library.get(b"lv2_descriptor\0") }
+            .context("symbol 'lv2_descriptor' not found in library")?;
+
+        // 3. Find the descriptor matching the requested URI
+        let mut descriptor: *const LV2Descriptor = ptr::null();
+        for idx in 0..128 {
+            let desc = unsafe { lv2_descriptor_fn(idx) };
+            if desc.is_null() {
+                break;
+            }
+            let desc_uri = unsafe { CStr::from_ptr((*desc).uri) }
+                .to_str()
+                .unwrap_or("");
+            if desc_uri == uri {
+                descriptor = desc;
+                break;
+            }
+        }
+        if descriptor.is_null() {
+            bail!("LV2 plugin URI '{uri}' not found in {lib_path}");
+        }
+
+        // 4. Set up URID map
+        let mut urid_map = Box::new(UridMap::new());
+        let mut lv2_urid_map_struct = Box::new(LV2UridMap {
+            handle: urid_map.as_mut() as *mut UridMap as *mut c_void,
+            map: Some(urid_map_callback),
+        });
+
+        let urid_map_uri_cstr = CString::new(LV2_URID_MAP_URI).unwrap();
+        let buf_size_uri_cstr = CString::new(LV2_BUF_SIZE_BOUNDED_URI).unwrap();
+
+        // 5. Build features array
+        let features = vec![
+            LV2Feature {
+                uri: urid_map_uri_cstr.as_ptr(),
+                data: lv2_urid_map_struct.as_mut() as *mut LV2UridMap as *mut c_void,
+            },
+            LV2Feature {
+                uri: buf_size_uri_cstr.as_ptr(),
+                data: ptr::null_mut(),
+            },
+        ];
+
+        // Null-terminated array of pointers
+        let mut feature_ptrs: Vec<*const LV2Feature> =
+            features.iter().map(|f| f as *const LV2Feature).collect();
+        feature_ptrs.push(ptr::null());
+
+        // 6. Instantiate
+        let bundle_path_cstr =
+            CString::new(bundle_path).context("invalid bundle_path for C string")?;
+
+        let instantiate = unsafe { (*descriptor).instantiate }
+            .context("LV2 descriptor has no instantiate function")?;
+
+        let handle = unsafe {
+            instantiate(
+                descriptor,
+                sample_rate,
+                bundle_path_cstr.as_ptr(),
+                feature_ptrs.as_ptr(),
+            )
+        };
+
+        if handle.is_null() {
+            bail!("LV2 plugin instantiate returned null for URI '{uri}'");
+        }
+
+        // 7. Activate
+        if let Some(activate) = unsafe { (*descriptor).activate } {
+            unsafe { activate(handle) };
+        }
+
+        log::info!("LV2 plugin loaded: {uri} from {lib_path}");
+
+        Ok(Self {
+            _library: library,
+            descriptor,
+            handle,
+            _urid_map: urid_map,
+            _lv2_urid_map_struct: lv2_urid_map_struct,
+            _features: features,
+            _feature_ptrs: feature_ptrs,
+            _urid_map_uri_cstr: urid_map_uri_cstr,
+            _buf_size_uri_cstr: buf_size_uri_cstr,
+            _bundle_path_cstr: bundle_path_cstr,
+        })
+    }
+
+    /// Connect a port to a data buffer.
+    ///
+    /// # Safety
+    /// The caller must ensure `data` points to valid memory that outlives the
+    /// next `run()` call and matches the port type.
+    pub unsafe fn connect_port(&self, port_index: u32, data: *mut c_void) {
+        if let Some(connect) = unsafe { (*self.descriptor).connect_port } {
+            unsafe { connect(self.handle, port_index, data) };
+        }
+    }
+
+    /// Run the plugin for `n_samples` frames.
+    pub fn run(&self, n_samples: u32) {
+        if let Some(run_fn) = unsafe { (*self.descriptor).run } {
+            unsafe { run_fn(self.handle, n_samples) };
+        }
+    }
+}
+
+impl Drop for Lv2Plugin {
+    fn drop(&mut self) {
+        unsafe {
+            if let Some(deactivate) = (*self.descriptor).deactivate {
+                deactivate(self.handle);
+            }
+            if let Some(cleanup) = (*self.descriptor).cleanup {
+                cleanup(self.handle);
+            }
+        }
+        log::debug!("LV2 plugin instance cleaned up");
+    }
+}

--- a/crates/lv2/src/lib.rs
+++ b/crates/lv2/src/lib.rs
@@ -1,0 +1,59 @@
+mod host;
+mod processor;
+
+pub use host::{Lv2Plugin, Lv2PortInfo, Lv2PortKind};
+pub use processor::Lv2Processor;
+
+use anyhow::Result;
+
+/// Build a ready-to-use mono LV2 processor.
+///
+/// - `lib_path`: full path to the plugin shared library (`.dylib`/`.so`/`.dll`)
+/// - `uri`: LV2 plugin URI
+/// - `sample_rate`: audio sample rate
+/// - `bundle_path`: path to the `.lv2` bundle directory containing TTL metadata
+/// - `audio_in_ports`: port indices for audio inputs
+/// - `audio_out_ports`: port indices for audio outputs
+/// - `control_ports`: `(port_index, initial_value)` pairs for control ports
+pub fn build_lv2_processor(
+    lib_path: &str,
+    uri: &str,
+    sample_rate: f64,
+    bundle_path: &str,
+    audio_in_ports: &[usize],
+    audio_out_ports: &[usize],
+    control_ports: &[(usize, f32)],
+) -> Result<Lv2Processor> {
+    let plugin = Lv2Plugin::load(lib_path, uri, sample_rate, bundle_path)?;
+    Ok(Lv2Processor::new(
+        plugin,
+        audio_in_ports,
+        audio_out_ports,
+        control_ports,
+    ))
+}
+
+/// Platform-specific default directory for prebuilt LV2 shared libraries,
+/// relative to the project root.
+pub fn default_lv2_lib_dir() -> &'static str {
+    #[cfg(target_os = "macos")]
+    {
+        "libs/lv2/macos-universal"
+    }
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    {
+        "libs/lv2/linux-x86_64"
+    }
+    #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+    {
+        "libs/lv2/linux-aarch64"
+    }
+    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+    {
+        "libs/lv2/windows-x64"
+    }
+    #[cfg(all(target_os = "windows", target_arch = "aarch64"))]
+    {
+        "libs/lv2/windows-arm64"
+    }
+}

--- a/crates/lv2/src/processor.rs
+++ b/crates/lv2/src/processor.rs
@@ -1,0 +1,100 @@
+use crate::host::Lv2Plugin;
+use block_core::MonoProcessor;
+use std::ffi::c_void;
+
+/// Audio processor wrapping a loaded LV2 plugin instance.
+///
+/// Ports are connected once at construction; `process_sample` simply writes
+/// the input, calls `run(1)` and reads the output.
+pub struct Lv2Processor {
+    plugin: Lv2Plugin,
+    // Scratch buffers — kept alive so the pointers stay valid.
+    in_buf: Box<[f32; 1]>,
+    out_buf: Box<[f32; 1]>,
+    // Control port values — kept alive and connected.
+    control_values: Vec<f32>,
+}
+
+impl Lv2Processor {
+    /// Create a new processor.
+    ///
+    /// - `plugin`: an already-loaded LV2 plugin instance
+    /// - `audio_in_ports`: port indices for audio inputs
+    /// - `audio_out_ports`: port indices for audio outputs
+    /// - `control_ports`: `(port_index, initial_value)` pairs
+    ///
+    /// Ports are connected immediately and remain connected for the lifetime
+    /// of this struct (buffer addresses never change).
+    pub fn new(
+        plugin: Lv2Plugin,
+        audio_in_ports: &[usize],
+        audio_out_ports: &[usize],
+        control_ports: &[(usize, f32)],
+    ) -> Self {
+        let mut in_buf = Box::new([0.0f32; 1]);
+        let mut out_buf = Box::new([0.0f32; 1]);
+        let mut control_values: Vec<f32> = control_ports.iter().map(|(_, v)| *v).collect();
+
+        // Connect audio input ports
+        for &port_idx in audio_in_ports {
+            unsafe {
+                plugin.connect_port(
+                    port_idx as u32,
+                    in_buf.as_mut_ptr() as *mut c_void,
+                );
+            }
+        }
+
+        // Connect audio output ports
+        for &port_idx in audio_out_ports {
+            unsafe {
+                plugin.connect_port(
+                    port_idx as u32,
+                    out_buf.as_mut_ptr() as *mut c_void,
+                );
+            }
+        }
+
+        // Connect control ports
+        for (i, (port_idx, _)) in control_ports.iter().enumerate() {
+            unsafe {
+                plugin.connect_port(
+                    *port_idx as u32,
+                    &mut control_values[i] as *mut f32 as *mut c_void,
+                );
+            }
+        }
+
+        Self {
+            plugin,
+            in_buf,
+            out_buf,
+            control_values,
+        }
+    }
+
+    /// Update a control port value by its position in the `control_ports`
+    /// slice that was passed to `new()`.
+    pub fn set_control(&mut self, control_index: usize, value: f32) {
+        if control_index < self.control_values.len() {
+            self.control_values[control_index] = value;
+        }
+    }
+}
+
+impl MonoProcessor for Lv2Processor {
+    fn process_sample(&mut self, input: f32) -> f32 {
+        self.in_buf[0] = input;
+        self.plugin.run(1);
+        self.out_buf[0]
+    }
+
+    fn process_block(&mut self, buffer: &mut [f32]) {
+        // Sample-by-sample for v1; block optimization can come later.
+        for sample in buffer.iter_mut() {
+            self.in_buf[0] = *sample;
+            self.plugin.run(1);
+            *sample = self.out_buf[0];
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Create `lv2` hosting crate with dlopen-based plugin loading (no lilv dependency)
- Add ChowCentaur as first LV2 model in `block-gain`
- LV2 C ABI types defined manually as repr(C) structs
- Minimal URID map implementation for plugin feature requirements
- Platform-specific binary discovery (macOS/Linux/Windows)

## Changes

### New: `crates/lv2/`
- `host.rs` — LV2 plugin loading via `libloading`, URID map, feature negotiation
- `processor.rs` — `Lv2Processor` implementing `MonoProcessor` (sample-by-sample v1)
- `lib.rs` — Public API: `build_lv2_processor()`, `default_lv2_lib_dir()`

### New: `crates/block-gain/src/lv2_chowcentaur.rs`
- ChowCentaur (Klon Centaur emulation) registered as gain model
- Parameters: Gain (0-100%), Treble (0-100%), Level (0-100%), Mode (Traditional/Neural)
- Resolves binary from `libs/lv2/<platform>/` and bundle from `plugins/ChowCentaur.lv2/`

## Test plan

- [ ] `cargo check -p lv2 -p block-gain` passes
- [ ] ChowCentaur appears in gain block picker
- [ ] Audio passes through plugin when added to chain
- [ ] Parameter changes affect audio output

Closes #4 (partial — first LV2 plugin integrated, more to follow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)