### PR TITLE
feat: add input mode selector to Chain Editor

### DIFF
--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -1590,6 +1590,7 @@ pub fn run_desktop_app(
             editor_window.set_editor_save_label(window.get_chain_editor_save_label());
             editor_window.set_is_create_mode(true);
             editor_window.set_selected_instrument_index(instrument_string_to_index(&draft.instrument));
+            editor_window.set_selected_input_mode_index(input_mode_to_index(draft.input_mode));
             window.set_selected_chain_input_device_index(selected_device_index(
                 &input_chain_devices,
                 draft.input_device_id.as_deref(),
@@ -1663,6 +1664,7 @@ pub fn run_desktop_app(
                 editor_window.set_editor_save_label(window.get_chain_editor_save_label());
                 editor_window.set_is_create_mode(false);
                 editor_window.set_selected_instrument_index(instrument_string_to_index(&draft.instrument));
+                editor_window.set_selected_input_mode_index(input_mode_to_index(draft.input_mode));
             }
             editor_window.set_status_message("".into());
             clear_status(&window, &toast_timer);
@@ -2199,6 +2201,16 @@ pub fn run_desktop_app(
                 log::debug!("[select_instrument] draft updated to '{}'", draft.instrument);
             } else {
                 log::warn!("[select_instrument] no draft to update!");
+            }
+        });
+    }
+    {
+        let chain_draft = chain_draft.clone();
+        chain_editor_window.on_select_input_mode(move |index| {
+            let mode = input_mode_from_index(index);
+            log::debug!("[select_input_mode] index={}, mode={:?}", index, mode);
+            if let Some(draft) = chain_draft.borrow_mut().as_mut() {
+                draft.input_mode = mode;
             }
         });
     }

--- a/crates/adapter-gui/ui/app-window.slint
+++ b/crates/adapter-gui/ui/app-window.slint
@@ -55,12 +55,14 @@ export component ChainEditorWindow inherits Window {
     in-out property <string> status-message;
     in property <bool> is-create-mode: true;
     in-out property <int> selected-instrument-index: 0;
+    in-out property <int> selected-input-mode-index: 0;
     callback update-chain-name(string);
     callback open-input();
     callback open-output();
     callback save-chain();
     callback cancel-chain();
     callback select-instrument(int);
+    callback select-input-mode(int);
     title: "OpenRig · Configurar chain";
     min-width: 980px;
     min-height: 680px;
@@ -79,12 +81,14 @@ export component ChainEditorWindow inherits Window {
         status-message: root.status-message;
         is-create-mode: root.is-create-mode;
         selected-instrument-index: root.selected-instrument-index;
+        selected-input-mode-index: root.selected-input-mode-index;
         update-chain-name(value) => { root.update-chain-name(value); }
         open-input => { root.open-input(); }
         open-output => { root.open-output(); }
         save-chain => { root.save-chain(); }
         cancel-chain => { root.cancel-chain(); }
         select-instrument(index) => { root.select-instrument(index); }
+        select-input-mode(index) => { root.select-input-mode(index); }
     }
 }
 

--- a/crates/adapter-gui/ui/pages/chain_editor.slint
+++ b/crates/adapter-gui/ui/pages/chain_editor.slint
@@ -130,13 +130,16 @@ export component ChainEditorPage inherits Rectangle {
     in-out property <string> status-message;
     in property <bool> is-create-mode: true;
     in-out property <int> selected-instrument-index: 0;
+    in-out property <int> selected-input-mode-index: 0;
     in property <[string]> instrument-labels: ["Guitarra", "Violao", "Baixo", "Voz", "Teclado", "Bateria", "Outro"];
+    in property <[string]> input-mode-labels: ["Mono", "Stereo", "Dual Mono"];
     callback update-chain-name(string);
     callback open-input();
     callback open-output();
     callback save-chain();
     callback cancel-chain();
     callback select-instrument(int);
+    callback select-input-mode(int);
 
     background: #171a1f;
 
@@ -265,9 +268,68 @@ export component ChainEditorPage inherits Rectangle {
         background: #2a2f38;
     }
 
+    Text {
+        x: 32px;
+        y: 248px;
+        width: 120px;
+        height: 16px;
+        text: "Tipo de Entrada";
+        color: #7a8694;
+        font-size: 11px;
+        font-weight: 600;
+    }
+
+    Rectangle {
+        x: 32px;
+        y: 268px;
+        width: parent.width - 64px;
+        height: 48px;
+        background: transparent;
+
+        for label[index] in root.input-mode-labels : Rectangle {
+            x: index * 120px;
+            y: 0px;
+            width: 108px;
+            height: 44px;
+            background: index == root.selected-input-mode-index ? #2a5da8 : #1d2025;
+            border-width: 1px;
+            border-color: index == root.selected-input-mode-index ? #45a7ff : #41454e;
+            border-radius: 4px;
+
+            Text {
+                width: parent.width;
+                height: parent.height;
+                text: label;
+                color: index == root.selected-input-mode-index ? #f4f7fb : #8a94a2;
+                horizontal-alignment: center;
+                vertical-alignment: center;
+                font-size: 12px;
+                font-weight: 600;
+            }
+
+            TouchArea {
+                width: parent.width;
+                height: parent.height;
+                mouse-cursor: pointer;
+                clicked => {
+                    root.selected-input-mode-index = index;
+                    root.select-input-mode(index);
+                }
+            }
+        }
+    }
+
+    Rectangle {
+        x: 32px;
+        y: 324px;
+        width: parent.width - 64px;
+        height: 1px;
+        background: #2a2f38;
+    }
+
     EditRow {
         x: 32px;
-        y: 244px;
+        y: 332px;
         width: parent.width - 64px;
         label: "Entrada";
         summary: root.input-summary;
@@ -276,7 +338,7 @@ export component ChainEditorPage inherits Rectangle {
 
     Rectangle {
         x: 32px;
-        y: 296px;
+        y: 384px;
         width: parent.width - 64px;
         height: 1px;
         background: #2a2f38;
@@ -284,7 +346,7 @@ export component ChainEditorPage inherits Rectangle {
 
     EditRow {
         x: 32px;
-        y: 304px;
+        y: 392px;
         width: parent.width - 64px;
         label: "Saída";
         summary: root.output-summary;
@@ -293,7 +355,7 @@ export component ChainEditorPage inherits Rectangle {
 
     Rectangle {
         x: 32px;
-        y: 356px;
+        y: 444px;
         width: parent.width - 64px;
         height: 1px;
         background: #2a2f38;


### PR DESCRIPTION
## Summary
- Add Mono/Stereo/Dual Mono toggle selector to Chain Editor UI
- Follow exact same pattern as instrument selector
- Bind to existing `input_mode` field in chain draft

Closes #2