### PR TITLE
fix(engine): pass actual sample rate to tuner pitch detection

### DIFF
--- a/crates/engine/src/runtime.rs
+++ b/crates/engine/src/runtime.rs
@@ -202,6 +202,8 @@ pub struct ChainRuntimeState {
     tuner_shared_buffer: Mutex<Vec<f32>>,
     /// Tuner state owned by UI thread only (never touched by audio).
     pub tuner_reading: Mutex<block_util::TunerReading>,
+    /// Sample rate for pitch detection (Hz).
+    sample_rate: f32,
     #[allow(dead_code)]
     last_input_nanos: AtomicU64,
     measured_latency_nanos: AtomicU64,
@@ -226,10 +228,12 @@ impl ChainRuntimeState {
 
     /// Called from UI thread: run detection on accumulated samples.
     pub fn poll_tuner(&self) -> Option<block_util::TunerReading> {
+        // Need ~46ms of audio for reliable pitch detection
+        let min_samples = (self.sample_rate * 0.046) as usize;
         // Grab samples quickly
         let samples = {
             let mut buf = self.tuner_shared_buffer.try_lock().ok()?;
-            if buf.len() < 2048 {
+            if buf.len() < min_samples {
                 return self.tuner_reading.try_lock().ok().and_then(|r| {
                     if r.frequency.is_some() { Some(r.clone()) } else { None }
                 });
@@ -240,7 +244,7 @@ impl ChainRuntimeState {
         };
 
         // Run detection outside any lock (takes ~1ms, fine for UI thread)
-        let reading = detect_pitch(&samples);
+        let reading = detect_pitch(&samples, self.sample_rate);
 
         // Store for next poll if no detection
         if let Ok(mut tr) = self.tuner_reading.try_lock() {
@@ -393,6 +397,7 @@ pub fn build_chain_runtime_state(chain: &Chain, sample_rate: f32) -> Result<Chai
         output: Mutex::new(ChainOutputState { output_routes }),
         tuner_shared_buffer: Mutex::new(Vec::with_capacity(8192)),
         tuner_reading: Mutex::new(block_util::TunerReading::default()),
+        sample_rate,
         last_input_nanos: AtomicU64::new(0),
         measured_latency_nanos: AtomicU64::new(0),
     })
@@ -1515,8 +1520,7 @@ fn block_has_active_tuner(block: &BlockRuntimeNode) -> bool {
 }
 
 /// Simple AMDF pitch detection — runs on UI thread, NOT audio thread.
-fn detect_pitch(samples: &[f32]) -> block_util::TunerReading {
-    let sample_rate = 44100.0_f32; // TODO: pass actual sample rate
+fn detect_pitch(samples: &[f32], sample_rate: f32) -> block_util::TunerReading {
     let rms = (samples.iter().map(|s| s * s).sum::<f32>() / samples.len() as f32).sqrt();
     if rms < 0.01 || samples.len() < 512 {
         return block_util::TunerReading::default();


### PR DESCRIPTION
## Summary
- `detect_pitch` was hardcoded to 44100 Hz sample rate, causing wrong AMDF period calculations on devices running at 48kHz/96kHz — tuner showed no readings
- Store `sample_rate` in `ChainRuntimeState` and pass it to `detect_pitch`
- Minimum buffer threshold now scales with sample rate (~46ms of audio)

Closes #37

## Test plan
- [x] `cargo build --package engine` compiles without errors
- [x] No new test regressions (7 pre-existing failures on develop)
- [ ] Manual test: add tuner block, play guitar, verify readings appear