### PR TITLE
fix: trim output queue from back to avoid audio clicks/pops

### DIFF
--- a/crates/engine/src/runtime.rs
+++ b/crates/engine/src/runtime.rs
@@ -1145,7 +1145,7 @@ pub fn process_output_f32(
 
 fn trim_output_queue(queue: &mut VecDeque<AudioFrame>) {
     while queue.len() > MAX_BUFFERED_OUTPUT_FRAMES {
-        queue.pop_front();
+        queue.pop_back();
     }
 }
 


### PR DESCRIPTION
Fix audible clicks and pops caused by incorrect queue trimming in the audio engine.

When the output queue overflowed, `pop_front()` discarded the oldest frames (next to be played), causing abrupt audio discontinuities. Changed to `pop_back()` so overflow trims the newest unscheduled frames instead.

Closes #3

Generated with [Claude Code](https://claude.ai/code)