### PR TITLE
feat: I/O blocks — Input, Output, Insert as AudioBlockKind variants

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ OpenRig é um pedalboard virtual para músicos. O usuário monta sua cadeia de e
 - **Block Editor** — editar parâmetros de um bloco (knobs, sliders, switches)
 - **Compact Chain View** — visão compacta com power switches e troca rápida de modelo
 - **Settings** — dispositivos de áudio (input/output), sample rate, buffer size
-- **Chain Editor** — nome da chain, instrumento, endpoints de I/O
+- **Chain Editor** — nome da chain, instrumento, I/O blocks (Input/Output como blocos na cadeia)
 
 ### Tipos de bloco e para que servem
 
@@ -131,16 +131,22 @@ electric_guitar, acoustic_guitar, bass, voice, keys, drums, generic
 
 Cada chain tem um instrumento que filtra quais blocos podem ser adicionados.
 
-### Configuração de áudio
+### Configuração de áudio — I/O como blocos
 
-- **Multi-input/multi-output**: cada chain tem N inputs e M outputs
-  - Cada input tem: `name`, `device_id`, `mode` (mono/stereo/dual_mono), `channels`
-  - Cada output tem: `name`, `device_id`, `mode` (mono/stereo), `channels`
-  - Cada input roda sua propria instancia paralela da cadeia de blocos
+Input e Output são variantes de `AudioBlockKind` (`InputBlock`, `OutputBlock`) dentro de `chain.blocks`. Não existem listas separadas `Chain.inputs` / `Chain.outputs`.
+
+- **Primeiro bloco** da chain é sempre um Input (fixo, não removível)
+- **Último bloco** da chain é sempre um Output (fixo, não removível)
+- Blocos extras de Input/Output podem ser adicionados no meio da chain
+- Cada Input cria um stream paralelo isolado (instância independente da cadeia de blocos)
+- Output é um tap: copia o sinal sem interromper o fluxo
+- Cada InputBlock tem: `name`, `device_id`, `mode` (mono/stereo/dual_mono), `channels`
+- Cada OutputBlock tem: `name`, `device_id`, `mode` (mono/stereo), `channels`
 - Devices: input e output independentes (podem ser devices diferentes)
 - Sample rates: 44.1kHz, 48kHz, 88.2kHz, 96kHz
 - Buffer sizes: 32, 64, 128, 256, 512, 1024 samples
-- **Migração**: YAML antigo com `input_device_id`/`output_device_id` (campos únicos) é migrado automaticamente para o formato `inputs`/`outputs` ao carregar
+- **YAML**: serializa inputs/outputs como seções separadas (`inputs:` / `outputs:`) por legibilidade, mas internamente são blocos no vetor `blocks`
+- **Migração**: YAML antigo com `input_device_id`/`output_device_id` (campos únicos) é migrado automaticamente para o formato novo ao carregar
 
 ---
 
@@ -342,17 +348,17 @@ O campo `instrument` e salvo no YAML da chain. Valor padrao (retrocompatibilidad
 chains:
   - description: guitar 1
     instrument: electric_guitar
-    inputs:
+    inputs:                          # serialized separately for readability
       - name: Input 1
         device_id: "coreaudio:..."
         mode: mono
         channels: [0]
-    outputs:
+    outputs:                         # serialized separately for readability
       - name: Output 1
         device_id: "coreaudio:..."
         mode: stereo
         channels: [0, 1]
-    blocks:
+    blocks:                          # only effect blocks here (I/O blocks are in inputs/outputs)
       - type: preamp
         model: marshall_jcm_800_2203
         enabled: true
@@ -360,6 +366,13 @@ chains:
           volume: 70.0
           gain: 40.0
 ```
+
+Internamente, a Chain tem um único vetor `blocks: Vec<AudioBlock>` onde:
+- `blocks[0]` = InputBlock (fixo)
+- `blocks[1..N-1]` = blocos de efeito (Nam, Core, Select)
+- `blocks[N-1]` = OutputBlock (fixo)
+
+O YAML separa em `inputs:`, `outputs:` e `blocks:` apenas por legibilidade. Na deserialização, tudo é reunido no vetor `blocks`. Na serialização, InputBlock/OutputBlock são extraídos para as seções `inputs:`/`outputs:`.
 
 ---
 

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -3180,6 +3180,11 @@ pub fn run_desktop_app(
         let output_chain_devices = output_chain_devices.clone();
         let open_block_windows = open_block_windows.clone();
         let toast_timer = toast_timer.clone();
+        let weak_input_window_for_select = chain_input_window.as_weak();
+        let weak_output_window_for_select = chain_output_window.as_weak();
+        let chain_draft_for_select = chain_draft.clone();
+        let chain_input_channels_for_select = chain_input_channels.clone();
+        let chain_output_channels_for_select = chain_output_channels.clone();
         window.on_select_chain_block(move |chain_index, block_index| {
             let Some(window) = weak_main_window.upgrade() else {
                 return;
@@ -3198,6 +3203,51 @@ pub fn run_desktop_app(
                 set_status_error(&window, &toast_timer, "Block inválido.");
                 return;
             };
+            // Handle I/O blocks — open device/channel editor instead of block editor
+            match &block.kind {
+                AudioBlockKind::Input(_) => {
+                    let draft = chain_draft_from_chain(chain_index as usize, chain);
+                    // Find which input group index this block corresponds to
+                    let input_idx = chain.input_blocks().iter()
+                        .position(|(i, _)| *i == block_index as usize)
+                        .unwrap_or(0);
+                    let mut draft = draft;
+                    draft.editing_input_index = Some(input_idx);
+                    if let Some(input_group) = draft.inputs.get(input_idx) {
+                        if let Some(iw) = weak_input_window_for_select.upgrade() {
+                            apply_chain_input_window_state(
+                                &iw, input_group, &draft, &session.project,
+                                &input_chain_devices, &chain_input_channels_for_select,
+                            );
+                            *chain_draft_for_select.borrow_mut() = Some(draft);
+                            drop(session_borrow);
+                            show_child_window(window.window(), iw.window());
+                        }
+                    }
+                    return;
+                }
+                AudioBlockKind::Output(_) => {
+                    let draft = chain_draft_from_chain(chain_index as usize, chain);
+                    let output_idx = chain.output_blocks().iter()
+                        .position(|(i, _)| *i == block_index as usize)
+                        .unwrap_or(0);
+                    let mut draft = draft;
+                    draft.editing_output_index = Some(output_idx);
+                    if let Some(output_group) = draft.outputs.get(output_idx) {
+                        if let Some(ow) = weak_output_window_for_select.upgrade() {
+                            apply_chain_output_window_state(
+                                &ow, output_group,
+                                &output_chain_devices, &chain_output_channels_for_select,
+                            );
+                            *chain_draft_for_select.borrow_mut() = Some(draft);
+                            drop(session_borrow);
+                            show_child_window(window.window(), ow.window());
+                        }
+                    }
+                    return;
+                }
+                _ => {}
+            }
             log::info!("[select_chain_block] block at index {}: id='{}', kind={:?}", block_index, block.id.0, block.model_ref().map(|m| format!("{}/{}", m.effect_type, m.model)));
             let Some(editor_data) = block_editor_data(block) else {
                 set_status_error(&window, &toast_timer, "Esse block ainda não pode ser editado pela GUI.");
@@ -3956,11 +4006,19 @@ pub fn run_desktop_app(
                     log::warn!("=== START_BLOCK_INSERT: no chain at index {}, defaulting to electric_guitar ===", chain_index);
                     block_core::DEFAULT_INSTRUMENT.to_string()
                 });
+            // Map UI before_index to real chain.blocks index (UI excludes hidden I/O blocks)
+            let real_before_index = {
+                let session_borrow = project_session.borrow();
+                session_borrow.as_ref()
+                    .and_then(|s| s.project.chains.get(chain_index as usize))
+                    .map(|chain| ui_index_to_real_block_index(chain, before_index as usize))
+                    .unwrap_or(before_index as usize)
+            };
             *selected_block.borrow_mut() = None;
             *block_editor_draft.borrow_mut() = Some(BlockEditorDraft {
                 chain_index: chain_index as usize,
                 block_index: None,
-                before_index: before_index as usize,
+                before_index: real_before_index,
                 instrument: instrument.clone(),
                 effect_type: String::new(),
                 model_id: String::new(),
@@ -6814,6 +6872,24 @@ fn load_thumbnail_image(effect_type: &str, model_id: &str) -> (slint::Image, boo
         None => (slint::Image::default(), false, 0.0, 0.0)
     }
 }
+/// Map a UI block index (which excludes hidden first Input and last Output) to the real chain.blocks index.
+fn ui_index_to_real_block_index(chain: &Chain, ui_index: usize) -> usize {
+    let first_input_idx = chain.blocks.iter().position(|b| matches!(&b.kind, AudioBlockKind::Input(_)));
+    let last_output_idx = chain.blocks.iter().rposition(|b| matches!(&b.kind, AudioBlockKind::Output(_)));
+    let mut visible_count = 0;
+    for (real_idx, _) in chain.blocks.iter().enumerate() {
+        if Some(real_idx) == first_input_idx || Some(real_idx) == last_output_idx {
+            continue; // hidden
+        }
+        if visible_count == ui_index {
+            return real_idx;
+        }
+        visible_count += 1;
+    }
+    // If ui_index is past all visible blocks, return end (before last output)
+    last_output_idx.unwrap_or(chain.blocks.len())
+}
+
 fn chain_block_item_from_block(block: &AudioBlock) -> ChainBlockItem {
     let (kind, label) = match &block.kind {
         AudioBlockKind::Input(_) => ("input".to_string(), "input".to_string()),

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -5505,7 +5505,6 @@ fn replace_project_chains(
                     chain
                         .blocks
                         .iter()
-                        .filter(|b| !matches!(&b.kind, AudioBlockKind::Input(_) | AudioBlockKind::Output(_)))
                         .map(chain_block_item_from_block)
                         .collect::<Vec<_>>(),
                 ))),
@@ -6590,7 +6589,10 @@ fn load_thumbnail_image(effect_type: &str, model_id: &str) -> (slint::Image, boo
     }
 }
 fn chain_block_item_from_block(block: &AudioBlock) -> ChainBlockItem {
+    let is_io = matches!(&block.kind, AudioBlockKind::Input(_) | AudioBlockKind::Output(_));
     let (kind, label) = match &block.kind {
+        AudioBlockKind::Input(_) => ("input".to_string(), "input".to_string()),
+        AudioBlockKind::Output(_) => ("output".to_string(), "output".to_string()),
         AudioBlockKind::Select(select) => select
             .selected_option()
             .and_then(|option| option.model_ref())
@@ -6619,6 +6621,7 @@ fn chain_block_item_from_block(block: &AudioBlock) -> ChainBlockItem {
         label: label.into(),
         family: family.into(),
         enabled: block.enabled,
+        hidden: is_io,
         thumbnail,
         has_thumbnail,
         thumb_width,

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -22,7 +22,7 @@ use project::catalog::{supported_block_models, supported_block_type, supported_b
 use project::device::DeviceSettings;
 use project::param::{ParameterDomain, ParameterSet, ParameterUnit};
 use project::project::Project;
-use project::block::{InputBlock, OutputBlock};
+use project::block::{InputBlock, InputEntry, OutputBlock, OutputEntry};
 use project::chain::{Chain, ChainInputMode, ChainOutputMode};
 use rfd::FileDialog;
 use serde::{Deserialize, Serialize};
@@ -5088,9 +5088,11 @@ pub fn run_desktop_app(
                         enabled: true,
                         kind: AudioBlockKind::Input(InputBlock {
                             name: input_group.name.clone(),
-                            device_id: DeviceId(input_group.device_id.clone().unwrap_or_default()),
-                            mode: input_group.mode,
-                            channels: input_group.channels.clone(),
+                            entries: vec![InputEntry {
+                                device_id: DeviceId(input_group.device_id.clone().unwrap_or_default()),
+                                mode: input_group.mode,
+                                channels: input_group.channels.clone(),
+                            }],
                         }),
                     };
                     let insert_pos = before_index.min(chain.blocks.len());
@@ -5142,9 +5144,11 @@ pub fn run_desktop_app(
                     enabled: true,
                     kind: AudioBlockKind::Input(InputBlock {
                         name: ig.name.clone(),
-                        device_id: DeviceId(ig.device_id.clone().unwrap_or_default()),
-                        mode: ig.mode,
-                        channels: ig.channels.clone(),
+                        entries: vec![InputEntry {
+                            device_id: DeviceId(ig.device_id.clone().unwrap_or_default()),
+                            mode: ig.mode,
+                            channels: ig.channels.clone(),
+                        }],
                     }),
                 }).collect();
                 // Keep non-input, non-output blocks and existing output blocks
@@ -5284,9 +5288,11 @@ pub fn run_desktop_app(
                         enabled: true,
                         kind: AudioBlockKind::Output(OutputBlock {
                             name: output_group.name.clone(),
-                            device_id: DeviceId(output_group.device_id.clone().unwrap_or_default()),
-                            mode: output_group.mode,
-                            channels: output_group.channels.clone(),
+                            entries: vec![OutputEntry {
+                                device_id: DeviceId(output_group.device_id.clone().unwrap_or_default()),
+                                mode: output_group.mode,
+                                channels: output_group.channels.clone(),
+                            }],
                         }),
                     };
                     let insert_pos = before_index.min(chain.blocks.len());
@@ -5338,9 +5344,11 @@ pub fn run_desktop_app(
                     enabled: true,
                     kind: AudioBlockKind::Output(OutputBlock {
                         name: og.name.clone(),
-                        device_id: DeviceId(og.device_id.clone().unwrap_or_default()),
-                        mode: og.mode,
-                        channels: og.channels.clone(),
+                        entries: vec![OutputEntry {
+                            device_id: DeviceId(og.device_id.clone().unwrap_or_default()),
+                            mode: og.mode,
+                            channels: og.channels.clone(),
+                        }],
                     }),
                 }).collect();
                 // Keep non-output blocks (inputs and audio blocks)
@@ -5478,8 +5486,13 @@ pub fn run_desktop_app(
                     if other.id != chain_id && other.enabled {
                         for (_, other_input) in other.input_blocks() {
                             for (_, our_input) in &our_inputs {
-                                if other_input.device_id == our_input.device_id
-                                    && other_input.channels.iter().any(|ch| our_input.channels.contains(ch))
+                                let other_entries_conflict = other_input.entries.iter().any(|oe|
+                                    our_input.entries.iter().any(|ue|
+                                        oe.device_id == ue.device_id
+                                        && oe.channels.iter().any(|ch| ue.channels.contains(ch))
+                                    )
+                                );
+                                if other_entries_conflict
                                 {
                                     let other_name = other.description.as_deref().unwrap_or("outra chain");
                                     set_status_error(&window, &toast_timer, &format!("Input channel já em uso por '{}'", other_name));
@@ -5741,12 +5754,16 @@ fn replace_project_chains(
         .iter()
         .enumerate()
         .map(|(index, chain)| {
-            let input_settings = chain.first_input().and_then(|ib| {
-                project.device_settings.iter().find(|s| s.device_id == ib.device_id)
-            });
-            let output_settings = chain.last_output().and_then(|ob| {
-                project.device_settings.iter().find(|s| s.device_id == ob.device_id)
-            });
+            let input_settings = chain.first_input()
+                .and_then(|ib| ib.entries.first())
+                .and_then(|entry| {
+                    project.device_settings.iter().find(|s| s.device_id == entry.device_id)
+                });
+            let output_settings = chain.last_output()
+                .and_then(|ob| ob.entries.first())
+                .and_then(|entry| {
+                    project.device_settings.iter().find(|s| s.device_id == entry.device_id)
+                });
             let input_buffer =
                 input_settings.map(|s| s.buffer_size_frames).unwrap_or(256) as f32;
             let output_buffer =
@@ -5774,14 +5791,14 @@ fn replace_project_chains(
                 },
                 input_label: {
                     let input_chs: Vec<usize> = chain.input_blocks().into_iter()
-                        .flat_map(|(_, ib)| ib.channels.iter().copied())
+                        .flat_map(|(_, ib)| ib.entries.iter().flat_map(|e| e.channels.iter().copied()))
                         .collect();
                     chain_endpoint_label("In", &input_chs).into()
                 },
                 input_tooltip: chain_inputs_tooltip(chain, project, input_devices).into(),
                 output_label: {
                     let output_chs: Vec<usize> = chain.output_blocks().into_iter()
-                        .flat_map(|(_, ob)| ob.channels.iter().copied())
+                        .flat_map(|(_, ob)| ob.entries.iter().flat_map(|e| e.channels.iter().copied()))
                         .collect();
                     chain_endpoint_label("Out", &output_chs).into()
                 },
@@ -5825,18 +5842,21 @@ fn chain_inputs_tooltip(
     if input_blocks.is_empty() {
         return "No input configured".to_string();
     }
-    input_blocks.iter().map(|(_, input)| {
-        let device_name = devices
-            .iter()
-            .find(|d| d.id == input.device_id.0)
-            .map(|d| d.name.as_str())
-            .unwrap_or(&input.device_id.0);
-        let mode = match input.mode {
-            ChainInputMode::Mono => "Mono",
-            ChainInputMode::Stereo => "Stereo",
-            ChainInputMode::DualMono => "Dual Mono",
-        };
-        format!("{}: {} · {} · Ch {}", input.name, device_name, mode, format_channel_list(&input.channels))
+    input_blocks.iter().flat_map(|(_, input)| {
+        input.entries.iter().enumerate().map(move |(ei, entry)| {
+            let device_name = devices
+                .iter()
+                .find(|d| d.id == entry.device_id.0)
+                .map(|d| d.name.as_str())
+                .unwrap_or(&entry.device_id.0);
+            let mode = match entry.mode {
+                ChainInputMode::Mono => "Mono",
+                ChainInputMode::Stereo => "Stereo",
+                ChainInputMode::DualMono => "Dual Mono",
+            };
+            let label = if input.entries.len() == 1 { input.name.clone() } else { format!("{} #{}", input.name, ei + 1) };
+            format!("{}: {} · {} · Ch {}", label, device_name, mode, format_channel_list(&entry.channels))
+        })
     }).collect::<Vec<_>>().join("\n")
 }
 fn chain_outputs_tooltip(
@@ -5848,17 +5868,20 @@ fn chain_outputs_tooltip(
     if output_blocks.is_empty() {
         return "No output configured".to_string();
     }
-    output_blocks.iter().map(|(_, output)| {
-        let device_name = devices
-            .iter()
-            .find(|d| d.id == output.device_id.0)
-            .map(|d| d.name.as_str())
-            .unwrap_or(&output.device_id.0);
-        let mode = match output.mode {
-            ChainOutputMode::Mono => "Mono",
-            ChainOutputMode::Stereo => "Stereo",
-        };
-        format!("{}: {} · {} · Ch {}", output.name, device_name, mode, format_channel_list(&output.channels))
+    output_blocks.iter().flat_map(|(_, output)| {
+        output.entries.iter().enumerate().map(move |(ei, entry)| {
+            let device_name = devices
+                .iter()
+                .find(|d| d.id == entry.device_id.0)
+                .map(|d| d.name.as_str())
+                .unwrap_or(&entry.device_id.0);
+            let mode = match entry.mode {
+                ChainOutputMode::Mono => "Mono",
+                ChainOutputMode::Stereo => "Stereo",
+            };
+            let label = if output.entries.len() == 1 { output.name.clone() } else { format!("{} #{}", output.name, ei + 1) };
+            format!("{}: {} · {} · Ch {}", label, device_name, mode, format_channel_list(&entry.channels))
+        })
     }).collect::<Vec<_>>().join("\n")
 }
 fn format_channel_list(channels: &[usize]) -> String {
@@ -6788,15 +6811,17 @@ fn chain_draft_from_chain(index: usize, chain: &Chain) -> ChainDraft {
     } else {
         input_blocks
             .iter()
-            .map(|(_, input)| InputGroupDraft {
-                name: input.name.clone(),
-                device_id: if input.device_id.0.is_empty() {
-                    None
-                } else {
-                    Some(input.device_id.0.clone())
-                },
-                channels: input.channels.clone(),
-                mode: input.mode,
+            .map(|(_, input)| {
+                let first = input.entries.first();
+                InputGroupDraft {
+                    name: input.name.clone(),
+                    device_id: first
+                        .map(|e| &e.device_id.0)
+                        .filter(|id| !id.is_empty())
+                        .cloned(),
+                    channels: first.map(|e| e.channels.clone()).unwrap_or_default(),
+                    mode: first.map(|e| e.mode).unwrap_or_default(),
+                }
             })
             .collect()
     };
@@ -6811,15 +6836,17 @@ fn chain_draft_from_chain(index: usize, chain: &Chain) -> ChainDraft {
     } else {
         output_blocks
             .iter()
-            .map(|(_, output)| OutputGroupDraft {
-                name: output.name.clone(),
-                device_id: if output.device_id.0.is_empty() {
-                    None
-                } else {
-                    Some(output.device_id.0.clone())
-                },
-                channels: output.channels.clone(),
-                mode: output.mode,
+            .map(|(_, output)| {
+                let first = output.entries.first();
+                OutputGroupDraft {
+                    name: output.name.clone(),
+                    device_id: first
+                        .map(|e| &e.device_id.0)
+                        .filter(|id| !id.is_empty())
+                        .cloned(),
+                    channels: first.map(|e| e.channels.clone()).unwrap_or_default(),
+                    mode: first.map(|e| e.mode).unwrap_or_default(),
+                }
             })
             .collect()
     };
@@ -6959,8 +6986,9 @@ fn build_input_channel_items(
         })
         .flat_map(|(_, chain)| {
             chain.input_blocks().into_iter()
-                .filter(|(_, inp)| inp.device_id.0 == *device_id)
-                .flat_map(|(_, inp)| inp.channels.iter().copied().collect::<Vec<_>>())
+                .flat_map(|(_, inp)| inp.entries.iter())
+                .filter(|entry| entry.device_id.0 == *device_id)
+                .flat_map(|entry| entry.channels.iter().copied().collect::<Vec<_>>())
                 .collect::<Vec<_>>()
         })
         .collect::<Vec<_>>();
@@ -7014,9 +7042,11 @@ fn chain_from_draft(draft: &ChainDraft, existing_chain: Option<&Chain>) -> Chain
             enabled: true,
             kind: AudioBlockKind::Input(InputBlock {
                 name: ig.name.clone(),
-                device_id: DeviceId(ig.device_id.clone().unwrap_or_default()),
-                mode: ig.mode,
-                channels: ig.channels.clone(),
+                entries: vec![InputEntry {
+                    device_id: DeviceId(ig.device_id.clone().unwrap_or_default()),
+                    mode: ig.mode,
+                    channels: ig.channels.clone(),
+                }],
             }),
         })
         .collect();
@@ -7031,9 +7061,11 @@ fn chain_from_draft(draft: &ChainDraft, existing_chain: Option<&Chain>) -> Chain
             enabled: true,
             kind: AudioBlockKind::Output(OutputBlock {
                 name: og.name.clone(),
-                device_id: DeviceId(og.device_id.clone().unwrap_or_default()),
-                mode: og.mode,
-                channels: og.channels.clone(),
+                entries: vec![OutputEntry {
+                    device_id: DeviceId(og.device_id.clone().unwrap_or_default()),
+                    mode: og.mode,
+                    channels: og.channels.clone(),
+                }],
             }),
         })
         .collect();
@@ -7525,7 +7557,7 @@ mod tests {
     // --- ui_index_to_real_block_index tests ---
 
     use super::ui_index_to_real_block_index;
-    use project::block::{InputBlock, OutputBlock};
+    use project::block::{InputBlock, InputEntry, OutputBlock, OutputEntry};
     use project::chain::{Chain, ChainInputMode, ChainOutputMode};
     use domain::ids::{ChainId, DeviceId};
 
@@ -7546,18 +7578,22 @@ mod tests {
     fn input_kind() -> AudioBlockKind {
         AudioBlockKind::Input(InputBlock {
             name: "In".into(),
-            device_id: DeviceId("dev".into()),
-            mode: ChainInputMode::Mono,
-            channels: vec![0],
+            entries: vec![InputEntry {
+                device_id: DeviceId("dev".into()),
+                mode: ChainInputMode::Mono,
+                channels: vec![0],
+            }],
         })
     }
 
     fn output_kind() -> AudioBlockKind {
         AudioBlockKind::Output(OutputBlock {
             name: "Out".into(),
-            device_id: DeviceId("dev".into()),
-            mode: ChainOutputMode::Stereo,
-            channels: vec![0, 1],
+            entries: vec![OutputEntry {
+                device_id: DeviceId("dev".into()),
+                mode: ChainOutputMode::Stereo,
+                channels: vec![0, 1],
+            }],
         })
     }
 

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -6983,18 +6983,32 @@ fn chain_block_item_from_block(block: &AudioBlock) -> ChainBlockItem {
     let family = block_family_for_kind(&kind).to_string();
     let block_type = supported_block_type(&kind);
     let (thumbnail, has_thumbnail, thumb_width, thumb_height) = load_thumbnail_image(&kind, &label);
+
+    // I/O blocks are not registered effect types, so resolve icon_kind/type_label directly
+    let is_io = matches!(block.kind, AudioBlockKind::Input(_) | AudioBlockKind::Output(_));
+    let resolved_icon_kind: String = if is_io {
+        kind.clone()
+    } else {
+        block_type.as_ref().map(|e| e.icon_kind).unwrap_or("core").to_string()
+    };
+    let resolved_type_label: &str = if is_io {
+        match &block.kind {
+            AudioBlockKind::Input(_) => "INPUT",
+            AudioBlockKind::Output(_) => "OUTPUT",
+            _ => "BLOCK",
+        }
+    } else {
+        block_type
+            .as_ref()
+            .map(|e| e.display_label)
+            .unwrap_or("BLOCK")
+    };
+
+    let accent_color = crate::ui_state::accent_color_for_icon_kind(&resolved_icon_kind);
     ChainBlockItem {
         kind: kind.into(),
-        icon_kind: block_type
-            .as_ref()
-            .map(|entry| entry.icon_kind)
-            .unwrap_or("core")
-            .into(),
-        type_label: block_type
-            .as_ref()
-            .map(|entry| entry.display_label)
-            .unwrap_or("BLOCK")
-            .into(),
+        icon_kind: resolved_icon_kind.into(),
+        type_label: resolved_type_label.into(),
         label: label.into(),
         family: family.into(),
         enabled: block.enabled,
@@ -7003,9 +7017,7 @@ fn chain_block_item_from_block(block: &AudioBlock) -> ChainBlockItem {
         has_thumbnail,
         thumb_width,
         thumb_height,
-        accent_color: crate::ui_state::accent_color_for_icon_kind(
-            block_type.as_ref().map(|e| e.icon_kind).unwrap_or("core"),
-        ),
+        accent_color,
         icon_source: slint::Image::default(),
     }
 }

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -3559,6 +3559,11 @@ pub fn run_desktop_app(
                     }
                     return;
                 }
+                AudioBlockKind::Insert(_) => {
+                    log::info!("[select_chain_block] insert block at index {}: id='{}'", block_index, block.id.0);
+                    set_status_with_toast(&window, &toast_timer, "Insert block configuration not yet available in GUI.", "info");
+                    return;
+                }
                 _ => {}
             }
             log::info!("[select_chain_block] block at index {}: id='{}', kind={:?}", block_index, block.id.0, block.model_ref().map(|m| format!("{}/{}", m.effect_type, m.model)));
@@ -4384,8 +4389,44 @@ pub fn run_desktop_app(
             };
             log::debug!("on_choose_block_type: index={}, type='{}', instrument='{}'", index, block_type.effect_type, instrument);
 
-            // Handle I/O block types: open the dedicated I/O window instead of the block editor
+            // Handle I/O and Insert block types: open the dedicated window instead of the block editor
             let effect_type_str = block_type.effect_type.as_str();
+            if effect_type_str == "insert" {
+                // Insert block: create directly with empty endpoints
+                let (chain_index, before_index) = {
+                    let draft_borrow = block_editor_draft.borrow();
+                    let Some(draft) = draft_borrow.as_ref() else { return; };
+                    (draft.chain_index, draft.before_index)
+                };
+                let session_borrow = project_session_for_type.borrow();
+                let Some(session) = session_borrow.as_ref() else { return; };
+                let Some(chain) = session.project.chains.get(chain_index) else { return; };
+                let block_id = domain::ids::BlockId(format!("{}:insert:{}", chain.id.0, before_index));
+                drop(session_borrow);
+                let insert_block = project::block::AudioBlock {
+                    id: block_id,
+                    enabled: true,
+                    kind: AudioBlockKind::Insert(project::block::InsertBlock {
+                        model: "standard".to_string(),
+                        send: project::block::InsertEndpoint {
+                            device_id: domain::ids::DeviceId(String::new()),
+                            mode: ChainInputMode::Mono,
+                            channels: Vec::new(),
+                        },
+                        return_: project::block::InsertEndpoint {
+                            device_id: domain::ids::DeviceId(String::new()),
+                            mode: ChainInputMode::Mono,
+                            channels: Vec::new(),
+                        },
+                    }),
+                };
+                let mut session_borrow = project_session_for_type.borrow_mut();
+                let Some(session) = session_borrow.as_mut() else { return; };
+                let Some(chain) = session.project.chains.get_mut(chain_index) else { return; };
+                chain.blocks.insert(before_index, insert_block);
+                window.set_show_block_type_picker(false);
+                return;
+            }
             if effect_type_str == "input" || effect_type_str == "output" {
                 let (chain_index, before_index) = {
                     let draft_borrow = block_editor_draft.borrow();
@@ -6334,6 +6375,15 @@ fn block_type_picker_items(instrument: &str) -> Vec<BlockTypePickerItem> {
         accent_color: crate::ui_state::accent_color_for_icon_kind("routing"),
         icon_source: slint::Image::default(),
     });
+    items.push(BlockTypePickerItem {
+        effect_type: "insert".into(),
+        label: "INSERT".into(),
+        subtitle: "".into(),
+        icon_kind: "insert".into(),
+        use_panel_editor: false,
+        accent_color: crate::ui_state::accent_color_for_icon_kind("insert"),
+        icon_source: slint::Image::default(),
+    });
     items
 }
 fn block_model_picker_items(effect_type: &str, instrument: &str) -> Vec<BlockModelPickerItem> {
@@ -7330,6 +7380,7 @@ fn chain_block_item_from_block(block: &AudioBlock) -> ChainBlockItem {
     let (kind, label) = match &block.kind {
         AudioBlockKind::Input(_) => ("input".to_string(), "input".to_string()),
         AudioBlockKind::Output(_) => ("output".to_string(), "output".to_string()),
+        AudioBlockKind::Insert(_) => ("insert".to_string(), "insert".to_string()),
         AudioBlockKind::Select(select) => select
             .selected_option()
             .and_then(|option| option.model_ref())
@@ -7344,8 +7395,8 @@ fn chain_block_item_from_block(block: &AudioBlock) -> ChainBlockItem {
     let block_type = supported_block_type(&kind);
     let (thumbnail, has_thumbnail, thumb_width, thumb_height) = load_thumbnail_image(&kind, &label);
 
-    // I/O blocks are not registered effect types, so resolve icon_kind/type_label directly
-    let is_io = matches!(block.kind, AudioBlockKind::Input(_) | AudioBlockKind::Output(_));
+    // I/O and Insert blocks are not registered effect types, so resolve icon_kind/type_label directly
+    let is_io = matches!(block.kind, AudioBlockKind::Input(_) | AudioBlockKind::Output(_) | AudioBlockKind::Insert(_));
     let resolved_icon_kind: String = if is_io {
         kind.clone()
     } else {
@@ -7355,6 +7406,7 @@ fn chain_block_item_from_block(block: &AudioBlock) -> ChainBlockItem {
         match &block.kind {
             AudioBlockKind::Input(_) => "INPUT",
             AudioBlockKind::Output(_) => "OUTPUT",
+            AudioBlockKind::Insert(_) => "INSERT",
             _ => "BLOCK",
         }
     } else {

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -2912,7 +2912,6 @@ pub fn run_desktop_app(
     {
         let weak_window = window.as_weak();
         let weak_groups_window = chain_input_groups_window.as_weak();
-        let weak_chain_window = chain_editor_window.as_weak();
         let chain_draft = chain_draft.clone();
         let project_session = project_session.clone();
         let project_chains = project_chains.clone();
@@ -2921,7 +2920,6 @@ pub fn run_desktop_app(
         let project_dirty = project_dirty.clone();
         let input_chain_devices = input_chain_devices.clone();
         let output_chain_devices = output_chain_devices.clone();
-        let toast_timer = toast_timer.clone();
         chain_input_groups_window.on_save(move || {
             let Some(window) = weak_window.upgrade() else {
                 return;
@@ -2960,21 +2958,32 @@ pub fn run_desktop_app(
                 }
             }
             let editing_index = draft.editing_index;
-            // If editing a specific I/O block in the middle (not the fixed chip), update ONLY that block
-            if let (Some(chain_idx), Some(block_idx)) = (editing_index, draft.editing_io_block_index) {
-                let new_entries: Vec<InputEntry> = draft.inputs.iter()
-                    .filter(|ig| ig.device_id.is_some() && !ig.channels.is_empty())
-                    .map(|ig| InputEntry {
-                        name: ig.name.clone(),
-                        device_id: DeviceId(ig.device_id.clone().unwrap_or_default()),
-                        mode: ig.mode,
-                        channels: ig.channels.clone(),
-                    }).collect();
+            let io_block_idx = draft.editing_io_block_index;
+
+            // Build new entries from draft
+            let new_entries: Vec<InputEntry> = draft.inputs.iter()
+                .filter(|ig| ig.device_id.is_some() && !ig.channels.is_empty())
+                .map(|ig| InputEntry {
+                    name: ig.name.clone(),
+                    device_id: DeviceId(ig.device_id.clone().unwrap_or_default()),
+                    mode: ig.mode,
+                    channels: ig.channels.clone(),
+                }).collect();
+
+            if let Some(chain_idx) = editing_index {
                 if let Some(chain) = session.project.chains.get_mut(chain_idx) {
-                    if let Some(block) = chain.blocks.get_mut(block_idx) {
+                    // Find target block: specific index or first InputBlock
+                    let target_idx = io_block_idx.unwrap_or_else(|| {
+                        chain.blocks.iter().position(|b| matches!(&b.kind, AudioBlockKind::Input(_))).unwrap_or(0)
+                    });
+                    if let Some(block) = chain.blocks.get_mut(target_idx) {
                         if let AudioBlockKind::Input(ref mut ib) = block.kind {
                             ib.entries = new_entries;
                         }
+                    }
+                    if let Err(msg) = chain.validate_channel_conflicts() {
+                        groups_window.set_status_message(msg.into());
+                        return;
                     }
                     let chain_id = chain.id.clone();
                     if let Err(error) = sync_live_chain_runtime(&project_runtime, session, &chain_id) {
@@ -2984,47 +2993,9 @@ pub fn run_desktop_app(
                     replace_project_chains(&project_chains, &session.project, &input_chain_devices, &output_chain_devices);
                     sync_project_dirty(&window, session, &saved_project_snapshot, &project_dirty);
                 }
-                *chain_draft.borrow_mut() = None;
-                groups_window.set_status_message("".into());
-                let _ = groups_window.hide();
-                return;
-            }
-            let existing_chain =
-                editing_index.and_then(|index| session.project.chains.get(index).cloned());
-            let chain = chain_from_draft(&draft, existing_chain.as_ref());
-            if let Err(msg) = chain.validate_channel_conflicts() {
-                groups_window.set_status_message(msg.into());
-                return;
-            }
-            let chain_id = chain.id.clone();
-            if let Some(index) = editing_index {
-                if let Some(current) = session.project.chains.get_mut(index) {
-                    *current = chain;
-                }
-            }
-            if let Err(error) = sync_live_chain_runtime(&project_runtime, session, &chain_id) {
-                groups_window.set_status_message(error.to_string().into());
-                return;
-            }
-            replace_project_chains(
-                &project_chains,
-                &session.project,
-                &input_chain_devices,
-                &output_chain_devices,
-            );
-            if let Some(chain_window) = weak_chain_window.upgrade() {
-                apply_chain_io_groups(
-                    &window,
-                    &chain_window,
-                    &draft,
-                    &input_chain_devices,
-                    &output_chain_devices,
-                );
             }
             *chain_draft.borrow_mut() = None;
-            sync_project_dirty(&window, session, &saved_project_snapshot, &project_dirty);
             groups_window.set_status_message("".into());
-            clear_status(&window, &toast_timer);
             let _ = groups_window.hide();
         });
     }
@@ -3135,7 +3106,6 @@ pub fn run_desktop_app(
     {
         let weak_window = window.as_weak();
         let weak_groups_window = chain_output_groups_window.as_weak();
-        let weak_chain_window = chain_editor_window.as_weak();
         let chain_draft = chain_draft.clone();
         let project_session = project_session.clone();
         let project_chains = project_chains.clone();
@@ -3144,7 +3114,6 @@ pub fn run_desktop_app(
         let project_dirty = project_dirty.clone();
         let input_chain_devices = input_chain_devices.clone();
         let output_chain_devices = output_chain_devices.clone();
-        let toast_timer = toast_timer.clone();
         chain_output_groups_window.on_save(move || {
             let Some(window) = weak_window.upgrade() else {
                 return;
@@ -3183,21 +3152,32 @@ pub fn run_desktop_app(
                 }
             }
             let editing_index = draft.editing_index;
-            // If editing a specific output block in the middle, update ONLY that block
-            if let (Some(chain_idx), Some(block_idx)) = (editing_index, draft.editing_io_block_index) {
-                let new_entries: Vec<OutputEntry> = draft.outputs.iter()
-                    .filter(|og| og.device_id.is_some() && !og.channels.is_empty())
-                    .map(|og| OutputEntry {
-                        name: og.name.clone(),
-                        device_id: DeviceId(og.device_id.clone().unwrap_or_default()),
-                        mode: og.mode,
-                        channels: og.channels.clone(),
-                    }).collect();
+            let io_block_idx = draft.editing_io_block_index;
+
+            // Build new entries from draft
+            let new_entries: Vec<OutputEntry> = draft.outputs.iter()
+                .filter(|og| og.device_id.is_some() && !og.channels.is_empty())
+                .map(|og| OutputEntry {
+                    name: og.name.clone(),
+                    device_id: DeviceId(og.device_id.clone().unwrap_or_default()),
+                    mode: og.mode,
+                    channels: og.channels.clone(),
+                }).collect();
+
+            if let Some(chain_idx) = editing_index {
                 if let Some(chain) = session.project.chains.get_mut(chain_idx) {
-                    if let Some(block) = chain.blocks.get_mut(block_idx) {
+                    // Find target block: specific index or last OutputBlock
+                    let target_idx = io_block_idx.unwrap_or_else(|| {
+                        chain.blocks.iter().rposition(|b| matches!(&b.kind, AudioBlockKind::Output(_))).unwrap_or(chain.blocks.len().saturating_sub(1))
+                    });
+                    if let Some(block) = chain.blocks.get_mut(target_idx) {
                         if let AudioBlockKind::Output(ref mut ob) = block.kind {
                             ob.entries = new_entries;
                         }
+                    }
+                    if let Err(msg) = chain.validate_channel_conflicts() {
+                        groups_window.set_status_message(msg.into());
+                        return;
                     }
                     let chain_id = chain.id.clone();
                     if let Err(error) = sync_live_chain_runtime(&project_runtime, session, &chain_id) {
@@ -3207,47 +3187,9 @@ pub fn run_desktop_app(
                     replace_project_chains(&project_chains, &session.project, &input_chain_devices, &output_chain_devices);
                     sync_project_dirty(&window, session, &saved_project_snapshot, &project_dirty);
                 }
-                *chain_draft.borrow_mut() = None;
-                groups_window.set_status_message("".into());
-                let _ = groups_window.hide();
-                return;
-            }
-            let existing_chain =
-                editing_index.and_then(|index| session.project.chains.get(index).cloned());
-            let chain = chain_from_draft(&draft, existing_chain.as_ref());
-            if let Err(msg) = chain.validate_channel_conflicts() {
-                groups_window.set_status_message(msg.into());
-                return;
-            }
-            let chain_id = chain.id.clone();
-            if let Some(index) = editing_index {
-                if let Some(current) = session.project.chains.get_mut(index) {
-                    *current = chain;
-                }
-            }
-            if let Err(error) = sync_live_chain_runtime(&project_runtime, session, &chain_id) {
-                groups_window.set_status_message(error.to_string().into());
-                return;
-            }
-            replace_project_chains(
-                &project_chains,
-                &session.project,
-                &input_chain_devices,
-                &output_chain_devices,
-            );
-            if let Some(chain_window) = weak_chain_window.upgrade() {
-                apply_chain_io_groups(
-                    &window,
-                    &chain_window,
-                    &draft,
-                    &input_chain_devices,
-                    &output_chain_devices,
-                );
             }
             *chain_draft.borrow_mut() = None;
-            sync_project_dirty(&window, session, &saved_project_snapshot, &project_dirty);
             groups_window.set_status_message("".into());
-            clear_status(&window, &toast_timer);
             let _ = groups_window.hide();
         });
     }
@@ -7805,5 +7747,131 @@ mod tests {
         ]);
         // UI sees nothing, asking for 0 → before Output = real 1
         assert_eq!(ui_index_to_real_block_index(&chain, 0), 1);
+    }
+
+    #[test]
+    fn save_input_entries_does_not_move_middle_io_blocks() {
+        // Chain: [Input0, Gain, Input1, Delay, Output]
+        // Simulates what on_save does: update ONLY first InputBlock entries,
+        // verify middle InputBlock at position 2 is untouched.
+        let mut chain = test_chain(vec![
+            input_kind(),
+            effect_kind("gain"),
+            AudioBlockKind::Input(InputBlock {
+                model: "standard".into(),
+                entries: vec![InputEntry {
+                    name: "Middle In".into(),
+                    device_id: DeviceId("dev2".into()),
+                    mode: ChainInputMode::Mono,
+                    channels: vec![1],
+                }],
+            }),
+            effect_kind("delay"),
+            output_kind(),
+        ]);
+
+        // The save path with editing_io_block_index = None finds FIRST InputBlock
+        let target_idx = chain.blocks.iter()
+            .position(|b| matches!(&b.kind, AudioBlockKind::Input(_)))
+            .unwrap();
+        assert_eq!(target_idx, 0);
+
+        // Update first InputBlock entries (simulating save)
+        let new_entries = vec![InputEntry {
+            name: "Updated G1".into(),
+            device_id: DeviceId("dev_new".into()),
+            mode: ChainInputMode::Stereo,
+            channels: vec![2, 3],
+        }];
+        if let AudioBlockKind::Input(ref mut ib) = chain.blocks[target_idx].kind {
+            ib.entries = new_entries;
+        }
+
+        // Verify chain structure is unchanged
+        assert_eq!(chain.blocks.len(), 5);
+        assert!(matches!(&chain.blocks[0].kind, AudioBlockKind::Input(_)));
+        assert!(matches!(&chain.blocks[1].kind, AudioBlockKind::Core(_)));
+        assert!(matches!(&chain.blocks[2].kind, AudioBlockKind::Input(_)));
+        assert!(matches!(&chain.blocks[3].kind, AudioBlockKind::Core(_)));
+        assert!(matches!(&chain.blocks[4].kind, AudioBlockKind::Output(_)));
+
+        // Verify first InputBlock was updated
+        if let AudioBlockKind::Input(ref ib) = chain.blocks[0].kind {
+            assert_eq!(ib.entries.len(), 1);
+            assert_eq!(ib.entries[0].name, "Updated G1");
+            assert_eq!(ib.entries[0].device_id.0, "dev_new");
+        } else {
+            panic!("block 0 should be Input");
+        }
+
+        // Verify middle InputBlock at position 2 is UNTOUCHED
+        if let AudioBlockKind::Input(ref ib) = chain.blocks[2].kind {
+            assert_eq!(ib.entries.len(), 1);
+            assert_eq!(ib.entries[0].name, "Middle In");
+            assert_eq!(ib.entries[0].device_id.0, "dev2");
+            assert_eq!(ib.entries[0].channels, vec![1]);
+        } else {
+            panic!("block 2 should be Input");
+        }
+
+        // Verify block IDs haven't changed (no reconstruction)
+        assert_eq!(chain.blocks[0].id.0, "block:0");
+        assert_eq!(chain.blocks[1].id.0, "block:1");
+        assert_eq!(chain.blocks[2].id.0, "block:2");
+        assert_eq!(chain.blocks[3].id.0, "block:3");
+        assert_eq!(chain.blocks[4].id.0, "block:4");
+    }
+
+    #[test]
+    fn save_output_entries_finds_last_output_block() {
+        // Chain: [Input, Gain, Output_mid, Delay, Output_last]
+        // With editing_io_block_index = None, should find LAST OutputBlock
+        let mut chain = test_chain(vec![
+            input_kind(),
+            effect_kind("gain"),
+            AudioBlockKind::Output(OutputBlock {
+                model: "standard".into(),
+                entries: vec![OutputEntry {
+                    name: "Mid Out".into(),
+                    device_id: DeviceId("dev_mid".into()),
+                    mode: ChainOutputMode::Stereo,
+                    channels: vec![2, 3],
+                }],
+            }),
+            effect_kind("delay"),
+            output_kind(),
+        ]);
+
+        // The save path with editing_io_block_index = None finds LAST OutputBlock
+        let target_idx = chain.blocks.iter()
+            .rposition(|b| matches!(&b.kind, AudioBlockKind::Output(_)))
+            .unwrap();
+        assert_eq!(target_idx, 4);
+
+        // Update last OutputBlock entries
+        let new_entries = vec![OutputEntry {
+            name: "Updated Out".into(),
+            device_id: DeviceId("dev_updated".into()),
+            mode: ChainOutputMode::Mono,
+            channels: vec![0],
+        }];
+        if let AudioBlockKind::Output(ref mut ob) = chain.blocks[target_idx].kind {
+            ob.entries = new_entries;
+        }
+
+        // Verify middle OutputBlock at position 2 is UNTOUCHED
+        if let AudioBlockKind::Output(ref ob) = chain.blocks[2].kind {
+            assert_eq!(ob.entries[0].name, "Mid Out");
+            assert_eq!(ob.entries[0].device_id.0, "dev_mid");
+        } else {
+            panic!("block 2 should be Output");
+        }
+
+        // Verify last OutputBlock was updated
+        if let AudioBlockKind::Output(ref ob) = chain.blocks[4].kind {
+            assert_eq!(ob.entries[0].name, "Updated Out");
+        } else {
+            panic!("block 4 should be Output");
+        }
     }
 }

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -22,7 +22,8 @@ use project::catalog::{supported_block_models, supported_block_type, supported_b
 use project::device::DeviceSettings;
 use project::param::{ParameterDomain, ParameterSet, ParameterUnit};
 use project::project::Project;
-use project::chain::{Chain, ChainInput, ChainInputMode, ChainOutput, ChainOutputMixdown, ChainOutputMode};
+use project::block::{InputBlock, OutputBlock};
+use project::chain::{Chain, ChainInputMode, ChainOutputMode};
 use rfd::FileDialog;
 use serde::{Deserialize, Serialize};
 use slint::{Model, ModelRc, SharedString, Timer, TimerMode, VecModel};
@@ -323,13 +324,7 @@ struct ProjectChainYaml {
     #[serde(skip_serializing_if = "Option::is_none")]
     description: Option<String>,
     instrument: String,
-    input_device_id: String,
-    input_channels: Vec<usize>,
-    output_device_id: String,
-    output_channels: Vec<usize>,
     blocks: Vec<serde_yaml::Value>,
-    output_mixdown: ChainOutputMixdown,
-    input_mode: ChainInputMode,
 }
 #[derive(Debug, Serialize)]
 struct ConfigYaml {
@@ -4934,19 +4929,26 @@ pub fn run_desktop_app(
                 let Some(chain) = session.project.chains.get_mut(index) else {
                     return;
                 };
-                // Update the chain's inputs from draft
-                chain.inputs = draft.inputs.iter().map(|ig| ChainInput {
-                    name: ig.name.clone(),
-                    device_id: DeviceId(ig.device_id.clone().unwrap_or_default()),
-                    mode: ig.mode,
-                    channels: ig.channels.clone(),
+                // Rebuild chain blocks: replace all InputBlocks with new ones from draft
+                let new_input_blocks: Vec<AudioBlock> = draft.inputs.iter().enumerate().map(|(i, ig)| AudioBlock {
+                    id: BlockId(format!("{}:input:{}", chain.id.0, i)),
+                    enabled: true,
+                    kind: AudioBlockKind::Input(InputBlock {
+                        name: ig.name.clone(),
+                        device_id: DeviceId(ig.device_id.clone().unwrap_or_default()),
+                        mode: ig.mode,
+                        channels: ig.channels.clone(),
+                    }),
                 }).collect();
-                // Also update legacy fields from first input for backward compat
-                if let Some(first) = draft.inputs.first() {
-                    chain.input_device_id = DeviceId(first.device_id.clone().unwrap_or_default());
-                    chain.input_channels = first.channels.clone();
-                    chain.input_mode = first.mode;
-                }
+                // Keep non-input, non-output blocks and existing output blocks
+                let non_input_blocks: Vec<AudioBlock> = chain.blocks.iter()
+                    .filter(|b| !matches!(&b.kind, AudioBlockKind::Input(_)))
+                    .cloned()
+                    .collect();
+                let mut all_blocks = Vec::with_capacity(new_input_blocks.len() + non_input_blocks.len());
+                all_blocks.extend(new_input_blocks);
+                all_blocks.extend(non_input_blocks);
+                chain.blocks = all_blocks;
                 let chain_id = chain.id.clone();
                 if let Err(error) = sync_live_chain_runtime(&project_runtime, session, &chain_id) {
                     eprintln!("input editor save error: {error}");
@@ -5043,18 +5045,26 @@ pub fn run_desktop_app(
                 let Some(chain) = session.project.chains.get_mut(index) else {
                     return;
                 };
-                // Update the chain's outputs from draft
-                chain.outputs = draft.outputs.iter().map(|og| ChainOutput {
-                    name: og.name.clone(),
-                    device_id: DeviceId(og.device_id.clone().unwrap_or_default()),
-                    mode: og.mode,
-                    channels: og.channels.clone(),
+                // Rebuild chain blocks: replace all OutputBlocks with new ones from draft
+                let new_output_blocks: Vec<AudioBlock> = draft.outputs.iter().enumerate().map(|(i, og)| AudioBlock {
+                    id: BlockId(format!("{}:output:{}", chain.id.0, i)),
+                    enabled: true,
+                    kind: AudioBlockKind::Output(OutputBlock {
+                        name: og.name.clone(),
+                        device_id: DeviceId(og.device_id.clone().unwrap_or_default()),
+                        mode: og.mode,
+                        channels: og.channels.clone(),
+                    }),
                 }).collect();
-                // Also update legacy fields from first output for backward compat
-                if let Some(first) = draft.outputs.first() {
-                    chain.output_device_id = DeviceId(first.device_id.clone().unwrap_or_default());
-                    chain.output_channels = first.channels.clone();
-                }
+                // Keep non-output blocks (inputs and audio blocks)
+                let non_output_blocks: Vec<AudioBlock> = chain.blocks.iter()
+                    .filter(|b| !matches!(&b.kind, AudioBlockKind::Output(_)))
+                    .cloned()
+                    .collect();
+                let mut all_blocks = Vec::with_capacity(non_output_blocks.len() + new_output_blocks.len());
+                all_blocks.extend(non_output_blocks);
+                all_blocks.extend(new_output_blocks);
+                chain.blocks = all_blocks;
                 let chain_id = chain.id.clone();
                 if let Err(error) = sync_live_chain_runtime(&project_runtime, session, &chain_id) {
                     eprintln!("output editor save error: {error}");
@@ -5174,18 +5184,27 @@ pub fn run_desktop_app(
             log::info!("on_toggle_chain_enabled: index={}, will_enable={}", index, will_enable);
             // Check channel conflict before enabling
             if will_enable {
-                let input_id = chain.input_device_id.clone();
-                let input_channels = chain.input_channels.clone();
                 let chain_id = chain.id.clone();
-                for other in &session.project.chains {
-                    if other.id != chain_id && other.enabled
-                        && other.input_device_id == input_id
-                        && other.input_channels.iter().any(|ch| input_channels.contains(ch))
-                    {
-                        let other_name = other.description.as_deref().unwrap_or("outra chain");
-                        set_status_error(&window, &toast_timer, &format!("Input channel já em uso por '{}'", other_name));
-                        return;
+                let our_inputs = chain.input_blocks();
+                let mut conflict = false;
+                'outer: for other in &session.project.chains {
+                    if other.id != chain_id && other.enabled {
+                        for (_, other_input) in other.input_blocks() {
+                            for (_, our_input) in &our_inputs {
+                                if other_input.device_id == our_input.device_id
+                                    && other_input.channels.iter().any(|ch| our_input.channels.contains(ch))
+                                {
+                                    let other_name = other.description.as_deref().unwrap_or("outra chain");
+                                    set_status_error(&window, &toast_timer, &format!("Input channel já em uso por '{}'", other_name));
+                                    conflict = true;
+                                    break 'outer;
+                                }
+                            }
+                        }
                     }
+                }
+                if conflict {
+                    return;
                 }
             }
             let Some(chain) = session.project.chains.get_mut(index) else { return; };
@@ -5435,14 +5454,12 @@ fn replace_project_chains(
         .iter()
         .enumerate()
         .map(|(index, chain)| {
-            let input_settings = project
-                .device_settings
-                .iter()
-                .find(|s| s.device_id == chain.input_device_id);
-            let output_settings = project
-                .device_settings
-                .iter()
-                .find(|s| s.device_id == chain.output_device_id);
+            let input_settings = chain.first_input().and_then(|ib| {
+                project.device_settings.iter().find(|s| s.device_id == ib.device_id)
+            });
+            let output_settings = chain.last_output().and_then(|ob| {
+                project.device_settings.iter().find(|s| s.device_id == ob.device_id)
+            });
             let input_buffer =
                 input_settings.map(|s| s.buffer_size_frames).unwrap_or(256) as f32;
             let output_buffer =
@@ -5463,9 +5480,19 @@ fn replace_project_chains(
                 } else {
                     format!("{} blocks", chain.blocks.len()).into()
                 },
-                input_label: chain_endpoint_label("In", &chain.input_channels).into(),
+                input_label: {
+                    let input_chs: Vec<usize> = chain.input_blocks().into_iter()
+                        .flat_map(|(_, ib)| ib.channels.iter().copied())
+                        .collect();
+                    chain_endpoint_label("In", &input_chs).into()
+                },
                 input_tooltip: chain_inputs_tooltip(chain, project, input_devices).into(),
-                output_label: chain_endpoint_label("Out", &chain.output_channels).into(),
+                output_label: {
+                    let output_chs: Vec<usize> = chain.output_blocks().into_iter()
+                        .flat_map(|(_, ob)| ob.channels.iter().copied())
+                        .collect();
+                    chain_endpoint_label("Out", &output_chs).into()
+                },
                 output_tooltip: chain_outputs_tooltip(chain, project, output_devices)
                 .into(),
                 latency_ms,
@@ -5484,42 +5511,16 @@ fn replace_project_chains(
 fn chain_endpoint_label(prefix: &str, _channels: &[usize]) -> String {
     prefix.to_string()
 }
-fn chain_endpoint_tooltip(
-    _title: &str,
-    device_id: &str,
-    channels: &[usize],
-    project: &Project,
-    devices: &[AudioDeviceDescriptor],
-) -> String {
-    let device_name = devices
-        .iter()
-        .find(|device| device.id == device_id)
-        .map(|device| device.name.as_str())
-        .unwrap_or(device_id);
-    let settings = project
-        .device_settings
-        .iter()
-        .find(|setting| setting.device_id.0 == device_id);
-    let sample_rate = settings
-        .map(|setting| setting.sample_rate.to_string())
-        .unwrap_or_else(|| "n/d".to_string());
-    let buffer = settings
-        .map(|setting| setting.buffer_size_frames.to_string())
-        .unwrap_or_else(|| "n/d".to_string());
-    format!(
-        "{device_name}\nConfiguração: {sample_rate} Hz · {buffer} frames\nCanais: {}",
-        format_channel_list(channels)
-    )
-}
 fn chain_inputs_tooltip(
     chain: &Chain,
-    project: &Project,
+    _project: &Project,
     devices: &[AudioDeviceDescriptor],
 ) -> String {
-    if chain.inputs.is_empty() {
-        return chain_endpoint_tooltip("Entrada", &chain.input_device_id.0, &chain.input_channels, project, devices);
+    let input_blocks = chain.input_blocks();
+    if input_blocks.is_empty() {
+        return "No input configured".to_string();
     }
-    chain.inputs.iter().map(|input| {
+    input_blocks.iter().map(|(_, input)| {
         let device_name = devices
             .iter()
             .find(|d| d.id == input.device_id.0)
@@ -5535,13 +5536,14 @@ fn chain_inputs_tooltip(
 }
 fn chain_outputs_tooltip(
     chain: &Chain,
-    project: &Project,
+    _project: &Project,
     devices: &[AudioDeviceDescriptor],
 ) -> String {
-    if chain.outputs.is_empty() {
-        return chain_endpoint_tooltip("Saída", &chain.output_device_id.0, &chain.output_channels, project, devices);
+    let output_blocks = chain.output_blocks();
+    if output_blocks.is_empty() {
+        return "No output configured".to_string();
     }
-    chain.outputs.iter().map(|output| {
+    output_blocks.iter().map(|(_, output)| {
         let device_name = devices
             .iter()
             .find(|d| d.id == output.device_id.0)
@@ -6364,13 +6366,7 @@ fn build_project_yaml(session: &ProjectSession) -> Result<ProjectYaml> {
                 Ok(ProjectChainYaml {
                     description: chain.description.clone(),
                     instrument: chain.instrument.clone(),
-                    input_device_id: chain.input_device_id.0.clone(),
-                    input_channels: chain.input_channels.clone(),
-                    output_device_id: chain.output_device_id.0.clone(),
-                    output_channels: chain.output_channels.clone(),
                     blocks: serialize_audio_blocks(&chain.blocks)?,
-                    output_mixdown: chain.output_mixdown,
-                    input_mode: chain.input_mode,
                 })
             })
             .collect::<Result<Vec<_>>>()?,
@@ -6488,23 +6484,18 @@ fn create_chain_draft(
     }
 }
 fn chain_draft_from_chain(index: usize, chain: &Chain) -> ChainDraft {
-    let inputs: Vec<InputGroupDraft> = if chain.inputs.is_empty() {
-        // Legacy single-input chain
+    let input_blocks = chain.input_blocks();
+    let inputs: Vec<InputGroupDraft> = if input_blocks.is_empty() {
         vec![InputGroupDraft {
             name: "Input 1".to_string(),
-            device_id: if chain.input_device_id.0.is_empty() {
-                None
-            } else {
-                Some(chain.input_device_id.0.clone())
-            },
-            channels: chain.input_channels.clone(),
-            mode: chain.input_mode,
+            device_id: None,
+            channels: Vec::new(),
+            mode: ChainInputMode::Mono,
         }]
     } else {
-        chain
-            .inputs
+        input_blocks
             .iter()
-            .map(|input| InputGroupDraft {
+            .map(|(_, input)| InputGroupDraft {
                 name: input.name.clone(),
                 device_id: if input.device_id.0.is_empty() {
                     None
@@ -6516,27 +6507,18 @@ fn chain_draft_from_chain(index: usize, chain: &Chain) -> ChainDraft {
             })
             .collect()
     };
-    let outputs: Vec<OutputGroupDraft> = if chain.outputs.is_empty() {
-        // Legacy single-output chain
+    let output_blocks = chain.output_blocks();
+    let outputs: Vec<OutputGroupDraft> = if output_blocks.is_empty() {
         vec![OutputGroupDraft {
             name: "Output 1".to_string(),
-            device_id: if chain.output_device_id.0.is_empty() {
-                None
-            } else {
-                Some(chain.output_device_id.0.clone())
-            },
-            channels: chain.output_channels.clone(),
-            mode: if chain.output_channels.len() >= 2 {
-                ChainOutputMode::Stereo
-            } else {
-                ChainOutputMode::Mono
-            },
+            device_id: None,
+            channels: Vec::new(),
+            mode: ChainOutputMode::Stereo,
         }]
     } else {
-        chain
-            .outputs
+        output_blocks
             .iter()
-            .map(|output| OutputGroupDraft {
+            .map(|(_, output)| OutputGroupDraft {
                 name: output.name.clone(),
                 device_id: if output.device_id.0.is_empty() {
                     None
@@ -6662,16 +6644,10 @@ fn build_input_channel_items(
                 && draft.editing_index != Some(*index)
         })
         .flat_map(|(_, chain)| {
-            chain.inputs.iter()
-                .filter(|inp| inp.device_id.0 == *device_id)
-                .flat_map(|inp| inp.channels.iter().copied())
-                .chain(
-                    if chain.input_device_id.0 == *device_id {
-                        chain.input_channels.clone()
-                    } else {
-                        Vec::new()
-                    }
-                )
+            chain.input_blocks().into_iter()
+                .filter(|(_, inp)| inp.device_id.0 == *device_id)
+                .flat_map(|(_, inp)| inp.channels.iter().copied().collect::<Vec<_>>())
+                .collect::<Vec<_>>()
         })
         .collect::<Vec<_>>();
     (0..device.channels)
@@ -6714,29 +6690,56 @@ fn normalized_chain_description(name: &str) -> Option<String> {
     }
 }
 fn chain_from_draft(draft: &ChainDraft, existing_chain: Option<&Chain>) -> Chain {
-    let inputs: Vec<ChainInput> = draft
+    // Build input blocks from draft
+    let input_blocks: Vec<AudioBlock> = draft
         .inputs
         .iter()
-        .map(|ig| ChainInput {
-            name: ig.name.clone(),
-            device_id: DeviceId(ig.device_id.clone().unwrap_or_default()),
-            mode: ig.mode,
-            channels: ig.channels.clone(),
+        .enumerate()
+        .map(|(i, ig)| AudioBlock {
+            id: BlockId(format!("input:{}", i)),
+            enabled: true,
+            kind: AudioBlockKind::Input(InputBlock {
+                name: ig.name.clone(),
+                device_id: DeviceId(ig.device_id.clone().unwrap_or_default()),
+                mode: ig.mode,
+                channels: ig.channels.clone(),
+            }),
         })
         .collect();
-    let outputs: Vec<ChainOutput> = draft
+
+    // Build output blocks from draft
+    let output_blocks: Vec<AudioBlock> = draft
         .outputs
         .iter()
-        .map(|og| ChainOutput {
-            name: og.name.clone(),
-            device_id: DeviceId(og.device_id.clone().unwrap_or_default()),
-            mode: og.mode,
-            channels: og.channels.clone(),
+        .enumerate()
+        .map(|(i, og)| AudioBlock {
+            id: BlockId(format!("output:{}", i)),
+            enabled: true,
+            kind: AudioBlockKind::Output(OutputBlock {
+                name: og.name.clone(),
+                device_id: DeviceId(og.device_id.clone().unwrap_or_default()),
+                mode: og.mode,
+                channels: og.channels.clone(),
+            }),
         })
         .collect();
-    // Legacy fields from first input/output for backward compat
-    let first_input = draft.inputs.first();
-    let first_output = draft.outputs.first();
+
+    // Get existing non-I/O blocks
+    let audio_blocks: Vec<AudioBlock> = existing_chain
+        .map(|c| {
+            c.blocks
+                .iter()
+                .filter(|b| !matches!(&b.kind, AudioBlockKind::Input(_) | AudioBlockKind::Output(_)))
+                .cloned()
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let mut all_blocks = Vec::with_capacity(input_blocks.len() + audio_blocks.len() + output_blocks.len());
+    all_blocks.extend(input_blocks);
+    all_blocks.extend(audio_blocks);
+    all_blocks.extend(output_blocks);
+
     Chain {
         id: existing_chain
             .map(|c| c.id.clone())
@@ -6744,33 +6747,7 @@ fn chain_from_draft(draft: &ChainDraft, existing_chain: Option<&Chain>) -> Chain
         description: normalized_chain_description(&draft.name),
         instrument: draft.instrument.clone(),
         enabled: existing_chain.map(|c| c.enabled).unwrap_or(false),
-        inputs,
-        outputs,
-        input_device_id: DeviceId(
-            first_input
-                .and_then(|i| i.device_id.clone())
-                .unwrap_or_default(),
-        ),
-        input_channels: first_input
-            .map(|i| i.channels.clone())
-            .unwrap_or_default(),
-        output_device_id: DeviceId(
-            first_output
-                .and_then(|o| o.device_id.clone())
-                .unwrap_or_default(),
-        ),
-        output_channels: first_output
-            .map(|o| o.channels.clone())
-            .unwrap_or_default(),
-        blocks: existing_chain
-            .map(|c| c.blocks.clone())
-            .unwrap_or_default(),
-        output_mixdown: existing_chain
-            .map(|c| c.output_mixdown)
-            .unwrap_or(ChainOutputMixdown::Average),
-        input_mode: first_input
-            .map(|i| i.mode)
-            .unwrap_or(ChainInputMode::Mono),
+        blocks: all_blocks,
     }
 }
 fn stop_project_runtime(project_runtime: &Rc<RefCell<Option<ProjectRuntimeController>>>) {

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -5045,8 +5045,10 @@ pub fn run_desktop_app(
 
             // Handle I/O block insert mode: insert a single InputBlock at the stored position
             let io_insert = io_block_insert_draft_for_input_save.borrow().clone();
+            log::info!("[input_window.on_save] io_insert={:?}", io_insert.as_ref().map(|d| format!("kind={}, chain={}, before={}", d.kind, d.chain_index, d.before_index)));
             if let Some(io_draft) = io_insert {
                 if io_draft.kind == "input" {
+                    log::info!("[input_window.on_save] INSERTING NEW InputBlock at chain={}, before={}", io_draft.chain_index, io_draft.before_index);
                     // Extract what we need from chain_draft, then drop the borrow
                     let input_group = {
                         let draft_borrow = chain_draft.borrow();
@@ -5113,15 +5115,18 @@ pub fn run_desktop_app(
                 }
             }
 
+            log::info!("[input_window.on_save] NORMAL FLOW — editing existing entry in InputBlock");
             let mut draft_borrow = chain_draft.borrow_mut();
             let Some(draft) = draft_borrow.as_mut() else {
                 let _ = input_window.hide();
                 return;
             };
             let Some(gi) = draft.editing_input_index else {
+                log::warn!("[input_window.on_save] no editing_input_index set!");
                 let _ = input_window.hide();
                 return;
             };
+            log::info!("[input_window.on_save] editing_input_index={}, draft.inputs.len={}", gi, draft.inputs.len());
             let Some(input_group) = draft.inputs.get(gi) else {
                 let _ = input_window.hide();
                 return;

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -265,6 +265,10 @@ struct ChainDraft {
     outputs: Vec<OutputGroupDraft>,
     editing_input_index: Option<usize>,
     editing_output_index: Option<usize>,
+    /// Which block in chain.blocks is being edited by the I/O groups window.
+    /// None = editing the fixed chip (first input / last output).
+    /// Some(idx) = editing a specific I/O block at chain.blocks[idx].
+    editing_io_block_index: Option<usize>,
 }
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct SelectedBlock {
@@ -2956,6 +2960,35 @@ pub fn run_desktop_app(
                 }
             }
             let editing_index = draft.editing_index;
+            // If editing a specific I/O block in the middle (not the fixed chip), update ONLY that block
+            if let (Some(chain_idx), Some(block_idx)) = (editing_index, draft.editing_io_block_index) {
+                let new_entries: Vec<InputEntry> = draft.inputs.iter()
+                    .filter(|ig| ig.device_id.is_some() && !ig.channels.is_empty())
+                    .map(|ig| InputEntry {
+                        name: ig.name.clone(),
+                        device_id: DeviceId(ig.device_id.clone().unwrap_or_default()),
+                        mode: ig.mode,
+                        channels: ig.channels.clone(),
+                    }).collect();
+                if let Some(chain) = session.project.chains.get_mut(chain_idx) {
+                    if let Some(block) = chain.blocks.get_mut(block_idx) {
+                        if let AudioBlockKind::Input(ref mut ib) = block.kind {
+                            ib.entries = new_entries;
+                        }
+                    }
+                    let chain_id = chain.id.clone();
+                    if let Err(error) = sync_live_chain_runtime(&project_runtime, session, &chain_id) {
+                        groups_window.set_status_message(error.to_string().into());
+                        return;
+                    }
+                    replace_project_chains(&project_chains, &session.project, &input_chain_devices, &output_chain_devices);
+                    sync_project_dirty(&window, session, &saved_project_snapshot, &project_dirty);
+                }
+                *chain_draft.borrow_mut() = None;
+                groups_window.set_status_message("".into());
+                let _ = groups_window.hide();
+                return;
+            }
             let existing_chain =
                 editing_index.and_then(|index| session.project.chains.get(index).cloned());
             let chain = chain_from_draft(&draft, existing_chain.as_ref());
@@ -3150,6 +3183,35 @@ pub fn run_desktop_app(
                 }
             }
             let editing_index = draft.editing_index;
+            // If editing a specific output block in the middle, update ONLY that block
+            if let (Some(chain_idx), Some(block_idx)) = (editing_index, draft.editing_io_block_index) {
+                let new_entries: Vec<OutputEntry> = draft.outputs.iter()
+                    .filter(|og| og.device_id.is_some() && !og.channels.is_empty())
+                    .map(|og| OutputEntry {
+                        name: og.name.clone(),
+                        device_id: DeviceId(og.device_id.clone().unwrap_or_default()),
+                        mode: og.mode,
+                        channels: og.channels.clone(),
+                    }).collect();
+                if let Some(chain) = session.project.chains.get_mut(chain_idx) {
+                    if let Some(block) = chain.blocks.get_mut(block_idx) {
+                        if let AudioBlockKind::Output(ref mut ob) = block.kind {
+                            ob.entries = new_entries;
+                        }
+                    }
+                    let chain_id = chain.id.clone();
+                    if let Err(error) = sync_live_chain_runtime(&project_runtime, session, &chain_id) {
+                        groups_window.set_status_message(error.to_string().into());
+                        return;
+                    }
+                    replace_project_chains(&project_chains, &session.project, &input_chain_devices, &output_chain_devices);
+                    sync_project_dirty(&window, session, &saved_project_snapshot, &project_dirty);
+                }
+                *chain_draft.borrow_mut() = None;
+                groups_window.set_status_message("".into());
+                let _ = groups_window.hide();
+                return;
+            }
             let existing_chain =
                 editing_index.and_then(|index| session.project.chains.get(index).cloned());
             let chain = chain_from_draft(&draft, existing_chain.as_ref());
@@ -3248,6 +3310,7 @@ pub fn run_desktop_app(
                     }).collect();
                     let mut draft = chain_draft_from_chain(chain_index as usize, chain);
                     draft.inputs = inputs;
+                    draft.editing_io_block_index = Some(block_index as usize);
                     let (input_items, _) = build_io_group_items(&draft, &input_chain_devices, &output_chain_devices);
                     if let Some(gw) = weak_input_groups_for_select.upgrade() {
                         gw.set_groups(ModelRc::from(Rc::new(VecModel::from(input_items))));
@@ -3267,6 +3330,7 @@ pub fn run_desktop_app(
                     }).collect();
                     let mut draft = chain_draft_from_chain(chain_index as usize, chain);
                     draft.outputs = outputs;
+                    draft.editing_io_block_index = Some(block_index as usize);
                     let (_, output_items) = build_io_group_items(&draft, &input_chain_devices, &output_chain_devices);
                     if let Some(gw) = weak_output_groups_for_select.upgrade() {
                         gw.set_groups(ModelRc::from(Rc::new(VecModel::from(output_items))));
@@ -4134,6 +4198,7 @@ pub fn run_desktop_app(
                         outputs: Vec::new(),
                         editing_input_index: Some(0),
                         editing_output_index: None,
+        editing_io_block_index: None,
                     });
                     if let Some(input_window) = weak_input_window_for_type.upgrade() {
                         let draft_borrow = chain_draft_for_type.borrow();
@@ -4164,6 +4229,7 @@ pub fn run_desktop_app(
                         instrument: instrument.clone(),
                         inputs: Vec::new(),
                         outputs: vec![output_group.clone()],
+        editing_io_block_index: None,
                         editing_input_index: None,
                         editing_output_index: Some(0),
                     });
@@ -6833,6 +6899,7 @@ fn create_chain_draft(
         instrument: block_core::DEFAULT_INSTRUMENT.to_string(),
         inputs: vec![default_input],
         outputs: vec![default_output],
+        editing_io_block_index: None,
         editing_input_index: None,
         editing_output_index: None,
     }
@@ -6893,6 +6960,7 @@ fn chain_draft_from_chain(index: usize, chain: &Chain) -> ChainDraft {
             .unwrap_or_else(|| format!("Chain {}", index + 1)),
         instrument: chain.instrument.clone(),
         inputs,
+        editing_io_block_index: None,
         outputs,
         editing_input_index: None,
         editing_output_index: None,

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -3920,7 +3920,7 @@ pub fn run_desktop_app(
         let toast_timer = toast_timer.clone();
         let open_block_windows = open_block_windows.clone();
         window.on_reorder_chain_block(move |chain_index, from_index, before_index| {
-            log::info!("[reorder_chain_block] chain_index={}, from_index={}, before_index={}", chain_index, from_index, before_index);
+            log::info!("[reorder_chain_block] chain_index={}, from_index={} (real), before_index={} (UI)", chain_index, from_index, before_index);
             let Some(window) = weak_window.upgrade() else {
                 return;
             };
@@ -3938,11 +3938,15 @@ pub fn run_desktop_app(
                 if from_index < 0 || from_index >= block_count {
                     return;
                 }
-                let mut normalized_before = before_index.clamp(0, block_count);
-                if normalized_before == from_index || normalized_before == from_index + 1 {
+                // before_index is in UI space (excludes hidden first Input and last Output).
+                // Convert to real block index before operating on chain.blocks.
+                let real_before = ui_index_to_real_block_index(chain, before_index as usize) as i32;
+                log::info!("[reorder_chain_block] real_before={}", real_before);
+                if real_before == from_index || real_before == from_index + 1 {
                     return;
                 }
                 let block = chain.blocks.remove(from_index as usize);
+                let mut normalized_before = real_before;
                 if normalized_before > from_index {
                     normalized_before -= 1;
                 }

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -2481,7 +2481,25 @@ pub fn run_desktop_app(
             let Some(chain) = session.project.chains.get(index as usize) else {
                 return;
             };
-            let draft = chain_draft_from_chain(index as usize, chain);
+            // Only show entries from the FIRST InputBlock (position 0 chip)
+            let first_input = chain.first_input();
+            let inputs: Vec<InputGroupDraft> = first_input
+                .map(|ib| {
+                    ib.entries.iter().map(|e| InputGroupDraft {
+                        name: e.name.clone(),
+                        device_id: if e.device_id.0.is_empty() { None } else { Some(e.device_id.0.clone()) },
+                        channels: e.channels.clone(),
+                        mode: e.mode,
+                    }).collect()
+                })
+                .unwrap_or_else(|| vec![InputGroupDraft {
+                    name: "Input 1".to_string(),
+                    device_id: None,
+                    channels: Vec::new(),
+                    mode: ChainInputMode::Mono,
+                }]);
+            let mut draft = chain_draft_from_chain(index as usize, chain);
+            draft.inputs = inputs;
             let (input_items, _) =
                 build_io_group_items(&draft, &input_chain_devices, &output_chain_devices);
             groups_window
@@ -2512,7 +2530,25 @@ pub fn run_desktop_app(
             let Some(chain) = session.project.chains.get(index as usize) else {
                 return;
             };
-            let draft = chain_draft_from_chain(index as usize, chain);
+            // Only show entries from the LAST OutputBlock (fixed output chip)
+            let last_output = chain.last_output();
+            let outputs: Vec<OutputGroupDraft> = last_output
+                .map(|ob| {
+                    ob.entries.iter().map(|e| OutputGroupDraft {
+                        name: e.name.clone(),
+                        device_id: if e.device_id.0.is_empty() { None } else { Some(e.device_id.0.clone()) },
+                        channels: e.channels.clone(),
+                        mode: e.mode,
+                    }).collect()
+                })
+                .unwrap_or_else(|| vec![OutputGroupDraft {
+                    name: "Output 1".to_string(),
+                    device_id: None,
+                    channels: Vec::new(),
+                    mode: ChainOutputMode::Stereo,
+                }]);
+            let mut draft = chain_draft_from_chain(index as usize, chain);
+            draft.outputs = outputs;
             let (_, output_items) =
                 build_io_group_items(&draft, &input_chain_devices, &output_chain_devices);
             groups_window

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -12,7 +12,7 @@ use infra_filesystem::{
     AppConfig, FilesystemStorage, GuiAudioDeviceSettings, GuiAudioSettings, RecentProjectEntry,
 };
 use infra_yaml::{
-    load_chain_preset_file, save_chain_preset_file, serialize_audio_blocks, ChainBlocksPreset,
+    load_chain_preset_file, save_chain_preset_file, ChainBlocksPreset,
     YamlProjectRepository,
 };
 use project::block::{
@@ -311,27 +311,6 @@ enum ChainEditorMode {
 enum AudioSettingsMode {
     Gui,
     Project,
-}
-#[derive(Debug, Serialize)]
-struct ProjectYaml {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    device_settings: Vec<ProjectDeviceSettingsYaml>,
-    chains: Vec<ProjectChainYaml>,
-}
-#[derive(Debug, Serialize)]
-struct ProjectDeviceSettingsYaml {
-    device_id: String,
-    sample_rate: u32,
-    buffer_size_frames: u32,
-}
-#[derive(Debug, Serialize)]
-struct ProjectChainYaml {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<String>,
-    instrument: String,
-    blocks: Vec<serde_yaml::Value>,
 }
 #[derive(Debug, Serialize)]
 struct ConfigYaml {
@@ -6624,40 +6603,8 @@ fn build_project_device_rows(
     }
     rows
 }
-fn build_project_yaml(session: &ProjectSession) -> Result<ProjectYaml> {
-    Ok(ProjectYaml {
-        name: session
-            .project
-            .name
-            .as_ref()
-            .map(|name| name.trim().to_string())
-            .filter(|name| !name.is_empty()),
-        device_settings: session
-            .project
-            .device_settings
-            .iter()
-            .map(|setting| ProjectDeviceSettingsYaml {
-                device_id: setting.device_id.0.clone(),
-                sample_rate: setting.sample_rate,
-                buffer_size_frames: setting.buffer_size_frames,
-            })
-            .collect(),
-        chains: session
-            .project
-            .chains
-            .iter()
-            .map(|chain| -> Result<ProjectChainYaml> {
-                Ok(ProjectChainYaml {
-                    description: chain.description.clone(),
-                    instrument: chain.instrument.clone(),
-                    blocks: serialize_audio_blocks(&chain.blocks)?,
-                })
-            })
-            .collect::<Result<Vec<_>>>()?,
-    })
-}
 fn project_session_snapshot(session: &ProjectSession) -> Result<String> {
-    Ok(serde_yaml::to_string(&build_project_yaml(session)?)?)
+    infra_yaml::serialize_project(&session.project)
 }
 fn set_project_dirty(window: &AppWindow, project_dirty: &Rc<RefCell<bool>>, dirty: bool) {
     *project_dirty.borrow_mut() = dirty;

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -7521,4 +7521,136 @@ mod tests {
             .map(|entry| entry.model_id)
             .collect()
     }
+
+    // --- ui_index_to_real_block_index tests ---
+
+    use super::ui_index_to_real_block_index;
+    use project::block::{InputBlock, OutputBlock};
+    use project::chain::{Chain, ChainInputMode, ChainOutputMode};
+    use domain::ids::{ChainId, DeviceId};
+
+    fn test_chain(block_kinds: Vec<AudioBlockKind>) -> Chain {
+        Chain {
+            id: ChainId("test".into()),
+            description: None,
+            instrument: "electric_guitar".into(),
+            enabled: true,
+            blocks: block_kinds.into_iter().enumerate().map(|(i, kind)| AudioBlock {
+                id: BlockId(format!("block:{}", i)),
+                enabled: true,
+                kind,
+            }).collect(),
+        }
+    }
+
+    fn input_kind() -> AudioBlockKind {
+        AudioBlockKind::Input(InputBlock {
+            name: "In".into(),
+            device_id: DeviceId("dev".into()),
+            mode: ChainInputMode::Mono,
+            channels: vec![0],
+        })
+    }
+
+    fn output_kind() -> AudioBlockKind {
+        AudioBlockKind::Output(OutputBlock {
+            name: "Out".into(),
+            device_id: DeviceId("dev".into()),
+            mode: ChainOutputMode::Stereo,
+            channels: vec![0, 1],
+        })
+    }
+
+    fn effect_kind(effect_type: &str) -> AudioBlockKind {
+        AudioBlockKind::Core(CoreBlock {
+            effect_type: effect_type.into(),
+            model: "test".into(),
+            params: ParameterSet::default(),
+        })
+    }
+
+    #[test]
+    fn ui_index_maps_correctly_with_standard_chain() {
+        // [Input, Comp, Preamp, Delay, Output]
+        // UI sees: [Comp(0), Preamp(1), Delay(2)]
+        // Real:    [0=Input, 1=Comp, 2=Preamp, 3=Delay, 4=Output]
+        let chain = test_chain(vec![
+            input_kind(),
+            effect_kind("dynamics"),
+            effect_kind("preamp"),
+            effect_kind("delay"),
+            output_kind(),
+        ]);
+        assert_eq!(ui_index_to_real_block_index(&chain, 0), 1); // UI 0 = Comp = real 1
+        assert_eq!(ui_index_to_real_block_index(&chain, 1), 2); // UI 1 = Preamp = real 2
+        assert_eq!(ui_index_to_real_block_index(&chain, 2), 3); // UI 2 = Delay = real 3
+    }
+
+    #[test]
+    fn ui_index_past_end_returns_before_last_output() {
+        let chain = test_chain(vec![
+            input_kind(),
+            effect_kind("delay"),
+            output_kind(),
+        ]);
+        // UI sees [Delay(0)], asking for UI index 1 (past end) → before Output = real 2
+        assert_eq!(ui_index_to_real_block_index(&chain, 1), 2);
+    }
+
+    #[test]
+    fn ui_index_with_extra_input_in_middle() {
+        // [Input, Comp, Input2, Delay, Output]
+        // Hidden: first Input (0) and last Output (4)
+        // UI sees: [Comp(0), Input2(1), Delay(2)]
+        // Real:    [0=Input, 1=Comp, 2=Input2, 3=Delay, 4=Output]
+        let chain = test_chain(vec![
+            input_kind(),
+            effect_kind("dynamics"),
+            input_kind(),
+            effect_kind("delay"),
+            output_kind(),
+        ]);
+        assert_eq!(ui_index_to_real_block_index(&chain, 0), 1); // Comp
+        assert_eq!(ui_index_to_real_block_index(&chain, 1), 2); // Input2
+        assert_eq!(ui_index_to_real_block_index(&chain, 2), 3); // Delay
+    }
+
+    #[test]
+    fn ui_index_with_extra_output_in_middle() {
+        // [Input, Comp, Output_mid, Delay, Output]
+        // Hidden: first Input (0) and last Output (4)
+        // UI sees: [Comp(0), Output_mid(1), Delay(2)]
+        let chain = test_chain(vec![
+            input_kind(),
+            effect_kind("dynamics"),
+            output_kind(),
+            effect_kind("delay"),
+            output_kind(),
+        ]);
+        assert_eq!(ui_index_to_real_block_index(&chain, 0), 1); // Comp
+        assert_eq!(ui_index_to_real_block_index(&chain, 1), 2); // Output_mid (visible!)
+        assert_eq!(ui_index_to_real_block_index(&chain, 2), 3); // Delay
+    }
+
+    #[test]
+    fn ui_index_with_no_io_blocks() {
+        // [Comp, Delay] — no I/O blocks at all
+        let chain = test_chain(vec![
+            effect_kind("dynamics"),
+            effect_kind("delay"),
+        ]);
+        assert_eq!(ui_index_to_real_block_index(&chain, 0), 0);
+        assert_eq!(ui_index_to_real_block_index(&chain, 1), 1);
+    }
+
+    #[test]
+    fn ui_index_with_only_io_blocks() {
+        // [Input, Output] — no effect blocks
+        let chain = test_chain(vec![
+            input_kind(),
+            output_kind(),
+        ]);
+        // UI sees nothing, asking for 0 → before Output = real 1
+        assert_eq!(ui_index_to_real_block_index(&chain, 0), 1);
+    }
 }

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -4372,6 +4372,10 @@ pub fn run_desktop_app(
         let weak_input_window_for_type = chain_input_window.as_weak();
         let weak_output_window_for_type = chain_output_window.as_weak();
         let project_session_for_type = project_session.clone();
+        let project_runtime_for_type = project_runtime.clone();
+        let project_chains_for_type = project_chains.clone();
+        let saved_project_snapshot_for_type = saved_project_snapshot.clone();
+        let project_dirty_for_type = project_dirty.clone();
         let input_chain_devices_for_type = input_chain_devices.clone();
         let output_chain_devices_for_type = output_chain_devices.clone();
         let chain_input_channels_for_type = chain_input_channels.clone();
@@ -4424,6 +4428,12 @@ pub fn run_desktop_app(
                 let Some(session) = session_borrow.as_mut() else { return; };
                 let Some(chain) = session.project.chains.get_mut(chain_index) else { return; };
                 chain.blocks.insert(before_index, insert_block);
+                let chain_id = chain.id.clone();
+                if let Err(e) = sync_live_chain_runtime(&project_runtime_for_type, session, &chain_id) {
+                    log::error!("insert block create error: {e}");
+                }
+                replace_project_chains(&project_chains_for_type, &session.project, &input_chain_devices_for_type, &output_chain_devices_for_type);
+                sync_project_dirty(&window, session, &saved_project_snapshot_for_type, &project_dirty_for_type);
                 window.set_show_block_type_picker(false);
                 return;
             }

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -5089,8 +5089,9 @@ pub fn run_desktop_app(
                         id: BlockId::generate_for_chain(&real_chain_id),
                         enabled: true,
                         kind: AudioBlockKind::Input(InputBlock {
-                            name: input_group.name.clone(),
+                            model: "standard".to_string(),
                             entries: vec![InputEntry {
+                                name: input_group.name.clone(),
                                 device_id: DeviceId(input_group.device_id.clone().unwrap_or_default()),
                                 mode: input_group.mode,
                                 channels: input_group.channels.clone(),
@@ -5148,8 +5149,9 @@ pub fn run_desktop_app(
                     id: BlockId(format!("{}:input:{}", chain.id.0, i)),
                     enabled: true,
                     kind: AudioBlockKind::Input(InputBlock {
-                        name: ig.name.clone(),
+                        model: "standard".to_string(),
                         entries: vec![InputEntry {
+                            name: ig.name.clone(),
                             device_id: DeviceId(ig.device_id.clone().unwrap_or_default()),
                             mode: ig.mode,
                             channels: ig.channels.clone(),
@@ -5292,8 +5294,9 @@ pub fn run_desktop_app(
                         id: BlockId::generate_for_chain(&real_chain_id),
                         enabled: true,
                         kind: AudioBlockKind::Output(OutputBlock {
-                            name: output_group.name.clone(),
+                            model: "standard".to_string(),
                             entries: vec![OutputEntry {
+                                name: output_group.name.clone(),
                                 device_id: DeviceId(output_group.device_id.clone().unwrap_or_default()),
                                 mode: output_group.mode,
                                 channels: output_group.channels.clone(),
@@ -5348,8 +5351,9 @@ pub fn run_desktop_app(
                     id: BlockId(format!("{}:output:{}", chain.id.0, i)),
                     enabled: true,
                     kind: AudioBlockKind::Output(OutputBlock {
-                        name: og.name.clone(),
+                        model: "standard".to_string(),
                         entries: vec![OutputEntry {
+                            name: og.name.clone(),
                             device_id: DeviceId(og.device_id.clone().unwrap_or_default()),
                             mode: og.mode,
                             channels: og.channels.clone(),
@@ -5859,7 +5863,7 @@ fn chain_inputs_tooltip(
                 ChainInputMode::Stereo => "Stereo",
                 ChainInputMode::DualMono => "Dual Mono",
             };
-            let label = if input.entries.len() == 1 { input.name.clone() } else { format!("{} #{}", input.name, ei + 1) };
+            let label = if entry.name.is_empty() { format!("Input #{}", ei + 1) } else { entry.name.clone() };
             format!("{}: {} · {} · Ch {}", label, device_name, mode, format_channel_list(&entry.channels))
         })
     }).collect::<Vec<_>>().join("\n")
@@ -5884,7 +5888,7 @@ fn chain_outputs_tooltip(
                 ChainOutputMode::Mono => "Mono",
                 ChainOutputMode::Stereo => "Stereo",
             };
-            let label = if output.entries.len() == 1 { output.name.clone() } else { format!("{} #{}", output.name, ei + 1) };
+            let label = if entry.name.is_empty() { format!("Output #{}", ei + 1) } else { entry.name.clone() };
             format!("{}: {} · {} · Ch {}", label, device_name, mode, format_channel_list(&entry.channels))
         })
     }).collect::<Vec<_>>().join("\n")
@@ -6818,13 +6822,9 @@ fn chain_draft_from_chain(index: usize, chain: &Chain) -> ChainDraft {
         input_blocks
             .iter()
             .flat_map(|(_, input)| {
-                input.entries.iter().enumerate().map(move |(ei, entry)| {
+                input.entries.iter().map(move |entry| {
                     InputGroupDraft {
-                        name: if input.entries.len() == 1 {
-                            input.name.clone()
-                        } else {
-                            format!("{} {}", input.name, ei + 1)
-                        },
+                        name: if entry.name.is_empty() { "Input".to_string() } else { entry.name.clone() },
                         device_id: if entry.device_id.0.is_empty() { None } else { Some(entry.device_id.0.clone()) },
                         channels: entry.channels.clone(),
                         mode: entry.mode,
@@ -6845,13 +6845,9 @@ fn chain_draft_from_chain(index: usize, chain: &Chain) -> ChainDraft {
         output_blocks
             .iter()
             .flat_map(|(_, output)| {
-                output.entries.iter().enumerate().map(move |(ei, entry)| {
+                output.entries.iter().map(move |entry| {
                     OutputGroupDraft {
-                        name: if output.entries.len() == 1 {
-                            output.name.clone()
-                        } else {
-                            format!("{} {}", output.name, ei + 1)
-                        },
+                        name: if entry.name.is_empty() { "Output".to_string() } else { entry.name.clone() },
                         device_id: if entry.device_id.0.is_empty() { None } else { Some(entry.device_id.0.clone()) },
                         channels: entry.channels.clone(),
                         mode: entry.mode,
@@ -7048,6 +7044,7 @@ fn chain_from_draft(draft: &ChainDraft, existing_chain: Option<&Chain>) -> Chain
         .iter()
         .filter(|ig| ig.device_id.is_some() && !ig.channels.is_empty())
         .map(|ig| InputEntry {
+            name: ig.name.clone(),
             device_id: DeviceId(ig.device_id.clone().unwrap_or_default()),
             mode: ig.mode,
             channels: ig.channels.clone(),
@@ -7060,7 +7057,7 @@ fn chain_from_draft(draft: &ChainDraft, existing_chain: Option<&Chain>) -> Chain
             id: BlockId("input:0".into()),
             enabled: true,
             kind: AudioBlockKind::Input(InputBlock {
-                name: draft.inputs.first().map(|i| i.name.clone()).unwrap_or_else(|| "Input".into()),
+                model: "standard".to_string(),
                 entries: input_entries,
             }),
         }]
@@ -7072,6 +7069,7 @@ fn chain_from_draft(draft: &ChainDraft, existing_chain: Option<&Chain>) -> Chain
         .iter()
         .filter(|og| og.device_id.is_some() && !og.channels.is_empty())
         .map(|og| OutputEntry {
+            name: og.name.clone(),
             device_id: DeviceId(og.device_id.clone().unwrap_or_default()),
             mode: og.mode,
             channels: og.channels.clone(),
@@ -7084,7 +7082,7 @@ fn chain_from_draft(draft: &ChainDraft, existing_chain: Option<&Chain>) -> Chain
             id: BlockId("output:0".into()),
             enabled: true,
             kind: AudioBlockKind::Output(OutputBlock {
-                name: draft.outputs.first().map(|o| o.name.clone()).unwrap_or_else(|| "Output".into()),
+                model: "standard".to_string(),
                 entries: output_entries,
             }),
         }]
@@ -7597,8 +7595,9 @@ mod tests {
 
     fn input_kind() -> AudioBlockKind {
         AudioBlockKind::Input(InputBlock {
-            name: "In".into(),
+            model: "standard".into(),
             entries: vec![InputEntry {
+                name: "In".into(),
                 device_id: DeviceId("dev".into()),
                 mode: ChainInputMode::Mono,
                 channels: vec![0],
@@ -7608,8 +7607,9 @@ mod tests {
 
     fn output_kind() -> AudioBlockKind {
         AudioBlockKind::Output(OutputBlock {
-            name: "Out".into(),
+            model: "standard".into(),
             entries: vec![OutputEntry {
+                name: "Out".into(),
                 device_id: DeviceId("dev".into()),
                 mode: ChainOutputMode::Stereo,
                 channels: vec![0, 1],

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -5475,10 +5475,15 @@ fn replace_project_chains(
                     .into(),
                 subtitle: chain_routing_summary(chain).into(),
                 enabled: chain.enabled,
-                block_count_label: if chain.blocks.len() == 1 {
-                    "1 block".into()
-                } else {
-                    format!("{} blocks", chain.blocks.len()).into()
+                block_count_label: {
+                    let effect_block_count = chain.blocks.iter()
+                        .filter(|b| !matches!(&b.kind, AudioBlockKind::Input(_) | AudioBlockKind::Output(_)))
+                        .count();
+                    if effect_block_count == 1 {
+                        "1 block".into()
+                    } else {
+                        format!("{} blocks", effect_block_count).into()
+                    }
                 },
                 input_label: {
                     let input_chs: Vec<usize> = chain.input_blocks().into_iter()
@@ -5500,6 +5505,7 @@ fn replace_project_chains(
                     chain
                         .blocks
                         .iter()
+                        .filter(|b| !matches!(&b.kind, AudioBlockKind::Input(_) | AudioBlockKind::Output(_)))
                         .map(chain_block_item_from_block)
                         .collect::<Vec<_>>(),
                 ))),

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -299,6 +299,18 @@ struct IoBlockInsertDraft {
     before_index: usize,
     kind: String, // "input" or "output"
 }
+/// Transient state for editing an Insert block's send/return endpoints.
+#[derive(Debug, Clone)]
+struct InsertDraft {
+    chain_index: usize,
+    block_index: usize,
+    send_device_id: Option<String>,
+    send_channels: Vec<usize>,
+    send_mode: ChainInputMode,
+    return_device_id: Option<String>,
+    return_channels: Vec<usize>,
+    return_mode: ChainInputMode,
+}
 struct BlockEditorData {
     effect_type: String,
     model_id: String,
@@ -373,6 +385,7 @@ pub fn run_desktop_app(
     let project_session = Rc::new(RefCell::new(None::<ProjectSession>));
     let chain_draft = Rc::new(RefCell::new(None::<ChainDraft>));
     let io_block_insert_draft = Rc::new(RefCell::new(None::<IoBlockInsertDraft>));
+    let insert_draft = Rc::new(RefCell::new(None::<InsertDraft>));
     let selected_block = Rc::new(RefCell::new(None::<SelectedBlock>));
     let block_editor_draft = Rc::new(RefCell::new(None::<BlockEditorDraft>));
     let project_runtime = Rc::new(RefCell::new(None::<ProjectRuntimeController>));
@@ -396,6 +409,10 @@ pub fn run_desktop_app(
         ChainInputGroupsWindow::new().map_err(|error| anyhow!(error.to_string()))?;
     let chain_output_groups_window =
         ChainOutputGroupsWindow::new().map_err(|error| anyhow!(error.to_string()))?;
+    let chain_insert_window =
+        ChainInsertWindow::new().map_err(|error| anyhow!(error.to_string()))?;
+    let insert_send_channels = Rc::new(VecModel::from(Vec::<ChannelOptionItem>::new()));
+    let insert_return_channels = Rc::new(VecModel::from(Vec::<ChannelOptionItem>::new()));
     let block_editor_window =
         BlockEditorWindow::new().map_err(|error| anyhow!(error.to_string()))?;
     window.set_show_project_launcher(true);
@@ -684,6 +701,244 @@ pub fn run_desktop_app(
     chain_output_window.set_channels(ModelRc::from(chain_output_channels.clone()));
     chain_output_window.set_selected_device_index(-1);
     chain_output_window.set_status_message("".into());
+    chain_insert_window.set_send_device_options(ModelRc::from(chain_output_device_options.clone()));
+    chain_insert_window.set_return_device_options(ModelRc::from(chain_input_device_options.clone()));
+    chain_insert_window.set_send_channels(ModelRc::from(insert_send_channels.clone()));
+    chain_insert_window.set_return_channels(ModelRc::from(insert_return_channels.clone()));
+    chain_insert_window.set_selected_send_device_index(-1);
+    chain_insert_window.set_selected_return_device_index(-1);
+    chain_insert_window.set_status_message("".into());
+    // --- ChainInsertWindow callbacks ---
+    {
+        let insert_draft = insert_draft.clone();
+        let output_chain_devices = output_chain_devices.clone();
+        let insert_send_channels = insert_send_channels.clone();
+        chain_insert_window.on_select_send_device(move |index| {
+            let Some(device) = output_chain_devices.get(index as usize) else { return; };
+            let mut draft_borrow = insert_draft.borrow_mut();
+            let Some(draft) = draft_borrow.as_mut() else { return; };
+            draft.send_device_id = Some(device.id.clone());
+            draft.send_channels.clear();
+            let items = build_insert_send_channel_items(draft, &output_chain_devices);
+            replace_channel_options(&insert_send_channels, items);
+        });
+    }
+    {
+        let insert_draft = insert_draft.clone();
+        let insert_send_channels = insert_send_channels.clone();
+        chain_insert_window.on_toggle_send_channel(move |index, selected| {
+            let mut draft_borrow = insert_draft.borrow_mut();
+            let Some(draft) = draft_borrow.as_mut() else { return; };
+            let ch = index as usize;
+            if selected {
+                if !draft.send_channels.contains(&ch) {
+                    draft.send_channels.push(ch);
+                }
+            } else {
+                draft.send_channels.retain(|&c| c != ch);
+            }
+            if let Some(mut row) = insert_send_channels.row_data(index as usize) {
+                row.selected = selected;
+                insert_send_channels.set_row_data(index as usize, row);
+            }
+        });
+    }
+    {
+        let insert_draft = insert_draft.clone();
+        chain_insert_window.on_select_send_mode(move |index| {
+            let mut draft_borrow = insert_draft.borrow_mut();
+            let Some(draft) = draft_borrow.as_mut() else { return; };
+            draft.send_mode = insert_mode_from_index(index);
+            log::debug!("[select_send_mode] index={}, mode={:?}", index, draft.send_mode);
+        });
+    }
+    {
+        let insert_draft = insert_draft.clone();
+        let input_chain_devices = input_chain_devices.clone();
+        let insert_return_channels = insert_return_channels.clone();
+        chain_insert_window.on_select_return_device(move |index| {
+            let Some(device) = input_chain_devices.get(index as usize) else { return; };
+            let mut draft_borrow = insert_draft.borrow_mut();
+            let Some(draft) = draft_borrow.as_mut() else { return; };
+            draft.return_device_id = Some(device.id.clone());
+            draft.return_channels.clear();
+            let items = build_insert_return_channel_items(draft, &input_chain_devices);
+            replace_channel_options(&insert_return_channels, items);
+        });
+    }
+    {
+        let insert_draft = insert_draft.clone();
+        let insert_return_channels = insert_return_channels.clone();
+        chain_insert_window.on_toggle_return_channel(move |index, selected| {
+            let mut draft_borrow = insert_draft.borrow_mut();
+            let Some(draft) = draft_borrow.as_mut() else { return; };
+            let ch = index as usize;
+            if selected {
+                if !draft.return_channels.contains(&ch) {
+                    draft.return_channels.push(ch);
+                }
+            } else {
+                draft.return_channels.retain(|&c| c != ch);
+            }
+            if let Some(mut row) = insert_return_channels.row_data(index as usize) {
+                row.selected = selected;
+                insert_return_channels.set_row_data(index as usize, row);
+            }
+        });
+    }
+    {
+        let insert_draft = insert_draft.clone();
+        chain_insert_window.on_select_return_mode(move |index| {
+            let mut draft_borrow = insert_draft.borrow_mut();
+            let Some(draft) = draft_borrow.as_mut() else { return; };
+            draft.return_mode = insert_mode_from_index(index);
+            log::debug!("[select_return_mode] index={}, mode={:?}", index, draft.return_mode);
+        });
+    }
+    {
+        let insert_draft = insert_draft.clone();
+        let project_session = project_session.clone();
+        let project_runtime = project_runtime.clone();
+        let project_chains = project_chains.clone();
+        let input_chain_devices = input_chain_devices.clone();
+        let output_chain_devices = output_chain_devices.clone();
+        let saved_project_snapshot = saved_project_snapshot.clone();
+        let project_dirty = project_dirty.clone();
+        let weak_window = window.as_weak();
+        let weak_insert_window = chain_insert_window.as_weak();
+        chain_insert_window.on_toggle_enabled(move || {
+            let Some(window) = weak_window.upgrade() else { return; };
+            let Some(iw) = weak_insert_window.upgrade() else { return; };
+            let draft_borrow = insert_draft.borrow();
+            let Some(draft) = draft_borrow.as_ref() else { return; };
+            let chain_idx = draft.chain_index;
+            let block_idx = draft.block_index;
+            drop(draft_borrow);
+            let mut session_borrow = project_session.borrow_mut();
+            let Some(session) = session_borrow.as_mut() else { return; };
+            let Some(chain) = session.project.chains.get_mut(chain_idx) else { return; };
+            let Some(block) = chain.blocks.get_mut(block_idx) else { return; };
+            block.enabled = !block.enabled;
+            iw.set_block_enabled(block.enabled);
+            let chain_id = chain.id.clone();
+            if let Err(e) = sync_live_chain_runtime(&project_runtime, session, &chain_id) {
+                log::error!("toggle insert block enabled: {e}");
+            }
+            replace_project_chains(&project_chains, &session.project, &input_chain_devices, &output_chain_devices);
+            sync_project_dirty(&window, session, &saved_project_snapshot, &project_dirty);
+        });
+    }
+    {
+        let insert_draft = insert_draft.clone();
+        let project_session = project_session.clone();
+        let project_runtime = project_runtime.clone();
+        let project_chains = project_chains.clone();
+        let input_chain_devices = input_chain_devices.clone();
+        let output_chain_devices = output_chain_devices.clone();
+        let saved_project_snapshot = saved_project_snapshot.clone();
+        let project_dirty = project_dirty.clone();
+        let weak_window = window.as_weak();
+        let weak_insert_window = chain_insert_window.as_weak();
+        chain_insert_window.on_delete_block(move || {
+            let Some(window) = weak_window.upgrade() else { return; };
+            let Some(iw) = weak_insert_window.upgrade() else { return; };
+            let draft_borrow = insert_draft.borrow();
+            let Some(draft) = draft_borrow.as_ref() else { return; };
+            let chain_idx = draft.chain_index;
+            let block_idx = draft.block_index;
+            drop(draft_borrow);
+            *insert_draft.borrow_mut() = None;
+            let mut session_borrow = project_session.borrow_mut();
+            let Some(session) = session_borrow.as_mut() else { return; };
+            let Some(chain) = session.project.chains.get_mut(chain_idx) else { return; };
+            if block_idx < chain.blocks.len() {
+                chain.blocks.remove(block_idx);
+            }
+            let chain_id = chain.id.clone();
+            if let Err(e) = sync_live_chain_runtime(&project_runtime, session, &chain_id) {
+                log::error!("delete insert block: {e}");
+            }
+            replace_project_chains(&project_chains, &session.project, &input_chain_devices, &output_chain_devices);
+            sync_project_dirty(&window, session, &saved_project_snapshot, &project_dirty);
+            let _ = iw.hide();
+        });
+    }
+    {
+        let insert_draft = insert_draft.clone();
+        let project_session = project_session.clone();
+        let project_runtime = project_runtime.clone();
+        let project_chains = project_chains.clone();
+        let input_chain_devices = input_chain_devices.clone();
+        let output_chain_devices = output_chain_devices.clone();
+        let saved_project_snapshot = saved_project_snapshot.clone();
+        let project_dirty = project_dirty.clone();
+        let weak_window = window.as_weak();
+        let weak_insert_window = chain_insert_window.as_weak();
+        chain_insert_window.on_save(move || {
+            let Some(window) = weak_window.upgrade() else { return; };
+            let Some(iw) = weak_insert_window.upgrade() else { return; };
+            let draft_borrow = insert_draft.borrow();
+            let Some(draft) = draft_borrow.as_ref() else { return; };
+            if draft.send_device_id.is_none() || draft.send_channels.is_empty() {
+                iw.set_status_message("Selecione dispositivo e canais de envio.".into());
+                return;
+            }
+            if draft.return_device_id.is_none() || draft.return_channels.is_empty() {
+                iw.set_status_message("Selecione dispositivo e canais de retorno.".into());
+                return;
+            }
+            let chain_idx = draft.chain_index;
+            let block_idx = draft.block_index;
+            let send_endpoint = project::block::InsertEndpoint {
+                device_id: DeviceId(draft.send_device_id.clone().unwrap_or_default()),
+                mode: draft.send_mode,
+                channels: draft.send_channels.clone(),
+            };
+            let return_endpoint = project::block::InsertEndpoint {
+                device_id: DeviceId(draft.return_device_id.clone().unwrap_or_default()),
+                mode: draft.return_mode,
+                channels: draft.return_channels.clone(),
+            };
+            drop(draft_borrow);
+            *insert_draft.borrow_mut() = None;
+            let mut session_borrow = project_session.borrow_mut();
+            let Some(session) = session_borrow.as_mut() else {
+                let _ = iw.hide();
+                return;
+            };
+            let Some(chain) = session.project.chains.get_mut(chain_idx) else {
+                let _ = iw.hide();
+                return;
+            };
+            let Some(block) = chain.blocks.get_mut(block_idx) else {
+                let _ = iw.hide();
+                return;
+            };
+            if let AudioBlockKind::Insert(ref mut ib) = block.kind {
+                ib.send = send_endpoint;
+                ib.return_ = return_endpoint;
+            }
+            let chain_id = chain.id.clone();
+            if let Err(e) = sync_live_chain_runtime(&project_runtime, session, &chain_id) {
+                log::error!("insert save error: {e}");
+            }
+            replace_project_chains(&project_chains, &session.project, &input_chain_devices, &output_chain_devices);
+            sync_project_dirty(&window, session, &saved_project_snapshot, &project_dirty);
+            iw.set_status_message("".into());
+            let _ = iw.hide();
+        });
+    }
+    {
+        let insert_draft = insert_draft.clone();
+        let weak_insert_window = chain_insert_window.as_weak();
+        chain_insert_window.on_cancel(move || {
+            *insert_draft.borrow_mut() = None;
+            if let Some(iw) = weak_insert_window.upgrade() {
+                iw.set_status_message("".into());
+                let _ = iw.hide();
+            }
+        });
+    }
     {
         let input_devices = input_devices.clone();
         window.on_toggle_input_device(move |index, selected| {
@@ -3495,6 +3750,10 @@ pub fn run_desktop_app(
         let weak_input_groups_for_select = chain_input_groups_window.as_weak();
         let weak_output_groups_for_select = chain_output_groups_window.as_weak();
         let chain_draft_for_select = chain_draft.clone();
+        let weak_insert_window_for_select = chain_insert_window.as_weak();
+        let insert_draft_for_select = insert_draft.clone();
+        let insert_send_channels_for_select = insert_send_channels.clone();
+        let insert_return_channels_for_select = insert_return_channels.clone();
         window.on_select_chain_block(move |chain_index, block_index| {
             let Some(window) = weak_main_window.upgrade() else {
                 return;
@@ -3561,32 +3820,38 @@ pub fn run_desktop_app(
                 }
                 AudioBlockKind::Insert(ib) => {
                     log::info!("[select_chain_block] insert block at index {}: id='{}'", block_index, block.id.0);
-                    // Open input groups window with block controls (enable/disable + delete)
-                    // Send/Return config will be added later
-                    let send_summary = if ib.send.device_id.0.is_empty() {
-                        "Send: não configurado".to_string()
-                    } else {
-                        format!("Send: {} · Ch {}", ib.send.device_id.0.split(':').last().unwrap_or(&ib.send.device_id.0), ib.send.channels.iter().map(|c| (c+1).to_string()).collect::<Vec<_>>().join(", "))
+                    let draft = InsertDraft {
+                        chain_index: chain_index as usize,
+                        block_index: block_index as usize,
+                        send_device_id: if ib.send.device_id.0.is_empty() { None } else { Some(ib.send.device_id.0.clone()) },
+                        send_channels: ib.send.channels.clone(),
+                        send_mode: ib.send.mode,
+                        return_device_id: if ib.return_.device_id.0.is_empty() { None } else { Some(ib.return_.device_id.0.clone()) },
+                        return_channels: ib.return_.channels.clone(),
+                        return_mode: ib.return_.mode,
                     };
-                    let return_summary = if ib.return_.device_id.0.is_empty() {
-                        "Return: não configurado".to_string()
-                    } else {
-                        format!("Return: {} · Ch {}", ib.return_.device_id.0.split(':').last().unwrap_or(&ib.return_.device_id.0), ib.return_.channels.iter().map(|c| (c+1).to_string()).collect::<Vec<_>>().join(", "))
-                    };
-                    let items = vec![
-                        IoGroupItem { name: send_summary.into(), summary: "".into() },
-                        IoGroupItem { name: return_summary.into(), summary: "".into() },
-                    ];
-                    let mut draft = chain_draft_from_chain(chain_index as usize, chain);
-                    draft.editing_io_block_index = Some(block_index as usize);
-                    if let Some(gw) = weak_input_groups_for_select.upgrade() {
-                        gw.set_groups(ModelRc::from(Rc::new(VecModel::from(items))));
-                        gw.set_status_message("".into());
-                        gw.set_show_block_controls(true);
-                        gw.set_block_enabled(block.enabled);
-                        *chain_draft_for_select.borrow_mut() = Some(draft);
+                    let is_middle = block_index > 0 && (block_index as usize) < chain.blocks.len() - 1;
+                    if let Some(iw) = weak_insert_window_for_select.upgrade() {
+                        let send_items = build_insert_send_channel_items(&draft, &output_chain_devices);
+                        let return_items = build_insert_return_channel_items(&draft, &input_chain_devices);
+                        replace_channel_options(&insert_send_channels_for_select, send_items);
+                        replace_channel_options(&insert_return_channels_for_select, return_items);
+                        iw.set_selected_send_device_index(selected_device_index(
+                            &output_chain_devices,
+                            draft.send_device_id.as_deref(),
+                        ));
+                        iw.set_selected_return_device_index(selected_device_index(
+                            &input_chain_devices,
+                            draft.return_device_id.as_deref(),
+                        ));
+                        iw.set_selected_send_mode_index(insert_mode_to_index(draft.send_mode));
+                        iw.set_selected_return_mode_index(insert_mode_to_index(draft.return_mode));
+                        iw.set_show_block_controls(is_middle);
+                        iw.set_block_enabled(block.enabled);
+                        iw.set_status_message("".into());
+                        *insert_draft_for_select.borrow_mut() = Some(draft);
                         drop(session_borrow);
-                        show_child_window(window.window(), gw.window());
+                        show_child_window(window.window(), iw.window());
                     }
                     return;
                 }
@@ -4406,6 +4671,10 @@ pub fn run_desktop_app(
         let output_chain_devices_for_type = output_chain_devices.clone();
         let chain_input_channels_for_type = chain_input_channels.clone();
         let chain_output_channels_for_type = chain_output_channels.clone();
+        let weak_insert_window_for_type = chain_insert_window.as_weak();
+        let insert_draft_for_type = insert_draft.clone();
+        let insert_send_channels_for_type = insert_send_channels.clone();
+        let insert_return_channels_for_type = insert_return_channels.clone();
         window.on_choose_block_type(move |index| {
             let Some(window) = weak_window.upgrade() else {
                 return;
@@ -4461,6 +4730,31 @@ pub fn run_desktop_app(
                 replace_project_chains(&project_chains_for_type, &session.project, &input_chain_devices_for_type, &output_chain_devices_for_type);
                 sync_project_dirty(&window, session, &saved_project_snapshot_for_type, &project_dirty_for_type);
                 window.set_show_block_type_picker(false);
+                // Open the insert window to configure the newly created block
+                drop(session_borrow);
+                let draft = InsertDraft {
+                    chain_index,
+                    block_index: before_index,
+                    send_device_id: None,
+                    send_channels: Vec::new(),
+                    send_mode: ChainInputMode::Mono,
+                    return_device_id: None,
+                    return_channels: Vec::new(),
+                    return_mode: ChainInputMode::Mono,
+                };
+                if let Some(iw) = weak_insert_window_for_type.upgrade() {
+                    replace_channel_options(&insert_send_channels_for_type, Vec::new());
+                    replace_channel_options(&insert_return_channels_for_type, Vec::new());
+                    iw.set_selected_send_device_index(-1);
+                    iw.set_selected_return_device_index(-1);
+                    iw.set_selected_send_mode_index(0);
+                    iw.set_selected_return_mode_index(0);
+                    iw.set_show_block_controls(true);
+                    iw.set_block_enabled(true);
+                    iw.set_status_message("".into());
+                    *insert_draft_for_type.borrow_mut() = Some(draft);
+                    show_child_window(window.window(), iw.window());
+                }
                 return;
             }
             if effect_type_str == "input" || effect_type_str == "output" {
@@ -7527,6 +7821,57 @@ fn build_output_channel_items(
 }
 fn replace_channel_options(model: &Rc<VecModel<ChannelOptionItem>>, items: Vec<ChannelOptionItem>) {
     model.set_vec(items);
+}
+fn build_insert_send_channel_items(
+    draft: &InsertDraft,
+    output_devices: &[AudioDeviceDescriptor],
+) -> Vec<ChannelOptionItem> {
+    let Some(device_id) = draft.send_device_id.as_ref() else {
+        return Vec::new();
+    };
+    let Some(device) = output_devices.iter().find(|d| &d.id == device_id) else {
+        return Vec::new();
+    };
+    (0..device.channels)
+        .map(|channel| ChannelOptionItem {
+            index: channel as i32,
+            label: format!("Canal {}", channel + 1).into(),
+            selected: draft.send_channels.contains(&channel),
+            available: true,
+        })
+        .collect()
+}
+fn build_insert_return_channel_items(
+    draft: &InsertDraft,
+    input_devices: &[AudioDeviceDescriptor],
+) -> Vec<ChannelOptionItem> {
+    let Some(device_id) = draft.return_device_id.as_ref() else {
+        return Vec::new();
+    };
+    let Some(device) = input_devices.iter().find(|d| &d.id == device_id) else {
+        return Vec::new();
+    };
+    (0..device.channels)
+        .map(|channel| ChannelOptionItem {
+            index: channel as i32,
+            label: format!("Canal {}", channel + 1).into(),
+            selected: draft.return_channels.contains(&channel),
+            available: true,
+        })
+        .collect()
+}
+fn insert_mode_to_index(mode: ChainInputMode) -> i32 {
+    match mode {
+        ChainInputMode::Mono => 0,
+        ChainInputMode::Stereo => 1,
+        ChainInputMode::DualMono => 0,
+    }
+}
+fn insert_mode_from_index(index: i32) -> ChainInputMode {
+    match index {
+        1 => ChainInputMode::Stereo,
+        _ => ChainInputMode::Mono,
+    }
 }
 fn normalized_chain_description(name: &str) -> Option<String> {
     let trimmed = name.trim();

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -282,6 +282,13 @@ struct BlockEditorDraft {
     enabled: bool,
     is_select: bool,
 }
+/// Transient state for inserting an I/O block via the block type picker.
+#[derive(Debug, Clone)]
+struct IoBlockInsertDraft {
+    chain_index: usize,
+    before_index: usize,
+    kind: String, // "input" or "output"
+}
 struct BlockEditorData {
     effect_type: String,
     model_id: String,
@@ -376,6 +383,7 @@ pub fn run_desktop_app(
     let app_config = Rc::new(RefCell::new(load_and_sync_app_config()?));
     let project_session = Rc::new(RefCell::new(None::<ProjectSession>));
     let chain_draft = Rc::new(RefCell::new(None::<ChainDraft>));
+    let io_block_insert_draft = Rc::new(RefCell::new(None::<IoBlockInsertDraft>));
     let selected_block = Rc::new(RefCell::new(None::<SelectedBlock>));
     let block_editor_draft = Rc::new(RefCell::new(None::<BlockEditorDraft>));
     let project_runtime = Rc::new(RefCell::new(None::<ProjectRuntimeController>));
@@ -4000,6 +4008,15 @@ pub fn run_desktop_app(
         let block_model_option_labels = block_model_option_labels.clone();
         let block_parameter_items = block_parameter_items.clone();
         let weak_block_editor_window = block_editor_window.as_weak();
+        let chain_draft_for_type = chain_draft.clone();
+        let io_block_insert_draft_for_type = io_block_insert_draft.clone();
+        let weak_input_window_for_type = chain_input_window.as_weak();
+        let weak_output_window_for_type = chain_output_window.as_weak();
+        let project_session_for_type = project_session.clone();
+        let input_chain_devices_for_type = input_chain_devices.clone();
+        let output_chain_devices_for_type = output_chain_devices.clone();
+        let chain_input_channels_for_type = chain_input_channels.clone();
+        let chain_output_channels_for_type = chain_output_channels.clone();
         window.on_choose_block_type(move |index| {
             let Some(window) = weak_window.upgrade() else {
                 return;
@@ -4012,6 +4029,85 @@ pub fn run_desktop_app(
                 return;
             };
             log::debug!("on_choose_block_type: index={}, type='{}', instrument='{}'", index, block_type.effect_type, instrument);
+
+            // Handle I/O block types: open the dedicated I/O window instead of the block editor
+            let effect_type_str = block_type.effect_type.as_str();
+            if effect_type_str == "input" || effect_type_str == "output" {
+                let (chain_index, before_index) = {
+                    let draft_borrow = block_editor_draft.borrow();
+                    let Some(draft) = draft_borrow.as_ref() else { return; };
+                    (draft.chain_index, draft.before_index)
+                };
+                // Store the I/O insert draft
+                *io_block_insert_draft_for_type.borrow_mut() = Some(IoBlockInsertDraft {
+                    chain_index,
+                    before_index,
+                    kind: effect_type_str.to_string(),
+                });
+                window.set_show_block_type_picker(false);
+
+                if effect_type_str == "input" {
+                    // Set up a temporary chain draft for the input window callbacks
+                    let input_group = InputGroupDraft {
+                        name: "Input".to_string(),
+                        device_id: None,
+                        channels: Vec::new(),
+                        mode: ChainInputMode::Mono,
+                    };
+                    *chain_draft_for_type.borrow_mut() = Some(ChainDraft {
+                        editing_index: Some(chain_index),
+                        name: String::new(),
+                        instrument: instrument.clone(),
+                        inputs: vec![input_group.clone()],
+                        outputs: Vec::new(),
+                        editing_input_index: Some(0),
+                        editing_output_index: None,
+                    });
+                    if let Some(input_window) = weak_input_window_for_type.upgrade() {
+                        let draft_borrow = chain_draft_for_type.borrow();
+                        let draft = draft_borrow.as_ref().unwrap();
+                        if let Some(session) = project_session_for_type.borrow().as_ref() {
+                            apply_chain_input_window_state(
+                                &input_window,
+                                &input_group,
+                                draft,
+                                &session.project,
+                                &input_chain_devices_for_type,
+                                &chain_input_channels_for_type,
+                            );
+                        }
+                        show_child_window(window.window(), input_window.window());
+                    }
+                } else {
+                    // Set up a temporary chain draft for the output window callbacks
+                    let output_group = OutputGroupDraft {
+                        name: "Output".to_string(),
+                        device_id: None,
+                        channels: Vec::new(),
+                        mode: ChainOutputMode::Stereo,
+                    };
+                    *chain_draft_for_type.borrow_mut() = Some(ChainDraft {
+                        editing_index: Some(chain_index),
+                        name: String::new(),
+                        instrument: instrument.clone(),
+                        inputs: Vec::new(),
+                        outputs: vec![output_group.clone()],
+                        editing_input_index: None,
+                        editing_output_index: Some(0),
+                    });
+                    if let Some(output_window) = weak_output_window_for_type.upgrade() {
+                        apply_chain_output_window_state(
+                            &output_window,
+                            &output_group,
+                            &output_chain_devices_for_type,
+                            &chain_output_channels_for_type,
+                        );
+                        show_child_window(window.window(), output_window.window());
+                    }
+                }
+                return;
+            }
+
             let models = block_model_picker_items(block_type.effect_type.as_str(), &instrument);
             let Some(model) = models.first() else {
                 return;
@@ -4890,6 +4986,7 @@ pub fn run_desktop_app(
         let weak_chain_window = chain_editor_window.as_weak();
         let weak_input_groups_window = chain_input_groups_window.as_weak();
         let chain_draft = chain_draft.clone();
+        let io_block_insert_draft_for_input_save = io_block_insert_draft.clone();
         let project_session = project_session.clone();
         let project_chains = project_chains.clone();
         let project_runtime = project_runtime.clone();
@@ -4904,6 +5001,70 @@ pub fn run_desktop_app(
             let Some(input_window) = weak_input_window.upgrade() else {
                 return;
             };
+
+            // Handle I/O block insert mode: insert a single InputBlock at the stored position
+            if let Some(io_draft) = io_block_insert_draft_for_input_save.borrow().clone() {
+                if io_draft.kind == "input" {
+                    let draft_borrow = chain_draft.borrow();
+                    let Some(draft) = draft_borrow.as_ref() else {
+                        let _ = input_window.hide();
+                        *io_block_insert_draft_for_input_save.borrow_mut() = None;
+                        return;
+                    };
+                    let Some(input_group) = draft.inputs.first().cloned() else {
+                        let _ = input_window.hide();
+                        *io_block_insert_draft_for_input_save.borrow_mut() = None;
+                        return;
+                    };
+                    if input_group.device_id.is_none() || input_group.channels.is_empty() {
+                        input_window.set_status_message("Selecione dispositivo e canais.".into());
+                        return;
+                    }
+                    let chain_index = io_draft.chain_index;
+                    let before_index = io_draft.before_index;
+                    drop(draft_borrow);
+                    let mut session_borrow = project_session.borrow_mut();
+                    let Some(session) = session_borrow.as_mut() else {
+                        let _ = input_window.hide();
+                        *io_block_insert_draft_for_input_save.borrow_mut() = None;
+                        return;
+                    };
+                    let Some(chain) = session.project.chains.get_mut(chain_index) else {
+                        let _ = input_window.hide();
+                        *io_block_insert_draft_for_input_save.borrow_mut() = None;
+                        return;
+                    };
+                    let real_chain_id = chain.id.clone();
+                    let input_block = AudioBlock {
+                        id: BlockId::generate_for_chain(&real_chain_id),
+                        enabled: true,
+                        kind: AudioBlockKind::Input(InputBlock {
+                            name: input_group.name.clone(),
+                            device_id: DeviceId(input_group.device_id.clone().unwrap_or_default()),
+                            mode: input_group.mode,
+                            channels: input_group.channels.clone(),
+                        }),
+                    };
+                    let insert_pos = before_index.min(chain.blocks.len());
+                    chain.blocks.insert(insert_pos, input_block);
+                    if let Err(error) = sync_live_chain_runtime(&project_runtime, session, &real_chain_id) {
+                        eprintln!("io block insert error: {error}");
+                    }
+                    replace_project_chains(
+                        &project_chains,
+                        &session.project,
+                        &input_chain_devices,
+                        &output_chain_devices,
+                    );
+                    sync_project_dirty(&window, session, &saved_project_snapshot, &project_dirty);
+                    *io_block_insert_draft_for_input_save.borrow_mut() = None;
+                    *chain_draft.borrow_mut() = None;
+                    input_window.set_status_message("".into());
+                    let _ = input_window.hide();
+                    return;
+                }
+            }
+
             let mut draft_borrow = chain_draft.borrow_mut();
             let Some(draft) = draft_borrow.as_mut() else {
                 let _ = input_window.hide();
@@ -4984,19 +5145,31 @@ pub fn run_desktop_app(
     }
     {
         let weak_output_window = chain_output_window.as_weak();
+        let io_block_insert_draft_for_output_cancel = io_block_insert_draft.clone();
+        let chain_draft_for_output_cancel = chain_draft.clone();
         chain_output_window.on_cancel(move || {
             if let Some(output_window) = weak_output_window.upgrade() {
                 output_window.set_status_message("".into());
                 let _ = output_window.hide();
             }
+            if io_block_insert_draft_for_output_cancel.borrow().is_some() {
+                *io_block_insert_draft_for_output_cancel.borrow_mut() = None;
+                *chain_draft_for_output_cancel.borrow_mut() = None;
+            }
         });
     }
     {
         let weak_input_window = chain_input_window.as_weak();
+        let io_block_insert_draft_for_input_cancel = io_block_insert_draft.clone();
+        let chain_draft_for_input_cancel = chain_draft.clone();
         chain_input_window.on_cancel(move || {
             if let Some(input_window) = weak_input_window.upgrade() {
                 input_window.set_status_message("".into());
                 let _ = input_window.hide();
+            }
+            if io_block_insert_draft_for_input_cancel.borrow().is_some() {
+                *io_block_insert_draft_for_input_cancel.borrow_mut() = None;
+                *chain_draft_for_input_cancel.borrow_mut() = None;
             }
         });
     }
@@ -5006,6 +5179,7 @@ pub fn run_desktop_app(
         let weak_chain_window = chain_editor_window.as_weak();
         let weak_output_groups_window = chain_output_groups_window.as_weak();
         let chain_draft = chain_draft.clone();
+        let io_block_insert_draft_for_output_save = io_block_insert_draft.clone();
         let project_session = project_session.clone();
         let project_chains = project_chains.clone();
         let project_runtime = project_runtime.clone();
@@ -5020,6 +5194,70 @@ pub fn run_desktop_app(
             let Some(output_window) = weak_output_window.upgrade() else {
                 return;
             };
+
+            // Handle I/O block insert mode: insert a single OutputBlock at the stored position
+            if let Some(io_draft) = io_block_insert_draft_for_output_save.borrow().clone() {
+                if io_draft.kind == "output" {
+                    let draft_borrow = chain_draft.borrow();
+                    let Some(draft) = draft_borrow.as_ref() else {
+                        let _ = output_window.hide();
+                        *io_block_insert_draft_for_output_save.borrow_mut() = None;
+                        return;
+                    };
+                    let Some(output_group) = draft.outputs.first().cloned() else {
+                        let _ = output_window.hide();
+                        *io_block_insert_draft_for_output_save.borrow_mut() = None;
+                        return;
+                    };
+                    if output_group.device_id.is_none() || output_group.channels.is_empty() {
+                        output_window.set_status_message("Selecione dispositivo e canais.".into());
+                        return;
+                    }
+                    let chain_index = io_draft.chain_index;
+                    let before_index = io_draft.before_index;
+                    drop(draft_borrow);
+                    let mut session_borrow = project_session.borrow_mut();
+                    let Some(session) = session_borrow.as_mut() else {
+                        let _ = output_window.hide();
+                        *io_block_insert_draft_for_output_save.borrow_mut() = None;
+                        return;
+                    };
+                    let Some(chain) = session.project.chains.get_mut(chain_index) else {
+                        let _ = output_window.hide();
+                        *io_block_insert_draft_for_output_save.borrow_mut() = None;
+                        return;
+                    };
+                    let real_chain_id = chain.id.clone();
+                    let output_block = AudioBlock {
+                        id: BlockId::generate_for_chain(&real_chain_id),
+                        enabled: true,
+                        kind: AudioBlockKind::Output(OutputBlock {
+                            name: output_group.name.clone(),
+                            device_id: DeviceId(output_group.device_id.clone().unwrap_or_default()),
+                            mode: output_group.mode,
+                            channels: output_group.channels.clone(),
+                        }),
+                    };
+                    let insert_pos = before_index.min(chain.blocks.len());
+                    chain.blocks.insert(insert_pos, output_block);
+                    if let Err(error) = sync_live_chain_runtime(&project_runtime, session, &real_chain_id) {
+                        eprintln!("io block insert error: {error}");
+                    }
+                    replace_project_chains(
+                        &project_chains,
+                        &session.project,
+                        &input_chain_devices,
+                        &output_chain_devices,
+                    );
+                    sync_project_dirty(&window, session, &saved_project_snapshot, &project_dirty);
+                    *io_block_insert_draft_for_output_save.borrow_mut() = None;
+                    *chain_draft.borrow_mut() = None;
+                    output_window.set_status_message("".into());
+                    let _ = output_window.hide();
+                    return;
+                }
+            }
+
             let mut draft_borrow = chain_draft.borrow_mut();
             let Some(draft) = draft_borrow.as_mut() else {
                 let _ = output_window.hide();
@@ -5580,7 +5818,7 @@ fn format_channel_list(channels: &[usize]) -> String {
 }
 fn block_type_picker_items(instrument: &str) -> Vec<BlockTypePickerItem> {
     let mut seen = std::collections::BTreeSet::new();
-    supported_block_types()
+    let mut items: Vec<BlockTypePickerItem> = supported_block_types()
         .into_iter()
         .filter(|item| seen.insert(item.effect_type))
         .map(|item| BlockTypePickerItem {
@@ -5595,7 +5833,27 @@ fn block_type_picker_items(instrument: &str) -> Vec<BlockTypePickerItem> {
         .filter(|item| {
             instrument == block_core::INST_GENERIC || !block_model_picker_items(item.effect_type.as_str(), instrument).is_empty()
         })
-        .collect()
+        .collect();
+    // Add I/O block types
+    items.push(BlockTypePickerItem {
+        effect_type: "input".into(),
+        label: "INPUT".into(),
+        subtitle: "".into(),
+        icon_kind: "input".into(),
+        use_panel_editor: false,
+        accent_color: crate::ui_state::accent_color_for_icon_kind("routing"),
+        icon_source: slint::Image::default(),
+    });
+    items.push(BlockTypePickerItem {
+        effect_type: "output".into(),
+        label: "OUTPUT".into(),
+        subtitle: "".into(),
+        icon_kind: "output".into(),
+        use_panel_editor: false,
+        accent_color: crate::ui_state::accent_color_for_icon_kind("routing"),
+        icon_source: slint::Image::default(),
+    });
+    items
 }
 fn block_model_picker_items(effect_type: &str, instrument: &str) -> Vec<BlockModelPickerItem> {
     let all_models = supported_block_models(effect_type).unwrap_or_default();

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -3216,11 +3216,9 @@ pub fn run_desktop_app(
         let output_chain_devices = output_chain_devices.clone();
         let open_block_windows = open_block_windows.clone();
         let toast_timer = toast_timer.clone();
-        let weak_input_window_for_select = chain_input_window.as_weak();
-        let weak_output_window_for_select = chain_output_window.as_weak();
+        let weak_input_groups_for_select = chain_input_groups_window.as_weak();
+        let weak_output_groups_for_select = chain_output_groups_window.as_weak();
         let chain_draft_for_select = chain_draft.clone();
-        let chain_input_channels_for_select = chain_input_channels.clone();
-        let chain_output_channels_for_select = chain_output_channels.clone();
         window.on_select_chain_block(move |chain_index, block_index| {
             let Some(window) = weak_main_window.upgrade() else {
                 return;
@@ -3239,46 +3237,43 @@ pub fn run_desktop_app(
                 set_status_error(&window, &toast_timer, "Block inválido.");
                 return;
             };
-            // Handle I/O blocks — open device/channel editor instead of block editor
+            // Handle I/O blocks — open I/O groups window with entries of THIS specific block
             match &block.kind {
-                AudioBlockKind::Input(_) => {
-                    let draft = chain_draft_from_chain(chain_index as usize, chain);
-                    // Find which input group index this block corresponds to
-                    let input_idx = chain.input_blocks().iter()
-                        .position(|(i, _)| *i == block_index as usize)
-                        .unwrap_or(0);
-                    let mut draft = draft;
-                    draft.editing_input_index = Some(input_idx);
-                    if let Some(input_group) = draft.inputs.get(input_idx) {
-                        if let Some(iw) = weak_input_window_for_select.upgrade() {
-                            apply_chain_input_window_state(
-                                &iw, input_group, &draft, &session.project,
-                                &input_chain_devices, &chain_input_channels_for_select,
-                            );
-                            *chain_draft_for_select.borrow_mut() = Some(draft);
-                            drop(session_borrow);
-                            show_child_window(window.window(), iw.window());
-                        }
+                AudioBlockKind::Input(ib) => {
+                    let inputs: Vec<InputGroupDraft> = ib.entries.iter().map(|e| InputGroupDraft {
+                        name: e.name.clone(),
+                        device_id: if e.device_id.0.is_empty() { None } else { Some(e.device_id.0.clone()) },
+                        channels: e.channels.clone(),
+                        mode: e.mode,
+                    }).collect();
+                    let mut draft = chain_draft_from_chain(chain_index as usize, chain);
+                    draft.inputs = inputs;
+                    let (input_items, _) = build_io_group_items(&draft, &input_chain_devices, &output_chain_devices);
+                    if let Some(gw) = weak_input_groups_for_select.upgrade() {
+                        gw.set_groups(ModelRc::from(Rc::new(VecModel::from(input_items))));
+                        gw.set_status_message("".into());
+                        *chain_draft_for_select.borrow_mut() = Some(draft);
+                        drop(session_borrow);
+                        show_child_window(window.window(), gw.window());
                     }
                     return;
                 }
-                AudioBlockKind::Output(_) => {
-                    let draft = chain_draft_from_chain(chain_index as usize, chain);
-                    let output_idx = chain.output_blocks().iter()
-                        .position(|(i, _)| *i == block_index as usize)
-                        .unwrap_or(0);
-                    let mut draft = draft;
-                    draft.editing_output_index = Some(output_idx);
-                    if let Some(output_group) = draft.outputs.get(output_idx) {
-                        if let Some(ow) = weak_output_window_for_select.upgrade() {
-                            apply_chain_output_window_state(
-                                &ow, output_group,
-                                &output_chain_devices, &chain_output_channels_for_select,
-                            );
-                            *chain_draft_for_select.borrow_mut() = Some(draft);
-                            drop(session_borrow);
-                            show_child_window(window.window(), ow.window());
-                        }
+                AudioBlockKind::Output(ob) => {
+                    let outputs: Vec<OutputGroupDraft> = ob.entries.iter().map(|e| OutputGroupDraft {
+                        name: e.name.clone(),
+                        device_id: if e.device_id.0.is_empty() { None } else { Some(e.device_id.0.clone()) },
+                        channels: e.channels.clone(),
+                        mode: e.mode,
+                    }).collect();
+                    let mut draft = chain_draft_from_chain(chain_index as usize, chain);
+                    draft.outputs = outputs;
+                    let (_, output_items) = build_io_group_items(&draft, &input_chain_devices, &output_chain_devices);
+                    if let Some(gw) = weak_output_groups_for_select.upgrade() {
+                        gw.set_groups(ModelRc::from(Rc::new(VecModel::from(output_items))));
+                        gw.set_status_message("".into());
+                        *chain_draft_for_select.borrow_mut() = Some(draft);
+                        drop(session_borrow);
+                        show_child_window(window.window(), gw.window());
                     }
                     return;
                 }
@@ -5883,12 +5878,12 @@ fn chain_inputs_tooltip(
     _project: &Project,
     devices: &[AudioDeviceDescriptor],
 ) -> String {
-    let input_blocks = chain.input_blocks();
-    if input_blocks.is_empty() {
+    // Show only entries from the FIRST InputBlock (chip In)
+    let first_input = chain.first_input();
+    let Some(input) = first_input else {
         return "No input configured".to_string();
-    }
-    input_blocks.iter().flat_map(|(_, input)| {
-        input.entries.iter().enumerate().map(move |(ei, entry)| {
+    };
+    input.entries.iter().enumerate().map(|(ei, entry)| {
             let device_name = devices
                 .iter()
                 .find(|d| d.id == entry.device_id.0)
@@ -5901,7 +5896,6 @@ fn chain_inputs_tooltip(
             };
             let label = if entry.name.is_empty() { format!("Input #{}", ei + 1) } else { entry.name.clone() };
             format!("{}: {} · {} · Ch {}", label, device_name, mode, format_channel_list(&entry.channels))
-        })
     }).collect::<Vec<_>>().join("\n")
 }
 fn chain_outputs_tooltip(
@@ -5909,24 +5903,23 @@ fn chain_outputs_tooltip(
     _project: &Project,
     devices: &[AudioDeviceDescriptor],
 ) -> String {
-    let output_blocks = chain.output_blocks();
-    if output_blocks.is_empty() {
+    // Show only entries from the LAST OutputBlock (chip Out)
+    let last_output = chain.last_output();
+    let Some(output) = last_output else {
         return "No output configured".to_string();
-    }
-    output_blocks.iter().flat_map(|(_, output)| {
-        output.entries.iter().enumerate().map(move |(ei, entry)| {
-            let device_name = devices
-                .iter()
-                .find(|d| d.id == entry.device_id.0)
-                .map(|d| d.name.as_str())
-                .unwrap_or(&entry.device_id.0);
-            let mode = match entry.mode {
-                ChainOutputMode::Mono => "Mono",
-                ChainOutputMode::Stereo => "Stereo",
-            };
-            let label = if entry.name.is_empty() { format!("Output #{}", ei + 1) } else { entry.name.clone() };
-            format!("{}: {} · {} · Ch {}", label, device_name, mode, format_channel_list(&entry.channels))
-        })
+    };
+    output.entries.iter().enumerate().map(|(ei, entry)| {
+        let device_name = devices
+            .iter()
+            .find(|d| d.id == entry.device_id.0)
+            .map(|d| d.name.as_str())
+            .unwrap_or(&entry.device_id.0);
+        let mode = match entry.mode {
+            ChainOutputMode::Mono => "Mono",
+            ChainOutputMode::Stereo => "Stereo",
+        };
+        let label = if entry.name.is_empty() { format!("Output #{}", ei + 1) } else { entry.name.clone() };
+        format!("{}: {} · {} · Ch {}", label, device_name, mode, format_channel_list(&entry.channels))
     }).collect::<Vec<_>>().join("\n")
 }
 fn format_channel_list(channels: &[usize]) -> String {

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -2515,6 +2515,7 @@ pub fn run_desktop_app(
             groups_window
                 .set_groups(ModelRc::from(Rc::new(VecModel::from(input_items))));
             groups_window.set_status_message("".into());
+            groups_window.set_show_block_controls(false);
             *chain_draft.borrow_mut() = Some(draft);
             show_child_window(window.window(), groups_window.window());
         });
@@ -2564,6 +2565,7 @@ pub fn run_desktop_app(
             groups_window
                 .set_groups(ModelRc::from(Rc::new(VecModel::from(output_items))));
             groups_window.set_status_message("".into());
+            groups_window.set_show_block_controls(false);
             *chain_draft.borrow_mut() = Some(draft);
             show_child_window(window.window(), groups_window.window());
         });
@@ -3113,6 +3115,74 @@ pub fn run_desktop_app(
             let _ = groups_window.hide();
         });
     }
+    {
+        let chain_draft = chain_draft.clone();
+        let project_session = project_session.clone();
+        let project_runtime = project_runtime.clone();
+        let project_chains = project_chains.clone();
+        let input_chain_devices = input_chain_devices.clone();
+        let output_chain_devices = output_chain_devices.clone();
+        let saved_project_snapshot = saved_project_snapshot.clone();
+        let project_dirty = project_dirty.clone();
+        let weak_window = window.as_weak();
+        let weak_groups_window = chain_input_groups_window.as_weak();
+        chain_input_groups_window.on_toggle_enabled(move || {
+            let Some(window) = weak_window.upgrade() else { return; };
+            let Some(gw) = weak_groups_window.upgrade() else { return; };
+            let draft_borrow = chain_draft.borrow();
+            let Some(draft) = draft_borrow.as_ref() else { return; };
+            let Some(chain_idx) = draft.editing_index else { return; };
+            let Some(block_idx) = draft.editing_io_block_index else { return; };
+            drop(draft_borrow);
+            let mut session_borrow = project_session.borrow_mut();
+            let Some(session) = session_borrow.as_mut() else { return; };
+            let Some(chain) = session.project.chains.get_mut(chain_idx) else { return; };
+            let Some(block) = chain.blocks.get_mut(block_idx) else { return; };
+            block.enabled = !block.enabled;
+            gw.set_block_enabled(block.enabled);
+            let chain_id = chain.id.clone();
+            if let Err(e) = sync_live_chain_runtime(&project_runtime, session, &chain_id) {
+                log::error!("toggle I/O block enabled: {e}");
+            }
+            replace_project_chains(&project_chains, &session.project, &input_chain_devices, &output_chain_devices);
+            sync_project_dirty(&window, session, &saved_project_snapshot, &project_dirty);
+        });
+    }
+    {
+        let chain_draft = chain_draft.clone();
+        let project_session = project_session.clone();
+        let project_runtime = project_runtime.clone();
+        let project_chains = project_chains.clone();
+        let input_chain_devices = input_chain_devices.clone();
+        let output_chain_devices = output_chain_devices.clone();
+        let saved_project_snapshot = saved_project_snapshot.clone();
+        let project_dirty = project_dirty.clone();
+        let weak_window = window.as_weak();
+        let weak_groups_window = chain_input_groups_window.as_weak();
+        chain_input_groups_window.on_delete_block(move || {
+            let Some(window) = weak_window.upgrade() else { return; };
+            let Some(gw) = weak_groups_window.upgrade() else { return; };
+            let draft_borrow = chain_draft.borrow();
+            let Some(draft) = draft_borrow.as_ref() else { return; };
+            let Some(chain_idx) = draft.editing_index else { return; };
+            let Some(block_idx) = draft.editing_io_block_index else { return; };
+            drop(draft_borrow);
+            *chain_draft.borrow_mut() = None;
+            let mut session_borrow = project_session.borrow_mut();
+            let Some(session) = session_borrow.as_mut() else { return; };
+            let Some(chain) = session.project.chains.get_mut(chain_idx) else { return; };
+            if block_idx < chain.blocks.len() {
+                chain.blocks.remove(block_idx);
+            }
+            let chain_id = chain.id.clone();
+            if let Err(e) = sync_live_chain_runtime(&project_runtime, session, &chain_id) {
+                log::error!("delete I/O block: {e}");
+            }
+            replace_project_chains(&project_chains, &session.project, &input_chain_devices, &output_chain_devices);
+            sync_project_dirty(&window, session, &saved_project_snapshot, &project_dirty);
+            let _ = gw.hide();
+        });
+    }
     // --- ChainOutputGroupsWindow callbacks ---
     {
         let weak_window = window.as_weak();
@@ -3339,6 +3409,74 @@ pub fn run_desktop_app(
         });
     }
     {
+        let chain_draft = chain_draft.clone();
+        let project_session = project_session.clone();
+        let project_runtime = project_runtime.clone();
+        let project_chains = project_chains.clone();
+        let input_chain_devices = input_chain_devices.clone();
+        let output_chain_devices = output_chain_devices.clone();
+        let saved_project_snapshot = saved_project_snapshot.clone();
+        let project_dirty = project_dirty.clone();
+        let weak_window = window.as_weak();
+        let weak_groups_window = chain_output_groups_window.as_weak();
+        chain_output_groups_window.on_toggle_enabled(move || {
+            let Some(window) = weak_window.upgrade() else { return; };
+            let Some(gw) = weak_groups_window.upgrade() else { return; };
+            let draft_borrow = chain_draft.borrow();
+            let Some(draft) = draft_borrow.as_ref() else { return; };
+            let Some(chain_idx) = draft.editing_index else { return; };
+            let Some(block_idx) = draft.editing_io_block_index else { return; };
+            drop(draft_borrow);
+            let mut session_borrow = project_session.borrow_mut();
+            let Some(session) = session_borrow.as_mut() else { return; };
+            let Some(chain) = session.project.chains.get_mut(chain_idx) else { return; };
+            let Some(block) = chain.blocks.get_mut(block_idx) else { return; };
+            block.enabled = !block.enabled;
+            gw.set_block_enabled(block.enabled);
+            let chain_id = chain.id.clone();
+            if let Err(e) = sync_live_chain_runtime(&project_runtime, session, &chain_id) {
+                log::error!("toggle I/O block enabled: {e}");
+            }
+            replace_project_chains(&project_chains, &session.project, &input_chain_devices, &output_chain_devices);
+            sync_project_dirty(&window, session, &saved_project_snapshot, &project_dirty);
+        });
+    }
+    {
+        let chain_draft = chain_draft.clone();
+        let project_session = project_session.clone();
+        let project_runtime = project_runtime.clone();
+        let project_chains = project_chains.clone();
+        let input_chain_devices = input_chain_devices.clone();
+        let output_chain_devices = output_chain_devices.clone();
+        let saved_project_snapshot = saved_project_snapshot.clone();
+        let project_dirty = project_dirty.clone();
+        let weak_window = window.as_weak();
+        let weak_groups_window = chain_output_groups_window.as_weak();
+        chain_output_groups_window.on_delete_block(move || {
+            let Some(window) = weak_window.upgrade() else { return; };
+            let Some(gw) = weak_groups_window.upgrade() else { return; };
+            let draft_borrow = chain_draft.borrow();
+            let Some(draft) = draft_borrow.as_ref() else { return; };
+            let Some(chain_idx) = draft.editing_index else { return; };
+            let Some(block_idx) = draft.editing_io_block_index else { return; };
+            drop(draft_borrow);
+            *chain_draft.borrow_mut() = None;
+            let mut session_borrow = project_session.borrow_mut();
+            let Some(session) = session_borrow.as_mut() else { return; };
+            let Some(chain) = session.project.chains.get_mut(chain_idx) else { return; };
+            if block_idx < chain.blocks.len() {
+                chain.blocks.remove(block_idx);
+            }
+            let chain_id = chain.id.clone();
+            if let Err(e) = sync_live_chain_runtime(&project_runtime, session, &chain_id) {
+                log::error!("delete I/O block: {e}");
+            }
+            replace_project_chains(&project_chains, &session.project, &input_chain_devices, &output_chain_devices);
+            sync_project_dirty(&window, session, &saved_project_snapshot, &project_dirty);
+            let _ = gw.hide();
+        });
+    }
+    {
         let weak_main_window = window.as_weak();
         let selected_block = selected_block.clone();
         let block_editor_draft = block_editor_draft.clone();
@@ -3391,6 +3529,8 @@ pub fn run_desktop_app(
                     if let Some(gw) = weak_input_groups_for_select.upgrade() {
                         gw.set_groups(ModelRc::from(Rc::new(VecModel::from(input_items))));
                         gw.set_status_message("".into());
+                        gw.set_show_block_controls(true);
+                        gw.set_block_enabled(block.enabled);
                         *chain_draft_for_select.borrow_mut() = Some(draft);
                         drop(session_borrow);
                         show_child_window(window.window(), gw.window());
@@ -3411,6 +3551,8 @@ pub fn run_desktop_app(
                     if let Some(gw) = weak_output_groups_for_select.upgrade() {
                         gw.set_groups(ModelRc::from(Rc::new(VecModel::from(output_items))));
                         gw.set_status_message("".into());
+                        gw.set_show_block_controls(true);
+                        gw.set_block_enabled(block.enabled);
                         *chain_draft_for_select.borrow_mut() = Some(draft);
                         drop(session_borrow);
                         show_child_window(window.window(), gw.window());

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -5057,6 +5057,7 @@ pub fn run_desktop_app(
                         &output_chain_devices,
                     );
                     sync_project_dirty(&window, session, &saved_project_snapshot, &project_dirty);
+                    drop(session_borrow);
                     *io_block_insert_draft_for_input_save.borrow_mut() = None;
                     *chain_draft.borrow_mut() = None;
                     input_window.set_status_message("".into());
@@ -5250,6 +5251,7 @@ pub fn run_desktop_app(
                         &output_chain_devices,
                     );
                     sync_project_dirty(&window, session, &saved_project_snapshot, &project_dirty);
+                    drop(session_borrow);
                     *io_block_insert_draft_for_output_save.borrow_mut() = None;
                     *chain_draft.borrow_mut() = None;
                     output_window.set_status_message("".into());

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -5505,7 +5505,13 @@ fn replace_project_chains(
                     chain
                         .blocks
                         .iter()
-                        .map(chain_block_item_from_block)
+                        .enumerate()
+                        .filter(|(_, b)| !matches!(&b.kind, AudioBlockKind::Input(_) | AudioBlockKind::Output(_)))
+                        .map(|(real_idx, b)| {
+                            let mut item = chain_block_item_from_block(b);
+                            item.real_index = real_idx as i32;
+                            item
+                        })
                         .collect::<Vec<_>>(),
                 ))),
             }
@@ -6589,7 +6595,6 @@ fn load_thumbnail_image(effect_type: &str, model_id: &str) -> (slint::Image, boo
     }
 }
 fn chain_block_item_from_block(block: &AudioBlock) -> ChainBlockItem {
-    let is_io = matches!(&block.kind, AudioBlockKind::Input(_) | AudioBlockKind::Output(_));
     let (kind, label) = match &block.kind {
         AudioBlockKind::Input(_) => ("input".to_string(), "input".to_string()),
         AudioBlockKind::Output(_) => ("output".to_string(), "output".to_string()),
@@ -6621,7 +6626,7 @@ fn chain_block_item_from_block(block: &AudioBlock) -> ChainBlockItem {
         label: label.into(),
         family: family.into(),
         enabled: block.enabled,
-        hidden: is_io,
+        real_index: 0,
         thumbnail,
         has_thumbnail,
         thumb_width,

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -3559,9 +3559,35 @@ pub fn run_desktop_app(
                     }
                     return;
                 }
-                AudioBlockKind::Insert(_) => {
+                AudioBlockKind::Insert(ib) => {
                     log::info!("[select_chain_block] insert block at index {}: id='{}'", block_index, block.id.0);
-                    set_status_with_toast(&window, &toast_timer, "Insert block configuration not yet available in GUI.", "info");
+                    // Open input groups window with block controls (enable/disable + delete)
+                    // Send/Return config will be added later
+                    let send_summary = if ib.send.device_id.0.is_empty() {
+                        "Send: não configurado".to_string()
+                    } else {
+                        format!("Send: {} · Ch {}", ib.send.device_id.0.split(':').last().unwrap_or(&ib.send.device_id.0), ib.send.channels.iter().map(|c| (c+1).to_string()).collect::<Vec<_>>().join(", "))
+                    };
+                    let return_summary = if ib.return_.device_id.0.is_empty() {
+                        "Return: não configurado".to_string()
+                    } else {
+                        format!("Return: {} · Ch {}", ib.return_.device_id.0.split(':').last().unwrap_or(&ib.return_.device_id.0), ib.return_.channels.iter().map(|c| (c+1).to_string()).collect::<Vec<_>>().join(", "))
+                    };
+                    let items = vec![
+                        IoGroupItem { name: send_summary.into(), summary: "".into() },
+                        IoGroupItem { name: return_summary.into(), summary: "".into() },
+                    ];
+                    let mut draft = chain_draft_from_chain(chain_index as usize, chain);
+                    draft.editing_io_block_index = Some(block_index as usize);
+                    if let Some(gw) = weak_input_groups_for_select.upgrade() {
+                        gw.set_groups(ModelRc::from(Rc::new(VecModel::from(items))));
+                        gw.set_status_message("".into());
+                        gw.set_show_block_controls(true);
+                        gw.set_block_enabled(block.enabled);
+                        *chain_draft_for_select.borrow_mut() = Some(draft);
+                        drop(session_borrow);
+                        show_child_window(window.window(), gw.window());
+                    }
                     return;
                 }
                 _ => {}

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -5747,19 +5747,26 @@ fn replace_project_chains(
                 output_tooltip: chain_outputs_tooltip(chain, project, output_devices)
                 .into(),
                 latency_ms,
-                blocks: ModelRc::from(Rc::new(VecModel::from(
-                    chain
-                        .blocks
-                        .iter()
-                        .enumerate()
-                        .filter(|(_, b)| !matches!(&b.kind, AudioBlockKind::Input(_) | AudioBlockKind::Output(_)))
-                        .map(|(real_idx, b)| {
-                            let mut item = chain_block_item_from_block(b);
-                            item.real_index = real_idx as i32;
-                            item
-                        })
-                        .collect::<Vec<_>>(),
-                ))),
+                blocks: {
+                    let first_input_idx = chain.blocks.iter().position(|b| matches!(&b.kind, AudioBlockKind::Input(_)));
+                    let last_output_idx = chain.blocks.iter().rposition(|b| matches!(&b.kind, AudioBlockKind::Output(_)));
+                    ModelRc::from(Rc::new(VecModel::from(
+                        chain
+                            .blocks
+                            .iter()
+                            .enumerate()
+                            .filter(|(i, _)| {
+                                // Hide only the first Input (fixed chip) and last Output (fixed chip)
+                                Some(*i) != first_input_idx && Some(*i) != last_output_idx
+                            })
+                            .map(|(real_idx, b)| {
+                                let mut item = chain_block_item_from_block(b);
+                                item.real_index = real_idx as i32;
+                                item
+                            })
+                            .collect::<Vec<_>>(),
+                    )))
+                },
             }
         })
         .collect::<Vec<_>>();

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -269,6 +269,12 @@ struct ChainDraft {
     /// None = editing the fixed chip (first input / last output).
     /// Some(idx) = editing a specific I/O block at chain.blocks[idx].
     editing_io_block_index: Option<usize>,
+    /// True when a new input entry was added as placeholder and the input config
+    /// window is open. If the user cancels, the placeholder should be removed.
+    adding_new_input: bool,
+    /// True when a new output entry was added as placeholder and the output config
+    /// window is open. If the user cancels, the placeholder should be removed.
+    adding_new_output: bool,
 }
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct SelectedBlock {
@@ -2671,67 +2677,118 @@ pub fn run_desktop_app(
     {
         let weak_window = window.as_weak();
         let weak_chain_window = chain_editor_window.as_weak();
+        let weak_input_window = chain_input_window.as_weak();
         let chain_draft = chain_draft.clone();
+        let project_session = project_session.clone();
         let input_chain_devices = input_chain_devices.clone();
         let output_chain_devices = output_chain_devices.clone();
+        let chain_input_channels = chain_input_channels.clone();
         chain_editor_window.on_add_input(move || {
             let Some(window) = weak_window.upgrade() else {
                 return;
             };
-            let Some(chain_window) = weak_chain_window.upgrade() else {
+            let Some(input_window) = weak_input_window.upgrade() else {
                 return;
             };
-            let mut draft_borrow = chain_draft.borrow_mut();
-            let Some(draft) = draft_borrow.as_mut() else {
+            let new_idx = {
+                let mut draft_borrow = chain_draft.borrow_mut();
+                let Some(draft) = draft_borrow.as_mut() else {
+                    return;
+                };
+                let idx = draft.inputs.len();
+                draft.inputs.push(InputGroupDraft {
+                    name: format!("Input {}", idx + 1),
+                    device_id: input_chain_devices.first().map(|d| d.id.clone()),
+                    channels: Vec::new(),
+                    mode: ChainInputMode::Mono,
+                });
+                draft.editing_input_index = Some(idx);
+                draft.adding_new_input = true;
+                if let Some(chain_window) = weak_chain_window.upgrade() {
+                    apply_chain_io_groups(
+                        &window,
+                        &chain_window,
+                        draft,
+                        &input_chain_devices,
+                        &output_chain_devices,
+                    );
+                }
+                idx
+            };
+            let draft_borrow = chain_draft.borrow();
+            let Some(draft) = draft_borrow.as_ref() else {
                 return;
             };
-            let idx = draft.inputs.len() + 1;
-            draft.inputs.push(InputGroupDraft {
-                name: format!("Input {}", idx),
-                device_id: input_chain_devices.first().map(|d| d.id.clone()),
-                channels: Vec::new(),
-                mode: ChainInputMode::Mono,
-            });
-            apply_chain_io_groups(
-                &window,
-                &chain_window,
-                draft,
-                &input_chain_devices,
-                &output_chain_devices,
-            );
+            let session_borrow = project_session.borrow();
+            let Some(session) = session_borrow.as_ref() else {
+                return;
+            };
+            if let Some(input_group) = draft.inputs.get(new_idx) {
+                apply_chain_input_window_state(
+                    &input_window,
+                    input_group,
+                    draft,
+                    &session.project,
+                    &input_chain_devices,
+                    &chain_input_channels,
+                );
+            }
+            show_child_window(window.window(), input_window.window());
         });
     }
     {
         let weak_window = window.as_weak();
         let weak_chain_window = chain_editor_window.as_weak();
+        let weak_output_window = chain_output_window.as_weak();
         let chain_draft = chain_draft.clone();
         let input_chain_devices = input_chain_devices.clone();
         let output_chain_devices = output_chain_devices.clone();
+        let chain_output_channels = chain_output_channels.clone();
         chain_editor_window.on_add_output(move || {
             let Some(window) = weak_window.upgrade() else {
                 return;
             };
-            let Some(chain_window) = weak_chain_window.upgrade() else {
+            let Some(output_window) = weak_output_window.upgrade() else {
                 return;
             };
-            let mut draft_borrow = chain_draft.borrow_mut();
-            let Some(draft) = draft_borrow.as_mut() else {
+            let new_idx = {
+                let mut draft_borrow = chain_draft.borrow_mut();
+                let Some(draft) = draft_borrow.as_mut() else {
+                    return;
+                };
+                let idx = draft.outputs.len();
+                draft.outputs.push(OutputGroupDraft {
+                    name: format!("Output {}", idx + 1),
+                    device_id: output_chain_devices.first().map(|d| d.id.clone()),
+                    channels: Vec::new(),
+                    mode: ChainOutputMode::Stereo,
+                });
+                draft.editing_output_index = Some(idx);
+                draft.adding_new_output = true;
+                if let Some(chain_window) = weak_chain_window.upgrade() {
+                    apply_chain_io_groups(
+                        &window,
+                        &chain_window,
+                        draft,
+                        &input_chain_devices,
+                        &output_chain_devices,
+                    );
+                }
+                idx
+            };
+            let draft_borrow = chain_draft.borrow();
+            let Some(draft) = draft_borrow.as_ref() else {
                 return;
             };
-            let idx = draft.outputs.len() + 1;
-            draft.outputs.push(OutputGroupDraft {
-                name: format!("Output {}", idx),
-                device_id: output_chain_devices.first().map(|d| d.id.clone()),
-                channels: Vec::new(),
-                mode: ChainOutputMode::Stereo,
-            });
-            apply_chain_io_groups(
-                &window,
-                &chain_window,
-                draft,
-                &input_chain_devices,
-                &output_chain_devices,
-            );
+            if let Some(output_group) = draft.outputs.get(new_idx) {
+                apply_chain_output_window_state(
+                    &output_window,
+                    output_group,
+                    &output_chain_devices,
+                    &chain_output_channels,
+                );
+            }
+            show_child_window(window.window(), output_window.window());
         });
     }
     {
@@ -2751,6 +2808,10 @@ pub fn run_desktop_app(
             let Some(draft) = draft_borrow.as_mut() else {
                 return;
             };
+            // Fixed block (chip In/Out): must keep at least one entry
+            if draft.editing_io_block_index.is_none() && draft.inputs.len() <= 1 {
+                return;
+            }
             let gi = group_index as usize;
             if gi < draft.inputs.len() {
                 draft.inputs.remove(gi);
@@ -2789,6 +2850,10 @@ pub fn run_desktop_app(
             let Some(draft) = draft_borrow.as_mut() else {
                 return;
             };
+            // Fixed block (chip In/Out): must keep at least one entry
+            if draft.editing_io_block_index.is_none() && draft.outputs.len() <= 1 {
+                return;
+            }
             let gi = group_index as usize;
             if gi < draft.outputs.len() {
                 draft.outputs.remove(gi);
@@ -2866,6 +2931,11 @@ pub fn run_desktop_app(
             let Some(draft) = draft_borrow.as_mut() else {
                 return;
             };
+            // Fixed block (chip In/Out): must keep at least one entry
+            if draft.editing_io_block_index.is_none() && draft.inputs.len() <= 1 {
+                groups_window.set_status_message("É necessário pelo menos uma entrada.".into());
+                return;
+            }
             let gi = group_index as usize;
             if gi < draft.inputs.len() {
                 draft.inputs.remove(gi);
@@ -2884,29 +2954,62 @@ pub fn run_desktop_app(
         });
     }
     {
+        let weak_window = window.as_weak();
         let weak_groups_window = chain_input_groups_window.as_weak();
+        let weak_input_window = chain_input_window.as_weak();
         let chain_draft = chain_draft.clone();
+        let project_session = project_session.clone();
         let input_chain_devices = input_chain_devices.clone();
         let output_chain_devices = output_chain_devices.clone();
+        let chain_input_channels = chain_input_channels.clone();
         chain_input_groups_window.on_add_group(move || {
-            let Some(groups_window) = weak_groups_window.upgrade() else {
+            let Some(window) = weak_window.upgrade() else {
                 return;
             };
-            let mut draft_borrow = chain_draft.borrow_mut();
-            let Some(draft) = draft_borrow.as_mut() else {
+            let Some(input_window) = weak_input_window.upgrade() else {
                 return;
             };
-            let idx = draft.inputs.len() + 1;
-            draft.inputs.push(InputGroupDraft {
-                name: format!("Input {}", idx),
-                device_id: input_chain_devices.first().map(|d| d.id.clone()),
-                channels: Vec::new(),
-                mode: ChainInputMode::Mono,
-            });
-            let (input_items, _) =
-                build_io_group_items(draft, &input_chain_devices, &output_chain_devices);
-            groups_window
-                .set_groups(ModelRc::from(Rc::new(VecModel::from(input_items))));
+            let new_idx = {
+                let mut draft_borrow = chain_draft.borrow_mut();
+                let Some(draft) = draft_borrow.as_mut() else {
+                    return;
+                };
+                let idx = draft.inputs.len();
+                draft.inputs.push(InputGroupDraft {
+                    name: format!("Input {}", idx + 1),
+                    device_id: input_chain_devices.first().map(|d| d.id.clone()),
+                    channels: Vec::new(),
+                    mode: ChainInputMode::Mono,
+                });
+                draft.editing_input_index = Some(idx);
+                draft.adding_new_input = true;
+                if let Some(groups_window) = weak_groups_window.upgrade() {
+                    let (input_items, _) =
+                        build_io_group_items(draft, &input_chain_devices, &output_chain_devices);
+                    groups_window
+                        .set_groups(ModelRc::from(Rc::new(VecModel::from(input_items))));
+                }
+                idx
+            };
+            let draft_borrow = chain_draft.borrow();
+            let Some(draft) = draft_borrow.as_ref() else {
+                return;
+            };
+            let session_borrow = project_session.borrow();
+            let Some(session) = session_borrow.as_ref() else {
+                return;
+            };
+            if let Some(input_group) = draft.inputs.get(new_idx) {
+                apply_chain_input_window_state(
+                    &input_window,
+                    input_group,
+                    draft,
+                    &session.project,
+                    &input_chain_devices,
+                    &chain_input_channels,
+                );
+            }
+            show_child_window(window.window(), input_window.window());
         });
     }
     {
@@ -3060,6 +3163,11 @@ pub fn run_desktop_app(
             let Some(draft) = draft_borrow.as_mut() else {
                 return;
             };
+            // Fixed block (chip In/Out): must keep at least one entry
+            if draft.editing_io_block_index.is_none() && draft.outputs.len() <= 1 {
+                groups_window.set_status_message("É necessário pelo menos uma saída.".into());
+                return;
+            }
             let gi = group_index as usize;
             if gi < draft.outputs.len() {
                 draft.outputs.remove(gi);
@@ -3078,29 +3186,55 @@ pub fn run_desktop_app(
         });
     }
     {
+        let weak_window = window.as_weak();
         let weak_groups_window = chain_output_groups_window.as_weak();
+        let weak_output_window = chain_output_window.as_weak();
         let chain_draft = chain_draft.clone();
         let input_chain_devices = input_chain_devices.clone();
         let output_chain_devices = output_chain_devices.clone();
+        let chain_output_channels = chain_output_channels.clone();
         chain_output_groups_window.on_add_group(move || {
-            let Some(groups_window) = weak_groups_window.upgrade() else {
+            let Some(window) = weak_window.upgrade() else {
                 return;
             };
-            let mut draft_borrow = chain_draft.borrow_mut();
-            let Some(draft) = draft_borrow.as_mut() else {
+            let Some(output_window) = weak_output_window.upgrade() else {
                 return;
             };
-            let idx = draft.outputs.len() + 1;
-            draft.outputs.push(OutputGroupDraft {
-                name: format!("Output {}", idx),
-                device_id: output_chain_devices.first().map(|d| d.id.clone()),
-                channels: Vec::new(),
-                mode: ChainOutputMode::Stereo,
-            });
-            let (_, output_items) =
-                build_io_group_items(draft, &input_chain_devices, &output_chain_devices);
-            groups_window
-                .set_groups(ModelRc::from(Rc::new(VecModel::from(output_items))));
+            let new_idx = {
+                let mut draft_borrow = chain_draft.borrow_mut();
+                let Some(draft) = draft_borrow.as_mut() else {
+                    return;
+                };
+                let idx = draft.outputs.len();
+                draft.outputs.push(OutputGroupDraft {
+                    name: format!("Output {}", idx + 1),
+                    device_id: output_chain_devices.first().map(|d| d.id.clone()),
+                    channels: Vec::new(),
+                    mode: ChainOutputMode::Stereo,
+                });
+                draft.editing_output_index = Some(idx);
+                draft.adding_new_output = true;
+                if let Some(groups_window) = weak_groups_window.upgrade() {
+                    let (_, output_items) =
+                        build_io_group_items(draft, &input_chain_devices, &output_chain_devices);
+                    groups_window
+                        .set_groups(ModelRc::from(Rc::new(VecModel::from(output_items))));
+                }
+                idx
+            };
+            let draft_borrow = chain_draft.borrow();
+            let Some(draft) = draft_borrow.as_ref() else {
+                return;
+            };
+            if let Some(output_group) = draft.outputs.get(new_idx) {
+                apply_chain_output_window_state(
+                    &output_window,
+                    output_group,
+                    &output_chain_devices,
+                    &chain_output_channels,
+                );
+            }
+            show_child_window(window.window(), output_window.window());
         });
     }
     {
@@ -4141,6 +4275,8 @@ pub fn run_desktop_app(
                         editing_input_index: Some(0),
                         editing_output_index: None,
         editing_io_block_index: None,
+                        adding_new_input: false,
+                        adding_new_output: false,
                     });
                     if let Some(input_window) = weak_input_window_for_type.upgrade() {
                         let draft_borrow = chain_draft_for_type.borrow();
@@ -4174,6 +4310,8 @@ pub fn run_desktop_app(
         editing_io_block_index: None,
                         editing_input_index: None,
                         editing_output_index: Some(0),
+                        adding_new_input: false,
+                        adding_new_output: false,
                     });
                     if let Some(output_window) = weak_output_window_for_type.upgrade() {
                         apply_chain_output_window_state(
@@ -5235,14 +5373,21 @@ pub fn run_desktop_app(
                 groups_window
                     .set_groups(ModelRc::from(Rc::new(VecModel::from(input_items))));
             }
+            // Clear the adding flag on successful save
+            draft.adding_new_input = false;
             input_window.set_status_message("".into());
             let _ = input_window.hide();
         });
     }
     {
         let weak_output_window = chain_output_window.as_weak();
+        let weak_chain_window_for_out_cancel = chain_editor_window.as_weak();
+        let weak_window_for_out_cancel = window.as_weak();
+        let weak_output_groups_for_cancel = chain_output_groups_window.as_weak();
         let io_block_insert_draft_for_output_cancel = io_block_insert_draft.clone();
         let chain_draft_for_output_cancel = chain_draft.clone();
+        let input_chain_devices_for_out_cancel = input_chain_devices.clone();
+        let output_chain_devices_for_out_cancel = output_chain_devices.clone();
         chain_output_window.on_cancel(move || {
             if let Some(output_window) = weak_output_window.upgrade() {
                 output_window.set_status_message("".into());
@@ -5251,13 +5396,49 @@ pub fn run_desktop_app(
             if io_block_insert_draft_for_output_cancel.borrow().is_some() {
                 *io_block_insert_draft_for_output_cancel.borrow_mut() = None;
                 *chain_draft_for_output_cancel.borrow_mut() = None;
+                return;
+            }
+            // If we were adding a new entry, remove the placeholder
+            let mut draft_borrow = chain_draft_for_output_cancel.borrow_mut();
+            if let Some(draft) = draft_borrow.as_mut() {
+                if draft.adding_new_output {
+                    if let Some(idx) = draft.editing_output_index {
+                        if idx < draft.outputs.len() {
+                            draft.outputs.remove(idx);
+                        }
+                    }
+                    draft.adding_new_output = false;
+                    draft.editing_output_index = None;
+                    // Refresh chain editor window
+                    if let (Some(window), Some(chain_window)) = (weak_window_for_out_cancel.upgrade(), weak_chain_window_for_out_cancel.upgrade()) {
+                        apply_chain_io_groups(
+                            &window,
+                            &chain_window,
+                            draft,
+                            &input_chain_devices_for_out_cancel,
+                            &output_chain_devices_for_out_cancel,
+                        );
+                    }
+                    // Refresh groups window if open
+                    if let Some(groups_window) = weak_output_groups_for_cancel.upgrade() {
+                        let (_, output_items) =
+                            build_io_group_items(draft, &input_chain_devices_for_out_cancel, &output_chain_devices_for_out_cancel);
+                        groups_window
+                            .set_groups(ModelRc::from(Rc::new(VecModel::from(output_items))));
+                    }
+                }
             }
         });
     }
     {
         let weak_input_window = chain_input_window.as_weak();
+        let weak_chain_window_for_cancel = chain_editor_window.as_weak();
+        let weak_window_for_cancel = window.as_weak();
+        let weak_input_groups_for_cancel = chain_input_groups_window.as_weak();
         let io_block_insert_draft_for_input_cancel = io_block_insert_draft.clone();
         let chain_draft_for_input_cancel = chain_draft.clone();
+        let input_chain_devices_for_cancel = input_chain_devices.clone();
+        let output_chain_devices_for_cancel = output_chain_devices.clone();
         chain_input_window.on_cancel(move || {
             if let Some(input_window) = weak_input_window.upgrade() {
                 input_window.set_status_message("".into());
@@ -5266,6 +5447,37 @@ pub fn run_desktop_app(
             if io_block_insert_draft_for_input_cancel.borrow().is_some() {
                 *io_block_insert_draft_for_input_cancel.borrow_mut() = None;
                 *chain_draft_for_input_cancel.borrow_mut() = None;
+                return;
+            }
+            // If we were adding a new entry, remove the placeholder
+            let mut draft_borrow = chain_draft_for_input_cancel.borrow_mut();
+            if let Some(draft) = draft_borrow.as_mut() {
+                if draft.adding_new_input {
+                    if let Some(idx) = draft.editing_input_index {
+                        if idx < draft.inputs.len() {
+                            draft.inputs.remove(idx);
+                        }
+                    }
+                    draft.adding_new_input = false;
+                    draft.editing_input_index = None;
+                    // Refresh chain editor window
+                    if let (Some(window), Some(chain_window)) = (weak_window_for_cancel.upgrade(), weak_chain_window_for_cancel.upgrade()) {
+                        apply_chain_io_groups(
+                            &window,
+                            &chain_window,
+                            draft,
+                            &input_chain_devices_for_cancel,
+                            &output_chain_devices_for_cancel,
+                        );
+                    }
+                    // Refresh groups window if open
+                    if let Some(groups_window) = weak_input_groups_for_cancel.upgrade() {
+                        let (input_items, _) =
+                            build_io_group_items(draft, &input_chain_devices_for_cancel, &output_chain_devices_for_cancel);
+                        groups_window
+                            .set_groups(ModelRc::from(Rc::new(VecModel::from(input_items))));
+                    }
+                }
             }
         });
     }
@@ -5437,6 +5649,8 @@ pub fn run_desktop_app(
                 groups_window
                     .set_groups(ModelRc::from(Rc::new(VecModel::from(output_items))));
             }
+            // Clear the adding flag on successful save
+            draft.adding_new_output = false;
             output_window.set_status_message("".into());
             let _ = output_window.hide();
         });
@@ -6844,6 +7058,8 @@ fn create_chain_draft(
         editing_io_block_index: None,
         editing_input_index: None,
         editing_output_index: None,
+        adding_new_input: false,
+        adding_new_output: false,
     }
 }
 fn chain_draft_from_chain(index: usize, chain: &Chain) -> ChainDraft {
@@ -6906,6 +7122,8 @@ fn chain_draft_from_chain(index: usize, chain: &Chain) -> ChainDraft {
         outputs,
         editing_input_index: None,
         editing_output_index: None,
+        adding_new_input: false,
+        adding_new_output: false,
     }
 }
 fn load_thumbnail_image(effect_type: &str, model_id: &str) -> (slint::Image, bool, f32, f32) {

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -6809,19 +6809,22 @@ fn chain_draft_from_chain(index: usize, chain: &Chain) -> ChainDraft {
             mode: ChainInputMode::Mono,
         }]
     } else {
+        // Expand ALL entries from ALL InputBlocks into separate drafts
         input_blocks
             .iter()
-            .map(|(_, input)| {
-                let first = input.entries.first();
-                InputGroupDraft {
-                    name: input.name.clone(),
-                    device_id: first
-                        .map(|e| &e.device_id.0)
-                        .filter(|id| !id.is_empty())
-                        .cloned(),
-                    channels: first.map(|e| e.channels.clone()).unwrap_or_default(),
-                    mode: first.map(|e| e.mode).unwrap_or_default(),
-                }
+            .flat_map(|(_, input)| {
+                input.entries.iter().enumerate().map(move |(ei, entry)| {
+                    InputGroupDraft {
+                        name: if input.entries.len() == 1 {
+                            input.name.clone()
+                        } else {
+                            format!("{} {}", input.name, ei + 1)
+                        },
+                        device_id: if entry.device_id.0.is_empty() { None } else { Some(entry.device_id.0.clone()) },
+                        channels: entry.channels.clone(),
+                        mode: entry.mode,
+                    }
+                })
             })
             .collect()
     };
@@ -6836,17 +6839,19 @@ fn chain_draft_from_chain(index: usize, chain: &Chain) -> ChainDraft {
     } else {
         output_blocks
             .iter()
-            .map(|(_, output)| {
-                let first = output.entries.first();
-                OutputGroupDraft {
-                    name: output.name.clone(),
-                    device_id: first
-                        .map(|e| &e.device_id.0)
-                        .filter(|id| !id.is_empty())
-                        .cloned(),
-                    channels: first.map(|e| e.channels.clone()).unwrap_or_default(),
-                    mode: first.map(|e| e.mode).unwrap_or_default(),
-                }
+            .flat_map(|(_, output)| {
+                output.entries.iter().enumerate().map(move |(ei, entry)| {
+                    OutputGroupDraft {
+                        name: if output.entries.len() == 1 {
+                            output.name.clone()
+                        } else {
+                            format!("{} {}", output.name, ei + 1)
+                        },
+                        device_id: if entry.device_id.0.is_empty() { None } else { Some(entry.device_id.0.clone()) },
+                        channels: entry.channels.clone(),
+                        mode: entry.mode,
+                    }
+                })
             })
             .collect()
     };
@@ -7032,43 +7037,53 @@ fn normalized_chain_description(name: &str) -> Option<String> {
     }
 }
 fn chain_from_draft(draft: &ChainDraft, existing_chain: Option<&Chain>) -> Chain {
-    // Build input blocks from draft
-    let input_blocks: Vec<AudioBlock> = draft
+    // All draft inputs become entries of a SINGLE fixed InputBlock
+    let input_entries: Vec<InputEntry> = draft
         .inputs
         .iter()
-        .enumerate()
-        .map(|(i, ig)| AudioBlock {
-            id: BlockId(format!("input:{}", i)),
+        .filter(|ig| ig.device_id.is_some() && !ig.channels.is_empty())
+        .map(|ig| InputEntry {
+            device_id: DeviceId(ig.device_id.clone().unwrap_or_default()),
+            mode: ig.mode,
+            channels: ig.channels.clone(),
+        })
+        .collect();
+    let input_blocks: Vec<AudioBlock> = if input_entries.is_empty() {
+        Vec::new()
+    } else {
+        vec![AudioBlock {
+            id: BlockId("input:0".into()),
             enabled: true,
             kind: AudioBlockKind::Input(InputBlock {
-                name: ig.name.clone(),
-                entries: vec![InputEntry {
-                    device_id: DeviceId(ig.device_id.clone().unwrap_or_default()),
-                    mode: ig.mode,
-                    channels: ig.channels.clone(),
-                }],
+                name: draft.inputs.first().map(|i| i.name.clone()).unwrap_or_else(|| "Input".into()),
+                entries: input_entries,
             }),
-        })
-        .collect();
+        }]
+    };
 
-    // Build output blocks from draft
-    let output_blocks: Vec<AudioBlock> = draft
+    // All draft outputs become entries of a SINGLE fixed OutputBlock
+    let output_entries: Vec<OutputEntry> = draft
         .outputs
         .iter()
-        .enumerate()
-        .map(|(i, og)| AudioBlock {
-            id: BlockId(format!("output:{}", i)),
-            enabled: true,
-            kind: AudioBlockKind::Output(OutputBlock {
-                name: og.name.clone(),
-                entries: vec![OutputEntry {
-                    device_id: DeviceId(og.device_id.clone().unwrap_or_default()),
-                    mode: og.mode,
-                    channels: og.channels.clone(),
-                }],
-            }),
+        .filter(|og| og.device_id.is_some() && !og.channels.is_empty())
+        .map(|og| OutputEntry {
+            device_id: DeviceId(og.device_id.clone().unwrap_or_default()),
+            mode: og.mode,
+            channels: og.channels.clone(),
         })
         .collect();
+    let output_blocks: Vec<AudioBlock> = if output_entries.is_empty() {
+        Vec::new()
+    } else {
+        vec![AudioBlock {
+            id: BlockId("output:0".into()),
+            enabled: true,
+            kind: AudioBlockKind::Output(OutputBlock {
+                name: draft.outputs.first().map(|o| o.name.clone()).unwrap_or_else(|| "Output".into()),
+                entries: output_entries,
+            }),
+        }]
+    };
 
     // Get existing non-I/O blocks
     let audio_blocks: Vec<AudioBlock> = existing_chain

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -5003,18 +5003,25 @@ pub fn run_desktop_app(
             };
 
             // Handle I/O block insert mode: insert a single InputBlock at the stored position
-            if let Some(io_draft) = io_block_insert_draft_for_input_save.borrow().clone() {
+            let io_insert = io_block_insert_draft_for_input_save.borrow().clone();
+            if let Some(io_draft) = io_insert {
                 if io_draft.kind == "input" {
-                    let draft_borrow = chain_draft.borrow();
-                    let Some(draft) = draft_borrow.as_ref() else {
-                        let _ = input_window.hide();
-                        *io_block_insert_draft_for_input_save.borrow_mut() = None;
-                        return;
-                    };
-                    let Some(input_group) = draft.inputs.first().cloned() else {
-                        let _ = input_window.hide();
-                        *io_block_insert_draft_for_input_save.borrow_mut() = None;
-                        return;
+                    // Extract what we need from chain_draft, then drop the borrow
+                    let input_group = {
+                        let draft_borrow = chain_draft.borrow();
+                        let Some(draft) = draft_borrow.as_ref() else {
+                            let _ = input_window.hide();
+                            drop(draft_borrow);
+                            *io_block_insert_draft_for_input_save.borrow_mut() = None;
+                            return;
+                        };
+                        let Some(ig) = draft.inputs.first().cloned() else {
+                            let _ = input_window.hide();
+                            drop(draft_borrow);
+                            *io_block_insert_draft_for_input_save.borrow_mut() = None;
+                            return;
+                        };
+                        ig
                     };
                     if input_group.device_id.is_none() || input_group.channels.is_empty() {
                         input_window.set_status_message("Selecione dispositivo e canais.".into());
@@ -5022,16 +5029,16 @@ pub fn run_desktop_app(
                     }
                     let chain_index = io_draft.chain_index;
                     let before_index = io_draft.before_index;
-                    drop(draft_borrow);
+                    // Clear drafts BEFORE touching session to avoid borrow conflicts
+                    *io_block_insert_draft_for_input_save.borrow_mut() = None;
+                    *chain_draft.borrow_mut() = None;
                     let mut session_borrow = project_session.borrow_mut();
                     let Some(session) = session_borrow.as_mut() else {
                         let _ = input_window.hide();
-                        *io_block_insert_draft_for_input_save.borrow_mut() = None;
                         return;
                     };
                     let Some(chain) = session.project.chains.get_mut(chain_index) else {
                         let _ = input_window.hide();
-                        *io_block_insert_draft_for_input_save.borrow_mut() = None;
                         return;
                     };
                     let real_chain_id = chain.id.clone();
@@ -5057,9 +5064,6 @@ pub fn run_desktop_app(
                         &output_chain_devices,
                     );
                     sync_project_dirty(&window, session, &saved_project_snapshot, &project_dirty);
-                    drop(session_borrow);
-                    *io_block_insert_draft_for_input_save.borrow_mut() = None;
-                    *chain_draft.borrow_mut() = None;
                     input_window.set_status_message("".into());
                     let _ = input_window.hide();
                     return;
@@ -5197,18 +5201,24 @@ pub fn run_desktop_app(
             };
 
             // Handle I/O block insert mode: insert a single OutputBlock at the stored position
-            if let Some(io_draft) = io_block_insert_draft_for_output_save.borrow().clone() {
+            let io_insert = io_block_insert_draft_for_output_save.borrow().clone();
+            if let Some(io_draft) = io_insert {
                 if io_draft.kind == "output" {
-                    let draft_borrow = chain_draft.borrow();
-                    let Some(draft) = draft_borrow.as_ref() else {
-                        let _ = output_window.hide();
-                        *io_block_insert_draft_for_output_save.borrow_mut() = None;
-                        return;
-                    };
-                    let Some(output_group) = draft.outputs.first().cloned() else {
-                        let _ = output_window.hide();
-                        *io_block_insert_draft_for_output_save.borrow_mut() = None;
-                        return;
+                    let output_group = {
+                        let draft_borrow = chain_draft.borrow();
+                        let Some(draft) = draft_borrow.as_ref() else {
+                            let _ = output_window.hide();
+                            drop(draft_borrow);
+                            *io_block_insert_draft_for_output_save.borrow_mut() = None;
+                            return;
+                        };
+                        let Some(og) = draft.outputs.first().cloned() else {
+                            let _ = output_window.hide();
+                            drop(draft_borrow);
+                            *io_block_insert_draft_for_output_save.borrow_mut() = None;
+                            return;
+                        };
+                        og
                     };
                     if output_group.device_id.is_none() || output_group.channels.is_empty() {
                         output_window.set_status_message("Selecione dispositivo e canais.".into());
@@ -5216,16 +5226,15 @@ pub fn run_desktop_app(
                     }
                     let chain_index = io_draft.chain_index;
                     let before_index = io_draft.before_index;
-                    drop(draft_borrow);
+                    *io_block_insert_draft_for_output_save.borrow_mut() = None;
+                    *chain_draft.borrow_mut() = None;
                     let mut session_borrow = project_session.borrow_mut();
                     let Some(session) = session_borrow.as_mut() else {
                         let _ = output_window.hide();
-                        *io_block_insert_draft_for_output_save.borrow_mut() = None;
                         return;
                     };
                     let Some(chain) = session.project.chains.get_mut(chain_index) else {
                         let _ = output_window.hide();
-                        *io_block_insert_draft_for_output_save.borrow_mut() = None;
                         return;
                     };
                     let real_chain_id = chain.id.clone();
@@ -5251,9 +5260,6 @@ pub fn run_desktop_app(
                         &output_chain_devices,
                     );
                     sync_project_dirty(&window, session, &saved_project_snapshot, &project_dirty);
-                    drop(session_borrow);
-                    *io_block_insert_draft_for_output_save.borrow_mut() = None;
-                    *chain_draft.borrow_mut() = None;
                     output_window.set_status_message("".into());
                     let _ = output_window.hide();
                     return;

--- a/crates/adapter-gui/src/ui_state.rs
+++ b/crates/adapter-gui/src/ui_state.rs
@@ -59,6 +59,8 @@ pub fn accent_color_for_icon_kind(icon_kind: &str) -> slint::Color {
         "utility" => slint::Color::from_argb_u8(255, 0x95, 0xa0, 0xb2),
         "nam" => slint::Color::from_argb_u8(255, 0xff, 0x7c, 0xd7),
         "pitch" => slint::Color::from_argb_u8(255, 0x8f, 0x8c, 0xff),
+        "input" => slint::Color::from_argb_u8(255, 0x45, 0xa7, 0xff),
+        "output" => slint::Color::from_argb_u8(255, 0x45, 0xa7, 0xff),
         _ => slint::Color::from_argb_u8(255, 0x7f, 0xb0, 0xff),
     }
 }
@@ -103,6 +105,7 @@ pub fn block_family_for_kind(kind: &str) -> &'static str {
         EFFECT_TYPE_MODULATION => "modulation",
         EFFECT_TYPE_DELAY | EFFECT_TYPE_REVERB => "space",
         EFFECT_TYPE_UTILITY => "utility",
+        "input" | "output" => "routing",
         _ => "utility",
     }
 }

--- a/crates/adapter-gui/src/ui_state.rs
+++ b/crates/adapter-gui/src/ui_state.rs
@@ -113,10 +113,16 @@ pub fn insertion_slot_indices(block_count: usize) -> Vec<usize> {
 }
 
 pub fn chain_routing_summary(chain: &Chain) -> String {
+    let input_channels: Vec<usize> = chain.input_blocks().into_iter()
+        .flat_map(|(_, ib)| ib.channels.iter().copied())
+        .collect();
+    let output_channels: Vec<usize> = chain.output_blocks().into_iter()
+        .flat_map(|(_, ob)| ob.channels.iter().copied())
+        .collect();
     format!(
         "Entrada {} -> Saida {}",
-        channels_label(&chain.input_channels),
-        channels_label(&chain.output_channels),
+        channels_label(&input_channels),
+        channels_label(&output_channels),
     )
 }
 
@@ -132,7 +138,8 @@ fn channels_label(channels: &[usize]) -> String {
 mod tests {
     use super::{insertion_slot_indices, block_drawer_state, chain_routing_summary, BlockDrawerMode};
     use domain::ids::{DeviceId, ChainId};
-    use project::chain::{Chain, ChainInputMode, ChainOutputMixdown};
+    use project::block::{AudioBlock, AudioBlockKind, InputBlock, OutputBlock};
+    use project::chain::{Chain, ChainInputMode, ChainOutputMode};
 
     #[test]
     fn insertion_slots_cover_edges_and_between_positions() {
@@ -160,20 +167,34 @@ mod tests {
 
     #[test]
     fn routing_summary_uses_human_friendly_channel_numbers() {
+        use domain::ids::BlockId;
         let chain = Chain {
             id: ChainId("chain:1".to_string()),
             description: Some("Guitarra".to_string()),
             instrument: block_core::INST_ELECTRIC_GUITAR.to_string(),
             enabled: true,
-            inputs: Vec::new(),
-            outputs: Vec::new(),
-            input_device_id: DeviceId("in".to_string()),
-            input_channels: vec![0],
-            output_device_id: DeviceId("out".to_string()),
-            output_channels: vec![0, 1],
-            blocks: Vec::new(),
-            output_mixdown: ChainOutputMixdown::Average,
-            input_mode: ChainInputMode::Mono,
+            blocks: vec![
+                AudioBlock {
+                    id: BlockId("chain:1:input:0".into()),
+                    enabled: true,
+                    kind: AudioBlockKind::Input(InputBlock {
+                        name: "Input 1".to_string(),
+                        device_id: DeviceId("in".to_string()),
+                        mode: ChainInputMode::Mono,
+                        channels: vec![0],
+                    }),
+                },
+                AudioBlock {
+                    id: BlockId("chain:1:output:0".into()),
+                    enabled: true,
+                    kind: AudioBlockKind::Output(OutputBlock {
+                        name: "Output 1".to_string(),
+                        device_id: DeviceId("out".to_string()),
+                        mode: ChainOutputMode::Stereo,
+                        channels: vec![0, 1],
+                    }),
+                },
+            ],
         };
 
         assert_eq!(

--- a/crates/adapter-gui/src/ui_state.rs
+++ b/crates/adapter-gui/src/ui_state.rs
@@ -178,8 +178,9 @@ mod tests {
                     id: BlockId("chain:1:input:0".into()),
                     enabled: true,
                     kind: AudioBlockKind::Input(InputBlock {
-                        name: "Input 1".to_string(),
+                        model: "standard".to_string(),
                         entries: vec![InputEntry {
+                            name: "Input 1".to_string(),
                             device_id: DeviceId("in".to_string()),
                             mode: ChainInputMode::Mono,
                             channels: vec![0],
@@ -190,8 +191,9 @@ mod tests {
                     id: BlockId("chain:1:output:0".into()),
                     enabled: true,
                     kind: AudioBlockKind::Output(OutputBlock {
-                        name: "Output 1".to_string(),
+                        model: "standard".to_string(),
                         entries: vec![OutputEntry {
+                            name: "Output 1".to_string(),
                             device_id: DeviceId("out".to_string()),
                             mode: ChainOutputMode::Stereo,
                             channels: vec![0, 1],

--- a/crates/adapter-gui/src/ui_state.rs
+++ b/crates/adapter-gui/src/ui_state.rs
@@ -59,6 +59,7 @@ pub fn accent_color_for_icon_kind(icon_kind: &str) -> slint::Color {
         "utility" => slint::Color::from_argb_u8(255, 0x95, 0xa0, 0xb2),
         "nam" => slint::Color::from_argb_u8(255, 0xff, 0x7c, 0xd7),
         "pitch" => slint::Color::from_argb_u8(255, 0x8f, 0x8c, 0xff),
+        "insert" => slint::Color::from_argb_u8(255, 0xf2, 0x9f, 0x38),
         "input" => slint::Color::from_argb_u8(255, 0x45, 0xa7, 0xff),
         "output" => slint::Color::from_argb_u8(255, 0x45, 0xa7, 0xff),
         _ => slint::Color::from_argb_u8(255, 0x7f, 0xb0, 0xff),
@@ -105,7 +106,7 @@ pub fn block_family_for_kind(kind: &str) -> &'static str {
         EFFECT_TYPE_MODULATION => "modulation",
         EFFECT_TYPE_DELAY | EFFECT_TYPE_REVERB => "space",
         EFFECT_TYPE_UTILITY => "utility",
-        "input" | "output" => "routing",
+        "input" | "output" | "insert" => "routing",
         _ => "utility",
     }
 }

--- a/crates/adapter-gui/src/ui_state.rs
+++ b/crates/adapter-gui/src/ui_state.rs
@@ -114,10 +114,10 @@ pub fn insertion_slot_indices(block_count: usize) -> Vec<usize> {
 
 pub fn chain_routing_summary(chain: &Chain) -> String {
     let input_channels: Vec<usize> = chain.input_blocks().into_iter()
-        .flat_map(|(_, ib)| ib.channels.iter().copied())
+        .flat_map(|(_, ib)| ib.entries.iter().flat_map(|e| e.channels.iter().copied()))
         .collect();
     let output_channels: Vec<usize> = chain.output_blocks().into_iter()
-        .flat_map(|(_, ob)| ob.channels.iter().copied())
+        .flat_map(|(_, ob)| ob.entries.iter().flat_map(|e| e.channels.iter().copied()))
         .collect();
     format!(
         "Entrada {} -> Saida {}",
@@ -138,7 +138,7 @@ fn channels_label(channels: &[usize]) -> String {
 mod tests {
     use super::{insertion_slot_indices, block_drawer_state, chain_routing_summary, BlockDrawerMode};
     use domain::ids::{DeviceId, ChainId};
-    use project::block::{AudioBlock, AudioBlockKind, InputBlock, OutputBlock};
+    use project::block::{AudioBlock, AudioBlockKind, InputBlock, InputEntry, OutputBlock, OutputEntry};
     use project::chain::{Chain, ChainInputMode, ChainOutputMode};
 
     #[test]
@@ -179,9 +179,11 @@ mod tests {
                     enabled: true,
                     kind: AudioBlockKind::Input(InputBlock {
                         name: "Input 1".to_string(),
-                        device_id: DeviceId("in".to_string()),
-                        mode: ChainInputMode::Mono,
-                        channels: vec![0],
+                        entries: vec![InputEntry {
+                            device_id: DeviceId("in".to_string()),
+                            mode: ChainInputMode::Mono,
+                            channels: vec![0],
+                        }],
                     }),
                 },
                 AudioBlock {
@@ -189,9 +191,11 @@ mod tests {
                     enabled: true,
                     kind: AudioBlockKind::Output(OutputBlock {
                         name: "Output 1".to_string(),
-                        device_id: DeviceId("out".to_string()),
-                        mode: ChainOutputMode::Stereo,
-                        channels: vec![0, 1],
+                        entries: vec![OutputEntry {
+                            device_id: DeviceId("out".to_string()),
+                            mode: ChainOutputMode::Stereo,
+                            channels: vec![0, 1],
+                        }],
                     }),
                 },
             ],

--- a/crates/adapter-gui/ui/app-window.slint
+++ b/crates/adapter-gui/ui/app-window.slint
@@ -182,11 +182,15 @@ export component ChainInputGroupsWindow inherits Window {
     default-font-size: 13px;
     in property <[IoGroupItem]> groups;
     in-out property <string> status-message;
+    in property <bool> show-block-controls: false;
+    in property <bool> block-enabled: true;
     callback edit-group(int);
     callback remove-group(int);
     callback add-group();
     callback save();
     callback cancel();
+    callback toggle-enabled();
+    callback delete-block();
     title: "OpenRig \u{00B7} Entradas da chain";
     min-width: 720px;
     min-height: 620px;
@@ -201,11 +205,15 @@ export component ChainInputGroupsWindow inherits Window {
         add-label: "+ Adicionar entrada";
         groups: root.groups;
         status-message <=> root.status-message;
+        show-block-controls: root.show-block-controls;
+        block-enabled: root.block-enabled;
         edit-group(index) => { root.edit-group(index); }
         remove-group(index) => { root.remove-group(index); }
         add-group => { root.add-group(); }
         save => { root.save(); }
         cancel => { root.cancel(); }
+        toggle-enabled => { root.toggle-enabled(); }
+        delete-block => { root.delete-block(); }
     }
 }
 
@@ -215,11 +223,15 @@ export component ChainOutputGroupsWindow inherits Window {
     default-font-size: 13px;
     in property <[IoGroupItem]> groups;
     in-out property <string> status-message;
+    in property <bool> show-block-controls: false;
+    in property <bool> block-enabled: true;
     callback edit-group(int);
     callback remove-group(int);
     callback add-group();
     callback save();
     callback cancel();
+    callback toggle-enabled();
+    callback delete-block();
     title: "OpenRig \u{00B7} Sa\u{00ED}das da chain";
     min-width: 720px;
     min-height: 620px;
@@ -234,11 +246,15 @@ export component ChainOutputGroupsWindow inherits Window {
         add-label: "+ Adicionar sa\u{00ED}da";
         groups: root.groups;
         status-message <=> root.status-message;
+        show-block-controls: root.show-block-controls;
+        block-enabled: root.block-enabled;
         edit-group(index) => { root.edit-group(index); }
         remove-group(index) => { root.remove-group(index); }
         add-group => { root.add-group(); }
         save => { root.save(); }
         cancel => { root.cancel(); }
+        toggle-enabled => { root.toggle-enabled(); }
+        delete-block => { root.delete-block(); }
     }
 }
 

--- a/crates/adapter-gui/ui/app-window.slint
+++ b/crates/adapter-gui/ui/app-window.slint
@@ -1,7 +1,7 @@
 import { ChannelOptionItem, DeviceSelectionItem, ProjectChainItem, RecentProjectItem, BlockModelPickerItem, BlockParameterItem, BlockTypePickerItem, BlockKnobOverlay, CompactBlockItem, BlockStreamData, BlockStreamEntry, IoGroupItem } from "models.slint";
 import { DesktopMain } from "desktop_main.slint";
 import { TouchMain } from "touch_main.slint";
-import { ProjectSettingsPage, ChainEditorPage, ChainEndpointEditorPage, BlockEditorPanel, BlockPanelEditor, CompactChainViewPage, ChainIoGroupsPage } from "pages/pages.slint";
+import { ProjectSettingsPage, ChainEditorPage, ChainEndpointEditorPage, ChainInsertEditorPage, BlockEditorPanel, BlockPanelEditor, CompactChainViewPage, ChainIoGroupsPage } from "pages/pages.slint";
 import { Toast } from "components/toast.slint";
 
 export component ProjectSettingsWindow inherits Window {
@@ -255,6 +255,71 @@ export component ChainOutputGroupsWindow inherits Window {
         cancel => { root.cancel(); }
         toggle-enabled => { root.toggle-enabled(); }
         delete-block => { root.delete-block(); }
+    }
+}
+
+export component ChainInsertWindow inherits Window {
+    icon: @image-url("assets/openrig-logomark.svg");
+    default-font-family: "Ek Mukta";
+    default-font-size: 13px;
+    // Send (output devices)
+    in property <[string]> send-device-options;
+    in-out property <int> selected-send-device-index;
+    in property <[ChannelOptionItem]> send-channels;
+    in-out property <int> selected-send-mode-index: 0;
+    // Return (input devices)
+    in property <[string]> return-device-options;
+    in-out property <int> selected-return-device-index;
+    in property <[ChannelOptionItem]> return-channels;
+    in-out property <int> selected-return-mode-index: 0;
+    // Block controls
+    in property <bool> show-block-controls: false;
+    in property <bool> block-enabled: true;
+    in-out property <string> status-message;
+    // Callbacks
+    callback select-send-device(int);
+    callback toggle-send-channel(int, bool);
+    callback select-send-mode(int);
+    callback select-return-device(int);
+    callback toggle-return-channel(int, bool);
+    callback select-return-mode(int);
+    callback toggle-enabled();
+    callback delete-block();
+    callback save();
+    callback cancel();
+
+    title: "OpenRig \u{00B7} Configurar Insert";
+    min-width: 720px;
+    min-height: 720px;
+    preferred-width: 860px;
+    preferred-height: 820px;
+    background: #040708;
+
+    ChainInsertEditorPage {
+        width: parent.width;
+        height: parent.height;
+        title: "Configurar Insert";
+        send-device-options: root.send-device-options;
+        selected-send-device-index <=> root.selected-send-device-index;
+        send-channels: root.send-channels;
+        selected-send-mode-index <=> root.selected-send-mode-index;
+        return-device-options: root.return-device-options;
+        selected-return-device-index <=> root.selected-return-device-index;
+        return-channels: root.return-channels;
+        selected-return-mode-index <=> root.selected-return-mode-index;
+        show-block-controls: root.show-block-controls;
+        block-enabled: root.block-enabled;
+        status-message: root.status-message;
+        select-send-device(index) => { root.select-send-device(index); }
+        toggle-send-channel(index, selected) => { root.toggle-send-channel(index, selected); }
+        select-send-mode(index) => { root.select-send-mode(index); }
+        select-return-device(index) => { root.select-return-device(index); }
+        toggle-return-channel(index, selected) => { root.toggle-return-channel(index, selected); }
+        select-return-mode(index) => { root.select-return-mode(index); }
+        toggle-enabled => { root.toggle-enabled(); }
+        delete-block => { root.delete-block(); }
+        save => { root.save(); }
+        cancel => { root.cancel(); }
     }
 }
 

--- a/crates/adapter-gui/ui/assets/input_arrow.svg
+++ b/crates/adapter-gui/ui/assets/input_arrow.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M8 24H36M36 24L24 14M36 24L24 34" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect x="36" y="12" width="4" height="24" rx="1" fill="currentColor"/>
+</svg>

--- a/crates/adapter-gui/ui/assets/insert_loop.svg
+++ b/crates/adapter-gui/ui/assets/insert_loop.svg
@@ -1,0 +1,6 @@
+<svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M32 16H20C15.58 16 12 19.58 12 24C12 28.42 15.58 32 20 32" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+  <path d="M16 32H28C32.42 32 36 28.42 36 24C36 19.58 32.42 16 28 16" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+  <path d="M28 12L32 16L28 20" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M20 28L16 32L20 36" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/crates/adapter-gui/ui/assets/output_arrow.svg
+++ b/crates/adapter-gui/ui/assets/output_arrow.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="8" y="12" width="4" height="24" rx="1" fill="currentColor"/>
+  <path d="M16 24H40M40 24L28 14M40 24L28 34" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/crates/adapter-gui/ui/components/effect_type_icon.slint
+++ b/crates/adapter-gui/ui/components/effect_type_icon.slint
@@ -21,6 +21,8 @@ export component EffectTypeIcon inherits Image {
         : root.icon-kind == "utility" ? @image-url("../assets/util.svg")
         : root.icon-kind == "nam" ? @image-url("../assets/nam.svg")
         : root.icon-kind == "pitch" ? @image-url("../assets/pitch.svg")
+        : root.icon-kind == "input" ? @image-url("../assets/input_arrow.svg")
+        : root.icon-kind == "output" ? @image-url("../assets/output_arrow.svg")
         : @image-url("../assets/gear.svg");
     image-fit: contain;
     colorize: root.tint;

--- a/crates/adapter-gui/ui/components/effect_type_icon.slint
+++ b/crates/adapter-gui/ui/components/effect_type_icon.slint
@@ -21,6 +21,7 @@ export component EffectTypeIcon inherits Image {
         : root.icon-kind == "utility" ? @image-url("../assets/util.svg")
         : root.icon-kind == "nam" ? @image-url("../assets/nam.svg")
         : root.icon-kind == "pitch" ? @image-url("../assets/pitch.svg")
+        : root.icon-kind == "insert" ? @image-url("../assets/insert_loop.svg")
         : root.icon-kind == "input" ? @image-url("../assets/input_arrow.svg")
         : root.icon-kind == "output" ? @image-url("../assets/output_arrow.svg")
         : @image-url("../assets/gear.svg");

--- a/crates/adapter-gui/ui/models.slint
+++ b/crates/adapter-gui/ui/models.slint
@@ -13,6 +13,7 @@ export struct ChainBlockItem {
     label: string,
     family: string,
     enabled: bool,
+    hidden: bool,
     thumbnail: image,
     has_thumbnail: bool,
     thumb_width: float,

--- a/crates/adapter-gui/ui/models.slint
+++ b/crates/adapter-gui/ui/models.slint
@@ -13,7 +13,7 @@ export struct ChainBlockItem {
     label: string,
     family: string,
     enabled: bool,
-    hidden: bool,
+    real_index: int,
     thumbnail: image,
     has_thumbnail: bool,
     thumb_width: float,

--- a/crates/adapter-gui/ui/pages/chain_insert_editor.slint
+++ b/crates/adapter-gui/ui/pages/chain_insert_editor.slint
@@ -1,0 +1,480 @@
+import { ComboBox, ScrollView } from "std-widgets.slint";
+import { ChannelOptionItem } from "../models.slint";
+
+component FooterButton inherits Rectangle {
+    in property <string> label;
+    in property <bool> primary: false;
+    in property <bool> danger: false;
+    callback clicked();
+
+    width: primary ? 80px : 96px;
+    height: 36px;
+    background: root.danger ? #5a1520 : (root.primary ? #188cff : #2a2f38);
+    border-width: 1px;
+    border-color: root.danger ? #ff4455 : (root.primary ? #45a7ff : #41464f);
+    border-radius: 6px;
+
+    Text {
+        width: parent.width;
+        height: parent.height;
+        text: root.label;
+        color: root.danger ? #ff4455 : #f4f7fb;
+        horizontal-alignment: center;
+        vertical-alignment: center;
+        font-size: 13px;
+        font-weight: 700;
+    }
+
+    TouchArea {
+        width: parent.width;
+        height: parent.height;
+        mouse-cursor: pointer;
+        clicked => { root.clicked(); }
+    }
+}
+
+component ChannelRow inherits Rectangle {
+    in property <ChannelOptionItem> channel;
+    callback toggled(bool);
+
+    height: 40px;
+    background: transparent;
+
+    Rectangle {
+        x: 0px;
+        y: parent.height - 1px;
+        width: parent.width;
+        height: 1px;
+        background: #252a33;
+    }
+
+    Rectangle {
+        x: 0px;
+        y: 10px;
+        width: 20px;
+        height: 20px;
+        background: root.channel.selected ? #188cff : #1e2229;
+        border-width: 1px;
+        border-color: root.channel.selected ? #45a7ff : (root.channel.available ? #3d4450 : #2a2f38);
+        border-radius: 4px;
+        opacity: root.channel.available ? 1 : 0.4;
+
+        if root.channel.selected : Text {
+            width: parent.width;
+            height: parent.height;
+            text: "\u{2713}";
+            color: #ffffff;
+            font-size: 12px;
+            font-weight: 700;
+            horizontal-alignment: center;
+            vertical-alignment: center;
+        }
+    }
+
+    Text {
+        x: 32px;
+        y: 0px;
+        width: parent.width - 32px;
+        height: parent.height;
+        text: root.channel.label;
+        color: root.channel.available
+            ? (root.channel.selected ? #edf2f9 : #8a95a5)
+            : #4a5060;
+        font-size: 13px;
+        font-weight: root.channel.selected ? 600 : 400;
+        vertical-alignment: center;
+    }
+
+    if root.channel.available : TouchArea {
+        x: 0px;
+        y: 0px;
+        width: parent.width;
+        height: parent.height;
+        mouse-cursor: pointer;
+        clicked => { root.toggled(!root.channel.selected); }
+    }
+}
+
+export component ChainInsertEditorPage inherits Rectangle {
+    in property <string> title: "Configurar Insert";
+    // Send (output devices)
+    in property <[string]> send-device-options;
+    in-out property <int> selected-send-device-index;
+    in property <[ChannelOptionItem]> send-channels;
+    in-out property <int> selected-send-mode-index: 0;
+    // Return (input devices)
+    in property <[string]> return-device-options;
+    in-out property <int> selected-return-device-index;
+    in property <[ChannelOptionItem]> return-channels;
+    in-out property <int> selected-return-mode-index: 0;
+    // Block controls
+    in property <bool> show-block-controls: false;
+    in property <bool> block-enabled: true;
+    in-out property <string> status-message;
+    // Callbacks
+    callback select-send-device(int);
+    callback toggle-send-channel(int, bool);
+    callback select-send-mode(int);
+    callback select-return-device(int);
+    callback toggle-return-channel(int, bool);
+    callback select-return-mode(int);
+    callback toggle-enabled();
+    callback delete-block();
+    callback save();
+    callback cancel();
+
+    background: #171a1f;
+
+    // Title
+    Text {
+        x: 32px;
+        y: 24px;
+        width: parent.width - 96px;
+        height: 28px;
+        text: root.title;
+        color: #edf2f9;
+        font-size: 20px;
+        font-weight: 800;
+    }
+
+    // Block controls (enable/disable + delete) — only for middle blocks
+    if root.show-block-controls : Rectangle {
+        x: parent.width - 96px;
+        y: 20px;
+        width: 64px;
+        height: 32px;
+        background: transparent;
+
+        Rectangle {
+            x: 0px;
+            y: 4px;
+            width: 24px;
+            height: 24px;
+            border-radius: 4px;
+            background: toggle-hover.has-hover ? #1e2229 : transparent;
+
+            Rectangle {
+                x: 8px;
+                y: 8px;
+                width: 8px;
+                height: 8px;
+                border-radius: 4px;
+                background: root.block-enabled ? #29df85 : #697382;
+            }
+
+            toggle-hover := TouchArea {
+                width: parent.width;
+                height: parent.height;
+                mouse-cursor: pointer;
+                clicked => { root.toggle-enabled(); }
+            }
+        }
+
+        Rectangle {
+            x: 32px;
+            y: 4px;
+            width: 24px;
+            height: 24px;
+            border-radius: 4px;
+            background: delete-hover.has-hover ? #2a1015 : transparent;
+
+            Image {
+                x: 2px;
+                y: 2px;
+                width: 20px;
+                height: 20px;
+                source: @image-url("../assets/trash.svg");
+                colorize: delete-hover.has-hover ? #ff4455 : #5a6270;
+                image-fit: contain;
+            }
+
+            delete-hover := TouchArea {
+                width: parent.width;
+                height: parent.height;
+                mouse-cursor: pointer;
+                clicked => { root.delete-block(); }
+            }
+        }
+    }
+
+    Rectangle {
+        x: 32px;
+        y: 60px;
+        width: parent.width - 64px;
+        height: 1px;
+        background: #2a2f38;
+    }
+
+    // ===== SEND SECTION =====
+    Text {
+        x: 32px;
+        y: 72px;
+        width: 200px;
+        height: 20px;
+        text: "Envio";
+        color: #edf2f9;
+        font-size: 15px;
+        font-weight: 700;
+    }
+
+    Text {
+        x: 32px;
+        y: 98px;
+        width: 120px;
+        height: 16px;
+        text: "Dispositivo";
+        color: #7a8694;
+        font-size: 11px;
+        font-weight: 600;
+    }
+
+    ComboBox {
+        x: 32px;
+        y: 116px;
+        width: parent.width - 64px;
+        height: 36px;
+        model: root.send-device-options;
+        current-index <=> root.selected-send-device-index;
+        selected(value) => { root.select-send-device(self.current-index); }
+    }
+
+    // Send mode selector
+    Text {
+        x: 32px;
+        y: 162px;
+        width: 120px;
+        height: 16px;
+        text: "Modo";
+        color: #7a8694;
+        font-size: 11px;
+        font-weight: 600;
+    }
+
+    Rectangle {
+        x: 32px;
+        y: 180px;
+        width: parent.width - 64px;
+        height: 36px;
+        background: transparent;
+
+        for label[index] in ["Mono", "Stereo"] : Rectangle {
+            x: index * 120px;
+            y: 0px;
+            width: 108px;
+            height: 36px;
+            background: index == root.selected-send-mode-index ? #2a5da8 : #1d2025;
+            border-width: 1px;
+            border-color: index == root.selected-send-mode-index ? #45a7ff : #41454e;
+            border-radius: 4px;
+
+            Text {
+                width: parent.width;
+                height: parent.height;
+                text: label;
+                color: index == root.selected-send-mode-index ? #f4f7fb : #8a94a2;
+                horizontal-alignment: center;
+                vertical-alignment: center;
+                font-size: 12px;
+                font-weight: 600;
+            }
+
+            TouchArea {
+                width: parent.width;
+                height: parent.height;
+                mouse-cursor: pointer;
+                clicked => {
+                    root.selected-send-mode-index = index;
+                    root.select-send-mode(index);
+                }
+            }
+        }
+    }
+
+    // Send channels
+    Text {
+        x: 32px;
+        y: 226px;
+        width: 120px;
+        height: 16px;
+        text: "Canais";
+        color: #7a8694;
+        font-size: 11px;
+        font-weight: 600;
+    }
+
+    // Each section takes half the remaining vertical space (total - fixed header/footer)
+    // Fixed: title 72px + send header 172px + footer 56px + return header 192px = 492px
+    // Channel areas split the remainder equally
+    private property <length> channel-area-height: (root.height - 560px) / 2;
+
+    ScrollView {
+        x: 32px;
+        y: 244px;
+        width: parent.width - 64px;
+        height: root.channel-area-height;
+        viewport-width: self.width;
+        viewport-height: Math.max(self.height, root.send-channels.length * 40px);
+
+        for channel[index] in root.send-channels : ChannelRow {
+            x: 0px;
+            y: index * 40px;
+            width: parent.width - 8px;
+            channel: channel;
+            toggled(selected) => { root.toggle-send-channel(index, selected); }
+        }
+    }
+
+    // Separator between sections
+    private property <length> return-start: 244px + root.channel-area-height + 8px;
+
+    Rectangle {
+        x: 32px;
+        y: root.return-start;
+        width: parent.width - 64px;
+        height: 1px;
+        background: #2a2f38;
+    }
+
+    // ===== RETURN SECTION =====
+    Text {
+        x: 32px;
+        y: root.return-start + 12px;
+        width: 200px;
+        height: 20px;
+        text: "Retorno";
+        color: #edf2f9;
+        font-size: 15px;
+        font-weight: 700;
+    }
+
+    Text {
+        x: 32px;
+        y: root.return-start + 38px;
+        width: 120px;
+        height: 16px;
+        text: "Dispositivo";
+        color: #7a8694;
+        font-size: 11px;
+        font-weight: 600;
+    }
+
+    ComboBox {
+        x: 32px;
+        y: root.return-start + 56px;
+        width: parent.width - 64px;
+        height: 36px;
+        model: root.return-device-options;
+        current-index <=> root.selected-return-device-index;
+        selected(value) => { root.select-return-device(self.current-index); }
+    }
+
+    // Return mode selector
+    Text {
+        x: 32px;
+        y: root.return-start + 102px;
+        width: 120px;
+        height: 16px;
+        text: "Modo";
+        color: #7a8694;
+        font-size: 11px;
+        font-weight: 600;
+    }
+
+    Rectangle {
+        x: 32px;
+        y: root.return-start + 120px;
+        width: parent.width - 64px;
+        height: 36px;
+        background: transparent;
+
+        for label[index] in ["Mono", "Stereo"] : Rectangle {
+            x: index * 120px;
+            y: 0px;
+            width: 108px;
+            height: 36px;
+            background: index == root.selected-return-mode-index ? #2a5da8 : #1d2025;
+            border-width: 1px;
+            border-color: index == root.selected-return-mode-index ? #45a7ff : #41454e;
+            border-radius: 4px;
+
+            Text {
+                width: parent.width;
+                height: parent.height;
+                text: label;
+                color: index == root.selected-return-mode-index ? #f4f7fb : #8a94a2;
+                horizontal-alignment: center;
+                vertical-alignment: center;
+                font-size: 12px;
+                font-weight: 600;
+            }
+
+            TouchArea {
+                width: parent.width;
+                height: parent.height;
+                mouse-cursor: pointer;
+                clicked => {
+                    root.selected-return-mode-index = index;
+                    root.select-return-mode(index);
+                }
+            }
+        }
+    }
+
+    // Return channels
+    Text {
+        x: 32px;
+        y: root.return-start + 166px;
+        width: 120px;
+        height: 16px;
+        text: "Canais";
+        color: #7a8694;
+        font-size: 11px;
+        font-weight: 600;
+    }
+
+    ScrollView {
+        x: 32px;
+        y: root.return-start + 184px;
+        width: parent.width - 64px;
+        height: root.height - root.return-start - 184px - 56px;
+        viewport-width: self.width;
+        viewport-height: Math.max(self.height, root.return-channels.length * 40px);
+
+        for channel[index] in root.return-channels : ChannelRow {
+            x: 0px;
+            y: index * 40px;
+            width: parent.width - 8px;
+            channel: channel;
+            toggled(selected) => { root.toggle-return-channel(index, selected); }
+        }
+    }
+
+    // Status message
+    if root.status-message != "" : Text {
+        x: 32px;
+        y: parent.height - 48px;
+        width: parent.width - 220px;
+        height: 16px;
+        text: root.status-message;
+        color: #ff6b6b;
+        font-size: 12px;
+        font-weight: 500;
+        vertical-alignment: center;
+    }
+
+    // Footer buttons
+    FooterButton {
+        x: parent.width - 196px;
+        y: parent.height - 52px;
+        label: "Cancelar";
+        clicked => { root.cancel(); }
+    }
+
+    FooterButton {
+        x: parent.width - 92px;
+        y: parent.height - 52px;
+        label: "OK";
+        primary: true;
+        clicked => { root.save(); }
+    }
+}

--- a/crates/adapter-gui/ui/pages/chain_io_groups.slint
+++ b/crates/adapter-gui/ui/pages/chain_io_groups.slint
@@ -177,23 +177,87 @@ export component ChainIoGroupsPage inherits Rectangle {
     in property <string> add-label;
     in property <[IoGroupItem]> groups;
     in-out property <string> status-message;
+    in property <bool> show-block-controls: false;
+    in property <bool> block-enabled: true;
     callback edit-group(int);
     callback remove-group(int);
     callback add-group();
     callback save();
     callback cancel();
+    callback toggle-enabled();
+    callback delete-block();
 
     background: #171a1f;
 
     Text {
         x: 32px;
         y: 28px;
-        width: parent.width - 64px;
+        width: parent.width - 100px;
         height: 28px;
         text: root.title;
         color: #edf2f9;
         font-size: 20px;
         font-weight: 800;
+    }
+
+    // Block controls (enable/disable + delete) — only for middle I/O blocks
+    if root.show-block-controls : Rectangle {
+        x: parent.width - 96px;
+        y: 24px;
+        width: 64px;
+        height: 32px;
+        background: transparent;
+
+        Rectangle {
+            x: 0px;
+            y: 4px;
+            width: 24px;
+            height: 24px;
+            border-radius: 4px;
+            background: toggle-hover.has-hover ? #1e2229 : transparent;
+
+            Rectangle {
+                x: 8px;
+                y: 8px;
+                width: 8px;
+                height: 8px;
+                border-radius: 4px;
+                background: root.block-enabled ? #29df85 : #697382;
+            }
+
+            toggle-hover := TouchArea {
+                width: parent.width;
+                height: parent.height;
+                mouse-cursor: pointer;
+                clicked => { root.toggle-enabled(); }
+            }
+        }
+
+        Rectangle {
+            x: 32px;
+            y: 4px;
+            width: 24px;
+            height: 24px;
+            border-radius: 4px;
+            background: delete-hover.has-hover ? #2a1015 : transparent;
+
+            Image {
+                x: 2px;
+                y: 2px;
+                width: 20px;
+                height: 20px;
+                source: @image-url("../assets/trash.svg");
+                colorize: delete-hover.has-hover ? #ff4455 : #5a6270;
+                image-fit: contain;
+            }
+
+            delete-hover := TouchArea {
+                width: parent.width;
+                height: parent.height;
+                mouse-cursor: pointer;
+                clicked => { root.delete-block(); }
+            }
+        }
     }
 
     Rectangle {

--- a/crates/adapter-gui/ui/pages/chain_io_groups.slint
+++ b/crates/adapter-gui/ui/pages/chain_io_groups.slint
@@ -78,21 +78,20 @@ component IoGroupRow inherits Rectangle {
     // Remove button
     Rectangle {
         x: parent.width - 52px;
-        y: 10px;
-        width: 24px;
-        height: 32px;
+        y: 12px;
+        width: 28px;
+        height: 28px;
         border-radius: 4px;
         background: remove-hover.has-hover ? #2a1015 : transparent;
 
-        Text {
-            width: parent.width;
-            height: parent.height;
-            text: "—";
-            color: remove-hover.has-hover ? #ff4455 : #5a6270;
-            font-size: 16px;
-            font-weight: 700;
-            horizontal-alignment: center;
-            vertical-alignment: center;
+        Image {
+            x: 4px;
+            y: 4px;
+            width: 20px;
+            height: 20px;
+            source: @image-url("../assets/trash.svg");
+            colorize: remove-hover.has-hover ? #ff4455 : #5a6270;
+            image-fit: contain;
         }
 
         remove-hover := TouchArea {

--- a/crates/adapter-gui/ui/pages/chain_io_groups.slint
+++ b/crates/adapter-gui/ui/pages/chain_io_groups.slint
@@ -82,18 +82,20 @@ component IoGroupRow inherits Rectangle {
         width: 24px;
         height: 32px;
         border-radius: 4px;
+        background: remove-hover.has-hover ? #2a1015 : transparent;
 
         Text {
             width: parent.width;
             height: parent.height;
-            text: "\u{2715}";
-            color: #5a6270;
-            font-size: 13px;
+            text: "—";
+            color: remove-hover.has-hover ? #ff4455 : #5a6270;
+            font-size: 16px;
+            font-weight: 700;
             horizontal-alignment: center;
             vertical-alignment: center;
         }
 
-        TouchArea {
+        remove-hover := TouchArea {
             width: parent.width;
             height: parent.height;
             mouse-cursor: pointer;

--- a/crates/adapter-gui/ui/pages/pages.slint
+++ b/crates/adapter-gui/ui/pages/pages.slint
@@ -4,11 +4,12 @@ import { ProjectSettingsPage } from "project_settings.slint";
 import { ProjectChainsPage, BlockEditorPanel } from "project_chains.slint";
 import { ChainEditorPage } from "chain_editor.slint";
 import { ChainEndpointEditorPage } from "chain_endpoint_editor.slint";
+import { ChainInsertEditorPage } from "chain_insert_editor.slint";
 import { BlockPanelEditor } from "block_panel_editor.slint";
 import { CompactChainViewPage } from "compact_chain_view.slint";
 import { ChainIoGroupsPage } from "chain_io_groups.slint";
 
-export { ProjectLauncherPage, ProjectSetupPage, ProjectSettingsPage, ProjectChainsPage, BlockEditorPanel, ChainEditorPage, ChainEndpointEditorPage, BlockPanelEditor, CompactChainViewPage, ChainIoGroupsPage }
+export { ProjectLauncherPage, ProjectSetupPage, ProjectSettingsPage, ProjectChainsPage, BlockEditorPanel, ChainEditorPage, ChainEndpointEditorPage, ChainInsertEditorPage, BlockPanelEditor, CompactChainViewPage, ChainIoGroupsPage }
 
 export component WizardConfigPage inherits Rectangle {
     background: transparent;

--- a/crates/adapter-gui/ui/pages/project_chains.slint
+++ b/crates/adapter-gui/ui/pages/project_chains.slint
@@ -807,8 +807,9 @@ component BlockChip inherits Rectangle {
     property <float> drag-origin-x: 0;
     property <float> drag-origin-y: 0;
 
-    width: 84px;
-    height: 100px;
+    width: root.block.hidden ? 0px : 84px;
+    height: root.block.hidden ? 0px : 100px;
+    visible: !root.block.hidden;
     background: transparent;
     border-width: 0px;
     border-radius: 6px;

--- a/crates/adapter-gui/ui/pages/project_chains.slint
+++ b/crates/adapter-gui/ui/pages/project_chains.slint
@@ -807,9 +807,8 @@ component BlockChip inherits Rectangle {
     property <float> drag-origin-x: 0;
     property <float> drag-origin-y: 0;
 
-    width: root.block.hidden ? 0px : 84px;
-    height: root.block.hidden ? 0px : 100px;
-    visible: !root.block.hidden;
+    width: 84px;
+    height: 100px;
     background: transparent;
     border-width: 0px;
     border-radius: 6px;
@@ -1329,22 +1328,22 @@ component ChainRow inherits Rectangle {
             x: 120px + Math.mod(block-index, root.blocks-per-row) * 116px;
             y: Math.floor(block-index / root.blocks-per-row) * 108px;
             block: block;
-            selected: root.dragging-chain-index == root.chain-index && root.dragging-block-index == block-index
+            selected: root.dragging-chain-index == root.chain-index && root.dragging-block-index == block.real_index
                 ? false
-                : root.selected-block-chain-index == root.chain-index && root.selected-block-index == block-index;
-            dragging: root.dragging-chain-index == root.chain-index && root.dragging-block-index == block-index;
-            clicked => { root.select-chain-block(root.chain-index, block-index); }
+                : root.selected-block-chain-index == root.chain-index && root.selected-block-index == block.real_index;
+            dragging: root.dragging-chain-index == root.chain-index && root.dragging-block-index == block.real_index;
+            clicked => { root.select-chain-block(root.chain-index, block.real_index); }
             drag-moved(pointer-x, pointer-y) => {
                 root.suppress-insert-hover = false;
                 root.dragging-chain-index = root.chain-index;
-                root.dragging-block-index = block-index;
+                root.dragging-block-index = block.real_index;
                 root.drag-hover-before-index = root.slot-index-for-position(pointer-x, pointer-y);
             }
             drag-finished(pointer-x, pointer-y) => {
-                if root.dragging-chain-index == root.chain-index && root.dragging-block-index == block-index {
+                if root.dragging-chain-index == root.chain-index && root.dragging-block-index == block.real_index {
                     let before-index = root.slot-index-for-position(pointer-x, pointer-y);
                     root.drag-hover-before-index = before-index;
-                    root.reorder-chain-block(root.chain-index, block-index, before-index);
+                    root.reorder-chain-block(root.chain-index, block.real_index, before-index);
                     root.dragging-chain-index = -1;
                     root.dragging-block-index = -1;
                     root.drag-hover-before-index = -1;

--- a/crates/application/src/validate.rs
+++ b/crates/application/src/validate.rs
@@ -35,52 +35,60 @@ pub fn validate_project(project: &Project) -> Result<()> {
             );
         }
 
-        // Validate each input block
+        // Validate each input block's entries
         for (_, input) in &input_blocks {
-            if input.device_id.0.trim().is_empty() {
-                bail!(
-                    "invalid project: chain '{}' input '{}' missing device_id",
-                    chain.id.0,
-                    input.name
-                );
+            for entry in &input.entries {
+                if entry.device_id.0.trim().is_empty() {
+                    bail!(
+                        "invalid project: chain '{}' input '{}' missing device_id",
+                        chain.id.0,
+                        input.name
+                    );
+                }
+                if entry.channels.is_empty() {
+                    bail!(
+                        "invalid project: chain '{}' input '{}' has no channels",
+                        chain.id.0,
+                        input.name
+                    );
+                }
+                validate_unique_channels(&entry.channels)
+                    .map_err(|error| anyhow!("invalid project: chain '{}' input '{}': {}", chain.id.0, input.name, error))?;
             }
-            if input.channels.is_empty() {
-                bail!(
-                    "invalid project: chain '{}' input '{}' has no channels",
-                    chain.id.0,
-                    input.name
-                );
-            }
-            validate_unique_channels(&input.channels)
-                .map_err(|error| anyhow!("invalid project: chain '{}' input '{}': {}", chain.id.0, input.name, error))?;
         }
 
-        // Validate each output block
+        // Validate each output block's entries
         for (_, output) in &output_blocks {
-            if output.device_id.0.trim().is_empty() {
-                bail!(
-                    "invalid project: chain '{}' output '{}' missing device_id",
-                    chain.id.0,
-                    output.name
-                );
+            for entry in &output.entries {
+                if entry.device_id.0.trim().is_empty() {
+                    bail!(
+                        "invalid project: chain '{}' output '{}' missing device_id",
+                        chain.id.0,
+                        output.name
+                    );
+                }
+                if entry.channels.is_empty() {
+                    bail!(
+                        "invalid project: chain '{}' output '{}' has no channels",
+                        chain.id.0,
+                        output.name
+                    );
+                }
+                validate_unique_channels(&entry.channels)
+                    .map_err(|error| anyhow!("invalid project: chain '{}' output '{}': {}", chain.id.0, output.name, error))?;
             }
-            if output.channels.is_empty() {
-                bail!(
-                    "invalid project: chain '{}' output '{}' has no channels",
-                    chain.id.0,
-                    output.name
-                );
-            }
-            validate_unique_channels(&output.channels)
-                .map_err(|error| anyhow!("invalid project: chain '{}' output '{}': {}", chain.id.0, output.name, error))?;
         }
 
-        // Use first input's channel count for layout determination
+        // Use first input entry's channel count for layout determination
         let first_input = input_blocks.first().expect("validated non-empty");
+        let first_input_entry = first_input.1.entries.first()
+            .ok_or_else(|| anyhow!("invalid project: chain '{}' input '{}' has no entries", chain.id.0, first_input.1.name))?;
         let input_layout =
-            layout_from_channel_count("chain input", &chain.id.0, first_input.1.channels.len())?;
+            layout_from_channel_count("chain input", &chain.id.0, first_input_entry.channels.len())?;
         let first_output = output_blocks.first().expect("validated non-empty");
-        layout_from_channel_count("chain output", &chain.id.0, first_output.1.channels.len())?;
+        let first_output_entry = first_output.1.entries.first()
+            .ok_or_else(|| anyhow!("invalid project: chain '{}' output '{}' has no entries", chain.id.0, first_output.1.name))?;
+        layout_from_channel_count("chain output", &chain.id.0, first_output_entry.channels.len())?;
 
         // Validate only audio blocks (non-I/O)
         let audio_blocks: Vec<&AudioBlock> = chain.blocks.iter()
@@ -135,16 +143,18 @@ fn validate_active_chain_input_channel_conflicts(chains: &[Chain]) -> Result<()>
     let mut claimed_channels: HashMap<(String, usize), String> = HashMap::new();
     for chain in chains.iter().filter(|chain| chain.enabled) {
         for (_, input) in chain.input_blocks() {
-            for channel in &input.channels {
-                let key = (input.device_id.0.clone(), *channel);
-                if let Some(existing_chain) = claimed_channels.insert(key.clone(), chain.id.0.clone()) {
-                    bail!(
-                        "invalid project: active chains '{}' and '{}' both use input device '{}' channel {}",
-                        existing_chain,
-                        chain.id.0,
-                        key.0,
-                        key.1
-                    );
+            for entry in &input.entries {
+                for channel in &entry.channels {
+                    let key = (entry.device_id.0.clone(), *channel);
+                    if let Some(existing_chain) = claimed_channels.insert(key.clone(), chain.id.0.clone()) {
+                        bail!(
+                            "invalid project: active chains '{}' and '{}' both use input device '{}' channel {}",
+                            existing_chain,
+                            chain.id.0,
+                            key.0,
+                            key.1
+                        );
+                    }
                 }
             }
         }

--- a/crates/application/src/validate.rs
+++ b/crates/application/src/validate.rs
@@ -92,9 +92,9 @@ pub fn validate_project(project: &Project) -> Result<()> {
             .ok_or_else(|| anyhow!("invalid project: chain '{}' output '{}' has no entries", chain.id.0, first_output.1.model))?;
         layout_from_channel_count("chain output", &chain.id.0, first_output_entry.channels.len())?;
 
-        // Validate only audio blocks (non-I/O)
+        // Validate only audio blocks (non-I/O, non-Insert)
         let audio_blocks: Vec<&AudioBlock> = chain.blocks.iter()
-            .filter(|b| !matches!(&b.kind, AudioBlockKind::Input(_) | AudioBlockKind::Output(_)))
+            .filter(|b| !matches!(&b.kind, AudioBlockKind::Input(_) | AudioBlockKind::Output(_) | AudioBlockKind::Insert(_)))
             .collect();
         validate_chain_blocks(chain, &audio_blocks, input_layout)?;
     }
@@ -248,8 +248,8 @@ fn resolve_block_output_layout(
                 )
             })
         }
-        // Input/Output blocks don't affect audio processing layout
-        AudioBlockKind::Input(_) | AudioBlockKind::Output(_) => Ok(input_layout),
+        // Input/Output/Insert blocks don't affect audio processing layout
+        AudioBlockKind::Input(_) | AudioBlockKind::Output(_) | AudioBlockKind::Insert(_) => Ok(input_layout),
     }
 }
 

--- a/crates/application/src/validate.rs
+++ b/crates/application/src/validate.rs
@@ -38,56 +38,58 @@ pub fn validate_project(project: &Project) -> Result<()> {
         // Validate each input block's entries
         for (_, input) in &input_blocks {
             for entry in &input.entries {
+                let entry_label = if entry.name.is_empty() { &input.model } else { &entry.name };
                 if entry.device_id.0.trim().is_empty() {
                     bail!(
                         "invalid project: chain '{}' input '{}' missing device_id",
                         chain.id.0,
-                        input.name
+                        entry_label
                     );
                 }
                 if entry.channels.is_empty() {
                     bail!(
                         "invalid project: chain '{}' input '{}' has no channels",
                         chain.id.0,
-                        input.name
+                        entry_label
                     );
                 }
                 validate_unique_channels(&entry.channels)
-                    .map_err(|error| anyhow!("invalid project: chain '{}' input '{}': {}", chain.id.0, input.name, error))?;
+                    .map_err(|error| anyhow!("invalid project: chain '{}' input '{}': {}", chain.id.0, entry_label, error))?;
             }
         }
 
         // Validate each output block's entries
         for (_, output) in &output_blocks {
             for entry in &output.entries {
+                let entry_label = if entry.name.is_empty() { &output.model } else { &entry.name };
                 if entry.device_id.0.trim().is_empty() {
                     bail!(
                         "invalid project: chain '{}' output '{}' missing device_id",
                         chain.id.0,
-                        output.name
+                        entry_label
                     );
                 }
                 if entry.channels.is_empty() {
                     bail!(
                         "invalid project: chain '{}' output '{}' has no channels",
                         chain.id.0,
-                        output.name
+                        entry_label
                     );
                 }
                 validate_unique_channels(&entry.channels)
-                    .map_err(|error| anyhow!("invalid project: chain '{}' output '{}': {}", chain.id.0, output.name, error))?;
+                    .map_err(|error| anyhow!("invalid project: chain '{}' output '{}': {}", chain.id.0, entry_label, error))?;
             }
         }
 
         // Use first input entry's channel count for layout determination
         let first_input = input_blocks.first().expect("validated non-empty");
         let first_input_entry = first_input.1.entries.first()
-            .ok_or_else(|| anyhow!("invalid project: chain '{}' input '{}' has no entries", chain.id.0, first_input.1.name))?;
+            .ok_or_else(|| anyhow!("invalid project: chain '{}' input '{}' has no entries", chain.id.0, first_input.1.model))?;
         let input_layout =
             layout_from_channel_count("chain input", &chain.id.0, first_input_entry.channels.len())?;
         let first_output = output_blocks.first().expect("validated non-empty");
         let first_output_entry = first_output.1.entries.first()
-            .ok_or_else(|| anyhow!("invalid project: chain '{}' output '{}' has no entries", chain.id.0, first_output.1.name))?;
+            .ok_or_else(|| anyhow!("invalid project: chain '{}' output '{}' has no entries", chain.id.0, first_output.1.model))?;
         layout_from_channel_count("chain output", &chain.id.0, first_output_entry.channels.len())?;
 
         // Validate only audio blocks (non-I/O)

--- a/crates/application/src/validate.rs
+++ b/crates/application/src/validate.rs
@@ -19,39 +19,74 @@ pub fn validate_project(project: &Project) -> Result<()> {
     validate_device_settings(project, &device_settings_by_id)?;
 
     for chain in &project.chains {
-        if chain.input_device_id.0.trim().is_empty() {
-            bail!(
-                "invalid project: chain '{}' missing input_device_id",
-                chain.id.0
-            );
-        }
-        if chain.output_device_id.0.trim().is_empty() {
-            bail!(
-                "invalid project: chain '{}' missing output_device_id",
-                chain.id.0
-            );
-        }
-        if chain.input_channels.is_empty() {
-            bail!(
-                "invalid project: chain '{}' has no input channels",
-                chain.id.0
-            );
-        }
-        if chain.output_channels.is_empty() {
-            bail!(
-                "invalid project: chain '{}' has no output channels",
-                chain.id.0
-            );
-        }
-        validate_unique_channels(&chain.input_channels)
-            .map_err(|error| anyhow!("invalid project: chain '{}': {}", chain.id.0, error))?;
-        validate_unique_channels(&chain.output_channels)
-            .map_err(|error| anyhow!("invalid project: chain '{}': {}", chain.id.0, error))?;
+        let input_blocks = chain.input_blocks();
+        let output_blocks = chain.output_blocks();
 
+        if input_blocks.is_empty() {
+            bail!(
+                "invalid project: chain '{}' has no input blocks",
+                chain.id.0
+            );
+        }
+        if output_blocks.is_empty() {
+            bail!(
+                "invalid project: chain '{}' has no output blocks",
+                chain.id.0
+            );
+        }
+
+        // Validate each input block
+        for (_, input) in &input_blocks {
+            if input.device_id.0.trim().is_empty() {
+                bail!(
+                    "invalid project: chain '{}' input '{}' missing device_id",
+                    chain.id.0,
+                    input.name
+                );
+            }
+            if input.channels.is_empty() {
+                bail!(
+                    "invalid project: chain '{}' input '{}' has no channels",
+                    chain.id.0,
+                    input.name
+                );
+            }
+            validate_unique_channels(&input.channels)
+                .map_err(|error| anyhow!("invalid project: chain '{}' input '{}': {}", chain.id.0, input.name, error))?;
+        }
+
+        // Validate each output block
+        for (_, output) in &output_blocks {
+            if output.device_id.0.trim().is_empty() {
+                bail!(
+                    "invalid project: chain '{}' output '{}' missing device_id",
+                    chain.id.0,
+                    output.name
+                );
+            }
+            if output.channels.is_empty() {
+                bail!(
+                    "invalid project: chain '{}' output '{}' has no channels",
+                    chain.id.0,
+                    output.name
+                );
+            }
+            validate_unique_channels(&output.channels)
+                .map_err(|error| anyhow!("invalid project: chain '{}' output '{}': {}", chain.id.0, output.name, error))?;
+        }
+
+        // Use first input's channel count for layout determination
+        let first_input = input_blocks.first().expect("validated non-empty");
         let input_layout =
-            layout_from_channel_count("chain input", &chain.id.0, chain.input_channels.len())?;
-        layout_from_channel_count("chain output", &chain.id.0, chain.output_channels.len())?;
-        validate_chain_blocks(chain, chain.blocks.as_slice(), input_layout)?;
+            layout_from_channel_count("chain input", &chain.id.0, first_input.1.channels.len())?;
+        let first_output = output_blocks.first().expect("validated non-empty");
+        layout_from_channel_count("chain output", &chain.id.0, first_output.1.channels.len())?;
+
+        // Validate only audio blocks (non-I/O)
+        let audio_blocks: Vec<&AudioBlock> = chain.blocks.iter()
+            .filter(|b| !matches!(&b.kind, AudioBlockKind::Input(_) | AudioBlockKind::Output(_)))
+            .collect();
+        validate_chain_blocks(chain, &audio_blocks, input_layout)?;
     }
 
     validate_active_chain_input_channel_conflicts(&project.chains)?;
@@ -78,7 +113,7 @@ fn layout_from_channel_count(
 
 fn validate_chain_blocks(
     chain: &Chain,
-    blocks: &[AudioBlock],
+    blocks: &[&AudioBlock],
     input_layout: AudioChannelLayout,
 ) -> Result<()> {
     if !chain.enabled {
@@ -99,16 +134,18 @@ fn validate_chain_blocks(
 fn validate_active_chain_input_channel_conflicts(chains: &[Chain]) -> Result<()> {
     let mut claimed_channels: HashMap<(String, usize), String> = HashMap::new();
     for chain in chains.iter().filter(|chain| chain.enabled) {
-        for channel in &chain.input_channels {
-            let key = (chain.input_device_id.0.clone(), *channel);
-            if let Some(existing_chain) = claimed_channels.insert(key.clone(), chain.id.0.clone()) {
-                bail!(
-                    "invalid project: active chains '{}' and '{}' both use input device '{}' channel {}",
-                    existing_chain,
-                    chain.id.0,
-                    key.0,
-                    key.1
-                );
+        for (_, input) in chain.input_blocks() {
+            for channel in &input.channels {
+                let key = (input.device_id.0.clone(), *channel);
+                if let Some(existing_chain) = claimed_channels.insert(key.clone(), chain.id.0.clone()) {
+                    bail!(
+                        "invalid project: active chains '{}' and '{}' both use input device '{}' channel {}",
+                        existing_chain,
+                        chain.id.0,
+                        key.0,
+                        key.1
+                    );
+                }
             }
         }
     }
@@ -199,6 +236,8 @@ fn resolve_block_output_layout(
                 )
             })
         }
+        // Input/Output blocks don't affect audio processing layout
+        AudioBlockKind::Input(_) | AudioBlockKind::Output(_) => Ok(input_layout),
     }
 }
 

--- a/crates/engine/src/runtime.rs
+++ b/crates/engine/src/runtime.rs
@@ -356,6 +356,7 @@ fn effective_inputs(chain: &Chain) -> Vec<InputEntry> {
     }
     // Fallback — no InputBlocks defined
     vec![InputEntry {
+        name: "Input".to_string(),
         device_id: domain::ids::DeviceId("".to_string()),
         mode: ChainInputMode::Mono,
         channels: vec![0],
@@ -374,6 +375,7 @@ fn effective_outputs(chain: &Chain) -> Vec<OutputEntry> {
     }
     // Fallback — no OutputBlocks defined
     vec![OutputEntry {
+        name: "Output".to_string(),
         device_id: domain::ids::DeviceId("".to_string()),
         mode: ChainOutputMode::Mono,
         channels: vec![0],
@@ -1635,8 +1637,9 @@ mod tests {
                     id: BlockId("chain:stereo:input:0".into()),
                     enabled: true,
                     kind: AudioBlockKind::Input(InputBlock {
-                        name: "Input 1".to_string(),
+                        model: "standard".to_string(),
                         entries: vec![InputEntry {
+                            name: "Input 1".to_string(),
                             device_id: DeviceId("input-device".into()),
                             mode: ChainInputMode::Mono,
                             channels: vec![0, 1],
@@ -1651,8 +1654,9 @@ mod tests {
                     id: BlockId("chain:stereo:output:0".into()),
                     enabled: true,
                     kind: AudioBlockKind::Output(OutputBlock {
-                        name: "Output 1".to_string(),
+                        model: "standard".to_string(),
                         entries: vec![OutputEntry {
+                            name: "Output 1".to_string(),
                             device_id: DeviceId("output-device".into()),
                             mode: ChainOutputMode::Stereo,
                             channels: vec![0, 1],
@@ -1696,8 +1700,9 @@ mod tests {
                     id: BlockId("chain:asset-backed:input:0".into()),
                     enabled: true,
                     kind: AudioBlockKind::Input(InputBlock {
-                        name: "Input 1".to_string(),
+                        model: "standard".to_string(),
                         entries: vec![InputEntry {
+                            name: "Input 1".to_string(),
                             device_id: DeviceId("input-device".into()),
                             mode: ChainInputMode::Mono,
                             channels: vec![0, 1],
@@ -1711,8 +1716,9 @@ mod tests {
                     id: BlockId("chain:asset-backed:output:0".into()),
                     enabled: true,
                     kind: AudioBlockKind::Output(OutputBlock {
-                        name: "Output 1".to_string(),
+                        model: "standard".to_string(),
                         entries: vec![OutputEntry {
+                            name: "Output 1".to_string(),
                             device_id: DeviceId("output-device".into()),
                             mode: ChainOutputMode::Stereo,
                             channels: vec![0, 1],

--- a/crates/engine/src/runtime.rs
+++ b/crates/engine/src/runtime.rs
@@ -1586,12 +1586,12 @@ pub fn process_output_f32(
     };
     let num_frames = out.len() / output_total_channels;
     let queue_len = route.queue.len();
-    if queue_len == 0 && output_index > 0 {
-        // Log only for non-primary outputs (Insert send) to avoid spam
+    // Log ALL output calls for Insert send (output_index > 0)
+    if output_index > 0 {
         static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
         let c = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         if c % 1000 == 0 {
-            log::warn!("[process_output] output_index={} queue EMPTY (call #{})", output_index, c);
+            log::warn!("[process_output] idx={} queue_len={} num_frames={} (call #{})", output_index, queue_len, num_frames, c);
         }
     }
 

--- a/crates/engine/src/runtime.rs
+++ b/crates/engine/src/runtime.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Result};
 use domain::ids::{BlockId, ChainId};
 use project::block::{
-    schema_for_block_model, AudioBlockKind, CoreBlock, InputBlock, NamBlock, OutputBlock, SelectBlock,
+    schema_for_block_model, AudioBlockKind, CoreBlock, InputEntry, NamBlock, OutputEntry, SelectBlock,
 };
 use project::param::ParameterSet;
 use project::project::Project;
@@ -318,7 +318,7 @@ pub fn build_chain_runtime_state(chain: &Chain, sample_rate: f32) -> Result<Chai
     // Collect all output channels for processing layout determination
     let all_output_channels: Vec<usize> = effective_outputs
         .iter()
-        .flat_map(|o| o.channels.iter().copied())
+        .flat_map(|e| e.channels.iter().copied())
         .collect();
 
     let mut input_states = Vec::with_capacity(effective_inputs.len());
@@ -344,32 +344,36 @@ pub fn build_chain_runtime_state(chain: &Chain, sample_rate: f32) -> Result<Chai
     })
 }
 
-/// Build effective inputs from chain's InputBlock entries.
+/// Build effective input entries from chain's InputBlock entries.
 /// Falls back to a single mono input on channel 0 if no InputBlocks exist.
-fn effective_inputs(chain: &Chain) -> Vec<InputBlock> {
-    let input_blocks: Vec<InputBlock> = chain.input_blocks().into_iter().map(|(_, ib)| ib.clone()).collect();
-    if !input_blocks.is_empty() {
-        return input_blocks;
+fn effective_inputs(chain: &Chain) -> Vec<InputEntry> {
+    let entries: Vec<InputEntry> = chain.input_blocks()
+        .into_iter()
+        .flat_map(|(_, ib)| ib.entries.iter().cloned())
+        .collect();
+    if !entries.is_empty() {
+        return entries;
     }
     // Fallback — no InputBlocks defined
-    vec![InputBlock {
-        name: "Input 1".to_string(),
+    vec![InputEntry {
         device_id: domain::ids::DeviceId("".to_string()),
         mode: ChainInputMode::Mono,
         channels: vec![0],
     }]
 }
 
-/// Build effective outputs from chain's OutputBlock entries.
+/// Build effective output entries from chain's OutputBlock entries.
 /// Falls back to a single mono output on channel 0 if no OutputBlocks exist.
-fn effective_outputs(chain: &Chain) -> Vec<OutputBlock> {
-    let output_blocks: Vec<OutputBlock> = chain.output_blocks().into_iter().map(|(_, ob)| ob.clone()).collect();
-    if !output_blocks.is_empty() {
-        return output_blocks;
+fn effective_outputs(chain: &Chain) -> Vec<OutputEntry> {
+    let entries: Vec<OutputEntry> = chain.output_blocks()
+        .into_iter()
+        .flat_map(|(_, ob)| ob.entries.iter().cloned())
+        .collect();
+    if !entries.is_empty() {
+        return entries;
     }
     // Fallback — no OutputBlocks defined
-    vec![OutputBlock {
-        name: "Output 1".to_string(),
+    vec![OutputEntry {
         device_id: domain::ids::DeviceId("".to_string()),
         mode: ChainOutputMode::Mono,
         channels: vec![0],
@@ -378,7 +382,7 @@ fn effective_outputs(chain: &Chain) -> Vec<OutputBlock> {
 
 fn build_input_processing_state(
     chain: &Chain,
-    input: &InputBlock,
+    input: &InputEntry,
     output_channels: &[usize],
     sample_rate: f32,
     existing_blocks: Option<Vec<BlockRuntimeNode>>,
@@ -399,9 +403,8 @@ fn build_input_processing_state(
         ChainInputMode::Stereo | ChainInputMode::DualMono => AudioChannelLayout::Stereo,
     };
     log::info!(
-        "chain '{}' input '{}' processing layout: input_read={}, processing={:?} (channels={:?} mode={:?})",
+        "chain '{}' input entry processing layout: input_read={}, processing={:?} (channels={:?} mode={:?})",
         chain.id.0,
-        input.name,
         layout_label(input_read_layout),
         proc_layout,
         input.channels,
@@ -420,7 +423,7 @@ fn build_input_processing_state(
     })
 }
 
-fn build_output_routing_state(output: &OutputBlock) -> OutputRoutingState {
+fn build_output_routing_state(output: &OutputEntry) -> OutputRoutingState {
     let output_layout = if output.channels.len() >= 2 {
         match output.mode {
             ChainOutputMode::Stereo => AudioChannelLayout::Stereo,
@@ -1434,7 +1437,7 @@ mod tests {
     use domain::ids::{BlockId, DeviceId, ChainId};
     use domain::value_objects::ParameterValue;
     use project::block::{
-        AudioBlock, AudioBlockKind, CoreBlock, InputBlock, OutputBlock, SelectBlock, schema_for_block_model,
+        AudioBlock, AudioBlockKind, CoreBlock, InputBlock, InputEntry, OutputBlock, OutputEntry, SelectBlock, schema_for_block_model,
     };
     use project::param::ParameterSet;
     use project::project::Project;
@@ -1633,9 +1636,11 @@ mod tests {
                     enabled: true,
                     kind: AudioBlockKind::Input(InputBlock {
                         name: "Input 1".to_string(),
-                        device_id: DeviceId("input-device".into()),
-                        mode: ChainInputMode::Mono,
-                        channels: vec![0, 1],
+                        entries: vec![InputEntry {
+                            device_id: DeviceId("input-device".into()),
+                            mode: ChainInputMode::Mono,
+                            channels: vec![0, 1],
+                        }],
                     }),
                 },
                 compressor_block("chain:stereo:block:0"),
@@ -1647,9 +1652,11 @@ mod tests {
                     enabled: true,
                     kind: AudioBlockKind::Output(OutputBlock {
                         name: "Output 1".to_string(),
-                        device_id: DeviceId("output-device".into()),
-                        mode: ChainOutputMode::Stereo,
-                        channels: vec![0, 1],
+                        entries: vec![OutputEntry {
+                            device_id: DeviceId("output-device".into()),
+                            mode: ChainOutputMode::Stereo,
+                            channels: vec![0, 1],
+                        }],
                     }),
                 },
             ],
@@ -1690,9 +1697,11 @@ mod tests {
                     enabled: true,
                     kind: AudioBlockKind::Input(InputBlock {
                         name: "Input 1".to_string(),
-                        device_id: DeviceId("input-device".into()),
-                        mode: ChainInputMode::Mono,
-                        channels: vec![0, 1],
+                        entries: vec![InputEntry {
+                            device_id: DeviceId("input-device".into()),
+                            mode: ChainInputMode::Mono,
+                            channels: vec![0, 1],
+                        }],
                     }),
                 },
                 marshall_preamp_block("chain:asset-backed:block:0"),
@@ -1703,9 +1712,11 @@ mod tests {
                     enabled: true,
                     kind: AudioBlockKind::Output(OutputBlock {
                         name: "Output 1".to_string(),
-                        device_id: DeviceId("output-device".into()),
-                        mode: ChainOutputMode::Stereo,
-                        channels: vec![0, 1],
+                        entries: vec![OutputEntry {
+                            device_id: DeviceId("output-device".into()),
+                            mode: ChainOutputMode::Stereo,
+                            channels: vec![0, 1],
+                        }],
                     }),
                 },
             ],

--- a/crates/engine/src/runtime.rs
+++ b/crates/engine/src/runtime.rs
@@ -347,9 +347,13 @@ pub fn build_chain_runtime_state(chain: &Chain, sample_rate: f32) -> Result<Chai
 /// Build effective input entries from chain's InputBlock entries.
 /// Falls back to a single mono input on channel 0 if no InputBlocks exist.
 fn effective_inputs(chain: &Chain) -> Vec<InputEntry> {
-    let entries: Vec<InputEntry> = chain.input_blocks()
-        .into_iter()
-        .flat_map(|(_, ib)| ib.entries.iter().cloned())
+    let entries: Vec<InputEntry> = chain.blocks.iter()
+        .filter(|b| b.enabled)
+        .filter_map(|b| match &b.kind {
+            AudioBlockKind::Input(ib) => Some(ib),
+            _ => None,
+        })
+        .flat_map(|ib| ib.entries.iter().cloned())
         .collect();
     if !entries.is_empty() {
         return entries;
@@ -366,9 +370,13 @@ fn effective_inputs(chain: &Chain) -> Vec<InputEntry> {
 /// Build effective output entries from chain's OutputBlock entries.
 /// Falls back to a single mono output on channel 0 if no OutputBlocks exist.
 fn effective_outputs(chain: &Chain) -> Vec<OutputEntry> {
-    let entries: Vec<OutputEntry> = chain.output_blocks()
-        .into_iter()
-        .flat_map(|(_, ob)| ob.entries.iter().cloned())
+    let entries: Vec<OutputEntry> = chain.blocks.iter()
+        .filter(|b| b.enabled)
+        .filter_map(|b| match &b.kind {
+            AudioBlockKind::Output(ob) => Some(ob),
+            _ => None,
+        })
+        .flat_map(|ob| ob.entries.iter().cloned())
         .collect();
     if !entries.is_empty() {
         return entries;

--- a/crates/engine/src/runtime.rs
+++ b/crates/engine/src/runtime.rs
@@ -345,9 +345,10 @@ pub fn build_chain_runtime_state(chain: &Chain, sample_rate: f32) -> Result<Chai
 }
 
 /// Build effective input entries from chain's InputBlock entries.
+/// Also includes Insert block return endpoints as input streams.
 /// Falls back to a single mono input on channel 0 if no InputBlocks exist.
 fn effective_inputs(chain: &Chain) -> Vec<InputEntry> {
-    let entries: Vec<InputEntry> = chain.blocks.iter()
+    let mut entries: Vec<InputEntry> = chain.blocks.iter()
         .filter(|b| b.enabled)
         .filter_map(|b| match &b.kind {
             AudioBlockKind::Input(ib) => Some(ib),
@@ -355,10 +356,34 @@ fn effective_inputs(chain: &Chain) -> Vec<InputEntry> {
         })
         .flat_map(|ib| ib.entries.iter().cloned())
         .collect();
+
+    // Include Insert block return endpoints as input streams
+    // (must match the order used in infra-cpal resolve_chain_inputs)
+    let insert_return_entries: Vec<InputEntry> = chain.blocks.iter()
+        .filter(|b| b.enabled)
+        .filter_map(|b| match &b.kind {
+            AudioBlockKind::Insert(ib) => Some(InputEntry {
+                name: "Insert Return".to_string(),
+                device_id: ib.return_.device_id.clone(),
+                mode: ib.return_.mode,
+                channels: ib.return_.channels.clone(),
+            }),
+            _ => None,
+        })
+        .collect();
+    entries.extend(insert_return_entries);
+
     if !entries.is_empty() {
+        for (i, entry) in entries.iter().enumerate() {
+            log::info!(
+                "chain '{}' effective_input[{}]: name='{}', device='{}', mode={:?}, channels={:?}",
+                chain.id.0, i, entry.name, entry.device_id.0, entry.mode, entry.channels,
+            );
+        }
         return entries;
     }
     // Fallback — no InputBlocks defined
+    log::info!("chain '{}' effective_inputs: fallback to single mono input", chain.id.0);
     vec![InputEntry {
         name: "Input".to_string(),
         device_id: domain::ids::DeviceId("".to_string()),
@@ -368,9 +393,10 @@ fn effective_inputs(chain: &Chain) -> Vec<InputEntry> {
 }
 
 /// Build effective output entries from chain's OutputBlock entries.
+/// Also includes Insert block send endpoints as output streams.
 /// Falls back to a single mono output on channel 0 if no OutputBlocks exist.
 fn effective_outputs(chain: &Chain) -> Vec<OutputEntry> {
-    let entries: Vec<OutputEntry> = chain.blocks.iter()
+    let mut entries: Vec<OutputEntry> = chain.blocks.iter()
         .filter(|b| b.enabled)
         .filter_map(|b| match &b.kind {
             AudioBlockKind::Output(ob) => Some(ob),
@@ -378,10 +404,37 @@ fn effective_outputs(chain: &Chain) -> Vec<OutputEntry> {
         })
         .flat_map(|ob| ob.entries.iter().cloned())
         .collect();
+
+    // Include Insert block send endpoints as output streams
+    // (must match the order used in infra-cpal resolve_chain_outputs)
+    let insert_send_entries: Vec<OutputEntry> = chain.blocks.iter()
+        .filter(|b| b.enabled)
+        .filter_map(|b| match &b.kind {
+            AudioBlockKind::Insert(ib) => Some(OutputEntry {
+                name: "Insert Send".to_string(),
+                device_id: ib.send.device_id.clone(),
+                mode: match ib.send.mode {
+                    ChainInputMode::Mono => ChainOutputMode::Mono,
+                    _ => ChainOutputMode::Stereo,
+                },
+                channels: ib.send.channels.clone(),
+            }),
+            _ => None,
+        })
+        .collect();
+    entries.extend(insert_send_entries);
+
     if !entries.is_empty() {
+        for (i, entry) in entries.iter().enumerate() {
+            log::info!(
+                "chain '{}' effective_output[{}]: name='{}', device='{}', mode={:?}, channels={:?}",
+                chain.id.0, i, entry.name, entry.device_id.0, entry.mode, entry.channels,
+            );
+        }
         return entries;
     }
     // Fallback — no OutputBlocks defined
+    log::info!("chain '{}' effective_outputs: fallback to single mono output", chain.id.0);
     vec![OutputEntry {
         name: "Output".to_string(),
         device_id: domain::ids::DeviceId("".to_string()),

--- a/crates/engine/src/runtime.rs
+++ b/crates/engine/src/runtime.rs
@@ -316,7 +316,18 @@ pub fn build_runtime_graph(
 pub fn build_chain_runtime_state(chain: &Chain, sample_rate: f32) -> Result<ChainRuntimeState> {
     let eff_inputs = effective_inputs(chain);
     let eff_outputs = effective_outputs(chain);
+    log::info!("[build_chain_runtime] chain='{}' eff_inputs={} eff_outputs={}", chain.id.0, eff_inputs.len(), eff_outputs.len());
+    for (i, inp) in eff_inputs.iter().enumerate() {
+        log::info!("[build_chain_runtime]   input[{}]: name='{}' device='{}' channels={:?}", i, inp.name, inp.device_id.0, inp.channels);
+    }
+    for (i, out) in eff_outputs.iter().enumerate() {
+        log::info!("[build_chain_runtime]   output[{}]: name='{}' device='{}' channels={:?}", i, out.name, out.device_id.0, out.channels);
+    }
     let segments = split_chain_into_segments(chain, &eff_inputs, &eff_outputs);
+    log::info!("[build_chain_runtime] segments={}", segments.len());
+    for (i, seg) in segments.iter().enumerate() {
+        log::info!("[build_chain_runtime]   segment[{}]: input='{}' blocks={:?} output_routes={:?}", i, seg.input.name, seg.block_indices, seg.output_route_indices);
+    }
 
     let mut input_states = Vec::with_capacity(segments.len());
     for segment in &segments {

--- a/crates/engine/src/runtime.rs
+++ b/crates/engine/src/runtime.rs
@@ -566,8 +566,8 @@ fn build_runtime_block_nodes(
             }
             continue;
         }
-        // Input/Output blocks are routing metadata; skip them in the processing chain
-        if matches!(&block.kind, AudioBlockKind::Input(_) | AudioBlockKind::Output(_)) {
+        // Input/Output/Insert blocks are routing metadata; skip them in the processing chain
+        if matches!(&block.kind, AudioBlockKind::Input(_) | AudioBlockKind::Output(_) | AudioBlockKind::Insert(_)) {
             continue;
         }
         if let AudioBlockKind::Select(select) = &block.kind {
@@ -647,8 +647,8 @@ fn build_block_runtime_node(
         AudioBlockKind::Select(select) => {
             build_select_runtime_node(chain, block, select, input_layout, sample_rate, None)?
         }
-        // Input/Output blocks are routing-only; they don't process audio in the block chain
-        AudioBlockKind::Input(_) | AudioBlockKind::Output(_) => bypass_runtime_node(block, input_layout),
+        // Input/Output/Insert blocks are routing-only; they don't process audio in the block chain
+        AudioBlockKind::Input(_) | AudioBlockKind::Output(_) | AudioBlockKind::Insert(_) => bypass_runtime_node(block, input_layout),
     })
 }
 

--- a/crates/engine/src/runtime.rs
+++ b/crates/engine/src/runtime.rs
@@ -1445,12 +1445,8 @@ pub fn process_input_f32(
             }
         }
         Ok(mut output) => {
-        let route_indices = if segment_routes.is_empty() {
-            // Legacy: push to all output routes
-            (0..output.output_routes.len()).collect::<Vec<_>>()
-        } else {
-            segment_routes
-        };
+        // TEMP: always push to all routes to diagnose Insert issue
+        let route_indices: Vec<usize> = (0..output.output_routes.len()).collect();
         for &route_idx in &route_indices {
             if let Some(route) = output.output_routes.get_mut(route_idx) {
                 let existing_len = route.queue.len();

--- a/crates/engine/src/runtime.rs
+++ b/crates/engine/src/runtime.rs
@@ -693,7 +693,18 @@ pub fn update_chain_runtime_state(
 ) -> Result<()> {
     let effective_ins = effective_inputs(chain);
     let effective_outs = effective_outputs(chain);
+    log::info!("[update_runtime] chain='{}' inputs={} outputs={}", chain.id.0, effective_ins.len(), effective_outs.len());
+    for (i, inp) in effective_ins.iter().enumerate() {
+        log::info!("[update_runtime]   in[{}]: '{}' dev='{}' ch={:?}", i, inp.name, inp.device_id.0, inp.channels);
+    }
+    for (i, out) in effective_outs.iter().enumerate() {
+        log::info!("[update_runtime]   out[{}]: '{}' dev='{}' ch={:?}", i, out.name, out.device_id.0, out.channels);
+    }
     let segments = split_chain_into_segments(chain, &effective_ins, &effective_outs);
+    log::info!("[update_runtime] segments={}", segments.len());
+    for (i, seg) in segments.iter().enumerate() {
+        log::info!("[update_runtime]   seg[{}]: in='{}' blocks={:?} out_routes={:?}", i, seg.input.name, seg.block_indices, seg.output_route_indices);
+    }
 
     // Step 1: Extract existing blocks from all input states (brief lock)
     let mut existing_per_input: Vec<Vec<BlockRuntimeNode>> = {

--- a/crates/engine/src/runtime.rs
+++ b/crates/engine/src/runtime.rs
@@ -1567,6 +1567,15 @@ pub fn process_output_f32(
         }
     };
     let num_frames = out.len() / output_total_channels;
+    let queue_len = route.queue.len();
+    if queue_len == 0 && output_index > 0 {
+        // Log only for non-primary outputs (Insert send) to avoid spam
+        static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let c = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        if c % 1000 == 0 {
+            log::warn!("[process_output] output_index={} queue EMPTY (call #{})", output_index, c);
+        }
+    }
 
     for frame in out.chunks_mut(output_total_channels).take(num_frames) {
         frame.fill(0.0);

--- a/crates/engine/src/runtime.rs
+++ b/crates/engine/src/runtime.rs
@@ -345,10 +345,9 @@ pub fn build_chain_runtime_state(chain: &Chain, sample_rate: f32) -> Result<Chai
 }
 
 /// Build effective input entries from chain's InputBlock entries.
-/// Also includes Insert block return endpoints as input streams.
 /// Falls back to a single mono input on channel 0 if no InputBlocks exist.
 fn effective_inputs(chain: &Chain) -> Vec<InputEntry> {
-    let mut entries: Vec<InputEntry> = chain.blocks.iter()
+    let entries: Vec<InputEntry> = chain.blocks.iter()
         .filter(|b| b.enabled)
         .filter_map(|b| match &b.kind {
             AudioBlockKind::Input(ib) => Some(ib),
@@ -356,34 +355,10 @@ fn effective_inputs(chain: &Chain) -> Vec<InputEntry> {
         })
         .flat_map(|ib| ib.entries.iter().cloned())
         .collect();
-
-    // Include Insert block return endpoints as input streams
-    // (must match the order used in infra-cpal resolve_chain_inputs)
-    let insert_return_entries: Vec<InputEntry> = chain.blocks.iter()
-        .filter(|b| b.enabled)
-        .filter_map(|b| match &b.kind {
-            AudioBlockKind::Insert(ib) => Some(InputEntry {
-                name: "Insert Return".to_string(),
-                device_id: ib.return_.device_id.clone(),
-                mode: ib.return_.mode,
-                channels: ib.return_.channels.clone(),
-            }),
-            _ => None,
-        })
-        .collect();
-    entries.extend(insert_return_entries);
-
     if !entries.is_empty() {
-        for (i, entry) in entries.iter().enumerate() {
-            log::info!(
-                "chain '{}' effective_input[{}]: name='{}', device='{}', mode={:?}, channels={:?}",
-                chain.id.0, i, entry.name, entry.device_id.0, entry.mode, entry.channels,
-            );
-        }
         return entries;
     }
     // Fallback — no InputBlocks defined
-    log::info!("chain '{}' effective_inputs: fallback to single mono input", chain.id.0);
     vec![InputEntry {
         name: "Input".to_string(),
         device_id: domain::ids::DeviceId("".to_string()),
@@ -393,10 +368,9 @@ fn effective_inputs(chain: &Chain) -> Vec<InputEntry> {
 }
 
 /// Build effective output entries from chain's OutputBlock entries.
-/// Also includes Insert block send endpoints as output streams.
 /// Falls back to a single mono output on channel 0 if no OutputBlocks exist.
 fn effective_outputs(chain: &Chain) -> Vec<OutputEntry> {
-    let mut entries: Vec<OutputEntry> = chain.blocks.iter()
+    let entries: Vec<OutputEntry> = chain.blocks.iter()
         .filter(|b| b.enabled)
         .filter_map(|b| match &b.kind {
             AudioBlockKind::Output(ob) => Some(ob),
@@ -404,37 +378,10 @@ fn effective_outputs(chain: &Chain) -> Vec<OutputEntry> {
         })
         .flat_map(|ob| ob.entries.iter().cloned())
         .collect();
-
-    // Include Insert block send endpoints as output streams
-    // (must match the order used in infra-cpal resolve_chain_outputs)
-    let insert_send_entries: Vec<OutputEntry> = chain.blocks.iter()
-        .filter(|b| b.enabled)
-        .filter_map(|b| match &b.kind {
-            AudioBlockKind::Insert(ib) => Some(OutputEntry {
-                name: "Insert Send".to_string(),
-                device_id: ib.send.device_id.clone(),
-                mode: match ib.send.mode {
-                    ChainInputMode::Mono => ChainOutputMode::Mono,
-                    _ => ChainOutputMode::Stereo,
-                },
-                channels: ib.send.channels.clone(),
-            }),
-            _ => None,
-        })
-        .collect();
-    entries.extend(insert_send_entries);
-
     if !entries.is_empty() {
-        for (i, entry) in entries.iter().enumerate() {
-            log::info!(
-                "chain '{}' effective_output[{}]: name='{}', device='{}', mode={:?}, channels={:?}",
-                chain.id.0, i, entry.name, entry.device_id.0, entry.mode, entry.channels,
-            );
-        }
         return entries;
     }
     // Fallback — no OutputBlocks defined
-    log::info!("chain '{}' effective_outputs: fallback to single mono output", chain.id.0);
     vec![OutputEntry {
         name: "Output".to_string(),
         device_id: domain::ids::DeviceId("".to_string()),

--- a/crates/engine/src/runtime.rs
+++ b/crates/engine/src/runtime.rs
@@ -1,12 +1,12 @@
 use anyhow::{anyhow, Result};
 use domain::ids::{BlockId, ChainId};
 use project::block::{
-    schema_for_block_model, AudioBlockKind, CoreBlock, NamBlock, SelectBlock,
+    schema_for_block_model, AudioBlockKind, CoreBlock, InputBlock, NamBlock, OutputBlock, SelectBlock,
 };
 use project::param::ParameterSet;
 use project::project::Project;
 use project::chain::{
-    Chain, ChainInput, ChainInputMode, ChainOutputMixdown, ChainOutputMode, ProcessingLayout,
+    Chain, ChainInputMode, ChainOutputMixdown, ChainOutputMode, ProcessingLayout,
 };
 use block_amp::build_amp_processor_for_layout;
 use block_preamp::build_preamp_processor_for_layout;
@@ -344,59 +344,41 @@ pub fn build_chain_runtime_state(chain: &Chain, sample_rate: f32) -> Result<Chai
     })
 }
 
-/// Build effective inputs from chain, falling back to legacy fields if `inputs` is empty.
-fn effective_inputs(chain: &Chain) -> Vec<ChainInput> {
-    if !chain.inputs.is_empty() {
-        return chain.inputs.clone();
+/// Build effective inputs from chain's InputBlock entries.
+/// Falls back to a single mono input on channel 0 if no InputBlocks exist.
+fn effective_inputs(chain: &Chain) -> Vec<InputBlock> {
+    let input_blocks: Vec<InputBlock> = chain.input_blocks().into_iter().map(|(_, ib)| ib.clone()).collect();
+    if !input_blocks.is_empty() {
+        return input_blocks;
     }
-    // Legacy fallback
-    if chain.input_device_id.0.is_empty() && chain.input_channels.is_empty() {
-        // Completely empty — return a single mono input on channel 0 so processing works
-        return vec![ChainInput {
-            name: "Input 1".to_string(),
-            device_id: chain.input_device_id.clone(),
-            mode: chain.input_mode,
-            channels: if chain.input_channels.is_empty() {
-                vec![0]
-            } else {
-                chain.input_channels.clone()
-            },
-        }];
-    }
-    vec![ChainInput {
+    // Fallback — no InputBlocks defined
+    vec![InputBlock {
         name: "Input 1".to_string(),
-        device_id: chain.input_device_id.clone(),
-        mode: chain.input_mode,
-        channels: chain.input_channels.clone(),
+        device_id: domain::ids::DeviceId("".to_string()),
+        mode: ChainInputMode::Mono,
+        channels: vec![0],
     }]
 }
 
-/// Build effective outputs from chain, falling back to legacy fields if `outputs` is empty.
-fn effective_outputs(chain: &Chain) -> Vec<project::chain::ChainOutput> {
-    if !chain.outputs.is_empty() {
-        return chain.outputs.clone();
+/// Build effective outputs from chain's OutputBlock entries.
+/// Falls back to a single mono output on channel 0 if no OutputBlocks exist.
+fn effective_outputs(chain: &Chain) -> Vec<OutputBlock> {
+    let output_blocks: Vec<OutputBlock> = chain.output_blocks().into_iter().map(|(_, ob)| ob.clone()).collect();
+    if !output_blocks.is_empty() {
+        return output_blocks;
     }
-    // Legacy fallback
-    let mode = if chain.output_channels.len() >= 2 {
-        ChainOutputMode::Stereo
-    } else {
-        ChainOutputMode::Mono
-    };
-    vec![project::chain::ChainOutput {
+    // Fallback — no OutputBlocks defined
+    vec![OutputBlock {
         name: "Output 1".to_string(),
-        device_id: chain.output_device_id.clone(),
-        mode,
-        channels: if chain.output_channels.is_empty() {
-            vec![0]
-        } else {
-            chain.output_channels.clone()
-        },
+        device_id: domain::ids::DeviceId("".to_string()),
+        mode: ChainOutputMode::Mono,
+        channels: vec![0],
     }]
 }
 
 fn build_input_processing_state(
     chain: &Chain,
-    input: &ChainInput,
+    input: &InputBlock,
     output_channels: &[usize],
     sample_rate: f32,
     existing_blocks: Option<Vec<BlockRuntimeNode>>,
@@ -438,7 +420,7 @@ fn build_input_processing_state(
     })
 }
 
-fn build_output_routing_state(output: &project::chain::ChainOutput) -> OutputRoutingState {
+fn build_output_routing_state(output: &OutputBlock) -> OutputRoutingState {
     let output_layout = if output.channels.len() >= 2 {
         match output.mode {
             ChainOutputMode::Stereo => AudioChannelLayout::Stereo,
@@ -571,6 +553,10 @@ fn build_runtime_block_nodes(
             }
             continue;
         }
+        // Input/Output blocks are routing metadata; skip them in the processing chain
+        if matches!(&block.kind, AudioBlockKind::Input(_) | AudioBlockKind::Output(_)) {
+            continue;
+        }
         if let AudioBlockKind::Select(select) = &block.kind {
             let existing_select_node = reusable_nodes
                 .remove(&block.id)
@@ -648,6 +634,8 @@ fn build_block_runtime_node(
         AudioBlockKind::Select(select) => {
             build_select_runtime_node(chain, block, select, input_layout, sample_rate, None)?
         }
+        // Input/Output blocks are routing-only; they don't process audio in the block chain
+        AudioBlockKind::Input(_) | AudioBlockKind::Output(_) => bypass_runtime_node(block, input_layout),
     })
 }
 
@@ -1446,11 +1434,11 @@ mod tests {
     use domain::ids::{BlockId, DeviceId, ChainId};
     use domain::value_objects::ParameterValue;
     use project::block::{
-        AudioBlock, AudioBlockKind, CoreBlock, SelectBlock, schema_for_block_model,
+        AudioBlock, AudioBlockKind, CoreBlock, InputBlock, OutputBlock, SelectBlock, schema_for_block_model,
     };
     use project::param::ParameterSet;
     use project::project::Project;
-    use project::chain::{Chain, ChainInputMode, ChainOutputMixdown};
+    use project::chain::{Chain, ChainInputMode, ChainOutputMode};
     use std::collections::HashMap;
     use std::sync::Arc;
 
@@ -1466,12 +1454,6 @@ mod tests {
                 description: Some("Cab test".into()),
                 instrument: "electric_guitar".to_string(),
                 enabled: true,
-                inputs: Vec::new(),
-                outputs: Vec::new(),
-                input_device_id: DeviceId("input-device".into()),
-                input_channels: vec![0],
-                output_device_id: DeviceId("output-device".into()),
-                output_channels: vec![0],
                 blocks: vec![AudioBlock {
                     id: BlockId("chain:0:block:0".into()),
                     enabled: true,
@@ -1481,8 +1463,6 @@ mod tests {
                         params,
                     }),
                 }],
-                output_mixdown: ChainOutputMixdown::Average,
-                input_mode: ChainInputMode::Mono,
             }],
         };
 
@@ -1506,12 +1486,6 @@ mod tests {
                 description: Some("Cab test".into()),
                 instrument: "electric_guitar".to_string(),
                 enabled: true,
-                inputs: Vec::new(),
-                outputs: Vec::new(),
-                input_device_id: DeviceId("input-device".into()),
-                input_channels: vec![0],
-                output_device_id: DeviceId("output-device".into()),
-                output_channels: vec![0],
                 blocks: vec![AudioBlock {
                     id: BlockId("chain:0:block:0".into()),
                     enabled: true,
@@ -1521,8 +1495,6 @@ mod tests {
                         params,
                     }),
                 }],
-                output_mixdown: ChainOutputMixdown::Average,
-                input_mode: ChainInputMode::Mono,
             }],
         };
 
@@ -1655,20 +1627,32 @@ mod tests {
             description: Some("Stereo isolation".into()),
             instrument: "electric_guitar".to_string(),
             enabled: true,
-            inputs: Vec::new(),
-            outputs: Vec::new(),
-            input_device_id: DeviceId("input-device".into()),
-            input_channels: vec![0, 1],
-            output_device_id: DeviceId("output-device".into()),
-            output_channels: vec![0, 1],
             blocks: vec![
+                AudioBlock {
+                    id: BlockId("chain:stereo:input:0".into()),
+                    enabled: true,
+                    kind: AudioBlockKind::Input(InputBlock {
+                        name: "Input 1".to_string(),
+                        device_id: DeviceId("input-device".into()),
+                        mode: ChainInputMode::Mono,
+                        channels: vec![0, 1],
+                    }),
+                },
                 compressor_block("chain:stereo:block:0"),
                 preamp_block("chain:stereo:block:1"),
                 native_cab_block("chain:stereo:block:2"),
                 reverb_block("chain:stereo:block:3"),
+                AudioBlock {
+                    id: BlockId("chain:stereo:output:0".into()),
+                    enabled: true,
+                    kind: AudioBlockKind::Output(OutputBlock {
+                        name: "Output 1".to_string(),
+                        device_id: DeviceId("output-device".into()),
+                        mode: ChainOutputMode::Stereo,
+                        channels: vec![0, 1],
+                    }),
+                },
             ],
-            output_mixdown: ChainOutputMixdown::Average,
-            input_mode: ChainInputMode::Mono,
         };
         let runtime =
             Arc::new(build_chain_runtime_state(&chain, 48_000.0).expect("runtime state should build"));
@@ -1700,19 +1684,31 @@ mod tests {
             description: Some("Stereo isolation asset-backed".into()),
             instrument: "electric_guitar".to_string(),
             enabled: true,
-            inputs: Vec::new(),
-            outputs: Vec::new(),
-            input_device_id: DeviceId("input-device".into()),
-            input_channels: vec![0, 1],
-            output_device_id: DeviceId("output-device".into()),
-            output_channels: vec![0, 1],
             blocks: vec![
+                AudioBlock {
+                    id: BlockId("chain:asset-backed:input:0".into()),
+                    enabled: true,
+                    kind: AudioBlockKind::Input(InputBlock {
+                        name: "Input 1".to_string(),
+                        device_id: DeviceId("input-device".into()),
+                        mode: ChainInputMode::Mono,
+                        channels: vec![0, 1],
+                    }),
+                },
                 marshall_preamp_block("chain:asset-backed:block:0"),
                 ir_cab_block("chain:asset-backed:block:1"),
                 reverb_block("chain:asset-backed:block:2"),
+                AudioBlock {
+                    id: BlockId("chain:asset-backed:output:0".into()),
+                    enabled: true,
+                    kind: AudioBlockKind::Output(OutputBlock {
+                        name: "Output 1".to_string(),
+                        device_id: DeviceId("output-device".into()),
+                        mode: ChainOutputMode::Stereo,
+                        channels: vec![0, 1],
+                    }),
+                },
             ],
-            output_mixdown: ChainOutputMixdown::Average,
-            input_mode: ChainInputMode::Mono,
         };
         let runtime =
             Arc::new(build_chain_runtime_state(&chain, 48_000.0).expect("runtime state should build"));
@@ -1779,15 +1775,7 @@ mod tests {
             description: Some("Tuner chain".into()),
             instrument: "electric_guitar".to_string(),
             enabled: true,
-            inputs: Vec::new(),
-            outputs: Vec::new(),
-            input_device_id: DeviceId("input-device".into()),
-            input_channels: vec![0],
-            output_device_id: DeviceId("output-device".into()),
-            output_channels: vec![0],
             blocks,
-            output_mixdown: ChainOutputMixdown::Average,
-            input_mode: ChainInputMode::Mono,
         }
     }
 
@@ -1944,12 +1932,6 @@ mod tests {
             description: Some("Delay select".into()),
             instrument: "electric_guitar".to_string(),
             enabled: true,
-            inputs: Vec::new(),
-            outputs: Vec::new(),
-            input_device_id: DeviceId("input-device".into()),
-            input_channels: vec![0],
-            output_device_id: DeviceId("output-device".into()),
-            output_channels: vec![0],
             blocks: vec![AudioBlock {
                 id: BlockId(format!("{id}:block:0")),
                 enabled: true,
@@ -1961,8 +1943,6 @@ mod tests {
                     ],
                 }),
             }],
-            output_mixdown: ChainOutputMixdown::Average,
-            input_mode: ChainInputMode::Mono,
         }
     }
 

--- a/crates/engine/src/runtime.rs
+++ b/crates/engine/src/runtime.rs
@@ -1422,6 +1422,13 @@ pub fn process_input_f32(
     // Collect processed frames and output routing info, then release processing lock
     let processed: Vec<AudioFrame> = input_state.frame_buffer.drain(..).collect();
     let segment_routes = input_state.output_route_indices.clone();
+    if input_index == 0 {
+        static INPUT0_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let c = INPUT0_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        if c % 1000 == 0 {
+            log::info!("[process_input] idx=0 frames={} routes={:?} (call #{})", processed.len(), segment_routes, c);
+        }
+    }
     drop(processing);
 
     // Mix processed frames into this segment's output routes only.

--- a/crates/engine/src/runtime.rs
+++ b/crates/engine/src/runtime.rs
@@ -1445,8 +1445,12 @@ pub fn process_input_f32(
             }
         }
         Ok(mut output) => {
-        // TEMP: always push to all routes to diagnose Insert issue
-        let route_indices: Vec<usize> = (0..output.output_routes.len()).collect();
+        let route_indices = if segment_routes.is_empty() {
+            // Legacy: push to all output routes
+            (0..output.output_routes.len()).collect::<Vec<_>>()
+        } else {
+            segment_routes
+        };
         for &route_idx in &route_indices {
             if let Some(route) = output.output_routes.get_mut(route_idx) {
                 let existing_len = route.queue.len();

--- a/crates/engine/src/runtime.rs
+++ b/crates/engine/src/runtime.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Result};
 use domain::ids::{BlockId, ChainId};
 use project::block::{
-    schema_for_block_model, AudioBlockKind, CoreBlock, InputEntry, NamBlock, OutputEntry, SelectBlock,
+    schema_for_block_model, AudioBlockKind, CoreBlock, InputEntry, InsertBlock, NamBlock, OutputEntry, SelectBlock,
 };
 use project::param::ParameterSet;
 use project::project::Project;
@@ -225,6 +225,9 @@ struct InputProcessingState {
     frame_buffer: Vec<AudioFrame>,
     /// Remaining frames of fade-in after a rebuild (0 = no fade active).
     fade_in_remaining: usize,
+    /// Which output route indices this input/segment should push frames to.
+    /// Empty means push to ALL output routes (legacy behaviour).
+    output_route_indices: Vec<usize>,
 }
 
 struct ChainProcessingState {
@@ -311,24 +314,31 @@ pub fn build_runtime_graph(
 }
 
 pub fn build_chain_runtime_state(chain: &Chain, sample_rate: f32) -> Result<ChainRuntimeState> {
-    // Resolve effective inputs: use new multi-input if available, else legacy fallback
-    let effective_inputs = effective_inputs(chain);
-    let effective_outputs = effective_outputs(chain);
+    let eff_inputs = effective_inputs(chain);
+    let eff_outputs = effective_outputs(chain);
+    let segments = split_chain_into_segments(chain, &eff_inputs, &eff_outputs);
 
-    // Collect all output channels for processing layout determination
-    let all_output_channels: Vec<usize> = effective_outputs
-        .iter()
-        .flat_map(|e| e.channels.iter().copied())
-        .collect();
-
-    let mut input_states = Vec::with_capacity(effective_inputs.len());
-    for input in &effective_inputs {
-        let input_state = build_input_processing_state(chain, input, &all_output_channels, sample_rate, None)?;
+    let mut input_states = Vec::with_capacity(segments.len());
+    for segment in &segments {
+        // Determine output channels for this segment's outputs (for processing layout)
+        let segment_output_channels: Vec<usize> = segment.output_route_indices.iter()
+            .filter_map(|&idx| eff_outputs.get(idx))
+            .flat_map(|e| e.channels.iter().copied())
+            .collect();
+        let input_state = build_input_processing_state(
+            chain,
+            &segment.input,
+            &segment_output_channels,
+            sample_rate,
+            None,
+            Some(&segment.block_indices),
+            segment.output_route_indices.clone(),
+        )?;
         input_states.push(input_state);
     }
 
-    let mut output_routes = Vec::with_capacity(effective_outputs.len());
-    for output in &effective_outputs {
+    let mut output_routes = Vec::with_capacity(eff_outputs.len());
+    for output in &eff_outputs {
         output_routes.push(build_output_routing_state(output));
     }
 
@@ -344,10 +354,11 @@ pub fn build_chain_runtime_state(chain: &Chain, sample_rate: f32) -> Result<Chai
     })
 }
 
-/// Build effective input entries from chain's InputBlock entries.
-/// Falls back to a single mono input on channel 0 if no InputBlocks exist.
+/// Build effective input entries from chain's InputBlock entries, plus Insert return entries.
+/// Order: InputBlock entries first, then Insert return entries (matches CPAL stream order).
+/// Falls back to a single mono input on channel 0 if no InputBlocks exist and no Inserts.
 fn effective_inputs(chain: &Chain) -> Vec<InputEntry> {
-    let entries: Vec<InputEntry> = chain.blocks.iter()
+    let mut entries: Vec<InputEntry> = chain.blocks.iter()
         .filter(|b| b.enabled)
         .filter_map(|b| match &b.kind {
             AudioBlockKind::Input(ib) => Some(ib),
@@ -355,6 +366,17 @@ fn effective_inputs(chain: &Chain) -> Vec<InputEntry> {
         })
         .flat_map(|ib| ib.entries.iter().cloned())
         .collect();
+
+    // Append Insert return entries (as inputs for segments after each Insert)
+    let insert_returns: Vec<InputEntry> = chain.blocks.iter()
+        .filter(|b| b.enabled)
+        .filter_map(|b| match &b.kind {
+            AudioBlockKind::Insert(ib) => Some(insert_return_as_input_entry(ib)),
+            _ => None,
+        })
+        .collect();
+    entries.extend(insert_returns);
+
     if !entries.is_empty() {
         return entries;
     }
@@ -367,10 +389,11 @@ fn effective_inputs(chain: &Chain) -> Vec<InputEntry> {
     }]
 }
 
-/// Build effective output entries from chain's OutputBlock entries.
-/// Falls back to a single mono output on channel 0 if no OutputBlocks exist.
+/// Build effective output entries from chain's OutputBlock entries, plus Insert send entries.
+/// Order: OutputBlock entries first, then Insert send entries (matches CPAL stream order).
+/// Falls back to a single mono output on channel 0 if no OutputBlocks exist and no Inserts.
 fn effective_outputs(chain: &Chain) -> Vec<OutputEntry> {
-    let entries: Vec<OutputEntry> = chain.blocks.iter()
+    let mut entries: Vec<OutputEntry> = chain.blocks.iter()
         .filter(|b| b.enabled)
         .filter_map(|b| match &b.kind {
             AudioBlockKind::Output(ob) => Some(ob),
@@ -378,6 +401,17 @@ fn effective_outputs(chain: &Chain) -> Vec<OutputEntry> {
         })
         .flat_map(|ob| ob.entries.iter().cloned())
         .collect();
+
+    // Append Insert send entries (as outputs for segments before each Insert)
+    let insert_sends: Vec<OutputEntry> = chain.blocks.iter()
+        .filter(|b| b.enabled)
+        .filter_map(|b| match &b.kind {
+            AudioBlockKind::Insert(ib) => Some(insert_send_as_output_entry(ib)),
+            _ => None,
+        })
+        .collect();
+    entries.extend(insert_sends);
+
     if !entries.is_empty() {
         return entries;
     }
@@ -390,12 +424,201 @@ fn effective_outputs(chain: &Chain) -> Vec<OutputEntry> {
     }]
 }
 
+/// Convert an InsertBlock's return endpoint to an InputEntry.
+fn insert_return_as_input_entry(insert: &InsertBlock) -> InputEntry {
+    InputEntry {
+        name: "Insert Return".to_string(),
+        device_id: insert.return_.device_id.clone(),
+        mode: insert.return_.mode,
+        channels: insert.return_.channels.clone(),
+    }
+}
+
+/// Convert an InsertBlock's send endpoint to an OutputEntry.
+fn insert_send_as_output_entry(insert: &InsertBlock) -> OutputEntry {
+    OutputEntry {
+        name: "Insert Send".to_string(),
+        device_id: insert.send.device_id.clone(),
+        mode: match insert.send.mode {
+            ChainInputMode::Mono => ChainOutputMode::Mono,
+            _ => ChainOutputMode::Stereo,
+        },
+        channels: insert.send.channels.clone(),
+    }
+}
+
+/// Describes a chain segment: an input source, its effect blocks, and its output targets.
+struct ChainSegment {
+    input: InputEntry,
+    /// Indices of the AudioBlocks in chain.blocks that belong to this segment's effect chain.
+    block_indices: Vec<usize>,
+    /// Indices into the effective_outputs list that this segment pushes to.
+    output_route_indices: Vec<usize>,
+}
+
+/// Split a chain into segments at enabled Insert block boundaries.
+///
+/// Example: [Input, Comp, EQ, Insert, Delay, Reverb, Output]
+///   Segment 1: input=InputBlock entries, blocks=[Comp, EQ], outputs=[Insert send]
+///   Segment 2: input=Insert return,      blocks=[Delay, Reverb], outputs=[OutputBlock entries]
+///
+/// If no Insert blocks exist, a single segment covers the entire chain.
+fn split_chain_into_segments(chain: &Chain, effective_ins: &[InputEntry], effective_outs: &[OutputEntry]) -> Vec<ChainSegment> {
+    // Count regular InputBlock entries and OutputBlock entries
+    let regular_input_count: usize = chain.blocks.iter()
+        .filter(|b| b.enabled)
+        .filter_map(|b| match &b.kind {
+            AudioBlockKind::Input(ib) => Some(ib.entries.len()),
+            _ => None,
+        })
+        .sum();
+    let regular_output_count: usize = chain.blocks.iter()
+        .filter(|b| b.enabled)
+        .filter_map(|b| match &b.kind {
+            AudioBlockKind::Output(ob) => Some(ob.entries.len()),
+            _ => None,
+        })
+        .sum();
+
+    // Find positions of enabled Insert blocks in chain.blocks
+    let insert_positions: Vec<usize> = chain.blocks.iter()
+        .enumerate()
+        .filter(|(_, b)| b.enabled && matches!(&b.kind, AudioBlockKind::Insert(_)))
+        .map(|(i, _)| i)
+        .collect();
+
+    if insert_positions.is_empty() {
+        // No inserts — single segment, all inputs push to all outputs
+        let block_indices: Vec<usize> = chain.blocks.iter()
+            .enumerate()
+            .filter(|(_, b)| !matches!(&b.kind, AudioBlockKind::Input(_) | AudioBlockKind::Output(_) | AudioBlockKind::Insert(_)))
+            .map(|(i, _)| i)
+            .collect();
+        let all_output_indices: Vec<usize> = (0..effective_outs.len()).collect();
+        // One segment per regular input entry
+        return effective_ins.iter().enumerate().map(|(_i, input)| {
+            ChainSegment {
+                input: input.clone(),
+                block_indices: block_indices.clone(),
+                output_route_indices: all_output_indices.clone(),
+            }
+        }).filter(|_| true) // keep type inference happy
+        .take(if regular_input_count > 0 { regular_input_count } else { effective_ins.len() })
+        .collect();
+    }
+
+    // With inserts: split into segments
+    let mut segments = Vec::new();
+    let mut insert_return_idx = regular_input_count; // Insert return entries start after regular inputs
+    let mut insert_send_idx = regular_output_count;  // Insert send entries start after regular outputs
+
+    // Segment boundaries: [start_of_chain .. first_insert, first_insert .. second_insert, ...]
+    let mut segment_start: usize = 0;
+    for (insert_order, &insert_pos) in insert_positions.iter().enumerate() {
+        // Effect blocks for this segment: blocks between segment_start and insert_pos
+        // (excluding Input, Output, Insert routing blocks)
+        let block_indices: Vec<usize> = (segment_start..insert_pos)
+            .filter(|&i| {
+                let b = &chain.blocks[i];
+                !matches!(&b.kind, AudioBlockKind::Input(_) | AudioBlockKind::Output(_) | AudioBlockKind::Insert(_))
+            })
+            .collect();
+
+        // Output routes for this segment: the Insert send entry
+        // Also include any OutputBlock entries that appear BEFORE this Insert
+        let mut output_indices = Vec::new();
+        // Regular OutputBlock entries that appear before this insert position
+        let mut regular_out_idx = 0;
+        for b in &chain.blocks[..insert_pos] {
+            if b.enabled {
+                if let AudioBlockKind::Output(ob) = &b.kind {
+                    for _ in 0..ob.entries.len() {
+                        output_indices.push(regular_out_idx);
+                        regular_out_idx += 1;
+                    }
+                } else {
+                    // still need to count outputs
+                }
+            }
+        }
+        // The Insert send for this segment
+        output_indices.push(insert_send_idx);
+
+        if insert_order == 0 {
+            // First segment: use regular InputBlock entries
+            let input_count = if regular_input_count > 0 { regular_input_count } else { 1 };
+            for i in 0..input_count {
+                segments.push(ChainSegment {
+                    input: effective_ins[i].clone(),
+                    block_indices: block_indices.clone(),
+                    output_route_indices: output_indices.clone(),
+                });
+            }
+        } else {
+            // Subsequent segments before an insert: use previous insert's return
+            let prev_return_idx = insert_return_idx - 1;
+            segments.push(ChainSegment {
+                input: effective_ins[prev_return_idx].clone(),
+                block_indices,
+                output_route_indices: output_indices,
+            });
+        }
+
+        insert_return_idx += 1;
+        insert_send_idx += 1;
+        segment_start = insert_pos + 1;
+    }
+
+    // Final segment: after the last Insert to end of chain
+    let block_indices: Vec<usize> = (segment_start..chain.blocks.len())
+        .filter(|&i| {
+            let b = &chain.blocks[i];
+            !matches!(&b.kind, AudioBlockKind::Input(_) | AudioBlockKind::Output(_) | AudioBlockKind::Insert(_))
+        })
+        .collect();
+
+    // Output routes: regular OutputBlock entries that appear AFTER the last Insert
+    let last_insert_pos = *insert_positions.last().unwrap();
+    let mut output_indices = Vec::new();
+    let mut regular_out_idx = 0;
+    for (bi, b) in chain.blocks.iter().enumerate() {
+        if b.enabled {
+            if let AudioBlockKind::Output(ob) = &b.kind {
+                if bi > last_insert_pos {
+                    for _ in 0..ob.entries.len() {
+                        output_indices.push(regular_out_idx);
+                        regular_out_idx += 1;
+                    }
+                } else {
+                    regular_out_idx += ob.entries.len();
+                }
+            }
+        }
+    }
+    // If no OutputBlocks after last insert, use all regular output indices
+    if output_indices.is_empty() {
+        output_indices = (0..regular_output_count).collect();
+    }
+
+    // Last insert's return is the input for this segment
+    let last_return_idx = insert_return_idx - 1;
+    segments.push(ChainSegment {
+        input: effective_ins[last_return_idx].clone(),
+        block_indices,
+        output_route_indices: output_indices,
+    });
+
+    segments
+}
+
 fn build_input_processing_state(
     chain: &Chain,
     input: &InputEntry,
     output_channels: &[usize],
     sample_rate: f32,
     existing_blocks: Option<Vec<BlockRuntimeNode>>,
+    block_indices: Option<&[usize]>,
+    output_route_indices: Vec<usize>,
 ) -> Result<InputProcessingState> {
     // Use both input and output channel info to determine processing layout
     // (matches legacy behavior: mono input + stereo output = stereo processing)
@@ -421,7 +644,7 @@ fn build_input_processing_state(
         input.mode,
     );
     let (blocks, _output_layout) =
-        build_runtime_block_nodes(chain, processing_layout_channel, sample_rate, existing_blocks)?;
+        build_runtime_block_nodes(chain, processing_layout_channel, sample_rate, existing_blocks, block_indices)?;
 
     Ok(InputProcessingState {
         input_read_layout,
@@ -430,6 +653,7 @@ fn build_input_processing_state(
         blocks,
         frame_buffer: Vec::with_capacity(1024),
         fade_in_remaining: FADE_IN_FRAMES,
+        output_route_indices,
     })
 }
 
@@ -458,10 +682,7 @@ pub fn update_chain_runtime_state(
 ) -> Result<()> {
     let effective_ins = effective_inputs(chain);
     let effective_outs = effective_outputs(chain);
-    let all_output_channels: Vec<usize> = effective_outs
-        .iter()
-        .flat_map(|o| o.channels.iter().copied())
-        .collect();
+    let segments = split_chain_into_segments(chain, &effective_ins, &effective_outs);
 
     // Step 1: Extract existing blocks from all input states (brief lock)
     let mut existing_per_input: Vec<Vec<BlockRuntimeNode>> = {
@@ -474,14 +695,26 @@ pub fn update_chain_runtime_state(
     };
 
     // Step 2: Build new input states OUTSIDE the lock (no audio interruption)
-    let mut new_input_states = Vec::with_capacity(effective_ins.len());
-    for (i, input) in effective_ins.iter().enumerate() {
+    let mut new_input_states = Vec::with_capacity(segments.len());
+    for (i, segment) in segments.iter().enumerate() {
         let existing = if i < existing_per_input.len() {
             Some(std::mem::take(&mut existing_per_input[i]))
         } else {
             None
         };
-        let input_state = build_input_processing_state(chain, input, &all_output_channels, sample_rate, existing)?;
+        let segment_output_channels: Vec<usize> = segment.output_route_indices.iter()
+            .filter_map(|&idx| effective_outs.get(idx))
+            .flat_map(|e| e.channels.iter().copied())
+            .collect();
+        let input_state = build_input_processing_state(
+            chain,
+            &segment.input,
+            &segment_output_channels,
+            sample_rate,
+            existing,
+            Some(&segment.block_indices),
+            segment.output_route_indices.clone(),
+        )?;
         new_input_states.push(input_state);
     }
 
@@ -544,6 +777,7 @@ fn build_runtime_block_nodes(
     input_layout: AudioChannelLayout,
     sample_rate: f32,
     existing: Option<Vec<BlockRuntimeNode>>,
+    block_indices: Option<&[usize]>,
 ) -> Result<(Vec<BlockRuntimeNode>, AudioChannelLayout)> {
     let mut blocks = Vec::new();
     let mut current_layout = input_layout;
@@ -553,7 +787,15 @@ fn build_runtime_block_nodes(
         .map(|node| (node.block_id.clone(), node))
         .collect::<HashMap<_, _>>();
 
-    for block in &chain.blocks {
+    // If block_indices is provided, iterate only those blocks; otherwise iterate all
+    let block_iter: Vec<&project::block::AudioBlock> = match block_indices {
+        Some(indices) => indices.iter()
+            .filter_map(|&i| chain.blocks.get(i))
+            .collect(),
+        None => chain.blocks.iter().collect(),
+    };
+
+    for block in block_iter {
         // Disabled blocks: try to reuse existing node (keeps processor alive
         // for instant re-enable), otherwise create a bypass node.
         if !block.enabled {
@@ -1086,6 +1328,7 @@ pub fn process_input_f32(
         blocks,
         frame_buffer,
         fade_in_remaining,
+        output_route_indices: _,
     } = input_state;
 
     let tuner_enabled = blocks.iter().any(block_has_active_tuner);
@@ -1154,27 +1397,36 @@ pub fn process_input_f32(
         }
     }
 
-    // Collect processed frames into a local vec, then release processing lock
+    // Collect processed frames and output routing info, then release processing lock
     let processed: Vec<AudioFrame> = input_state.frame_buffer.drain(..).collect();
+    let segment_routes = input_state.output_route_indices.clone();
     drop(processing);
 
-    // Mix processed frames into all output routes.
+    // Mix processed frames into this segment's output routes only.
     // If the queue already has frames (from another input), sum them.
     // Otherwise, push new frames.
     if let Ok(mut output) = runtime.output.try_lock() {
-        for route in output.output_routes.iter_mut() {
-            let existing_len = route.queue.len();
-            for (i, &frame) in processed.iter().enumerate() {
-                if i < existing_len {
-                    // Sum with existing frame from another input
-                    let existing = &mut route.queue[i];
-                    *existing = mix_frames(*existing, frame);
-                } else {
-                    // No existing frame yet — push as-is
-                    route.queue.push_back(frame);
+        let route_indices = if segment_routes.is_empty() {
+            // Legacy: push to all output routes
+            (0..output.output_routes.len()).collect::<Vec<_>>()
+        } else {
+            segment_routes
+        };
+        for &route_idx in &route_indices {
+            if let Some(route) = output.output_routes.get_mut(route_idx) {
+                let existing_len = route.queue.len();
+                for (i, &frame) in processed.iter().enumerate() {
+                    if i < existing_len {
+                        // Sum with existing frame from another input
+                        let existing = &mut route.queue[i];
+                        *existing = mix_frames(*existing, frame);
+                    } else {
+                        // No existing frame yet — push as-is
+                        route.queue.push_back(frame);
+                    }
                 }
+                trim_output_queue(&mut route.queue);
             }
-            trim_output_queue(&mut route.queue);
         }
     }
 }

--- a/crates/engine/src/runtime.rs
+++ b/crates/engine/src/runtime.rs
@@ -1434,7 +1434,17 @@ pub fn process_input_f32(
     // Mix processed frames into this segment's output routes only.
     // If the queue already has frames (from another input), sum them.
     // Otherwise, push new frames.
-    if let Ok(mut output) = runtime.output.try_lock() {
+    match runtime.output.try_lock() {
+        Err(_) => {
+            if input_index == 0 {
+                static LOCK_FAIL: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+                let c = LOCK_FAIL.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                if c % 100 == 0 {
+                    log::warn!("[process_input] idx=0 OUTPUT LOCK FAILED (#{}) — {} frames DROPPED", c, processed.len());
+                }
+            }
+        }
+        Ok(mut output) => {
         let route_indices = if segment_routes.is_empty() {
             // Legacy: push to all output routes
             (0..output.output_routes.len()).collect::<Vec<_>>()
@@ -1456,6 +1466,7 @@ pub fn process_input_f32(
                 }
                 trim_output_queue(&mut route.queue);
             }
+        }
         }
     }
 }

--- a/crates/infra-cpal/src/lib.rs
+++ b/crates/infra-cpal/src/lib.rs
@@ -413,12 +413,6 @@ fn resolve_chain_inputs(
     if input_entries.is_empty() {
         bail!("chain '{}' has no input blocks configured", chain.id.0);
     }
-    for (i, entry) in input_entries.iter().enumerate() {
-        log::info!(
-            "resolve_chain_inputs: chain '{}' input[{}]: name='{}', device='{}', mode={:?}, channels={:?}",
-            chain.id.0, i, entry.name, entry.device_id.0, entry.mode, entry.channels,
-        );
-    }
     input_entries
         .iter()
         .map(|input| resolve_input_device_for_chain_input(host, project, input))
@@ -450,12 +444,6 @@ fn resolve_chain_outputs(
     output_entries.extend(insert_refs);
     if output_entries.is_empty() {
         bail!("chain '{}' has no output blocks configured", chain.id.0);
-    }
-    for (i, entry) in output_entries.iter().enumerate() {
-        log::info!(
-            "resolve_chain_outputs: chain '{}' output[{}]: name='{}', device='{}', mode={:?}, channels={:?}",
-            chain.id.0, i, entry.name, entry.device_id.0, entry.mode, entry.channels,
-        );
     }
     output_entries
         .iter()
@@ -848,17 +836,8 @@ fn build_chain_streams(
     resolved: ResolvedChainAudioConfig,
     runtime: Arc<ChainRuntimeState>,
 ) -> Result<(Vec<Stream>, Vec<Stream>)> {
-    log::info!(
-        "build_chain_streams: chain '{}' creating {} input stream(s) and {} output stream(s)",
-        chain_id.0, resolved.inputs.len(), resolved.outputs.len(),
-    );
     let mut input_streams = Vec::new();
     for (i, resolved_input) in resolved.inputs.into_iter().enumerate() {
-        log::info!(
-            "build_chain_streams: chain '{}' input_stream[{}] device='{}'",
-            chain_id.0, i,
-            resolved_input.settings.as_ref().map(|s| s.device_id.0.as_str()).unwrap_or("<default>"),
-        );
         let stream =
             build_input_stream_for_input(chain_id, i, resolved_input, runtime.clone())?;
         input_streams.push(stream);
@@ -866,11 +845,6 @@ fn build_chain_streams(
 
     let mut output_streams = Vec::new();
     for (j, resolved_output) in resolved.outputs.into_iter().enumerate() {
-        log::info!(
-            "build_chain_streams: chain '{}' output_stream[{}] device='{}'",
-            chain_id.0, j,
-            resolved_output.settings.as_ref().map(|s| s.device_id.0.as_str()).unwrap_or("<default>"),
-        );
         let stream =
             build_output_stream_for_output(chain_id, j, resolved_output, runtime.clone())?;
         output_streams.push(stream);

--- a/crates/infra-cpal/src/lib.rs
+++ b/crates/infra-cpal/src/lib.rs
@@ -8,7 +8,7 @@ use domain::ids::ChainId;
 use engine::runtime::{process_input_f32, process_output_f32, RuntimeGraph, ChainRuntimeState};
 use project::device::DeviceSettings;
 use project::project::Project;
-use project::block::{InputBlock, OutputBlock};
+use project::block::{InputEntry, OutputEntry};
 use project::chain::Chain;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -284,7 +284,7 @@ pub fn resolve_project_chain_sample_rates(project: &Project) -> Result<HashMap<C
 fn resolve_input_device_for_chain_input(
     host: &cpal::Host,
     project: &Project,
-    input: &InputBlock,
+    input: &InputEntry,
 ) -> Result<ResolvedInputDevice> {
     let settings = project
         .device_settings
@@ -337,7 +337,7 @@ fn resolve_input_device_for_chain_input(
 fn resolve_output_device_for_chain_output(
     host: &cpal::Host,
     project: &Project,
-    output: &OutputBlock,
+    output: &OutputEntry,
 ) -> Result<ResolvedOutputDevice> {
     let settings = project
         .device_settings
@@ -392,11 +392,14 @@ fn resolve_chain_inputs(
     project: &Project,
     chain: &Chain,
 ) -> Result<Vec<ResolvedInputDevice>> {
-    let input_blocks: Vec<&InputBlock> = chain.input_blocks().into_iter().map(|(_, ib)| ib).collect();
-    if input_blocks.is_empty() {
+    let input_entries: Vec<&InputEntry> = chain.input_blocks()
+        .into_iter()
+        .flat_map(|(_, ib)| ib.entries.iter())
+        .collect();
+    if input_entries.is_empty() {
         bail!("chain '{}' has no input blocks configured", chain.id.0);
     }
-    input_blocks
+    input_entries
         .iter()
         .map(|input| resolve_input_device_for_chain_input(host, project, input))
         .collect()
@@ -407,11 +410,14 @@ fn resolve_chain_outputs(
     project: &Project,
     chain: &Chain,
 ) -> Result<Vec<ResolvedOutputDevice>> {
-    let output_blocks: Vec<&OutputBlock> = chain.output_blocks().into_iter().map(|(_, ob)| ob).collect();
-    if output_blocks.is_empty() {
+    let output_entries: Vec<&OutputEntry> = chain.output_blocks()
+        .into_iter()
+        .flat_map(|(_, ob)| ob.entries.iter())
+        .collect();
+    if output_entries.is_empty() {
         bail!("chain '{}' has no output blocks configured", chain.id.0);
     }
-    output_blocks
+    output_entries
         .iter()
         .map(|output| resolve_output_device_for_chain_output(host, project, output))
         .collect()
@@ -489,11 +495,15 @@ fn validate_channels_against_devices(project: &Project, host: &cpal::Host) -> Re
 
 fn validate_chain_channels_against_devices(host: &cpal::Host, chain: &Chain) -> Result<()> {
     for (_, input) in chain.input_blocks() {
-        validate_input_channels_against_device(host, &chain.id.0, &input.device_id.0, &input.channels)?;
+        for entry in &input.entries {
+            validate_input_channels_against_device(host, &chain.id.0, &entry.device_id.0, &entry.channels)?;
+        }
     }
 
     for (_, output) in chain.output_blocks() {
-        validate_output_channels_against_device(host, &chain.id.0, &output.device_id.0, &output.channels)?;
+        for entry in &output.entries {
+            validate_output_channels_against_device(host, &chain.id.0, &entry.device_id.0, &entry.channels)?;
+        }
     }
 
     Ok(())
@@ -813,9 +823,12 @@ fn build_chain_stream_signature_multi(
     inputs: &[ResolvedInputDevice],
     outputs: &[ResolvedOutputDevice],
 ) -> ChainStreamSignature {
-    let chain_input_blocks: Vec<&InputBlock> = chain.input_blocks().into_iter().map(|(_, ib)| ib).collect();
-    let input_sigs: Vec<InputStreamSignature> = if !chain_input_blocks.is_empty() {
-        chain_input_blocks
+    let chain_input_entries: Vec<&InputEntry> = chain.input_blocks()
+        .into_iter()
+        .flat_map(|(_, ib)| ib.entries.iter())
+        .collect();
+    let input_sigs: Vec<InputStreamSignature> = if !chain_input_entries.is_empty() {
+        chain_input_entries
             .iter()
             .zip(inputs.iter())
             .map(|(ci, ri)| InputStreamSignature {
@@ -839,9 +852,12 @@ fn build_chain_stream_signature_multi(
             .collect()
     };
 
-    let chain_output_blocks: Vec<&OutputBlock> = chain.output_blocks().into_iter().map(|(_, ob)| ob).collect();
-    let output_sigs: Vec<OutputStreamSignature> = if !chain_output_blocks.is_empty() {
-        chain_output_blocks
+    let chain_output_entries: Vec<&OutputEntry> = chain.output_blocks()
+        .into_iter()
+        .flat_map(|(_, ob)| ob.entries.iter())
+        .collect();
+    let output_sigs: Vec<OutputStreamSignature> = if !chain_output_entries.is_empty() {
+        chain_output_entries
             .iter()
             .zip(outputs.iter())
             .map(|(co, ro)| OutputStreamSignature {

--- a/crates/infra-cpal/src/lib.rs
+++ b/crates/infra-cpal/src/lib.rs
@@ -413,6 +413,12 @@ fn resolve_chain_inputs(
     if input_entries.is_empty() {
         bail!("chain '{}' has no input blocks configured", chain.id.0);
     }
+    for (i, entry) in input_entries.iter().enumerate() {
+        log::info!(
+            "resolve_chain_inputs: chain '{}' input[{}]: name='{}', device='{}', mode={:?}, channels={:?}",
+            chain.id.0, i, entry.name, entry.device_id.0, entry.mode, entry.channels,
+        );
+    }
     input_entries
         .iter()
         .map(|input| resolve_input_device_for_chain_input(host, project, input))
@@ -444,6 +450,12 @@ fn resolve_chain_outputs(
     output_entries.extend(insert_refs);
     if output_entries.is_empty() {
         bail!("chain '{}' has no output blocks configured", chain.id.0);
+    }
+    for (i, entry) in output_entries.iter().enumerate() {
+        log::info!(
+            "resolve_chain_outputs: chain '{}' output[{}]: name='{}', device='{}', mode={:?}, channels={:?}",
+            chain.id.0, i, entry.name, entry.device_id.0, entry.mode, entry.channels,
+        );
     }
     output_entries
         .iter()
@@ -836,8 +848,17 @@ fn build_chain_streams(
     resolved: ResolvedChainAudioConfig,
     runtime: Arc<ChainRuntimeState>,
 ) -> Result<(Vec<Stream>, Vec<Stream>)> {
+    log::info!(
+        "build_chain_streams: chain '{}' creating {} input stream(s) and {} output stream(s)",
+        chain_id.0, resolved.inputs.len(), resolved.outputs.len(),
+    );
     let mut input_streams = Vec::new();
     for (i, resolved_input) in resolved.inputs.into_iter().enumerate() {
+        log::info!(
+            "build_chain_streams: chain '{}' input_stream[{}] device='{}'",
+            chain_id.0, i,
+            resolved_input.settings.as_ref().map(|s| s.device_id.0.as_str()).unwrap_or("<default>"),
+        );
         let stream =
             build_input_stream_for_input(chain_id, i, resolved_input, runtime.clone())?;
         input_streams.push(stream);
@@ -845,6 +866,11 @@ fn build_chain_streams(
 
     let mut output_streams = Vec::new();
     for (j, resolved_output) in resolved.outputs.into_iter().enumerate() {
+        log::info!(
+            "build_chain_streams: chain '{}' output_stream[{}] device='{}'",
+            chain_id.0, j,
+            resolved_output.settings.as_ref().map(|s| s.device_id.0.as_str()).unwrap_or("<default>"),
+        );
         let stream =
             build_output_stream_for_output(chain_id, j, resolved_output, runtime.clone())?;
         output_streams.push(stream);

--- a/crates/infra-cpal/src/lib.rs
+++ b/crates/infra-cpal/src/lib.rs
@@ -8,7 +8,7 @@ use domain::ids::ChainId;
 use engine::runtime::{process_input_f32, process_output_f32, RuntimeGraph, ChainRuntimeState};
 use project::device::DeviceSettings;
 use project::project::Project;
-use project::block::{InputEntry, OutputEntry};
+use project::block::{AudioBlockKind, InputEntry, OutputEntry};
 use project::chain::Chain;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -392,9 +392,13 @@ fn resolve_chain_inputs(
     project: &Project,
     chain: &Chain,
 ) -> Result<Vec<ResolvedInputDevice>> {
-    let input_entries: Vec<&InputEntry> = chain.input_blocks()
-        .into_iter()
-        .flat_map(|(_, ib)| ib.entries.iter())
+    let input_entries: Vec<&InputEntry> = chain.blocks.iter()
+        .filter(|b| b.enabled)
+        .filter_map(|b| match &b.kind {
+            AudioBlockKind::Input(ib) => Some(ib),
+            _ => None,
+        })
+        .flat_map(|ib| ib.entries.iter())
         .collect();
     if input_entries.is_empty() {
         bail!("chain '{}' has no input blocks configured", chain.id.0);
@@ -410,9 +414,13 @@ fn resolve_chain_outputs(
     project: &Project,
     chain: &Chain,
 ) -> Result<Vec<ResolvedOutputDevice>> {
-    let output_entries: Vec<&OutputEntry> = chain.output_blocks()
-        .into_iter()
-        .flat_map(|(_, ob)| ob.entries.iter())
+    let output_entries: Vec<&OutputEntry> = chain.blocks.iter()
+        .filter(|b| b.enabled)
+        .filter_map(|b| match &b.kind {
+            AudioBlockKind::Output(ob) => Some(ob),
+            _ => None,
+        })
+        .flat_map(|ob| ob.entries.iter())
         .collect();
     if output_entries.is_empty() {
         bail!("chain '{}' has no output blocks configured", chain.id.0);

--- a/crates/infra-cpal/src/lib.rs
+++ b/crates/infra-cpal/src/lib.rs
@@ -8,7 +8,7 @@ use domain::ids::ChainId;
 use engine::runtime::{process_input_f32, process_output_f32, RuntimeGraph, ChainRuntimeState};
 use project::device::DeviceSettings;
 use project::project::Project;
-use project::block::{AudioBlockKind, InputEntry, OutputEntry};
+use project::block::{AudioBlockKind, InputEntry, InsertBlock, OutputEntry};
 use project::chain::Chain;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -392,7 +392,7 @@ fn resolve_chain_inputs(
     project: &Project,
     chain: &Chain,
 ) -> Result<Vec<ResolvedInputDevice>> {
-    let input_entries: Vec<&InputEntry> = chain.blocks.iter()
+    let mut input_entries: Vec<&InputEntry> = chain.blocks.iter()
         .filter(|b| b.enabled)
         .filter_map(|b| match &b.kind {
             AudioBlockKind::Input(ib) => Some(ib),
@@ -400,6 +400,16 @@ fn resolve_chain_inputs(
         })
         .flat_map(|ib| ib.entries.iter())
         .collect();
+    // Include Insert block return endpoints as input streams
+    let insert_return_entries: Vec<InputEntry> = chain.blocks.iter()
+        .filter(|b| b.enabled)
+        .filter_map(|b| match &b.kind {
+            AudioBlockKind::Insert(ib) => Some(insert_return_as_input_entry(ib)),
+            _ => None,
+        })
+        .collect();
+    let insert_refs: Vec<&InputEntry> = insert_return_entries.iter().collect();
+    input_entries.extend(insert_refs);
     if input_entries.is_empty() {
         bail!("chain '{}' has no input blocks configured", chain.id.0);
     }
@@ -414,7 +424,7 @@ fn resolve_chain_outputs(
     project: &Project,
     chain: &Chain,
 ) -> Result<Vec<ResolvedOutputDevice>> {
-    let output_entries: Vec<&OutputEntry> = chain.blocks.iter()
+    let mut output_entries: Vec<&OutputEntry> = chain.blocks.iter()
         .filter(|b| b.enabled)
         .filter_map(|b| match &b.kind {
             AudioBlockKind::Output(ob) => Some(ob),
@@ -422,6 +432,16 @@ fn resolve_chain_outputs(
         })
         .flat_map(|ob| ob.entries.iter())
         .collect();
+    // Include Insert block send endpoints as output streams
+    let insert_send_entries: Vec<OutputEntry> = chain.blocks.iter()
+        .filter(|b| b.enabled)
+        .filter_map(|b| match &b.kind {
+            AudioBlockKind::Insert(ib) => Some(insert_send_as_output_entry(ib)),
+            _ => None,
+        })
+        .collect();
+    let insert_refs: Vec<&OutputEntry> = insert_send_entries.iter().collect();
+    output_entries.extend(insert_refs);
     if output_entries.is_empty() {
         bail!("chain '{}' has no output blocks configured", chain.id.0);
     }
@@ -429,6 +449,30 @@ fn resolve_chain_outputs(
         .iter()
         .map(|output| resolve_output_device_for_chain_output(host, project, output))
         .collect()
+}
+
+/// Convert an InsertBlock's return endpoint to an InputEntry for stream resolution.
+fn insert_return_as_input_entry(insert: &InsertBlock) -> InputEntry {
+    InputEntry {
+        name: "Insert Return".to_string(),
+        device_id: insert.return_.device_id.clone(),
+        mode: insert.return_.mode,
+        channels: insert.return_.channels.clone(),
+    }
+}
+
+/// Convert an InsertBlock's send endpoint to an OutputEntry for stream resolution.
+fn insert_send_as_output_entry(insert: &InsertBlock) -> OutputEntry {
+    use project::chain::ChainOutputMode;
+    OutputEntry {
+        name: "Insert Send".to_string(),
+        device_id: insert.send.device_id.clone(),
+        mode: match insert.send.mode {
+            project::chain::ChainInputMode::Mono => ChainOutputMode::Mono,
+            _ => ChainOutputMode::Stereo,
+        },
+        channels: insert.send.channels.clone(),
+    }
 }
 
 fn resolve_enabled_chain_audio_configs(
@@ -511,6 +555,16 @@ fn validate_chain_channels_against_devices(host: &cpal::Host, chain: &Chain) -> 
     for (_, output) in chain.output_blocks() {
         for entry in &output.entries {
             validate_output_channels_against_device(host, &chain.id.0, &entry.device_id.0, &entry.channels)?;
+        }
+    }
+
+    // Validate Insert block endpoints
+    for (_, insert) in chain.insert_blocks() {
+        if !insert.send.device_id.0.is_empty() {
+            validate_output_channels_against_device(host, &chain.id.0, &insert.send.device_id.0, &insert.send.channels)?;
+        }
+        if !insert.return_.device_id.0.is_empty() {
+            validate_input_channels_against_device(host, &chain.id.0, &insert.return_.device_id.0, &insert.return_.channels)?;
         }
     }
 

--- a/crates/infra-cpal/src/lib.rs
+++ b/crates/infra-cpal/src/lib.rs
@@ -8,7 +8,8 @@ use domain::ids::ChainId;
 use engine::runtime::{process_input_f32, process_output_f32, RuntimeGraph, ChainRuntimeState};
 use project::device::DeviceSettings;
 use project::project::Project;
-use project::chain::{Chain, ChainInput, ChainOutput};
+use project::block::{InputBlock, OutputBlock};
+use project::chain::Chain;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -279,116 +280,11 @@ pub fn resolve_project_chain_sample_rates(project: &Project) -> Result<HashMap<C
     Ok(sample_rates)
 }
 
-fn resolve_input_device_for_chain(
-    host: &cpal::Host,
-    project: &Project,
-    chain: &Chain,
-) -> Result<ResolvedInputDevice> {
-    let settings = project
-        .device_settings
-        .iter()
-        .find(|settings| settings.device_id == chain.input_device_id)
-        .cloned();
-    let device = find_input_device_by_id(host, &chain.input_device_id.0)?.ok_or_else(|| {
-        anyhow!(
-            "input device '{}' not found by device_id",
-            chain.input_device_id.0
-        )
-    })?;
-    let default_config = device.default_input_config().with_context(|| {
-        format!(
-            "failed to get default input config for '{}'",
-            chain.input_device_id.0
-        )
-    })?;
-    let supported_ranges = device
-        .supported_input_configs()
-        .with_context(|| {
-            format!(
-                "failed to enumerate input configs for '{}'",
-                chain.input_device_id.0
-            )
-        })?
-        .collect::<Vec<_>>();
-    let required_channels = required_channel_count(&chain.input_channels);
-    let supported = select_supported_stream_config(
-        &default_config,
-        &supported_ranges,
-        settings.as_ref().map(|settings| settings.sample_rate),
-        required_channels,
-        &chain.input_device_id.0,
-    )?;
-    if let Some(settings) = &settings {
-        validate_buffer_size(
-            settings.buffer_size_frames,
-            supported.buffer_size(),
-            &settings.device_id.0,
-        )?;
-    }
-    Ok(ResolvedInputDevice {
-        settings,
-        device,
-        supported,
-    })
-}
-
-fn resolve_output_device_for_chain(
-    host: &cpal::Host,
-    project: &Project,
-    chain: &Chain,
-) -> Result<ResolvedOutputDevice> {
-    let settings = project
-        .device_settings
-        .iter()
-        .find(|settings| settings.device_id == chain.output_device_id)
-        .cloned();
-    let device = find_output_device_by_id(host, &chain.output_device_id.0)?.ok_or_else(|| {
-        anyhow!(
-            "output device '{}' not found by device_id",
-            chain.output_device_id.0
-        )
-    })?;
-    let default_config = device.default_output_config().with_context(|| {
-        format!(
-            "failed to get default output config for '{}'",
-            chain.output_device_id.0
-        )
-    })?;
-    let supported_ranges = device
-        .supported_output_configs()
-        .with_context(|| {
-            format!(
-                "failed to enumerate output configs for '{}'",
-                chain.output_device_id.0
-            )
-        })?
-        .collect::<Vec<_>>();
-    let required_channels = required_channel_count(&chain.output_channels);
-    let supported = select_supported_stream_config(
-        &default_config,
-        &supported_ranges,
-        settings.as_ref().map(|settings| settings.sample_rate),
-        required_channels,
-        &chain.output_device_id.0,
-    )?;
-    if let Some(settings) = &settings {
-        validate_buffer_size(
-            settings.buffer_size_frames,
-            supported.buffer_size(),
-            &settings.device_id.0,
-        )?;
-    }
-    Ok(ResolvedOutputDevice {
-        settings,
-        device,
-        supported,
-    })
-}
 
 fn resolve_input_device_for_chain_input(
     host: &cpal::Host,
     project: &Project,
-    input: &ChainInput,
+    input: &InputBlock,
 ) -> Result<ResolvedInputDevice> {
     let settings = project
         .device_settings
@@ -441,7 +337,7 @@ fn resolve_input_device_for_chain_input(
 fn resolve_output_device_for_chain_output(
     host: &cpal::Host,
     project: &Project,
-    output: &ChainOutput,
+    output: &OutputBlock,
 ) -> Result<ResolvedOutputDevice> {
     let settings = project
         .device_settings
@@ -496,16 +392,14 @@ fn resolve_chain_inputs(
     project: &Project,
     chain: &Chain,
 ) -> Result<Vec<ResolvedInputDevice>> {
-    if !chain.inputs.is_empty() {
-        chain
-            .inputs
-            .iter()
-            .map(|input| resolve_input_device_for_chain_input(host, project, input))
-            .collect()
-    } else {
-        // Legacy fallback: single input from chain.input_device_id
-        Ok(vec![resolve_input_device_for_chain(host, project, chain)?])
+    let input_blocks: Vec<&InputBlock> = chain.input_blocks().into_iter().map(|(_, ib)| ib).collect();
+    if input_blocks.is_empty() {
+        bail!("chain '{}' has no input blocks configured", chain.id.0);
     }
+    input_blocks
+        .iter()
+        .map(|input| resolve_input_device_for_chain_input(host, project, input))
+        .collect()
 }
 
 fn resolve_chain_outputs(
@@ -513,16 +407,14 @@ fn resolve_chain_outputs(
     project: &Project,
     chain: &Chain,
 ) -> Result<Vec<ResolvedOutputDevice>> {
-    if !chain.outputs.is_empty() {
-        chain
-            .outputs
-            .iter()
-            .map(|output| resolve_output_device_for_chain_output(host, project, output))
-            .collect()
-    } else {
-        // Legacy fallback: single output from chain.output_device_id
-        Ok(vec![resolve_output_device_for_chain(host, project, chain)?])
+    let output_blocks: Vec<&OutputBlock> = chain.output_blocks().into_iter().map(|(_, ob)| ob).collect();
+    if output_blocks.is_empty() {
+        bail!("chain '{}' has no output blocks configured", chain.id.0);
     }
+    output_blocks
+        .iter()
+        .map(|output| resolve_output_device_for_chain_output(host, project, output))
+        .collect()
 }
 
 fn resolve_enabled_chain_audio_configs(
@@ -596,22 +488,12 @@ fn validate_channels_against_devices(project: &Project, host: &cpal::Host) -> Re
 }
 
 fn validate_chain_channels_against_devices(host: &cpal::Host, chain: &Chain) -> Result<()> {
-    if !chain.inputs.is_empty() {
-        for input in &chain.inputs {
-            validate_input_channels_against_device(host, &chain.id.0, &input.device_id.0, &input.channels)?;
-        }
-    } else {
-        // Legacy fallback
-        validate_input_channels_against_device(host, &chain.id.0, &chain.input_device_id.0, &chain.input_channels)?;
+    for (_, input) in chain.input_blocks() {
+        validate_input_channels_against_device(host, &chain.id.0, &input.device_id.0, &input.channels)?;
     }
 
-    if !chain.outputs.is_empty() {
-        for output in &chain.outputs {
-            validate_output_channels_against_device(host, &chain.id.0, &output.device_id.0, &output.channels)?;
-        }
-    } else {
-        // Legacy fallback
-        validate_output_channels_against_device(host, &chain.id.0, &chain.output_device_id.0, &chain.output_channels)?;
+    for (_, output) in chain.output_blocks() {
+        validate_output_channels_against_device(host, &chain.id.0, &output.device_id.0, &output.channels)?;
     }
 
     Ok(())
@@ -931,9 +813,9 @@ fn build_chain_stream_signature_multi(
     inputs: &[ResolvedInputDevice],
     outputs: &[ResolvedOutputDevice],
 ) -> ChainStreamSignature {
-    let input_sigs: Vec<InputStreamSignature> = if !chain.inputs.is_empty() {
-        chain
-            .inputs
+    let chain_input_blocks: Vec<&InputBlock> = chain.input_blocks().into_iter().map(|(_, ib)| ib).collect();
+    let input_sigs: Vec<InputStreamSignature> = if !chain_input_blocks.is_empty() {
+        chain_input_blocks
             .iter()
             .zip(inputs.iter())
             .map(|(ci, ri)| InputStreamSignature {
@@ -948,8 +830,8 @@ fn build_chain_stream_signature_multi(
         inputs
             .iter()
             .map(|ri| InputStreamSignature {
-                device_id: chain.input_device_id.0.clone(),
-                channels: chain.input_channels.clone(),
+                device_id: String::new(),
+                channels: Vec::new(),
                 stream_channels: ri.supported.channels(),
                 sample_rate: resolved_input_sample_rate(ri),
                 buffer_size_frames: resolved_input_buffer_size_frames(ri),
@@ -957,9 +839,9 @@ fn build_chain_stream_signature_multi(
             .collect()
     };
 
-    let output_sigs: Vec<OutputStreamSignature> = if !chain.outputs.is_empty() {
-        chain
-            .outputs
+    let chain_output_blocks: Vec<&OutputBlock> = chain.output_blocks().into_iter().map(|(_, ob)| ob).collect();
+    let output_sigs: Vec<OutputStreamSignature> = if !chain_output_blocks.is_empty() {
+        chain_output_blocks
             .iter()
             .zip(outputs.iter())
             .map(|(co, ro)| OutputStreamSignature {
@@ -974,8 +856,8 @@ fn build_chain_stream_signature_multi(
         outputs
             .iter()
             .map(|ro| OutputStreamSignature {
-                device_id: chain.output_device_id.0.clone(),
-                channels: chain.output_channels.clone(),
+                device_id: String::new(),
+                channels: Vec::new(),
                 stream_channels: ro.supported.channels(),
                 sample_rate: resolved_output_sample_rate(ro),
                 buffer_size_frames: resolved_output_buffer_size_frames(ro),

--- a/crates/infra-yaml/src/lib.rs
+++ b/crates/infra-yaml/src/lib.rs
@@ -192,6 +192,8 @@ impl DeviceSettingsYaml {
 
 #[derive(Debug, Deserialize, Serialize)]
 struct ChainInputEntryYaml {
+    #[serde(default)]
+    name: String,
     device_id: String,
     #[serde(default)]
     mode: ChainInputMode,
@@ -200,7 +202,10 @@ struct ChainInputEntryYaml {
 
 #[derive(Debug, Deserialize, Serialize)]
 struct ChainInputYaml {
-    #[serde(default = "default_input_yaml_name")]
+    #[serde(default = "default_io_yaml_model")]
+    model: String,
+    // Legacy: name field migrated to entry-level
+    #[serde(default, skip_serializing)]
     name: String,
     // New format: entries list
     #[serde(default)]
@@ -214,12 +219,14 @@ struct ChainInputYaml {
     channels: Option<Vec<usize>>,
 }
 
-fn default_input_yaml_name() -> String {
-    "Input".to_string()
+fn default_io_yaml_model() -> String {
+    "standard".to_string()
 }
 
 #[derive(Debug, Deserialize, Serialize)]
 struct ChainOutputEntryYaml {
+    #[serde(default)]
+    name: String,
     device_id: String,
     #[serde(default)]
     mode: ChainOutputMode,
@@ -228,7 +235,10 @@ struct ChainOutputEntryYaml {
 
 #[derive(Debug, Deserialize, Serialize)]
 struct ChainOutputYaml {
-    #[serde(default = "default_output_yaml_name")]
+    #[serde(default = "default_io_yaml_model")]
+    model: String,
+    // Legacy: name field migrated to entry-level
+    #[serde(default, skip_serializing)]
     name: String,
     // New format: entries list
     #[serde(default)]
@@ -240,10 +250,6 @@ struct ChainOutputYaml {
     mode: Option<ChainOutputMode>,
     #[serde(default, skip_serializing)]
     channels: Option<Vec<usize>>,
-}
-
-fn default_output_yaml_name() -> String {
-    "Output".to_string()
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -310,14 +316,17 @@ impl ChainYaml {
 
         // Old format: convert separate inputs/outputs sections to blocks
         let mut input_blocks: Vec<AudioBlock> = self.inputs.into_iter().enumerate().map(|(i, inp)| {
+            let legacy_name = if inp.name.is_empty() { format!("Input {}", i + 1) } else { inp.name };
             let entries = if !inp.entries.is_empty() {
                 inp.entries.into_iter().map(|e| InputEntry {
+                    name: if e.name.is_empty() { legacy_name.clone() } else { e.name },
                     device_id: DeviceId(e.device_id),
                     mode: e.mode,
                     channels: e.channels,
                 }).collect()
             } else if let Some(device_id) = inp.device_id {
                 vec![InputEntry {
+                    name: legacy_name,
                     device_id: DeviceId(device_id),
                     mode: inp.mode.unwrap_or_default(),
                     channels: inp.channels.unwrap_or_default(),
@@ -329,21 +338,24 @@ impl ChainYaml {
                 id: BlockId(format!("{}:input:{}", chain_id.0, i)),
                 enabled: true,
                 kind: AudioBlockKind::Input(InputBlock {
-                    name: inp.name,
+                    model: inp.model,
                     entries,
                 }),
             }
         }).collect();
 
         let mut output_blocks: Vec<AudioBlock> = self.outputs.into_iter().enumerate().map(|(i, out)| {
+            let legacy_name = if out.name.is_empty() { format!("Output {}", i + 1) } else { out.name };
             let entries = if !out.entries.is_empty() {
                 out.entries.into_iter().map(|e| OutputEntry {
+                    name: if e.name.is_empty() { legacy_name.clone() } else { e.name },
                     device_id: DeviceId(e.device_id),
                     mode: e.mode,
                     channels: e.channels,
                 }).collect()
             } else if let Some(device_id) = out.device_id {
                 vec![OutputEntry {
+                    name: legacy_name,
                     device_id: DeviceId(device_id),
                     mode: out.mode.unwrap_or_default(),
                     channels: out.channels.unwrap_or_default(),
@@ -355,7 +367,7 @@ impl ChainYaml {
                 id: BlockId(format!("{}:output:{}", chain_id.0, i)),
                 enabled: true,
                 kind: AudioBlockKind::Output(OutputBlock {
-                    name: out.name,
+                    model: out.model,
                     entries,
                 }),
             }
@@ -369,8 +381,9 @@ impl ChainYaml {
                     id: BlockId(format!("{}:input:0", chain_id.0)),
                     enabled: true,
                     kind: AudioBlockKind::Input(InputBlock {
-                        name: "Input 1".to_string(),
+                        model: "standard".to_string(),
                         entries: vec![InputEntry {
+                            name: "Input 1".to_string(),
                             device_id: DeviceId(legacy_device),
                             mode: self.input_mode,
                             channels: self.input_channels.unwrap_or_default(),
@@ -392,8 +405,9 @@ impl ChainYaml {
                     id: BlockId(format!("{}:output:0", chain_id.0)),
                     enabled: true,
                     kind: AudioBlockKind::Output(OutputBlock {
-                        name: "Output 1".to_string(),
+                        model: "standard".to_string(),
                         entries: vec![OutputEntry {
+                            name: "Output 1".to_string(),
                             device_id: DeviceId(legacy_device),
                             mode,
                             channels: legacy_channels,
@@ -594,7 +608,10 @@ enum AudioBlockYaml {
     Input {
         #[serde(default = "default_enabled")]
         enabled: bool,
-        #[serde(default)]
+        #[serde(default = "default_io_yaml_model")]
+        model: String,
+        // Legacy: name field migrated to entry-level
+        #[serde(default, skip_serializing)]
         name: String,
         #[serde(default)]
         entries: Vec<ChainInputEntryYaml>,
@@ -610,7 +627,10 @@ enum AudioBlockYaml {
     Output {
         #[serde(default = "default_enabled")]
         enabled: bool,
-        #[serde(default)]
+        #[serde(default = "default_io_yaml_model")]
+        model: String,
+        // Legacy: name field migrated to entry-level
+        #[serde(default, skip_serializing)]
         name: String,
         #[serde(default)]
         entries: Vec<ChainOutputEntryYaml>,
@@ -676,20 +696,24 @@ impl AudioBlockYaml {
             }
             AudioBlockYaml::Input {
                 enabled,
+                model,
                 name,
                 entries,
                 device_id,
                 mode,
                 channels,
             } => {
+                let legacy_name = if name.is_empty() { "Input".to_string() } else { name };
                 let entries = if !entries.is_empty() {
                     entries.into_iter().map(|e| InputEntry {
+                        name: if e.name.is_empty() { legacy_name.clone() } else { e.name },
                         device_id: DeviceId(e.device_id),
                         mode: e.mode,
                         channels: e.channels,
                     }).collect()
                 } else if let Some(device_id) = device_id {
                     vec![InputEntry {
+                        name: legacy_name,
                         device_id: DeviceId(device_id),
                         mode: mode.unwrap_or_default(),
                         channels: channels.unwrap_or_default(),
@@ -701,27 +725,31 @@ impl AudioBlockYaml {
                     id: generated_id,
                     enabled,
                     kind: AudioBlockKind::Input(InputBlock {
-                        name: if name.is_empty() { "Input".to_string() } else { name },
+                        model,
                         entries,
                     }),
                 })
             }
             AudioBlockYaml::Output {
                 enabled,
+                model,
                 name,
                 entries,
                 device_id,
                 mode,
                 channels,
             } => {
+                let legacy_name = if name.is_empty() { "Output".to_string() } else { name };
                 let entries = if !entries.is_empty() {
                     entries.into_iter().map(|e| OutputEntry {
+                        name: if e.name.is_empty() { legacy_name.clone() } else { e.name },
                         device_id: DeviceId(e.device_id),
                         mode: e.mode,
                         channels: e.channels,
                     }).collect()
                 } else if let Some(device_id) = device_id {
                     vec![OutputEntry {
+                        name: legacy_name,
                         device_id: DeviceId(device_id),
                         mode: mode.unwrap_or_default(),
                         channels: channels.unwrap_or_default(),
@@ -733,7 +761,7 @@ impl AudioBlockYaml {
                     id: generated_id,
                     enabled,
                     kind: AudioBlockKind::Output(OutputBlock {
-                        name: if name.is_empty() { "Output".to_string() } else { name },
+                        model,
                         entries,
                     }),
                 })
@@ -822,8 +850,10 @@ impl AudioBlockYaml {
             }
             AudioBlockKind::Input(input) => Ok(Self::Input {
                 enabled: block.enabled,
-                name: input.name.clone(),
+                model: input.model.clone(),
+                name: String::new(),
                 entries: input.entries.iter().map(|e| ChainInputEntryYaml {
+                    name: e.name.clone(),
                     device_id: e.device_id.0.clone(),
                     mode: e.mode,
                     channels: e.channels.clone(),
@@ -834,8 +864,10 @@ impl AudioBlockYaml {
             }),
             AudioBlockKind::Output(output) => Ok(Self::Output {
                 enabled: block.enabled,
-                name: output.name.clone(),
+                model: output.model.clone(),
+                name: String::new(),
                 entries: output.entries.iter().map(|e| ChainOutputEntryYaml {
+                    name: e.name.clone(),
                     device_id: e.device_id.0.clone(),
                     mode: e.mode,
                     channels: e.channels.clone(),
@@ -1177,8 +1209,9 @@ mod tests {
                         id: BlockId("chain:0:input:0".into()),
                         enabled: true,
                         kind: AudioBlockKind::Input(InputBlock {
-                            name: "Input 1".to_string(),
+                            model: "standard".to_string(),
                             entries: vec![InputEntry {
+                                name: "Input 1".to_string(),
                                 device_id: DeviceId("input-device".into()),
                                 mode: ChainInputMode::Mono,
                                 channels: vec![0],
@@ -1189,8 +1222,9 @@ mod tests {
                         id: BlockId("chain:0:output:0".into()),
                         enabled: true,
                         kind: AudioBlockKind::Output(OutputBlock {
-                            name: "Output 1".to_string(),
+                            model: "standard".to_string(),
                             entries: vec![OutputEntry {
+                                name: "Output 1".to_string(),
                                 device_id: DeviceId("output-device".into()),
                                 mode: ChainOutputMode::Stereo,
                                 channels: vec![0, 1],

--- a/crates/infra-yaml/src/lib.rs
+++ b/crates/infra-yaml/src/lib.rs
@@ -193,13 +193,27 @@ impl DeviceSettingsYaml {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-struct ChainInputYaml {
-    #[serde(default = "default_input_yaml_name")]
-    name: String,
+struct ChainInputEntryYaml {
     device_id: String,
     #[serde(default)]
     mode: ChainInputMode,
     channels: Vec<usize>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct ChainInputYaml {
+    #[serde(default = "default_input_yaml_name")]
+    name: String,
+    // New format: entries list
+    #[serde(default)]
+    entries: Vec<ChainInputEntryYaml>,
+    // Legacy format: single device_id/mode/channels (for backward compat)
+    #[serde(default, skip_serializing)]
+    device_id: Option<String>,
+    #[serde(default, skip_serializing)]
+    mode: Option<ChainInputMode>,
+    #[serde(default, skip_serializing)]
+    channels: Option<Vec<usize>>,
 }
 
 fn default_input_yaml_name() -> String {
@@ -207,13 +221,27 @@ fn default_input_yaml_name() -> String {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-struct ChainOutputYaml {
-    #[serde(default = "default_output_yaml_name")]
-    name: String,
+struct ChainOutputEntryYaml {
     device_id: String,
     #[serde(default)]
     mode: ChainOutputMode,
     channels: Vec<usize>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct ChainOutputYaml {
+    #[serde(default = "default_output_yaml_name")]
+    name: String,
+    // New format: entries list
+    #[serde(default)]
+    entries: Vec<ChainOutputEntryYaml>,
+    // Legacy format: single device_id/mode/channels (for backward compat)
+    #[serde(default, skip_serializing)]
+    device_id: Option<String>,
+    #[serde(default, skip_serializing)]
+    mode: Option<ChainOutputMode>,
+    #[serde(default, skip_serializing)]
+    channels: Option<Vec<usize>>,
 }
 
 fn default_output_yaml_name() -> String {
@@ -256,32 +284,59 @@ impl ChainYaml {
         let chain_id = generated_chain_id(index);
         log::debug!("deserializing chain index={}, description={:?}, instrument='{}'", index, self.description, self.instrument);
 
-        // Convert new-format inputs to InputBlock entries
-        let mut input_blocks: Vec<AudioBlock> = self.inputs.into_iter().enumerate().map(|(i, inp)| AudioBlock {
-            id: BlockId(format!("{}:input:{}", chain_id.0, i)),
-            enabled: true,
-            kind: AudioBlockKind::Input(InputBlock {
-                name: inp.name,
-                entries: vec![InputEntry {
-                    device_id: DeviceId(inp.device_id),
-                    mode: inp.mode,
-                    channels: inp.channels,
-                }],
-            }),
+        // Convert inputs to InputBlock entries
+        let mut input_blocks: Vec<AudioBlock> = self.inputs.into_iter().enumerate().map(|(i, inp)| {
+            // If entries are present (new format), use them; otherwise fall back to legacy fields
+            let entries = if !inp.entries.is_empty() {
+                inp.entries.into_iter().map(|e| InputEntry {
+                    device_id: DeviceId(e.device_id),
+                    mode: e.mode,
+                    channels: e.channels,
+                }).collect()
+            } else if let Some(device_id) = inp.device_id {
+                vec![InputEntry {
+                    device_id: DeviceId(device_id),
+                    mode: inp.mode.unwrap_or_default(),
+                    channels: inp.channels.unwrap_or_default(),
+                }]
+            } else {
+                Vec::new()
+            };
+            AudioBlock {
+                id: BlockId(format!("{}:input:{}", chain_id.0, i)),
+                enabled: true,
+                kind: AudioBlockKind::Input(InputBlock {
+                    name: inp.name,
+                    entries,
+                }),
+            }
         }).collect();
 
-        // Convert new-format outputs to OutputBlock entries
-        let mut output_blocks: Vec<AudioBlock> = self.outputs.into_iter().enumerate().map(|(i, out)| AudioBlock {
-            id: BlockId(format!("{}:output:{}", chain_id.0, i)),
-            enabled: true,
-            kind: AudioBlockKind::Output(OutputBlock {
-                name: out.name,
-                entries: vec![OutputEntry {
-                    device_id: DeviceId(out.device_id),
-                    mode: out.mode,
-                    channels: out.channels,
-                }],
-            }),
+        // Convert outputs to OutputBlock entries
+        let mut output_blocks: Vec<AudioBlock> = self.outputs.into_iter().enumerate().map(|(i, out)| {
+            let entries = if !out.entries.is_empty() {
+                out.entries.into_iter().map(|e| OutputEntry {
+                    device_id: DeviceId(e.device_id),
+                    mode: e.mode,
+                    channels: e.channels,
+                }).collect()
+            } else if let Some(device_id) = out.device_id {
+                vec![OutputEntry {
+                    device_id: DeviceId(device_id),
+                    mode: out.mode.unwrap_or_default(),
+                    channels: out.channels.unwrap_or_default(),
+                }]
+            } else {
+                Vec::new()
+            };
+            AudioBlock {
+                id: BlockId(format!("{}:output:{}", chain_id.0, i)),
+                enabled: true,
+                kind: AudioBlockKind::Output(OutputBlock {
+                    name: out.name,
+                    entries,
+                }),
+            }
         }).collect();
 
         // Legacy migration: if no new-format inputs/outputs, create from legacy fields
@@ -353,24 +408,34 @@ impl ChainYaml {
     }
 
     fn from_chain(chain: &Chain) -> Result<Self> {
-        // Extract inputs/outputs from InputBlock/OutputBlock entries in blocks
-        // Each InputBlock/OutputBlock may have multiple entries; serialize one YAML entry per entry
-        let inputs: Vec<ChainInputYaml> = chain.input_blocks().into_iter().flat_map(|(_, ib)| {
-            ib.entries.iter().enumerate().map(move |(ei, entry)| ChainInputYaml {
-                name: if ib.entries.len() == 1 { ib.name.clone() } else { format!("{} #{}", ib.name, ei + 1) },
-                device_id: entry.device_id.0.clone(),
-                mode: entry.mode,
-                channels: entry.channels.clone(),
-            })
+        // Extract inputs/outputs from InputBlock/OutputBlock in blocks
+        // One YAML item per InputBlock/OutputBlock, with entries inside
+        let inputs: Vec<ChainInputYaml> = chain.input_blocks().into_iter().map(|(_, ib)| {
+            ChainInputYaml {
+                name: ib.name.clone(),
+                entries: ib.entries.iter().map(|e| ChainInputEntryYaml {
+                    device_id: e.device_id.0.clone(),
+                    mode: e.mode,
+                    channels: e.channels.clone(),
+                }).collect(),
+                device_id: None,
+                mode: None,
+                channels: None,
+            }
         }).collect();
 
-        let outputs: Vec<ChainOutputYaml> = chain.output_blocks().into_iter().flat_map(|(_, ob)| {
-            ob.entries.iter().enumerate().map(move |(ei, entry)| ChainOutputYaml {
-                name: if ob.entries.len() == 1 { ob.name.clone() } else { format!("{} #{}", ob.name, ei + 1) },
-                device_id: entry.device_id.0.clone(),
-                mode: entry.mode,
-                channels: entry.channels.clone(),
-            })
+        let outputs: Vec<ChainOutputYaml> = chain.output_blocks().into_iter().map(|(_, ob)| {
+            ChainOutputYaml {
+                name: ob.name.clone(),
+                entries: ob.entries.iter().map(|e| ChainOutputEntryYaml {
+                    device_id: e.device_id.0.clone(),
+                    mode: e.mode,
+                    channels: e.channels.clone(),
+                }).collect(),
+                device_id: None,
+                mode: None,
+                channels: None,
+            }
         }).collect();
 
         // Serialize only non-I/O blocks to the blocks array

--- a/crates/infra-yaml/src/lib.rs
+++ b/crates/infra-yaml/src/lib.rs
@@ -46,6 +46,7 @@ pub fn save_chain_preset_file(path: &Path, preset: &ChainBlocksPreset) -> Result
 pub fn serialize_audio_blocks(blocks: &[project::block::AudioBlock]) -> Result<Vec<Value>> {
     blocks
         .iter()
+        .filter(|block| !matches!(&block.kind, AudioBlockKind::Input(_) | AudioBlockKind::Output(_)))
         .map(|block| {
             Ok(serde_yaml::to_value(AudioBlockYaml::from_audio_block(
                 block,
@@ -148,6 +149,7 @@ impl PresetYaml {
             blocks: preset
                 .blocks
                 .iter()
+                .filter(|block| !matches!(&block.kind, AudioBlockKind::Input(_) | AudioBlockKind::Output(_)))
                 .map(|block| {
                     Ok(serde_yaml::to_value(AudioBlockYaml::from_audio_block(
                         block,

--- a/crates/infra-yaml/src/lib.rs
+++ b/crates/infra-yaml/src/lib.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Context, Result};
 use domain::ids::{BlockId, DeviceId, ChainId};
 use domain::value_objects::ParameterValue;
 use project::block::{
-    normalize_block_params, AudioBlock, AudioBlockKind, CoreBlock, InputBlock, NamBlock, OutputBlock, SelectBlock,
+    normalize_block_params, AudioBlock, AudioBlockKind, CoreBlock, InputBlock, InputEntry, NamBlock, OutputBlock, OutputEntry, SelectBlock,
 };
 use project::device::DeviceSettings;
 use project::param::ParameterSet;
@@ -262,9 +262,11 @@ impl ChainYaml {
             enabled: true,
             kind: AudioBlockKind::Input(InputBlock {
                 name: inp.name,
-                device_id: DeviceId(inp.device_id),
-                mode: inp.mode,
-                channels: inp.channels,
+                entries: vec![InputEntry {
+                    device_id: DeviceId(inp.device_id),
+                    mode: inp.mode,
+                    channels: inp.channels,
+                }],
             }),
         }).collect();
 
@@ -274,9 +276,11 @@ impl ChainYaml {
             enabled: true,
             kind: AudioBlockKind::Output(OutputBlock {
                 name: out.name,
-                device_id: DeviceId(out.device_id),
-                mode: out.mode,
-                channels: out.channels,
+                entries: vec![OutputEntry {
+                    device_id: DeviceId(out.device_id),
+                    mode: out.mode,
+                    channels: out.channels,
+                }],
             }),
         }).collect();
 
@@ -289,9 +293,11 @@ impl ChainYaml {
                     enabled: true,
                     kind: AudioBlockKind::Input(InputBlock {
                         name: "Input 1".to_string(),
-                        device_id: DeviceId(legacy_device),
-                        mode: self.input_mode,
-                        channels: self.input_channels.unwrap_or_default(),
+                        entries: vec![InputEntry {
+                            device_id: DeviceId(legacy_device),
+                            mode: self.input_mode,
+                            channels: self.input_channels.unwrap_or_default(),
+                        }],
                     }),
                 });
             }
@@ -310,9 +316,11 @@ impl ChainYaml {
                     enabled: true,
                     kind: AudioBlockKind::Output(OutputBlock {
                         name: "Output 1".to_string(),
-                        device_id: DeviceId(legacy_device),
-                        mode,
-                        channels: legacy_channels,
+                        entries: vec![OutputEntry {
+                            device_id: DeviceId(legacy_device),
+                            mode,
+                            channels: legacy_channels,
+                        }],
                     }),
                 });
             }
@@ -346,18 +354,23 @@ impl ChainYaml {
 
     fn from_chain(chain: &Chain) -> Result<Self> {
         // Extract inputs/outputs from InputBlock/OutputBlock entries in blocks
-        let inputs: Vec<ChainInputYaml> = chain.input_blocks().into_iter().map(|(_, ib)| ChainInputYaml {
-            name: ib.name.clone(),
-            device_id: ib.device_id.0.clone(),
-            mode: ib.mode,
-            channels: ib.channels.clone(),
+        // Each InputBlock/OutputBlock may have multiple entries; serialize one YAML entry per entry
+        let inputs: Vec<ChainInputYaml> = chain.input_blocks().into_iter().flat_map(|(_, ib)| {
+            ib.entries.iter().enumerate().map(move |(ei, entry)| ChainInputYaml {
+                name: if ib.entries.len() == 1 { ib.name.clone() } else { format!("{} #{}", ib.name, ei + 1) },
+                device_id: entry.device_id.0.clone(),
+                mode: entry.mode,
+                channels: entry.channels.clone(),
+            })
         }).collect();
 
-        let outputs: Vec<ChainOutputYaml> = chain.output_blocks().into_iter().map(|(_, ob)| ChainOutputYaml {
-            name: ob.name.clone(),
-            device_id: ob.device_id.0.clone(),
-            mode: ob.mode,
-            channels: ob.channels.clone(),
+        let outputs: Vec<ChainOutputYaml> = chain.output_blocks().into_iter().flat_map(|(_, ob)| {
+            ob.entries.iter().enumerate().map(move |(ei, entry)| ChainOutputYaml {
+                name: if ob.entries.len() == 1 { ob.name.clone() } else { format!("{} #{}", ob.name, ei + 1) },
+                device_id: entry.device_id.0.clone(),
+                mode: entry.mode,
+                channels: entry.channels.clone(),
+            })
         }).collect();
 
         // Serialize only non-I/O blocks to the blocks array
@@ -971,7 +984,7 @@ mod tests {
     };
     use domain::ids::{BlockId, DeviceId, ChainId};
     use project::block::{
-        AudioBlock, AudioBlockKind, CoreBlock, InputBlock, OutputBlock, SelectBlock,
+        AudioBlock, AudioBlockKind, CoreBlock, InputBlock, InputEntry, OutputBlock, OutputEntry, SelectBlock,
     };
     use project::param::ParameterSet;
     use project::project::Project;
@@ -1001,9 +1014,11 @@ mod tests {
                         enabled: true,
                         kind: AudioBlockKind::Input(InputBlock {
                             name: "Input 1".to_string(),
-                            device_id: DeviceId("input-device".into()),
-                            mode: ChainInputMode::Mono,
-                            channels: vec![0],
+                            entries: vec![InputEntry {
+                                device_id: DeviceId("input-device".into()),
+                                mode: ChainInputMode::Mono,
+                                channels: vec![0],
+                            }],
                         }),
                     },
                     AudioBlock {
@@ -1011,9 +1026,11 @@ mod tests {
                         enabled: true,
                         kind: AudioBlockKind::Output(OutputBlock {
                             name: "Output 1".to_string(),
-                            device_id: DeviceId("output-device".into()),
-                            mode: ChainOutputMode::Stereo,
-                            channels: vec![0, 1],
+                            entries: vec![OutputEntry {
+                                device_id: DeviceId("output-device".into()),
+                                mode: ChainOutputMode::Stereo,
+                                channels: vec![0, 1],
+                            }],
                         }),
                     },
                 ],
@@ -1035,12 +1052,12 @@ mod tests {
         assert_eq!(loaded.chains[0].description, original.chains[0].description);
         let loaded_inputs = loaded.chains[0].input_blocks();
         assert_eq!(loaded_inputs.len(), 1);
-        assert_eq!(loaded_inputs[0].1.device_id, DeviceId("input-device".into()));
-        assert_eq!(loaded_inputs[0].1.channels, vec![0]);
+        assert_eq!(loaded_inputs[0].1.entries[0].device_id, DeviceId("input-device".into()));
+        assert_eq!(loaded_inputs[0].1.entries[0].channels, vec![0]);
         let loaded_outputs = loaded.chains[0].output_blocks();
         assert_eq!(loaded_outputs.len(), 1);
-        assert_eq!(loaded_outputs[0].1.device_id, DeviceId("output-device".into()));
-        assert_eq!(loaded_outputs[0].1.channels, vec![0, 1]);
+        assert_eq!(loaded_outputs[0].1.entries[0].device_id, DeviceId("output-device".into()));
+        assert_eq!(loaded_outputs[0].1.entries[0].channels, vec![0, 1]);
     }
 
     #[test]
@@ -1069,13 +1086,13 @@ chains:
         assert_eq!(project.chains.len(), 1);
         let inputs = project.chains[0].input_blocks();
         assert_eq!(inputs.len(), 1);
-        assert_eq!(inputs[0].1.device_id, DeviceId("legacy-input".into()));
-        assert_eq!(inputs[0].1.channels, vec![0]);
+        assert_eq!(inputs[0].1.entries[0].device_id, DeviceId("legacy-input".into()));
+        assert_eq!(inputs[0].1.entries[0].channels, vec![0]);
         let outputs = project.chains[0].output_blocks();
         assert_eq!(outputs.len(), 1);
-        assert_eq!(outputs[0].1.device_id, DeviceId("legacy-output".into()));
-        assert_eq!(outputs[0].1.channels, vec![0, 1]);
-        assert_eq!(outputs[0].1.mode, ChainOutputMode::Stereo);
+        assert_eq!(outputs[0].1.entries[0].device_id, DeviceId("legacy-output".into()));
+        assert_eq!(outputs[0].1.entries[0].channels, vec![0, 1]);
+        assert_eq!(outputs[0].1.entries[0].mode, ChainOutputMode::Stereo);
     }
 
     #[test]

--- a/crates/infra-yaml/src/lib.rs
+++ b/crates/infra-yaml/src/lib.rs
@@ -43,6 +43,11 @@ pub fn save_chain_preset_file(path: &Path, preset: &ChainBlocksPreset) -> Result
     Ok(())
 }
 
+pub fn serialize_project(project: &Project) -> Result<String> {
+    let dto = ProjectYaml::from_project(project)?;
+    Ok(serde_yaml::to_string(&dto)?)
+}
+
 pub fn serialize_audio_blocks(blocks: &[project::block::AudioBlock]) -> Result<Vec<Value>> {
     blocks
         .iter()

--- a/crates/infra-yaml/src/lib.rs
+++ b/crates/infra-yaml/src/lib.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Context, Result};
 use domain::ids::{BlockId, DeviceId, ChainId};
 use domain::value_objects::ParameterValue;
 use project::block::{
-    normalize_block_params, AudioBlock, AudioBlockKind, CoreBlock, InputBlock, InputEntry, NamBlock, OutputBlock, OutputEntry, SelectBlock,
+    normalize_block_params, AudioBlock, AudioBlockKind, CoreBlock, InputBlock, InputEntry, InsertBlock, InsertEndpoint, NamBlock, OutputBlock, OutputEntry, SelectBlock,
 };
 use project::device::DeviceSettings;
 use project::param::ParameterSet;
@@ -642,6 +642,26 @@ enum AudioBlockYaml {
         #[serde(default, skip_serializing)]
         channels: Option<Vec<usize>>,
     },
+    #[serde(rename = "insert")]
+    Insert {
+        #[serde(default = "default_enabled")]
+        enabled: bool,
+        #[serde(default = "default_io_yaml_model")]
+        model: String,
+        send: InsertEndpointYaml,
+        #[serde(rename = "return")]
+        return_: InsertEndpointYaml,
+    },
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct InsertEndpointYaml {
+    #[serde(default)]
+    device_id: String,
+    #[serde(default)]
+    mode: ChainInputMode,
+    #[serde(default)]
+    channels: Vec<usize>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -766,6 +786,28 @@ impl AudioBlockYaml {
                     }),
                 })
             }
+            AudioBlockYaml::Insert {
+                enabled,
+                model,
+                send,
+                return_,
+            } => Ok(AudioBlock {
+                id: generated_id,
+                enabled,
+                kind: AudioBlockKind::Insert(InsertBlock {
+                    model,
+                    send: InsertEndpoint {
+                        device_id: DeviceId(send.device_id),
+                        mode: send.mode,
+                        channels: send.channels,
+                    },
+                    return_: InsertEndpoint {
+                        device_id: DeviceId(return_.device_id),
+                        mode: return_.mode,
+                        channels: return_.channels,
+                    },
+                }),
+            }),
             other => {
                 let (effect_type, enabled, model, params) = extract_core_block_fields(other);
                 Ok(AudioBlock {
@@ -876,6 +918,20 @@ impl AudioBlockYaml {
                 mode: None,
                 channels: None,
             }),
+            AudioBlockKind::Insert(insert) => Ok(Self::Insert {
+                enabled: block.enabled,
+                model: insert.model.clone(),
+                send: InsertEndpointYaml {
+                    device_id: insert.send.device_id.0.clone(),
+                    mode: insert.send.mode,
+                    channels: insert.send.channels.clone(),
+                },
+                return_: InsertEndpointYaml {
+                    device_id: insert.return_.device_id.0.clone(),
+                    mode: insert.return_.mode,
+                    channels: insert.return_.channels.clone(),
+                },
+            }),
         }
     }
 }
@@ -941,6 +997,7 @@ fn extract_core_block_fields(yaml: AudioBlockYaml) -> (&'static str, bool, Strin
         AudioBlockYaml::Select { .. } => unreachable!("Select handled before extract_core_block_fields"),
         AudioBlockYaml::Input { .. } => unreachable!("Input handled before extract_core_block_fields"),
         AudioBlockYaml::Output { .. } => unreachable!("Output handled before extract_core_block_fields"),
+        AudioBlockYaml::Insert { .. } => unreachable!("Insert handled before extract_core_block_fields"),
     }
 }
 
@@ -1510,5 +1567,66 @@ chains:
                 params,
             }),
         }
+    }
+
+    #[test]
+    fn insert_block_yaml_roundtrip() {
+        use project::block::{InsertBlock, InsertEndpoint};
+        let block = AudioBlock {
+            id: BlockId("chain:0:block:1".into()),
+            enabled: true,
+            kind: AudioBlockKind::Insert(InsertBlock {
+                model: "standard".to_string(),
+                send: InsertEndpoint {
+                    device_id: DeviceId("mk300-out".into()),
+                    mode: ChainInputMode::Stereo,
+                    channels: vec![0, 1],
+                },
+                return_: InsertEndpoint {
+                    device_id: DeviceId("mk300-in".into()),
+                    mode: ChainInputMode::Stereo,
+                    channels: vec![0, 1],
+                },
+            }),
+        };
+        let yaml = super::AudioBlockYaml::from_audio_block(&block).expect("to yaml");
+        let value = serde_yaml::to_value(&yaml).expect("serialize");
+        let parsed: super::AudioBlockYaml = serde_yaml::from_value(value).expect("deserialize");
+        let chain_id = ChainId("chain:0".to_string());
+        let restored = parsed.into_audio_block(&chain_id, 1).expect("into block");
+        assert!(matches!(&restored.kind, AudioBlockKind::Insert(ib) if ib.send.device_id.0 == "mk300-out"));
+        assert!(matches!(&restored.kind, AudioBlockKind::Insert(ib) if ib.return_.device_id.0 == "mk300-in"));
+        assert!(matches!(&restored.kind, AudioBlockKind::Insert(ib) if ib.send.channels == vec![0, 1]));
+        assert!(matches!(&restored.kind, AudioBlockKind::Insert(ib) if ib.return_.channels == vec![0, 1]));
+        assert!(matches!(&restored.kind, AudioBlockKind::Insert(ib) if ib.send.mode == ChainInputMode::Stereo));
+    }
+
+    #[test]
+    fn disabled_insert_block_yaml_roundtrip() {
+        use project::block::{InsertBlock, InsertEndpoint};
+        let block = AudioBlock {
+            id: BlockId("chain:0:block:2".into()),
+            enabled: false,
+            kind: AudioBlockKind::Insert(InsertBlock {
+                model: "standard".to_string(),
+                send: InsertEndpoint {
+                    device_id: DeviceId(String::new()),
+                    mode: ChainInputMode::Mono,
+                    channels: Vec::new(),
+                },
+                return_: InsertEndpoint {
+                    device_id: DeviceId(String::new()),
+                    mode: ChainInputMode::Mono,
+                    channels: Vec::new(),
+                },
+            }),
+        };
+        let yaml = super::AudioBlockYaml::from_audio_block(&block).expect("to yaml");
+        let value = serde_yaml::to_value(&yaml).expect("serialize");
+        let parsed: super::AudioBlockYaml = serde_yaml::from_value(value).expect("deserialize");
+        let chain_id = ChainId("chain:0".to_string());
+        let restored = parsed.into_audio_block(&chain_id, 2).expect("into block");
+        assert!(!restored.enabled);
+        assert!(matches!(&restored.kind, AudioBlockKind::Insert(_)));
     }
 }

--- a/crates/infra-yaml/src/lib.rs
+++ b/crates/infra-yaml/src/lib.rs
@@ -51,7 +51,6 @@ pub fn serialize_project(project: &Project) -> Result<String> {
 pub fn serialize_audio_blocks(blocks: &[project::block::AudioBlock]) -> Result<Vec<Value>> {
     blocks
         .iter()
-        .filter(|block| !matches!(&block.kind, AudioBlockKind::Input(_) | AudioBlockKind::Output(_)))
         .map(|block| {
             Ok(serde_yaml::to_value(AudioBlockYaml::from_audio_block(
                 block,
@@ -154,7 +153,6 @@ impl PresetYaml {
             blocks: preset
                 .blocks
                 .iter()
-                .filter(|block| !matches!(&block.kind, AudioBlockKind::Input(_) | AudioBlockKind::Output(_)))
                 .map(|block| {
                     Ok(serde_yaml::to_value(AudioBlockYaml::from_audio_block(
                         block,
@@ -257,10 +255,10 @@ struct ChainYaml {
     instrument: String,
     #[serde(default = "default_enabled", skip_serializing)]
     enabled: bool,
-    // New multi-input/output fields
-    #[serde(default)]
+    // Legacy multi-input/output fields — kept for backward-compatible deserialization, skipped on serialization
+    #[serde(default, skip_serializing)]
     inputs: Vec<ChainInputYaml>,
-    #[serde(default)]
+    #[serde(default, skip_serializing)]
     outputs: Vec<ChainOutputYaml>,
     // Legacy fields — kept for backward-compatible deserialization, skipped on serialization
     #[serde(default, skip_serializing)]
@@ -284,9 +282,34 @@ impl ChainYaml {
         let chain_id = generated_chain_id(index);
         log::debug!("deserializing chain index={}, description={:?}, instrument='{}'", index, self.description, self.instrument);
 
-        // Convert inputs to InputBlock entries
+        // Parse all blocks from the blocks array (new format may include input/output blocks inline)
+        let parsed_blocks: Vec<AudioBlock> = self
+            .blocks
+            .into_iter()
+            .enumerate()
+            .filter_map(|(block_index, block)| {
+                load_audio_block_value(block, &chain_id, block_index)
+            })
+            .collect();
+
+        // Check if blocks already contain Input/Output (new inline format)
+        let has_inline_inputs = parsed_blocks.iter().any(|b| matches!(&b.kind, AudioBlockKind::Input(_)));
+        let has_inline_outputs = parsed_blocks.iter().any(|b| matches!(&b.kind, AudioBlockKind::Output(_)));
+
+        if has_inline_inputs || has_inline_outputs {
+            // New format: blocks already contain I/O inline, use as-is
+            let chain = Chain {
+                id: chain_id.clone(),
+                description: self.description,
+                instrument: self.instrument,
+                enabled: false,
+                blocks: parsed_blocks,
+            };
+            return Ok(chain);
+        }
+
+        // Old format: convert separate inputs/outputs sections to blocks
         let mut input_blocks: Vec<AudioBlock> = self.inputs.into_iter().enumerate().map(|(i, inp)| {
-            // If entries are present (new format), use them; otherwise fall back to legacy fields
             let entries = if !inp.entries.is_empty() {
                 inp.entries.into_iter().map(|e| InputEntry {
                     device_id: DeviceId(e.device_id),
@@ -312,7 +335,6 @@ impl ChainYaml {
             }
         }).collect();
 
-        // Convert outputs to OutputBlock entries
         let mut output_blocks: Vec<AudioBlock> = self.outputs.into_iter().enumerate().map(|(i, out)| {
             let entries = if !out.entries.is_empty() {
                 out.entries.into_iter().map(|e| OutputEntry {
@@ -339,7 +361,7 @@ impl ChainYaml {
             }
         }).collect();
 
-        // Legacy migration: if no new-format inputs/outputs, create from legacy fields
+        // Oldest legacy format: single input_device_id/output_device_id fields
         if input_blocks.is_empty() {
             let legacy_device = self.input_device_id.unwrap_or_default();
             if !legacy_device.is_empty() {
@@ -382,25 +404,16 @@ impl ChainYaml {
         }
 
         // Build blocks: inputs first, then audio blocks, then outputs
-        let audio_blocks: Vec<AudioBlock> = self
-            .blocks
-            .into_iter()
-            .enumerate()
-            .filter_map(|(block_index, block)| {
-                load_audio_block_value(block, &chain_id, block_index)
-            })
-            .collect();
-
-        let mut all_blocks = Vec::with_capacity(input_blocks.len() + audio_blocks.len() + output_blocks.len());
+        let mut all_blocks = Vec::with_capacity(input_blocks.len() + parsed_blocks.len() + output_blocks.len());
         all_blocks.extend(input_blocks);
-        all_blocks.extend(audio_blocks);
+        all_blocks.extend(parsed_blocks);
         all_blocks.extend(output_blocks);
 
         let chain = Chain {
             id: chain_id.clone(),
             description: self.description,
             instrument: self.instrument,
-            enabled: false, // chains always start disabled on load
+            enabled: false,
             blocks: all_blocks,
         };
 
@@ -408,41 +421,10 @@ impl ChainYaml {
     }
 
     fn from_chain(chain: &Chain) -> Result<Self> {
-        // Extract inputs/outputs from InputBlock/OutputBlock in blocks
-        // One YAML item per InputBlock/OutputBlock, with entries inside
-        let inputs: Vec<ChainInputYaml> = chain.input_blocks().into_iter().map(|(_, ib)| {
-            ChainInputYaml {
-                name: ib.name.clone(),
-                entries: ib.entries.iter().map(|e| ChainInputEntryYaml {
-                    device_id: e.device_id.0.clone(),
-                    mode: e.mode,
-                    channels: e.channels.clone(),
-                }).collect(),
-                device_id: None,
-                mode: None,
-                channels: None,
-            }
-        }).collect();
-
-        let outputs: Vec<ChainOutputYaml> = chain.output_blocks().into_iter().map(|(_, ob)| {
-            ChainOutputYaml {
-                name: ob.name.clone(),
-                entries: ob.entries.iter().map(|e| ChainOutputEntryYaml {
-                    device_id: e.device_id.0.clone(),
-                    mode: e.mode,
-                    channels: e.channels.clone(),
-                }).collect(),
-                device_id: None,
-                mode: None,
-                channels: None,
-            }
-        }).collect();
-
-        // Serialize only non-I/O blocks to the blocks array
+        // All blocks (including I/O) go into the blocks array
         let audio_blocks: Vec<Value> = chain
             .blocks
             .iter()
-            .filter(|block| !matches!(&block.kind, AudioBlockKind::Input(_) | AudioBlockKind::Output(_)))
             .map(|block| {
                 Ok(serde_yaml::to_value(AudioBlockYaml::from_audio_block(
                     block,
@@ -454,9 +436,8 @@ impl ChainYaml {
             description: chain.description.clone(),
             instrument: chain.instrument.clone(),
             enabled: chain.enabled,
-            inputs,
-            outputs,
-            // Legacy fields are None when serializing new format
+            inputs: Vec::new(),
+            outputs: Vec::new(),
             input_device_id: None,
             input_channels: None,
             output_device_id: None,
@@ -609,6 +590,38 @@ enum AudioBlockYaml {
         selected: String,
         options: Vec<SelectOptionYaml>,
     },
+    #[serde(rename = "input")]
+    Input {
+        #[serde(default = "default_enabled")]
+        enabled: bool,
+        #[serde(default)]
+        name: String,
+        #[serde(default)]
+        entries: Vec<ChainInputEntryYaml>,
+        // Legacy single-entry fields for backward compat
+        #[serde(default, skip_serializing)]
+        device_id: Option<String>,
+        #[serde(default, skip_serializing)]
+        mode: Option<ChainInputMode>,
+        #[serde(default, skip_serializing)]
+        channels: Option<Vec<usize>>,
+    },
+    #[serde(rename = "output")]
+    Output {
+        #[serde(default = "default_enabled")]
+        enabled: bool,
+        #[serde(default)]
+        name: String,
+        #[serde(default)]
+        entries: Vec<ChainOutputEntryYaml>,
+        // Legacy single-entry fields for backward compat
+        #[serde(default, skip_serializing)]
+        device_id: Option<String>,
+        #[serde(default, skip_serializing)]
+        mode: Option<ChainOutputMode>,
+        #[serde(default, skip_serializing)]
+        channels: Option<Vec<usize>>,
+    },
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -658,6 +671,70 @@ impl AudioBlockYaml {
                     kind: AudioBlockKind::Select(SelectBlock {
                         selected_block_id,
                         options,
+                    }),
+                })
+            }
+            AudioBlockYaml::Input {
+                enabled,
+                name,
+                entries,
+                device_id,
+                mode,
+                channels,
+            } => {
+                let entries = if !entries.is_empty() {
+                    entries.into_iter().map(|e| InputEntry {
+                        device_id: DeviceId(e.device_id),
+                        mode: e.mode,
+                        channels: e.channels,
+                    }).collect()
+                } else if let Some(device_id) = device_id {
+                    vec![InputEntry {
+                        device_id: DeviceId(device_id),
+                        mode: mode.unwrap_or_default(),
+                        channels: channels.unwrap_or_default(),
+                    }]
+                } else {
+                    Vec::new()
+                };
+                Ok(AudioBlock {
+                    id: generated_id,
+                    enabled,
+                    kind: AudioBlockKind::Input(InputBlock {
+                        name: if name.is_empty() { "Input".to_string() } else { name },
+                        entries,
+                    }),
+                })
+            }
+            AudioBlockYaml::Output {
+                enabled,
+                name,
+                entries,
+                device_id,
+                mode,
+                channels,
+            } => {
+                let entries = if !entries.is_empty() {
+                    entries.into_iter().map(|e| OutputEntry {
+                        device_id: DeviceId(e.device_id),
+                        mode: e.mode,
+                        channels: e.channels,
+                    }).collect()
+                } else if let Some(device_id) = device_id {
+                    vec![OutputEntry {
+                        device_id: DeviceId(device_id),
+                        mode: mode.unwrap_or_default(),
+                        channels: channels.unwrap_or_default(),
+                    }]
+                } else {
+                    Vec::new()
+                };
+                Ok(AudioBlock {
+                    id: generated_id,
+                    enabled,
+                    kind: AudioBlockKind::Output(OutputBlock {
+                        name: if name.is_empty() { "Output".to_string() } else { name },
+                        entries,
                     }),
                 })
             }
@@ -743,10 +820,30 @@ impl AudioBlockYaml {
                     options,
                 })
             }
-            // Input/Output blocks are not serialized as YAML audio blocks
-            AudioBlockKind::Input(_) | AudioBlockKind::Output(_) => {
-                Err(anyhow!("Input/Output blocks should not be serialized as audio block YAML"))
-            }
+            AudioBlockKind::Input(input) => Ok(Self::Input {
+                enabled: block.enabled,
+                name: input.name.clone(),
+                entries: input.entries.iter().map(|e| ChainInputEntryYaml {
+                    device_id: e.device_id.0.clone(),
+                    mode: e.mode,
+                    channels: e.channels.clone(),
+                }).collect(),
+                device_id: None,
+                mode: None,
+                channels: None,
+            }),
+            AudioBlockKind::Output(output) => Ok(Self::Output {
+                enabled: block.enabled,
+                name: output.name.clone(),
+                entries: output.entries.iter().map(|e| ChainOutputEntryYaml {
+                    device_id: e.device_id.0.clone(),
+                    mode: e.mode,
+                    channels: e.channels.clone(),
+                }).collect(),
+                device_id: None,
+                mode: None,
+                channels: None,
+            }),
         }
     }
 }
@@ -810,6 +907,8 @@ fn extract_core_block_fields(yaml: AudioBlockYaml) -> (&'static str, bool, Strin
         AudioBlockYaml::Pitch { enabled, model, params } => (block_core::EFFECT_TYPE_PITCH, enabled, model, params),
         AudioBlockYaml::Nam { enabled, model, params } => (block_core::EFFECT_TYPE_NAM, enabled, model, params),
         AudioBlockYaml::Select { .. } => unreachable!("Select handled before extract_core_block_fields"),
+        AudioBlockYaml::Input { .. } => unreachable!("Input handled before extract_core_block_fields"),
+        AudioBlockYaml::Output { .. } => unreachable!("Output handled before extract_core_block_fields"),
     }
 }
 
@@ -1186,8 +1285,8 @@ chains:
         model: {valid_delay_model}
         params:
           time_ms: 200
-          feedback: 0.5
-          mix: 0.3
+          feedback: 50
+          mix: 30
 "#,
             ),
         )
@@ -1230,14 +1329,14 @@ blocks:
     model: deleted_model
     params:
       time_ms: 200
-      feedback: 0.5
-      mix: 0.3
+      feedback: 50
+      mix: 30
   - type: delay
     model: {valid_delay_model}
     params:
       time_ms: 210
-      feedback: 0.4
-      mix: 0.25
+      feedback: 40
+      mix: 25
 "#,
             ),
         )
@@ -1288,15 +1387,15 @@ chains:
             model: {first_model}
             params:
               time_ms: 120
-              feedback: 0.2
-              mix: 0.3
+              feedback: 20
+              mix: 30
           - id: delay_b
             type: delay
             model: {second_model}
             params:
               time_ms: 240
-              feedback: 0.4
-              mix: 0.25
+              feedback: 40
+              mix: 25
 "#,
             ),
         )

--- a/crates/infra-yaml/src/lib.rs
+++ b/crates/infra-yaml/src/lib.rs
@@ -2,12 +2,12 @@ use anyhow::{anyhow, Context, Result};
 use domain::ids::{BlockId, DeviceId, ChainId};
 use domain::value_objects::ParameterValue;
 use project::block::{
-    normalize_block_params, AudioBlock, AudioBlockKind, CoreBlock, NamBlock, SelectBlock,
+    normalize_block_params, AudioBlock, AudioBlockKind, CoreBlock, InputBlock, NamBlock, OutputBlock, SelectBlock,
 };
 use project::device::DeviceSettings;
 use project::param::ParameterSet;
 use project::project::Project;
-use project::chain::{Chain, ChainInput, ChainInputMode, ChainOutput, ChainOutputMixdown, ChainOutputMode};
+use project::chain::{Chain, ChainInputMode, ChainOutputMixdown, ChainOutputMode};
 use serde::{Deserialize, Serialize};
 use serde_yaml::Value;
 use std::fs;
@@ -249,65 +249,121 @@ impl ChainYaml {
         let chain_id = generated_chain_id(index);
         log::debug!("deserializing chain index={}, description={:?}, instrument='{}'", index, self.description, self.instrument);
 
-        // Convert new-format inputs/outputs from YAML DTOs
-        let inputs: Vec<ChainInput> = self.inputs.into_iter().map(|i| ChainInput {
-            name: i.name,
-            device_id: DeviceId(i.device_id),
-            mode: i.mode,
-            channels: i.channels,
+        // Convert new-format inputs to InputBlock entries
+        let mut input_blocks: Vec<AudioBlock> = self.inputs.into_iter().enumerate().map(|(i, inp)| AudioBlock {
+            id: BlockId(format!("{}:input:{}", chain_id.0, i)),
+            enabled: true,
+            kind: AudioBlockKind::Input(InputBlock {
+                name: inp.name,
+                device_id: DeviceId(inp.device_id),
+                mode: inp.mode,
+                channels: inp.channels,
+            }),
         }).collect();
 
-        let outputs: Vec<ChainOutput> = self.outputs.into_iter().map(|o| ChainOutput {
-            name: o.name,
-            device_id: DeviceId(o.device_id),
-            mode: o.mode,
-            channels: o.channels,
+        // Convert new-format outputs to OutputBlock entries
+        let mut output_blocks: Vec<AudioBlock> = self.outputs.into_iter().enumerate().map(|(i, out)| AudioBlock {
+            id: BlockId(format!("{}:output:{}", chain_id.0, i)),
+            enabled: true,
+            kind: AudioBlockKind::Output(OutputBlock {
+                name: out.name,
+                device_id: DeviceId(out.device_id),
+                mode: out.mode,
+                channels: out.channels,
+            }),
         }).collect();
 
-        let mut chain = Chain {
+        // Legacy migration: if no new-format inputs/outputs, create from legacy fields
+        if input_blocks.is_empty() {
+            let legacy_device = self.input_device_id.unwrap_or_default();
+            if !legacy_device.is_empty() {
+                input_blocks.push(AudioBlock {
+                    id: BlockId(format!("{}:input:0", chain_id.0)),
+                    enabled: true,
+                    kind: AudioBlockKind::Input(InputBlock {
+                        name: "Input 1".to_string(),
+                        device_id: DeviceId(legacy_device),
+                        mode: self.input_mode,
+                        channels: self.input_channels.unwrap_or_default(),
+                    }),
+                });
+            }
+        }
+        if output_blocks.is_empty() {
+            let legacy_device = self.output_device_id.unwrap_or_default();
+            if !legacy_device.is_empty() {
+                let legacy_channels = self.output_channels.unwrap_or_default();
+                let mode = if legacy_channels.len() >= 2 {
+                    ChainOutputMode::Stereo
+                } else {
+                    ChainOutputMode::Mono
+                };
+                output_blocks.push(AudioBlock {
+                    id: BlockId(format!("{}:output:0", chain_id.0)),
+                    enabled: true,
+                    kind: AudioBlockKind::Output(OutputBlock {
+                        name: "Output 1".to_string(),
+                        device_id: DeviceId(legacy_device),
+                        mode,
+                        channels: legacy_channels,
+                    }),
+                });
+            }
+        }
+
+        // Build blocks: inputs first, then audio blocks, then outputs
+        let audio_blocks: Vec<AudioBlock> = self
+            .blocks
+            .into_iter()
+            .enumerate()
+            .filter_map(|(block_index, block)| {
+                load_audio_block_value(block, &chain_id, block_index)
+            })
+            .collect();
+
+        let mut all_blocks = Vec::with_capacity(input_blocks.len() + audio_blocks.len() + output_blocks.len());
+        all_blocks.extend(input_blocks);
+        all_blocks.extend(audio_blocks);
+        all_blocks.extend(output_blocks);
+
+        let chain = Chain {
             id: chain_id.clone(),
             description: self.description,
             instrument: self.instrument,
             enabled: false, // chains always start disabled on load
-            inputs,
-            outputs,
-            input_device_id: DeviceId(self.input_device_id.unwrap_or_default()),
-            input_channels: self.input_channels.unwrap_or_default(),
-            output_device_id: DeviceId(self.output_device_id.unwrap_or_default()),
-            output_channels: self.output_channels.unwrap_or_default(),
-            blocks: self
-                .blocks
-                .into_iter()
-                .enumerate()
-                .filter_map(|(block_index, block)| {
-                    load_audio_block_value(block, &chain_id, block_index)
-                })
-                .collect(),
-            output_mixdown: self.output_mixdown,
-            input_mode: self.input_mode,
+            blocks: all_blocks,
         };
-
-        // Migrate legacy single-input/output to multi-input/output if needed
-        chain.migrate_legacy_io();
 
         Ok(chain)
     }
 
     fn from_chain(chain: &Chain) -> Result<Self> {
-        // Serialize using new inputs/outputs format
-        let inputs = chain.inputs.iter().map(|i| ChainInputYaml {
-            name: i.name.clone(),
-            device_id: i.device_id.0.clone(),
-            mode: i.mode,
-            channels: i.channels.clone(),
+        // Extract inputs/outputs from InputBlock/OutputBlock entries in blocks
+        let inputs: Vec<ChainInputYaml> = chain.input_blocks().into_iter().map(|(_, ib)| ChainInputYaml {
+            name: ib.name.clone(),
+            device_id: ib.device_id.0.clone(),
+            mode: ib.mode,
+            channels: ib.channels.clone(),
         }).collect();
 
-        let outputs = chain.outputs.iter().map(|o| ChainOutputYaml {
-            name: o.name.clone(),
-            device_id: o.device_id.0.clone(),
-            mode: o.mode,
-            channels: o.channels.clone(),
+        let outputs: Vec<ChainOutputYaml> = chain.output_blocks().into_iter().map(|(_, ob)| ChainOutputYaml {
+            name: ob.name.clone(),
+            device_id: ob.device_id.0.clone(),
+            mode: ob.mode,
+            channels: ob.channels.clone(),
         }).collect();
+
+        // Serialize only non-I/O blocks to the blocks array
+        let audio_blocks: Vec<Value> = chain
+            .blocks
+            .iter()
+            .filter(|block| !matches!(&block.kind, AudioBlockKind::Input(_) | AudioBlockKind::Output(_)))
+            .map(|block| {
+                Ok(serde_yaml::to_value(AudioBlockYaml::from_audio_block(
+                    block,
+                )?)?)
+            })
+            .collect::<Result<Vec<_>>>()?;
 
         Ok(Self {
             description: chain.description.clone(),
@@ -320,17 +376,9 @@ impl ChainYaml {
             input_channels: None,
             output_device_id: None,
             output_channels: None,
-            blocks: chain
-                .blocks
-                .iter()
-                .map(|block| {
-                    Ok(serde_yaml::to_value(AudioBlockYaml::from_audio_block(
-                        block,
-                    )?)?)
-                })
-                .collect::<Result<Vec<_>>>()?,
-            output_mixdown: chain.output_mixdown,
-            input_mode: chain.input_mode,
+            blocks: audio_blocks,
+            output_mixdown: ChainOutputMixdown::Average,
+            input_mode: ChainInputMode::default(),
         })
     }
 }
@@ -609,6 +657,10 @@ impl AudioBlockYaml {
                     selected,
                     options,
                 })
+            }
+            // Input/Output blocks are not serialized as YAML audio blocks
+            AudioBlockKind::Input(_) | AudioBlockKind::Output(_) => {
+                Err(anyhow!("Input/Output blocks should not be serialized as audio block YAML"))
             }
         }
     }
@@ -912,11 +964,11 @@ mod tests {
     };
     use domain::ids::{BlockId, DeviceId, ChainId};
     use project::block::{
-        AudioBlock, AudioBlockKind, CoreBlock, SelectBlock,
+        AudioBlock, AudioBlockKind, CoreBlock, InputBlock, OutputBlock, SelectBlock,
     };
     use project::param::ParameterSet;
     use project::project::Project;
-    use project::chain::{Chain, ChainInput, ChainInputMode, ChainOutput, ChainOutputMixdown, ChainOutputMode};
+    use project::chain::{Chain, ChainInputMode, ChainOutputMode};
     use std::fs;
     use std::path::PathBuf;
     use tempfile::tempdir;
@@ -936,25 +988,28 @@ mod tests {
                 description: Some("Guitar 1".into()),
                 instrument: "electric_guitar".to_string(),
                 enabled: true,
-                inputs: vec![ChainInput {
-                    name: "Input 1".to_string(),
-                    device_id: DeviceId("input-device".into()),
-                    mode: ChainInputMode::Mono,
-                    channels: vec![0],
-                }],
-                outputs: vec![ChainOutput {
-                    name: "Output 1".to_string(),
-                    device_id: DeviceId("output-device".into()),
-                    mode: ChainOutputMode::Stereo,
-                    channels: vec![0, 1],
-                }],
-                input_device_id: DeviceId("".into()),
-                input_channels: vec![],
-                output_device_id: DeviceId("".into()),
-                output_channels: vec![],
-                blocks: Vec::new(),
-                output_mixdown: ChainOutputMixdown::Average,
-                input_mode: ChainInputMode::Mono,
+                blocks: vec![
+                    AudioBlock {
+                        id: BlockId("chain:0:input:0".into()),
+                        enabled: true,
+                        kind: AudioBlockKind::Input(InputBlock {
+                            name: "Input 1".to_string(),
+                            device_id: DeviceId("input-device".into()),
+                            mode: ChainInputMode::Mono,
+                            channels: vec![0],
+                        }),
+                    },
+                    AudioBlock {
+                        id: BlockId("chain:0:output:0".into()),
+                        enabled: true,
+                        kind: AudioBlockKind::Output(OutputBlock {
+                            name: "Output 1".to_string(),
+                            device_id: DeviceId("output-device".into()),
+                            mode: ChainOutputMode::Stereo,
+                            channels: vec![0, 1],
+                        }),
+                    },
+                ],
             }],
         };
 
@@ -971,12 +1026,14 @@ mod tests {
         assert_eq!(loaded.name, original.name);
         assert_eq!(loaded.chains.len(), 1);
         assert_eq!(loaded.chains[0].description, original.chains[0].description);
-        assert_eq!(loaded.chains[0].inputs.len(), 1);
-        assert_eq!(loaded.chains[0].inputs[0].device_id, DeviceId("input-device".into()));
-        assert_eq!(loaded.chains[0].inputs[0].channels, vec![0]);
-        assert_eq!(loaded.chains[0].outputs.len(), 1);
-        assert_eq!(loaded.chains[0].outputs[0].device_id, DeviceId("output-device".into()));
-        assert_eq!(loaded.chains[0].outputs[0].channels, vec![0, 1]);
+        let loaded_inputs = loaded.chains[0].input_blocks();
+        assert_eq!(loaded_inputs.len(), 1);
+        assert_eq!(loaded_inputs[0].1.device_id, DeviceId("input-device".into()));
+        assert_eq!(loaded_inputs[0].1.channels, vec![0]);
+        let loaded_outputs = loaded.chains[0].output_blocks();
+        assert_eq!(loaded_outputs.len(), 1);
+        assert_eq!(loaded_outputs[0].1.device_id, DeviceId("output-device".into()));
+        assert_eq!(loaded_outputs[0].1.channels, vec![0, 1]);
     }
 
     #[test]
@@ -1003,13 +1060,15 @@ chains:
             .expect("legacy project should load with migration");
 
         assert_eq!(project.chains.len(), 1);
-        assert_eq!(project.chains[0].inputs.len(), 1);
-        assert_eq!(project.chains[0].inputs[0].device_id, DeviceId("legacy-input".into()));
-        assert_eq!(project.chains[0].inputs[0].channels, vec![0]);
-        assert_eq!(project.chains[0].outputs.len(), 1);
-        assert_eq!(project.chains[0].outputs[0].device_id, DeviceId("legacy-output".into()));
-        assert_eq!(project.chains[0].outputs[0].channels, vec![0, 1]);
-        assert_eq!(project.chains[0].outputs[0].mode, ChainOutputMode::Stereo);
+        let inputs = project.chains[0].input_blocks();
+        assert_eq!(inputs.len(), 1);
+        assert_eq!(inputs[0].1.device_id, DeviceId("legacy-input".into()));
+        assert_eq!(inputs[0].1.channels, vec![0]);
+        let outputs = project.chains[0].output_blocks();
+        assert_eq!(outputs.len(), 1);
+        assert_eq!(outputs[0].1.device_id, DeviceId("legacy-output".into()));
+        assert_eq!(outputs[0].1.channels, vec![0, 1]);
+        assert_eq!(outputs[0].1.mode, ChainOutputMode::Stereo);
     }
 
     #[test]
@@ -1051,9 +1110,13 @@ chains:
             .expect("project should load while skipping invalid blocks");
 
         assert_eq!(project.chains.len(), 1);
-        assert_eq!(project.chains[0].blocks.len(), 1);
+        // 1 InputBlock + 1 valid delay block + 1 OutputBlock = 3 total
+        let audio_blocks: Vec<_> = project.chains[0].blocks.iter()
+            .filter(|b| !matches!(&b.kind, AudioBlockKind::Input(_) | AudioBlockKind::Output(_)))
+            .collect();
+        assert_eq!(audio_blocks.len(), 1);
         assert_eq!(
-            project.chains[0].blocks[0]
+            audio_blocks[0]
                 .model_ref()
                 .expect("remaining block should expose model")
                 .model,
@@ -1155,7 +1218,11 @@ chains:
             .load_current_project()
             .expect("project should load generic select blocks");
 
-        let select = match &project.chains[0].blocks[0].kind {
+        // Find the first non-I/O block (should be the select block)
+        let audio_block = project.chains[0].blocks.iter()
+            .find(|b| !matches!(&b.kind, AudioBlockKind::Input(_) | AudioBlockKind::Output(_)))
+            .expect("should have at least one audio block");
+        let select = match &audio_block.kind {
             AudioBlockKind::Select(select) => select,
             other => panic!("expected select block, got {:?}", other),
         };

--- a/crates/project/src/block.rs
+++ b/crates/project/src/block.rs
@@ -50,6 +50,8 @@ pub enum AudioBlockKind {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct InputEntry {
+    #[serde(default)]
+    pub name: String,
     pub device_id: DeviceId,
     #[serde(default)]
     pub mode: ChainInputMode,
@@ -58,21 +60,29 @@ pub struct InputEntry {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct OutputEntry {
+    #[serde(default)]
+    pub name: String,
     pub device_id: DeviceId,
     #[serde(default)]
     pub mode: ChainOutputMode,
     pub channels: Vec<usize>,
 }
 
+fn default_io_model() -> String {
+    "standard".to_string()
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct InputBlock {
-    pub name: String,
+    #[serde(default = "default_io_model")]
+    pub model: String,
     pub entries: Vec<InputEntry>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct OutputBlock {
-    pub name: String,
+    #[serde(default = "default_io_model")]
+    pub model: String,
     pub entries: Vec<OutputEntry>,
 }
 
@@ -592,14 +602,16 @@ mod tests {
     #[test]
     fn input_block_supports_multiple_entries() {
         let input = InputBlock {
-            name: "Guitars".to_string(),
+            model: "standard".to_string(),
             entries: vec![
                 InputEntry {
+                    name: "Guitar 1".to_string(),
                     device_id: DeviceId("scarlett".into()),
                     mode: ChainInputMode::Mono,
                     channels: vec![0],
                 },
                 InputEntry {
+                    name: "Guitar 2".to_string(),
                     device_id: DeviceId("scarlett".into()),
                     mode: ChainInputMode::Mono,
                     channels: vec![1],
@@ -614,14 +626,16 @@ mod tests {
     #[test]
     fn output_block_supports_multiple_entries() {
         let output = OutputBlock {
-            name: "Monitors".to_string(),
+            model: "standard".to_string(),
             entries: vec![
                 OutputEntry {
+                    name: "Monitors".to_string(),
                     device_id: DeviceId("scarlett".into()),
                     mode: ChainOutputMode::Stereo,
                     channels: vec![0, 1],
                 },
                 OutputEntry {
+                    name: "Headphones".to_string(),
                     device_id: DeviceId("macbook".into()),
                     mode: ChainOutputMode::Stereo,
                     channels: vec![0, 1],
@@ -636,8 +650,9 @@ mod tests {
     #[test]
     fn input_block_single_entry_works() {
         let input = InputBlock {
-            name: "Guitar".to_string(),
+            model: "standard".to_string(),
             entries: vec![InputEntry {
+                name: "Guitar".to_string(),
                 device_id: DeviceId("scarlett".into()),
                 mode: ChainInputMode::Mono,
                 channels: vec![0],
@@ -649,14 +664,16 @@ mod tests {
     #[test]
     fn input_block_validates_no_duplicate_device_channels() {
         let input = InputBlock {
-            name: "Bad".to_string(),
+            model: "standard".to_string(),
             entries: vec![
                 InputEntry {
+                    name: "Input A".to_string(),
                     device_id: DeviceId("scarlett".into()),
                     mode: ChainInputMode::Mono,
                     channels: vec![0],
                 },
                 InputEntry {
+                    name: "Input B".to_string(),
                     device_id: DeviceId("scarlett".into()),
                     mode: ChainInputMode::Mono,
                     channels: vec![0], // duplicate!
@@ -671,14 +688,16 @@ mod tests {
     #[test]
     fn input_block_allows_different_channels_same_device() {
         let input = InputBlock {
-            name: "OK".to_string(),
+            model: "standard".to_string(),
             entries: vec![
                 InputEntry {
+                    name: "Input A".to_string(),
                     device_id: DeviceId("scarlett".into()),
                     mode: ChainInputMode::Mono,
                     channels: vec![0],
                 },
                 InputEntry {
+                    name: "Input B".to_string(),
                     device_id: DeviceId("scarlett".into()),
                     mode: ChainInputMode::Mono,
                     channels: vec![1],
@@ -691,14 +710,16 @@ mod tests {
     #[test]
     fn input_block_allows_same_channel_different_devices() {
         let input = InputBlock {
-            name: "OK".to_string(),
+            model: "standard".to_string(),
             entries: vec![
                 InputEntry {
+                    name: "Input A".to_string(),
                     device_id: DeviceId("scarlett".into()),
                     mode: ChainInputMode::Mono,
                     channels: vec![0],
                 },
                 InputEntry {
+                    name: "Input B".to_string(),
                     device_id: DeviceId("macbook".into()),
                     mode: ChainInputMode::Mono,
                     channels: vec![0],

--- a/crates/project/src/block.rs
+++ b/crates/project/src/block.rs
@@ -49,8 +49,7 @@ pub enum AudioBlockKind {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct InputBlock {
-    pub name: String,
+pub struct InputEntry {
     pub device_id: DeviceId,
     #[serde(default)]
     pub mode: ChainInputMode,
@@ -58,12 +57,42 @@ pub struct InputBlock {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct OutputBlock {
-    pub name: String,
+pub struct OutputEntry {
     pub device_id: DeviceId,
     #[serde(default)]
     pub mode: ChainOutputMode,
     pub channels: Vec<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct InputBlock {
+    pub name: String,
+    pub entries: Vec<InputEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct OutputBlock {
+    pub name: String,
+    pub entries: Vec<OutputEntry>,
+}
+
+impl InputBlock {
+    pub fn validate_channel_conflicts(&self) -> Result<(), String> {
+        let mut used: Vec<(String, usize)> = Vec::new();
+        for entry in &self.entries {
+            for &ch in &entry.channels {
+                let key = (entry.device_id.0.clone(), ch);
+                if used.contains(&key) {
+                    return Err(format!(
+                        "Channel {} on device '{}' is used by multiple entries",
+                        ch, entry.device_id.0
+                    ));
+                }
+                used.push(key);
+            }
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -368,10 +397,11 @@ fn describe_block_audio(
 mod tests {
     use super::{
         normalize_block_params, schema_for_block_model, AudioBlock, AudioBlockKind, CoreBlock,
-        SelectBlock,
+        InputBlock, InputEntry, OutputBlock, OutputEntry, SelectBlock,
     };
+    use crate::chain::{ChainInputMode, ChainOutputMode};
     use crate::param::ParameterSet;
-    use domain::ids::BlockId;
+    use domain::ids::{BlockId, DeviceId};
 
     #[test]
     fn project_contract_exposes_family_schemas() {
@@ -556,4 +586,126 @@ mod tests {
             }),
         }
     }
+
+    // --- InputBlock/OutputBlock multi-entry tests ---
+
+    #[test]
+    fn input_block_supports_multiple_entries() {
+        let input = InputBlock {
+            name: "Guitars".to_string(),
+            entries: vec![
+                InputEntry {
+                    device_id: DeviceId("scarlett".into()),
+                    mode: ChainInputMode::Mono,
+                    channels: vec![0],
+                },
+                InputEntry {
+                    device_id: DeviceId("scarlett".into()),
+                    mode: ChainInputMode::Mono,
+                    channels: vec![1],
+                },
+            ],
+        };
+        assert_eq!(input.entries.len(), 2);
+        assert_eq!(input.entries[0].channels, vec![0]);
+        assert_eq!(input.entries[1].channels, vec![1]);
+    }
+
+    #[test]
+    fn output_block_supports_multiple_entries() {
+        let output = OutputBlock {
+            name: "Monitors".to_string(),
+            entries: vec![
+                OutputEntry {
+                    device_id: DeviceId("scarlett".into()),
+                    mode: ChainOutputMode::Stereo,
+                    channels: vec![0, 1],
+                },
+                OutputEntry {
+                    device_id: DeviceId("macbook".into()),
+                    mode: ChainOutputMode::Stereo,
+                    channels: vec![0, 1],
+                },
+            ],
+        };
+        assert_eq!(output.entries.len(), 2);
+        assert_eq!(output.entries[0].device_id.0, "scarlett");
+        assert_eq!(output.entries[1].device_id.0, "macbook");
+    }
+
+    #[test]
+    fn input_block_single_entry_works() {
+        let input = InputBlock {
+            name: "Guitar".to_string(),
+            entries: vec![InputEntry {
+                device_id: DeviceId("scarlett".into()),
+                mode: ChainInputMode::Mono,
+                channels: vec![0],
+            }],
+        };
+        assert_eq!(input.entries.len(), 1);
+    }
+
+    #[test]
+    fn input_block_validates_no_duplicate_device_channels() {
+        let input = InputBlock {
+            name: "Bad".to_string(),
+            entries: vec![
+                InputEntry {
+                    device_id: DeviceId("scarlett".into()),
+                    mode: ChainInputMode::Mono,
+                    channels: vec![0],
+                },
+                InputEntry {
+                    device_id: DeviceId("scarlett".into()),
+                    mode: ChainInputMode::Mono,
+                    channels: vec![0], // duplicate!
+                },
+            ],
+        };
+        let result = input.validate_channel_conflicts();
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Channel 0"));
+    }
+
+    #[test]
+    fn input_block_allows_different_channels_same_device() {
+        let input = InputBlock {
+            name: "OK".to_string(),
+            entries: vec![
+                InputEntry {
+                    device_id: DeviceId("scarlett".into()),
+                    mode: ChainInputMode::Mono,
+                    channels: vec![0],
+                },
+                InputEntry {
+                    device_id: DeviceId("scarlett".into()),
+                    mode: ChainInputMode::Mono,
+                    channels: vec![1],
+                },
+            ],
+        };
+        assert!(input.validate_channel_conflicts().is_ok());
+    }
+
+    #[test]
+    fn input_block_allows_same_channel_different_devices() {
+        let input = InputBlock {
+            name: "OK".to_string(),
+            entries: vec![
+                InputEntry {
+                    device_id: DeviceId("scarlett".into()),
+                    mode: ChainInputMode::Mono,
+                    channels: vec![0],
+                },
+                InputEntry {
+                    device_id: DeviceId("macbook".into()),
+                    mode: ChainInputMode::Mono,
+                    channels: vec![0],
+                },
+            ],
+        };
+        assert!(input.validate_channel_conflicts().is_ok());
+    }
+
 }

--- a/crates/project/src/block.rs
+++ b/crates/project/src/block.rs
@@ -1,4 +1,4 @@
-use domain::ids::BlockId;
+use domain::ids::{BlockId, DeviceId};
 use domain::value_objects::ParameterValue;
 use serde::{Deserialize, Serialize};
 use block_amp::{amp_model_schema, validate_amp_params};
@@ -19,6 +19,7 @@ use block_reverb::reverb_model_schema;
 use block_util::utility_model_schema;
 use block_wah::{validate_wah_params, wah_model_schema};
 
+use crate::chain::{ChainInputMode, ChainOutputMode};
 use crate::param::{BlockParameterDescriptor, ModelParameterSchema, ParameterSet};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -43,6 +44,26 @@ pub enum AudioBlockKind {
     Nam(NamBlock),
     Core(CoreBlock),
     Select(SelectBlock),
+    Input(InputBlock),
+    Output(OutputBlock),
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct InputBlock {
+    pub name: String,
+    pub device_id: DeviceId,
+    #[serde(default)]
+    pub mode: ChainInputMode,
+    pub channels: Vec<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct OutputBlock {
+    pub name: String,
+    pub device_id: DeviceId,
+    #[serde(default)]
+    pub mode: ChainOutputMode,
+    pub channels: Vec<usize>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -91,6 +112,7 @@ impl AudioBlock {
                 }
                 Ok(())
             }
+            AudioBlockKind::Input(_) | AudioBlockKind::Output(_) => Ok(()),
         }
     }
 
@@ -104,6 +126,7 @@ impl AudioBlock {
                 .selected_option()
                 .ok_or_else(|| "select block selected option does not exist".to_string())?
                 .parameter_descriptors(),
+            AudioBlockKind::Input(_) | AudioBlockKind::Output(_) => Ok(Vec::new()),
         }
     }
 
@@ -120,6 +143,7 @@ impl AudioBlock {
                 .selected_option()
                 .ok_or_else(|| "select block selected option does not exist".to_string())?
                 .audio_descriptors(),
+            AudioBlockKind::Input(_) | AudioBlockKind::Output(_) => Ok(Vec::new()),
         }
     }
 
@@ -131,7 +155,7 @@ impl AudioBlock {
                 params: &stage.params,
             }),
             AudioBlockKind::Core(core) => Some(core.model_ref()),
-            AudioBlockKind::Select(_) => None,
+            AudioBlockKind::Select(_) | AudioBlockKind::Input(_) | AudioBlockKind::Output(_) => None,
         }
     }
 }
@@ -190,8 +214,8 @@ impl SelectBlock {
 
         let mut effect_type = None::<&str>;
         for option in &self.options {
-            if matches!(option.kind, AudioBlockKind::Select(_)) {
-                return Err("select block options cannot themselves be select blocks".to_string());
+            if matches!(option.kind, AudioBlockKind::Select(_) | AudioBlockKind::Input(_) | AudioBlockKind::Output(_)) {
+                return Err("select block options cannot be select, input, or output blocks".to_string());
             }
 
             let model = option.model_ref().ok_or_else(|| {

--- a/crates/project/src/block.rs
+++ b/crates/project/src/block.rs
@@ -23,6 +23,23 @@ use crate::chain::{ChainInputMode, ChainOutputMode};
 use crate::param::{BlockParameterDescriptor, ModelParameterSchema, ParameterSet};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct InsertEndpoint {
+    pub device_id: DeviceId,
+    #[serde(default)]
+    pub mode: ChainInputMode,
+    pub channels: Vec<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct InsertBlock {
+    #[serde(default = "default_io_model")]
+    pub model: String,
+    pub send: InsertEndpoint,
+    #[serde(rename = "return")]
+    pub return_: InsertEndpoint,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AudioBlock {
     pub id: BlockId,
     #[serde(default = "default_enabled")]
@@ -46,6 +63,7 @@ pub enum AudioBlockKind {
     Select(SelectBlock),
     Input(InputBlock),
     Output(OutputBlock),
+    Insert(InsertBlock),
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -151,7 +169,7 @@ impl AudioBlock {
                 }
                 Ok(())
             }
-            AudioBlockKind::Input(_) | AudioBlockKind::Output(_) => Ok(()),
+            AudioBlockKind::Input(_) | AudioBlockKind::Output(_) | AudioBlockKind::Insert(_) => Ok(()),
         }
     }
 
@@ -165,7 +183,7 @@ impl AudioBlock {
                 .selected_option()
                 .ok_or_else(|| "select block selected option does not exist".to_string())?
                 .parameter_descriptors(),
-            AudioBlockKind::Input(_) | AudioBlockKind::Output(_) => Ok(Vec::new()),
+            AudioBlockKind::Input(_) | AudioBlockKind::Output(_) | AudioBlockKind::Insert(_) => Ok(Vec::new()),
         }
     }
 
@@ -182,7 +200,7 @@ impl AudioBlock {
                 .selected_option()
                 .ok_or_else(|| "select block selected option does not exist".to_string())?
                 .audio_descriptors(),
-            AudioBlockKind::Input(_) | AudioBlockKind::Output(_) => Ok(Vec::new()),
+            AudioBlockKind::Input(_) | AudioBlockKind::Output(_) | AudioBlockKind::Insert(_) => Ok(Vec::new()),
         }
     }
 
@@ -194,7 +212,7 @@ impl AudioBlock {
                 params: &stage.params,
             }),
             AudioBlockKind::Core(core) => Some(core.model_ref()),
-            AudioBlockKind::Select(_) | AudioBlockKind::Input(_) | AudioBlockKind::Output(_) => None,
+            AudioBlockKind::Select(_) | AudioBlockKind::Input(_) | AudioBlockKind::Output(_) | AudioBlockKind::Insert(_) => None,
         }
     }
 }
@@ -253,8 +271,8 @@ impl SelectBlock {
 
         let mut effect_type = None::<&str>;
         for option in &self.options {
-            if matches!(option.kind, AudioBlockKind::Select(_) | AudioBlockKind::Input(_) | AudioBlockKind::Output(_)) {
-                return Err("select block options cannot be select, input, or output blocks".to_string());
+            if matches!(option.kind, AudioBlockKind::Select(_) | AudioBlockKind::Input(_) | AudioBlockKind::Output(_) | AudioBlockKind::Insert(_)) {
+                return Err("select block options cannot be select, input, output, or insert blocks".to_string());
             }
 
             let model = option.model_ref().ok_or_else(|| {
@@ -407,7 +425,7 @@ fn describe_block_audio(
 mod tests {
     use super::{
         normalize_block_params, schema_for_block_model, AudioBlock, AudioBlockKind, CoreBlock,
-        InputBlock, InputEntry, OutputBlock, OutputEntry, SelectBlock,
+        InputBlock, InputEntry, InsertBlock, InsertEndpoint, OutputBlock, OutputEntry, SelectBlock,
     };
     use crate::chain::{ChainInputMode, ChainOutputMode};
     use crate::param::ParameterSet;
@@ -727,6 +745,118 @@ mod tests {
             ],
         };
         assert!(input.validate_channel_conflicts().is_ok());
+    }
+
+    // --- InsertBlock tests ---
+
+    #[test]
+    fn insert_block_clone_equality() {
+        let insert = InsertBlock {
+            model: "standard".to_string(),
+            send: InsertEndpoint {
+                device_id: DeviceId("mk300-out".into()),
+                mode: ChainInputMode::Stereo,
+                channels: vec![0, 1],
+            },
+            return_: InsertEndpoint {
+                device_id: DeviceId("mk300-in".into()),
+                mode: ChainInputMode::Stereo,
+                channels: vec![0, 1],
+            },
+        };
+        let block = AudioBlock {
+            id: BlockId("chain:0:insert:0".into()),
+            enabled: true,
+            kind: AudioBlockKind::Insert(insert.clone()),
+        };
+        let cloned = block.clone();
+        assert_eq!(block, cloned);
+        assert!(matches!(&block.kind, AudioBlockKind::Insert(ib) if ib.send.device_id.0 == "mk300-out"));
+        assert!(matches!(&block.kind, AudioBlockKind::Insert(ib) if ib.return_.device_id.0 == "mk300-in"));
+    }
+
+    #[test]
+    fn insert_block_in_chain_structure() {
+        let chain = crate::chain::Chain {
+            id: domain::ids::ChainId("chain:0".to_string()),
+            description: None,
+            instrument: "electric_guitar".to_string(),
+            enabled: true,
+            blocks: vec![
+                AudioBlock {
+                    id: BlockId("chain:0:input:0".into()),
+                    enabled: true,
+                    kind: AudioBlockKind::Input(InputBlock {
+                        model: "standard".to_string(),
+                        entries: vec![InputEntry {
+                            name: "Input 1".to_string(),
+                            device_id: DeviceId("scarlett".into()),
+                            mode: ChainInputMode::Mono,
+                            channels: vec![0],
+                        }],
+                    }),
+                },
+                AudioBlock {
+                    id: BlockId("chain:0:insert:0".into()),
+                    enabled: true,
+                    kind: AudioBlockKind::Insert(InsertBlock {
+                        model: "standard".to_string(),
+                        send: InsertEndpoint {
+                            device_id: DeviceId("mk300-out".into()),
+                            mode: ChainInputMode::Stereo,
+                            channels: vec![0, 1],
+                        },
+                        return_: InsertEndpoint {
+                            device_id: DeviceId("mk300-in".into()),
+                            mode: ChainInputMode::Stereo,
+                            channels: vec![0, 1],
+                        },
+                    }),
+                },
+                AudioBlock {
+                    id: BlockId("chain:0:output:0".into()),
+                    enabled: true,
+                    kind: AudioBlockKind::Output(OutputBlock {
+                        model: "standard".to_string(),
+                        entries: vec![OutputEntry {
+                            name: "Output 1".to_string(),
+                            device_id: DeviceId("scarlett".into()),
+                            mode: ChainOutputMode::Stereo,
+                            channels: vec![0, 1],
+                        }],
+                    }),
+                },
+            ],
+        };
+        let inserts = chain.insert_blocks();
+        assert_eq!(inserts.len(), 1);
+        assert_eq!(inserts[0].0, 1); // index 1
+        assert_eq!(inserts[0].1.send.device_id.0, "mk300-out");
+    }
+
+    #[test]
+    fn disabled_insert_block_validates_ok() {
+        let block = AudioBlock {
+            id: BlockId("chain:0:insert:0".into()),
+            enabled: false,
+            kind: AudioBlockKind::Insert(InsertBlock {
+                model: "standard".to_string(),
+                send: InsertEndpoint {
+                    device_id: DeviceId(String::new()),
+                    mode: ChainInputMode::Mono,
+                    channels: Vec::new(),
+                },
+                return_: InsertEndpoint {
+                    device_id: DeviceId(String::new()),
+                    mode: ChainInputMode::Mono,
+                    channels: Vec::new(),
+                },
+            }),
+        };
+        assert!(block.validate_params().is_ok());
+        assert_eq!(block.parameter_descriptors().unwrap(), Vec::new());
+        assert_eq!(block.audio_descriptors().unwrap(), Vec::new());
+        assert!(block.model_ref().is_none());
     }
 
 }

--- a/crates/project/src/chain.rs
+++ b/crates/project/src/chain.rs
@@ -1,7 +1,7 @@
 use domain::ids::ChainId;
 use serde::{Deserialize, Serialize};
 
-use crate::block::{AudioBlock, AudioBlockKind, InputBlock, InputEntry, OutputBlock};
+use crate::block::{AudioBlock, AudioBlockKind, InputBlock, InputEntry, InsertBlock, OutputBlock};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
@@ -98,6 +98,18 @@ impl Chain {
             .enumerate()
             .filter_map(|(i, b)| match &b.kind {
                 AudioBlockKind::Input(input) => Some((i, input)),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Returns all Insert blocks with their indices in the blocks vec.
+    pub fn insert_blocks(&self) -> Vec<(usize, &InsertBlock)> {
+        self.blocks
+            .iter()
+            .enumerate()
+            .filter_map(|(i, b)| match &b.kind {
+                AudioBlockKind::Insert(insert) => Some((i, insert)),
                 _ => None,
             })
             .collect()

--- a/crates/project/src/chain.rs
+++ b/crates/project/src/chain.rs
@@ -1,7 +1,7 @@
 use domain::ids::ChainId;
 use serde::{Deserialize, Serialize};
 
-use crate::block::{AudioBlock, AudioBlockKind, InputBlock, OutputBlock};
+use crate::block::{AudioBlock, AudioBlockKind, InputBlock, InputEntry, OutputBlock};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
@@ -68,10 +68,10 @@ pub fn processing_layout(
     }
 }
 
-/// Determines the processing layout from an InputBlock alone.
-pub fn processing_layout_for_input(input: &InputBlock) -> ProcessingLayout {
-    let ch_count = input.channels.len();
-    match input.mode {
+/// Determines the processing layout from an InputEntry.
+pub fn processing_layout_for_input_entry(entry: &InputEntry) -> ProcessingLayout {
+    let ch_count = entry.channels.len();
+    match entry.mode {
         ChainInputMode::DualMono if ch_count >= 2 => ProcessingLayout::DualMono,
         ChainInputMode::Stereo if ch_count >= 2 => ProcessingLayout::Stereo,
         _ => ProcessingLayout::Mono,
@@ -131,33 +131,37 @@ impl Chain {
         })
     }
 
-    /// Validate that no two inputs share the same device+channel,
-    /// and no two outputs share the same device+channel.
+    /// Validate that no two input entries share the same device+channel,
+    /// and no two output entries share the same device+channel.
     pub fn validate_channel_conflicts(&self) -> Result<(), String> {
         let mut used: Vec<(String, usize)> = Vec::new();
         for (_, input) in self.input_blocks() {
-            for &ch in &input.channels {
-                let key = (input.device_id.0.clone(), ch);
-                if used.contains(&key) {
-                    return Err(format!(
-                        "Channel {} on device '{}' is used by multiple inputs",
-                        ch, input.device_id.0
-                    ));
+            for entry in &input.entries {
+                for &ch in &entry.channels {
+                    let key = (entry.device_id.0.clone(), ch);
+                    if used.contains(&key) {
+                        return Err(format!(
+                            "Channel {} on device '{}' is used by multiple inputs",
+                            ch, entry.device_id.0
+                        ));
+                    }
+                    used.push(key);
                 }
-                used.push(key);
             }
         }
         let mut used: Vec<(String, usize)> = Vec::new();
         for (_, output) in self.output_blocks() {
-            for &ch in &output.channels {
-                let key = (output.device_id.0.clone(), ch);
-                if used.contains(&key) {
-                    return Err(format!(
-                        "Channel {} on device '{}' is used by multiple outputs",
-                        ch, output.device_id.0
-                    ));
+            for entry in &output.entries {
+                for &ch in &entry.channels {
+                    let key = (entry.device_id.0.clone(), ch);
+                    if used.contains(&key) {
+                        return Err(format!(
+                            "Channel {} on device '{}' is used by multiple outputs",
+                            ch, entry.device_id.0
+                        ));
+                    }
+                    used.push(key);
                 }
-                used.push(key);
             }
         }
         Ok(())

--- a/crates/project/src/chain.rs
+++ b/crates/project/src/chain.rs
@@ -1,7 +1,7 @@
-use domain::ids::{ChainId, DeviceId};
+use domain::ids::ChainId;
 use serde::{Deserialize, Serialize};
 
-use crate::block::AudioBlock;
+use crate::block::{AudioBlock, AudioBlockKind, InputBlock, OutputBlock};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
@@ -68,42 +68,14 @@ pub fn processing_layout(
     }
 }
 
-/// Determines the processing layout from a ChainInput alone.
-pub fn processing_layout_for_input(input: &ChainInput) -> ProcessingLayout {
+/// Determines the processing layout from an InputBlock alone.
+pub fn processing_layout_for_input(input: &InputBlock) -> ProcessingLayout {
     let ch_count = input.channels.len();
     match input.mode {
         ChainInputMode::DualMono if ch_count >= 2 => ProcessingLayout::DualMono,
         ChainInputMode::Stereo if ch_count >= 2 => ProcessingLayout::Stereo,
         _ => ProcessingLayout::Mono,
     }
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct ChainInput {
-    #[serde(default = "default_input_name")]
-    pub name: String,
-    pub device_id: DeviceId,
-    #[serde(default)]
-    pub mode: ChainInputMode,
-    pub channels: Vec<usize>,
-}
-
-fn default_input_name() -> String {
-    "Input".to_string()
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct ChainOutput {
-    #[serde(default = "default_output_name")]
-    pub name: String,
-    pub device_id: DeviceId,
-    #[serde(default)]
-    pub mode: ChainOutputMode,
-    pub channels: Vec<usize>,
-}
-
-fn default_output_name() -> String {
-    "Output".to_string()
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
@@ -114,60 +86,56 @@ pub struct Chain {
     pub description: Option<String>,
     pub instrument: String,
     pub enabled: bool,
-    // New multi-input/output fields
-    #[serde(default)]
-    pub inputs: Vec<ChainInput>,
-    #[serde(default)]
-    pub outputs: Vec<ChainOutput>,
     #[serde(default)]
     pub blocks: Vec<AudioBlock>,
-    // Legacy fields — kept for backward-compatible deserialization, skipped on serialization
-    #[serde(default, skip_serializing)]
-    pub input_device_id: DeviceId,
-    #[serde(default, skip_serializing)]
-    pub input_channels: Vec<usize>,
-    #[serde(default, skip_serializing)]
-    pub output_device_id: DeviceId,
-    #[serde(default, skip_serializing)]
-    pub output_channels: Vec<usize>,
-    #[serde(default, skip_serializing)]
-    pub output_mixdown: ChainOutputMixdown,
-    #[serde(default, skip_serializing)]
-    pub input_mode: ChainInputMode,
 }
 
 impl Chain {
-    /// Migrate legacy single-input/output to new multi-input/output model.
-    /// Called after deserialization.
-    pub fn migrate_legacy_io(&mut self) {
-        if self.inputs.is_empty() && !self.input_device_id.0.is_empty() {
-            self.inputs.push(ChainInput {
-                name: "Input 1".to_string(),
-                device_id: self.input_device_id.clone(),
-                mode: self.input_mode,
-                channels: self.input_channels.clone(),
-            });
-        }
-        if self.outputs.is_empty() && !self.output_device_id.0.is_empty() {
-            let mode = if self.output_channels.len() >= 2 {
-                ChainOutputMode::Stereo
-            } else {
-                ChainOutputMode::Mono
-            };
-            self.outputs.push(ChainOutput {
-                name: "Output 1".to_string(),
-                device_id: self.output_device_id.clone(),
-                mode,
-                channels: self.output_channels.clone(),
-            });
-        }
+    /// Returns all Input blocks with their indices in the blocks vec.
+    pub fn input_blocks(&self) -> Vec<(usize, &InputBlock)> {
+        self.blocks
+            .iter()
+            .enumerate()
+            .filter_map(|(i, b)| match &b.kind {
+                AudioBlockKind::Input(input) => Some((i, input)),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Returns all Output blocks with their indices in the blocks vec.
+    pub fn output_blocks(&self) -> Vec<(usize, &OutputBlock)> {
+        self.blocks
+            .iter()
+            .enumerate()
+            .filter_map(|(i, b)| match &b.kind {
+                AudioBlockKind::Output(output) => Some((i, output)),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Returns the first Input block, if any.
+    pub fn first_input(&self) -> Option<&InputBlock> {
+        self.blocks.iter().find_map(|b| match &b.kind {
+            AudioBlockKind::Input(input) => Some(input),
+            _ => None,
+        })
+    }
+
+    /// Returns the last Output block, if any.
+    pub fn last_output(&self) -> Option<&OutputBlock> {
+        self.blocks.iter().rev().find_map(|b| match &b.kind {
+            AudioBlockKind::Output(output) => Some(output),
+            _ => None,
+        })
     }
 
     /// Validate that no two inputs share the same device+channel,
     /// and no two outputs share the same device+channel.
     pub fn validate_channel_conflicts(&self) -> Result<(), String> {
         let mut used: Vec<(String, usize)> = Vec::new();
-        for input in &self.inputs {
+        for (_, input) in self.input_blocks() {
             for &ch in &input.channels {
                 let key = (input.device_id.0.clone(), ch);
                 if used.contains(&key) {
@@ -180,7 +148,7 @@ impl Chain {
             }
         }
         let mut used: Vec<(String, usize)> = Vec::new();
-        for output in &self.outputs {
+        for (_, output) in self.output_blocks() {
             for &ch in &output.channels {
                 let key = (output.device_id.0.clone(), ch);
                 if used.contains(&key) {

--- a/docs/superpowers/plans/2026-03-28-io-blocks-phase1.md
+++ b/docs/superpowers/plans/2026-03-28-io-blocks-phase1.md
@@ -1,0 +1,109 @@
+# I/O Blocks Phase 1 — Input and Output as blocks in the chain
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move Input/Output from separate lists (`Chain.inputs`/`Chain.outputs`) into `chain.blocks` as `AudioBlockKind::Input` and `AudioBlockKind::Output` variants.
+
+**Architecture:** I/O blocks live in `chain.blocks` alongside effect blocks. First block must be Input (fixed), last must be Output (fixed). Extra I/O blocks can be added in the middle. Each Input creates an isolated parallel stream. Output is a tap (copies signal, doesn't interrupt). The chain view keeps current In/Out chip visuals.
+
+**Branch:** `feature/issue-79`
+
+---
+
+## Task 1: Add InputBlock/OutputBlock to data model
+
+**Files:**
+- Modify: `crates/project/src/block.rs`
+- Modify: `crates/project/src/chain.rs`
+
+### Steps:
+- [ ] Add InputBlock and OutputBlock structs to block.rs
+- [ ] Add Input(InputBlock) and Output(OutputBlock) variants to AudioBlockKind
+- [ ] Update all match statements in AudioBlock methods (validate_params, parameter_descriptors, audio_descriptors, model_ref)
+- [ ] Update SelectBlock validation to reject Input/Output as options
+- [ ] Remove `Chain.inputs`, `Chain.outputs` and all related structs (ChainInput, ChainOutput)
+- [ ] Remove `migrate_legacy_io()`, `validate_channel_conflicts()`, `processing_layout_for_input()`
+- [ ] Add `Chain.input_blocks()` and `Chain.output_blocks()` helper methods that filter blocks by kind
+- [ ] Add `Chain.first_input()` and `Chain.last_output()` helpers
+- [ ] Add validation: chain must start with Input block and end with Output block
+- [ ] `cargo build` — fix all compilation errors in other crates
+- [ ] `cargo test` — fix broken tests
+- [ ] Commit
+
+## Task 2: Update YAML serialization and migration
+
+**Files:**
+- Modify: `crates/infra-yaml/src/lib.rs`
+- Modify: `project.yaml`
+- Modify: `~/.openrig/project.yaml`
+
+### Steps:
+- [ ] Update ChainYaml — remove ChainInputYaml/ChainOutputYaml, blocks now include I/O blocks
+- [ ] Add YAML serialization for InputBlock/OutputBlock (type: "input"/"output" in blocks list)
+- [ ] Update `into_chain()` — legacy migration: if chain has old `input_device_id` but no Input block in blocks, prepend Input block; if no Output block, append Output block
+- [ ] Update `from_chain()` — serialize I/O blocks inline in blocks list
+- [ ] Update `project.yaml` in repo root — convert inputs/outputs to Input/Output blocks in blocks list
+- [ ] Update `~/.openrig/project.yaml` — same conversion
+- [ ] `cargo build` + `cargo test`
+- [ ] Commit
+
+## Task 3: Update engine runtime
+
+**Files:**
+- Modify: `crates/engine/src/runtime.rs`
+
+### Steps:
+- [ ] Remove `effective_inputs()` / `effective_outputs()` — no longer needed
+- [ ] Update `build_chain_runtime_state()` — scan `chain.blocks` to find Input/Output blocks, build InputProcessingState for each Input, OutputRoutingState for each Output
+- [ ] For each Input block: blocks AFTER it (until next Input or end) are its processing chain
+- [ ] Input block at position N: its block chain = blocks[N+1..] that are not Input blocks (effect blocks only)
+- [ ] Output blocks in the chain are taps — when processing reaches an Output's position, copy current frame to that Output's queue
+- [ ] Ensure each Input has completely isolated state (own blocks, own frame_buffer)
+- [ ] Update `process_input_f32()` — no changes needed if InputProcessingState is built correctly
+- [ ] Update `process_output_f32()` — no changes needed if OutputRoutingState is built correctly
+- [ ] Update `update_chain_runtime_state()` — rebuild from blocks
+- [ ] Handle edge case: blocks between two Inputs are only processed by the first Input's stream
+- [ ] `cargo build` + `cargo test`
+- [ ] Commit
+
+## Task 4: Update CPAL stream building
+
+**Files:**
+- Modify: `crates/infra-cpal/src/lib.rs`
+
+### Steps:
+- [ ] Update `resolve_chain_inputs()` — scan chain.blocks for Input blocks instead of chain.inputs
+- [ ] Update `resolve_chain_outputs()` — scan chain.blocks for Output blocks instead of chain.outputs
+- [ ] Rest of CPAL should work since it already creates per-input/per-output streams
+- [ ] `cargo build` + `cargo test`
+- [ ] Commit
+
+## Task 5: Update GUI
+
+**Files:**
+- Modify: `crates/adapter-gui/src/lib.rs`
+- Modify: `crates/adapter-gui/ui/pages/chain_editor.slint`
+- Modify: `crates/adapter-gui/ui/app-window.slint`
+
+### Steps:
+- [ ] Remove InputGroupDraft/OutputGroupDraft — I/O is now in blocks
+- [ ] Update ChainDraft — remove inputs/outputs fields
+- [ ] Update chain_from_draft() — I/O blocks are part of blocks list
+- [ ] Update chain_draft_from_chain() — extract I/O info from blocks
+- [ ] Update chain_editor.slint — keep showing I/O groups section but populate from blocks
+- [ ] Update on_configure_chain_input/output — work with I/O blocks
+- [ ] Update tooltips — extract I/O info from blocks
+- [ ] `cargo build`
+- [ ] Commit
+
+## Task 6: Update docs and cleanup
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Remove: unused I/O group types if any
+
+### Steps:
+- [ ] Update CLAUDE.md
+- [ ] Final `cargo build` + `cargo test` — zero warnings
+- [ ] Commit
+- [ ] Create PR

--- a/docs/superpowers/plans/2026-03-29-io-blocks-gui-fixes.md
+++ b/docs/superpowers/plans/2026-03-29-io-blocks-gui-fixes.md
@@ -1,0 +1,346 @@
+# I/O Blocks GUI Fixes — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix all GUI bugs for I/O blocks: correct insert position from picker, proper entry add/remove flows, enable/disable LED, arrow icons for middle I/O blocks.
+
+**Architecture:** The key insight is that there are TWO separate save paths that must NEVER be mixed: (1) chip In/Out edits the fixed first/last block by updating entries in-place, (2) picker "+" creates a NEW block at a specific position. The `chain_from_draft` function must NEVER be called from the I/O groups save path — it reconstructs the entire chain and destroys block positions.
+
+**Tech Stack:** Rust, Slint UI
+
+**Branch:** `feature/issue-79`
+
+---
+
+### Task 1: Fix the save path — never use chain_from_draft for I/O edits
+
+The root cause of most bugs: `chain_input_groups_window.on_save` falls through to `chain_from_draft` when `editing_io_block_index` is `None` (chip In/Out). This reconstructs the entire chain and destroys positions.
+
+**Files:**
+- Modify: `crates/adapter-gui/src/lib.rs` (lines ~2925-3035 input save, ~3148-3270 output save)
+
+- [ ] **Step 1: Write test for save path**
+
+Add to `crates/adapter-gui/src/lib.rs` tests module:
+
+```rust
+#[test]
+fn chain_from_draft_does_not_move_middle_io_blocks() {
+    // Create a chain with Input at 0, effect at 1, Input at 2, effect at 3, Output at 4
+    let chain = Chain {
+        id: ChainId("test".into()),
+        description: None,
+        instrument: "electric_guitar".into(),
+        enabled: true,
+        blocks: vec![
+            AudioBlock { id: BlockId("input:0".into()), enabled: true,
+                kind: AudioBlockKind::Input(InputBlock { model: "standard".into(),
+                    entries: vec![InputEntry { name: "G1".into(), device_id: DeviceId("dev".into()), mode: ChainInputMode::Mono, channels: vec![0] }] }) },
+            AudioBlock { id: BlockId("gain:0".into()), enabled: true,
+                kind: AudioBlockKind::Core(CoreBlock { effect_type: "gain".into(), model: "volume".into(), params: ParameterSet::default() }) },
+            AudioBlock { id: BlockId("input:1".into()), enabled: true,
+                kind: AudioBlockKind::Input(InputBlock { model: "standard".into(),
+                    entries: vec![InputEntry { name: "G2".into(), device_id: DeviceId("dev".into()), mode: ChainInputMode::Mono, channels: vec![1] }] }) },
+            AudioBlock { id: BlockId("delay:0".into()), enabled: true,
+                kind: AudioBlockKind::Core(CoreBlock { effect_type: "delay".into(), model: "digital_clean".into(), params: ParameterSet::default() }) },
+            AudioBlock { id: BlockId("output:0".into()), enabled: true,
+                kind: AudioBlockKind::Output(OutputBlock { model: "standard".into(),
+                    entries: vec![OutputEntry { name: "Out".into(), device_id: DeviceId("dev".into()), mode: ChainOutputMode::Stereo, channels: vec![0, 1] }] }) },
+        ],
+    };
+    // Verify block order
+    assert!(matches!(&chain.blocks[0].kind, AudioBlockKind::Input(_)));
+    assert!(matches!(&chain.blocks[1].kind, AudioBlockKind::Core(_)));
+    assert!(matches!(&chain.blocks[2].kind, AudioBlockKind::Input(_)));
+    assert!(matches!(&chain.blocks[3].kind, AudioBlockKind::Core(_)));
+    assert!(matches!(&chain.blocks[4].kind, AudioBlockKind::Output(_)));
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes (this is a structural test)**
+
+Run: `cargo test --package adapter-gui -- chain_from_draft_does_not_move`
+
+- [ ] **Step 3: Rewrite input groups save to ALWAYS update in-place**
+
+In `chain_input_groups_window.on_save` (line ~2925), replace the fallthrough to `chain_from_draft` with direct block update:
+
+When `editing_io_block_index` is `None` (chip In), find the first InputBlock in `chain.blocks` and update its entries. When `Some(idx)`, update `chain.blocks[idx]`.
+
+**NEVER call `chain_from_draft`** from this save path.
+
+```rust
+// In chain_input_groups_window.on_save:
+let editing_index = draft.editing_index;
+let io_block_idx = draft.editing_io_block_index;
+
+// Build new entries from draft
+let new_entries: Vec<InputEntry> = draft.inputs.iter()
+    .filter(|ig| ig.device_id.is_some() && !ig.channels.is_empty())
+    .map(|ig| InputEntry {
+        name: ig.name.clone(),
+        device_id: DeviceId(ig.device_id.clone().unwrap_or_default()),
+        mode: ig.mode,
+        channels: ig.channels.clone(),
+    }).collect();
+
+if let Some(chain_idx) = editing_index {
+    if let Some(chain) = session.project.chains.get_mut(chain_idx) {
+        // Find target block: specific index or first InputBlock
+        let target_idx = io_block_idx.unwrap_or_else(|| {
+            chain.blocks.iter().position(|b| matches!(&b.kind, AudioBlockKind::Input(_))).unwrap_or(0)
+        });
+        if let Some(block) = chain.blocks.get_mut(target_idx) {
+            if let AudioBlockKind::Input(ref mut ib) = block.kind {
+                ib.entries = new_entries;
+            }
+        }
+        // sync runtime, refresh UI, set dirty
+    }
+}
+```
+
+- [ ] **Step 4: Same for output groups save**
+
+Same pattern for `chain_output_groups_window.on_save` — find last OutputBlock or specific block, update entries.
+
+- [ ] **Step 5: Run all tests**
+
+Run: `cargo test --package adapter-gui`
+Run: `cargo build` — zero warnings
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/adapter-gui/src/lib.rs
+git commit -m "fix(gui): I/O groups save updates block in-place, never reconstructs chain (#79)"
+```
+
+---
+
+### Task 2: Fix picker "+" insert position
+
+When the picker creates a new I/O block, it must insert at the exact position and NOT touch any other blocks.
+
+**Files:**
+- Modify: `crates/adapter-gui/src/lib.rs` (lines ~5046-5115 input insert, ~5246-5315 output insert)
+
+- [ ] **Step 1: Verify the `on_choose_block_type` sets correct before_index**
+
+Read the code at line ~4170. The `before_index` comes from `block_editor_draft.before_index` which was set by `on_start_block_insert`. This index is in UI space. Verify `ui_index_to_real_block_index` is called.
+
+- [ ] **Step 2: Verify the insert in `chain_input_window.on_save` inserts at correct position**
+
+The code at line ~5098 does `chain.blocks.insert(insert_pos, input_block)`. Verify `insert_pos` comes from `io_draft.before_index` which should already be in real space (set in `on_choose_block_type` after `on_start_block_insert` which calls `ui_index_to_real_block_index`).
+
+If not, add the mapping.
+
+- [ ] **Step 3: After insert, do NOT call chain_from_draft or any chain reconstruction**
+
+The insert path already creates a single block and inserts at position. Verify it does NOT call `chain_from_draft` anywhere after.
+
+- [ ] **Step 4: Test manually — insert Input between blocks, verify position**
+
+- [ ] **Step 5: Commit if changes were made**
+
+---
+
+### Task 3: Entry add flow — opens device config, returns to list
+
+**Files:**
+- Modify: `crates/adapter-gui/src/lib.rs` (on_add_input ~2677, on_add_output ~2710)
+- Modify: `crates/adapter-gui/ui/pages/chain_io_groups.slint`
+
+Currently `on_add_input` adds an empty InputGroupDraft to the list. The spec says it should open the device/channels/mode config window, and on save return to the list.
+
+- [ ] **Step 1: Change on_add_input to open ChainInputWindow**
+
+Instead of adding empty draft to list, open the input config window:
+```rust
+chain_editor_window.on_add_input(move || {
+    // Set editing_input_index to a new index
+    let mut draft_borrow = chain_draft.borrow_mut();
+    let Some(draft) = draft_borrow.as_mut() else { return; };
+    let new_idx = draft.inputs.len();
+    // Add placeholder
+    draft.inputs.push(InputGroupDraft {
+        name: format!("Input {}", new_idx + 1),
+        device_id: input_chain_devices.first().map(|d| d.id.clone()),
+        channels: Vec::new(),
+        mode: ChainInputMode::Mono,
+    });
+    draft.editing_input_index = Some(new_idx);
+    // Open input config window with the new entry
+    if let Some(iw) = weak_input_window.upgrade() {
+        let input_group = &draft.inputs[new_idx];
+        apply_chain_input_window_state(...);
+        show_child_window(...);
+    }
+});
+```
+
+- [ ] **Step 2: Same for on_add_output**
+
+- [ ] **Step 3: When input window saves (non-insert mode), refresh the groups list**
+
+In `chain_input_window.on_save`, after updating the draft entry, refresh the groups window list.
+
+- [ ] **Step 4: When input window cancels, remove the placeholder entry**
+
+If the user cancels, remove the entry that was added as placeholder.
+
+- [ ] **Step 5: Test the flow: click add → config window → save → back to list**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git commit -m "feat(gui): add entry opens device config window, returns to list on save (#79)"
+```
+
+---
+
+### Task 4: Remove entry validation — fixed blocks minimum 1
+
+**Files:**
+- Modify: `crates/adapter-gui/src/lib.rs` (on_remove_input ~2738, on_remove_output)
+- Modify: `crates/adapter-gui/ui/pages/chain_io_groups.slint`
+
+- [ ] **Step 1: In on_remove_input, check if this is a fixed block with 1 entry**
+
+```rust
+chain_editor_window.on_remove_input(move |group_index| {
+    let mut draft_borrow = chain_draft.borrow_mut();
+    let Some(draft) = draft_borrow.as_mut() else { return; };
+    // If this is the fixed block (editing_io_block_index is None) and only 1 entry, block removal
+    if draft.editing_io_block_index.is_none() && draft.inputs.len() <= 1 {
+        // Show message or just do nothing
+        return;
+    }
+    // Otherwise remove
+    let gi = group_index as usize;
+    if gi < draft.inputs.len() {
+        draft.inputs.remove(gi);
+    }
+    // Refresh UI
+});
+```
+
+- [ ] **Step 2: Same for on_remove_output**
+
+- [ ] **Step 3: Test — try removing last entry from chip In (should be blocked)**
+
+- [ ] **Step 4: Test — remove entry from middle block (should allow, block becomes empty)**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "fix(gui): prevent removing last entry from fixed I/O blocks (#79)"
+```
+
+---
+
+### Task 5: Arrow icons for middle I/O blocks
+
+**Files:**
+- Create: `crates/adapter-gui/ui/assets/input_arrow.svg`
+- Create: `crates/adapter-gui/ui/assets/output_arrow.svg`
+- Modify: `crates/adapter-gui/src/ui_state.rs` (accent_color_for_icon_kind)
+- Modify: `crates/adapter-gui/ui/pages/project_chains.slint` (EffectTypeIcon)
+
+- [ ] **Step 1: Create input_arrow.svg**
+
+Simple arrow-in SVG icon (similar to the "In" chip arrow but standalone):
+```svg
+<svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M8 24H36M36 24L24 14M36 24L24 34" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect x="36" y="12" width="4" height="24" rx="1" fill="currentColor"/>
+</svg>
+```
+
+- [ ] **Step 2: Create output_arrow.svg**
+
+Arrow-out SVG icon:
+```svg
+<svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="8" y="12" width="4" height="24" rx="1" fill="currentColor"/>
+  <path d="M16 24H40M40 24L28 14M40 24L28 34" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>
+```
+
+- [ ] **Step 3: Add "input" and "output" to accent_color_for_icon_kind**
+
+```rust
+"input" => slint::Color::from_argb_u8(255, 0x45, 0xa7, 0xff),   // blue
+"output" => slint::Color::from_argb_u8(255, 0x45, 0xa7, 0xff),  // blue
+```
+
+- [ ] **Step 4: Add "input" and "output" icon cases to EffectTypeIcon in Slint**
+
+In the EffectTypeIcon component, add:
+```slint
+if root.icon-kind == "input" : Image {
+    source: @image-url("../assets/input_arrow.svg");
+    colorize: root.tint;
+    image-fit: contain;
+    width: parent.width; height: parent.height;
+}
+if root.icon-kind == "output" : Image {
+    source: @image-url("../assets/output_arrow.svg");
+    colorize: root.tint;
+    image-fit: contain;
+    width: parent.width; height: parent.height;
+}
+```
+
+- [ ] **Step 5: Verify middle I/O blocks render with arrow icons**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/adapter-gui/ui/assets/input_arrow.svg crates/adapter-gui/ui/assets/output_arrow.svg
+git add crates/adapter-gui/src/ui_state.rs crates/adapter-gui/ui/pages/project_chains.slint
+git commit -m "feat(gui): arrow icons and accent colors for middle I/O blocks (#79)"
+```
+
+---
+
+### Task 6: Enable/disable LED on middle I/O blocks
+
+The LED already exists on all BlockChip components (line ~883 in project_chains.slint). It shows green/gray based on `block.enabled`. I/O blocks already have `enabled: bool` in AudioBlock.
+
+**Files:**
+- Modify: `crates/adapter-gui/src/lib.rs` (on_toggle_chain_block_enabled)
+
+- [ ] **Step 1: Verify toggle works for I/O blocks**
+
+The `on_toggle_chain_block_enabled` callback should work for any block type since it just flips `block.enabled`. Test clicking the LED on a middle I/O block.
+
+- [ ] **Step 2: If toggle doesn't work for I/O blocks, fix the callback**
+
+The callback may skip I/O blocks. Check if there's a filter.
+
+- [ ] **Step 3: Commit if changes were made**
+
+---
+
+### Self-Review
+
+Checking against spec (`docs/superpowers/specs/2026-03-29-io-blocks-design.md`):
+
+| Spec Requirement | Task |
+|---|---|
+| Chip In shows only first InputBlock entries | Already fixed (commit c8fbf21) |
+| Chip Out shows only last OutputBlock entries | Already fixed (commit c8fbf21) |
+| Click I/O block in middle opens its entries | Already fixed (commit 94d6dd1) |
+| Save updates ONLY the block being edited | **Task 1** |
+| Block position never changes on save | **Task 1** |
+| Picker creates new block at exact position | **Task 2** |
+| Add entry opens device config, returns to list | **Task 3** |
+| Fixed blocks minimum 1 entry | **Task 4** |
+| Middle blocks can have 0 entries | **Task 4** |
+| Arrow icons for middle I/O | **Task 5** |
+| Enable/disable LED | **Task 6** |
+| Disabled Input stops its stream | Already in engine |
+| Validation no duplicate device+channel | Already implemented |
+
+All spec requirements covered.

--- a/docs/superpowers/specs/2026-03-29-insert-block-design.md
+++ b/docs/superpowers/specs/2026-03-29-insert-block-design.md
@@ -1,0 +1,93 @@
+# Insert Block Design Spec
+
+## Overview
+
+An Insert block sends audio to an external device and receives it back, enabling hardware processing in the chain (external pedals, rack effects, pedalboards).
+
+## Data Model
+
+```rust
+pub struct InsertBlock {
+    pub model: String,  // "standard"
+    pub send: InsertEndpoint,
+    pub return_: InsertEndpoint,
+}
+
+pub struct InsertEndpoint {
+    pub device_id: DeviceId,
+    pub mode: ChainInputMode,  // Mono, Stereo, DualMono
+    pub channels: Vec<usize>,
+}
+```
+
+`InsertBlock` is a new variant of `AudioBlockKind`.
+
+## YAML Format
+
+```yaml
+- type: insert
+  enabled: true
+  model: standard
+  send:
+    device_id: "coreaudio:...MK-300..."
+    mode: stereo
+    channels: [0, 1]
+  return:
+    device_id: "coreaudio:...MK-300..."
+    mode: stereo
+    channels: [0, 1]
+```
+
+## Audio Processing
+
+1. Audio arrives at the Insert block
+2. **Send**: frames are written to the send device+channels (like an Output tap)
+3. **Return**: frames are read from the return device+channels (like an Input)
+4. The return frames replace the signal — blocks after the Insert process the returned audio
+5. **Disabled (bypass)**: signal passes through unchanged, no send/return streams created
+
+The Insert creates TWO audio streams:
+- One output stream (send) writing to the external device
+- One input stream (return) reading from the external device
+
+Latency: the external device adds latency (round-trip through hardware). This is inherent and expected.
+
+## Chain Example
+
+```
+[Scarlett In] → [Comp] → [EQ] → [Insert: MK-300] → [Delay] → [Reverb] → [Scarlett Out]
+                                   ↓           ↑
+                                 MK-300 Out   MK-300 In
+                                   ↓           ↑
+                                 External hardware processing
+```
+
+## Chain View
+
+- Visual: single block with loop/circular arrow icon
+- Label: "INSERT"
+- Draggable, removable
+- Enable/disable LED (disabled = bypass)
+- Click opens config window with Send and Return device/channels/mode
+
+## Behavior
+
+- **Send and Return are always paired** — one block, not two
+- **No blocks between Send and Return** — they are the same block
+- **Bypass when disabled** — signal passes through unchanged
+- **Can use different devices** for send and return
+- **Always 1 send + 1 return** — no multiple sends/returns
+
+## Config Window
+
+When clicking the Insert block, opens a config window with:
+- **Send section**: device selector, mode (mono/stereo), channel selector
+- **Return section**: device selector, mode (mono/stereo), channel selector
+- OK / Cancel buttons
+- Enable/disable toggle + delete (for middle blocks)
+
+## Validation
+
+- Send device+channels must be valid
+- Return device+channels must be valid
+- Send and return can use same or different devices

--- a/docs/superpowers/specs/2026-03-29-io-blocks-design.md
+++ b/docs/superpowers/specs/2026-03-29-io-blocks-design.md
@@ -1,0 +1,168 @@
+# I/O Blocks Design Spec
+
+## Overview
+
+Input and Output are blocks inside `chain.blocks`, positioned anywhere in the chain. Each Input creates an isolated parallel audio stream. Each Output is a tap that sums all active streams at that point.
+
+## Data Model
+
+```rust
+struct InputBlock {
+    model: String,             // "standard" (future: other types)
+    entries: Vec<InputEntry>,  // multiple device+channel configs
+}
+
+struct InputEntry {
+    name: String,
+    device_id: DeviceId,
+    mode: ChainInputMode,      // Mono, Stereo, DualMono
+    channels: Vec<usize>,
+}
+
+struct OutputBlock {
+    model: String,             // "standard" (future: aux_send, etc)
+    entries: Vec<OutputEntry>,
+}
+
+struct OutputEntry {
+    name: String,
+    device_id: DeviceId,
+    mode: ChainOutputMode,     // Mono, Stereo
+    channels: Vec<usize>,
+}
+```
+
+InputBlock and OutputBlock are variants of `AudioBlockKind` alongside Nam, Core, Select.
+
+## Chain Structure
+
+```
+[In chip] → [Tuner] → [TS9] → [Input block] → [Dynamics] → [Amp] → [Reverb] → [Out chip]
+  fixed                          middle block                                      fixed
+```
+
+- **First block** = InputBlock fixed (rendered as "In" chip, not draggable, not removable)
+- **Last block** = OutputBlock fixed (rendered as "Out" chip, not draggable, not removable)
+- **Middle I/O blocks** = rendered with arrow icon (input: arrow in, output: arrow out), draggable, removable, can be enabled/disabled
+
+## Audio Processing
+
+Each InputBlock creates **isolated parallel streams**. Every effect block after an Input gets its own processor instance per stream. Streams never interfere with each other.
+
+```
+[Input A: Guitar ch1] → [Comp instance 1] → [Preamp instance 1] → ...
+[Input B: Keys ch3+4]                     → [Preamp instance 2] → ...
+                                                                    ↓
+                                                          [Output: sum streams]
+```
+
+- **Input block at position N**: creates stream that processes blocks from N+1 forward
+- **Output block at position M**: taps (copies) all active streams at that point, sums them, sends to device
+- **Disabled Input**: its stream stops, blocks after it only process remaining active streams
+
+## User Flows
+
+### Chip In (fixed first InputBlock)
+
+1. Click chip "In"
+2. Opens entries list window showing entries of this block only
+3. Can edit/remove entries (minimum 1 entry required for fixed block)
+4. "+ Adicionar entrada" opens device/channels/mode config window
+5. After configuring, returns to entries list with new entry
+6. "OK" saves entries to this block only (nothing else moves)
+7. Project becomes dirty — user saves project separately
+
+### Chip Out (fixed last OutputBlock)
+
+Same as chip In but for outputs. Minimum 1 entry required.
+
+### Picker "+" → INPUT or OUTPUT
+
+1. Click "+" between blocks
+2. Select INPUT or OUTPUT from type picker
+3. Creates new I/O block at that exact position with empty entries
+4. Opens entries list window
+5. User adds entries via device/channels/mode config
+6. "OK" saves — block stays at inserted position
+
+### Click I/O block in middle
+
+1. Opens entries list window showing entries of that specific block
+2. Same editing flow as chips
+3. "OK" updates only that block — no other block moves or changes
+4. Can have zero entries (block becomes empty/inactive)
+
+### Enable/Disable I/O block in middle
+
+- Same LED toggle as effect blocks
+- Disabled Input: its stream stops
+- Disabled Output: stops sending to device at that point
+
+### Remove I/O block in middle
+
+- Can be removed like any block
+- Fixed first Input and last Output cannot be removed
+
+## YAML Format
+
+```yaml
+chains:
+  - description: Chain 1
+    instrument: electric_guitar
+    blocks:
+      - type: input
+        enabled: true
+        model: standard
+        entries:
+          - name: Guitar 1
+            device_id: "scarlett..."
+            mode: mono
+            channels: [0]
+      - type: gain
+        enabled: true
+        model: ibanez_ts9
+        params:
+          drive: 35.0
+      - type: input
+        enabled: true
+        model: standard
+        entries:
+          - name: Keys L
+            device_id: "scarlett..."
+            mode: stereo
+            channels: [2, 3]
+      - type: delay
+        enabled: true
+        model: digital_clean
+        params:
+          time_ms: 200
+      - type: output
+        enabled: true
+        model: standard
+        entries:
+          - name: Main Out
+            device_id: "scarlett..."
+            mode: stereo
+            channels: [0, 1]
+```
+
+## Visual
+
+- Fixed In/Out: current chip style (not changing)
+- Middle Input block: arrow-in icon, label "INPUT", draggable
+- Middle Output block: arrow-out icon, label "OUTPUT", draggable
+- LED toggle for enable/disable on middle I/O blocks
+
+## Validation
+
+- No two entries (across all blocks) share same device+channel for inputs
+- No two entries (across all blocks) share same device+channel for outputs
+- Fixed first/last blocks must have at least 1 entry
+- Middle blocks can have 0 entries (inactive)
+
+## Key Implementation Rules
+
+- **Save updates ONLY the block being edited** — never reconstructs the entire chain
+- **Block position never changes** on save — only entries inside the block change
+- **Each I/O block is independent** — editing one never affects another
+- **Draft state** tracks which specific block is being edited (`editing_io_block_index`)

--- a/project.yaml
+++ b/project.yaml
@@ -7,17 +7,14 @@ chains:
   - description: guitar 1
     instrument: electric_guitar
     enabled: true
-    inputs:
-      - name: Input 1
-        device_id: "coreaudio:AppleUSBAudioEngine:Focusrite:Scarlett 2i2 4th Gen:S21ANUD3C1EEBE:1,2"
-        mode: mono
-        channels: [0]
-    outputs:
-      - name: Output 1
-        device_id: "coreaudio:AppleUSBAudioEngine:Focusrite:Scarlett 2i2 4th Gen:S21ANUD3C1EEBE:1,2"
-        mode: stereo
-        channels: [0, 1]
     blocks:
+      - type: input
+        name: Input 1
+        entries:
+          - device_id: "coreaudio:AppleUSBAudioEngine:Focusrite:Scarlett 2i2 4th Gen:S21ANUD3C1EEBE:1,2"
+            mode: mono
+            channels: [0]
+
       - type: preamp
         model: marshall_jcm_800_2203
         enabled: true
@@ -32,3 +29,10 @@ chains:
           time_ms: 200
           feedback: 60
           mix: 55
+
+      - type: output
+        name: Output 1
+        entries:
+          - device_id: "coreaudio:AppleUSBAudioEngine:Focusrite:Scarlett 2i2 4th Gen:S21ANUD3C1EEBE:1,2"
+            mode: stereo
+            channels: [0, 1]

--- a/project.yaml
+++ b/project.yaml
@@ -9,9 +9,10 @@ chains:
     enabled: true
     blocks:
       - type: input
-        name: Input 1
+        model: standard
         entries:
-          - device_id: "coreaudio:AppleUSBAudioEngine:Focusrite:Scarlett 2i2 4th Gen:S21ANUD3C1EEBE:1,2"
+          - name: Input 1
+            device_id: "coreaudio:AppleUSBAudioEngine:Focusrite:Scarlett 2i2 4th Gen:S21ANUD3C1EEBE:1,2"
             mode: mono
             channels: [0]
 
@@ -31,8 +32,9 @@ chains:
           mix: 55
 
       - type: output
-        name: Output 1
+        model: standard
         entries:
-          - device_id: "coreaudio:AppleUSBAudioEngine:Focusrite:Scarlett 2i2 4th Gen:S21ANUD3C1EEBE:1,2"
+          - name: Output 1
+            device_id: "coreaudio:AppleUSBAudioEngine:Focusrite:Scarlett 2i2 4th Gen:S21ANUD3C1EEBE:1,2"
             mode: stereo
             channels: [0, 1]


### PR DESCRIPTION
## Summary

Complete redesign of chain I/O system. Input, Output, and Insert are now blocks inside chain.blocks.

### Phase 1: Input/Output blocks
- InputBlock/OutputBlock with multiple entries (device+mode+channels each)
- Fixed first Input and last Output (chips In/Out)
- Extra I/O blocks addable in the middle (draggable, removable)
- Each Input creates isolated parallel stream
- Output is non-destructive tap
- Enable/disable LED + delete for middle blocks
- Arrow icons for Input/Output blocks
- YAML inline in blocks array, backward compat

### Phase 3: Insert block
- InsertBlock with send (output) and return (input) endpoints
- Splits chain into segments at Insert points
- Each segment processes its own effect blocks
- Dedicated config window for send/return device/channels
- Loop arrow icon, enable/disable, delete
- Audio routing verified working with external hardware (MK-300)

### Known limitation
- Clock drift between different audio devices causes artifacts (#81)

Closes #79