### PR TITLE
fix(tuner): clear stale readings, fix layout and compact view

### DIFF
--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -2414,7 +2414,6 @@ pub fn run_desktop_app(
             {
                 let weak_cw = compact_win.as_weak();
                 let project_runtime_poll = project_runtime.clone();
-                let project_session_poll = project_session.clone();
                 let tuner_timer = Timer::default();
                 tuner_timer.start(
                     slint::TimerMode::Repeated,
@@ -2424,21 +2423,19 @@ pub fn run_desktop_app(
                         let rt_borrow = project_runtime_poll.borrow();
                         let Some(rt) = rt_borrow.as_ref() else { return; };
                         let reading = rt.poll_tuner_reading();
-                        if let Some(reading) = reading {
-                            let session_borrow = project_session_poll.borrow();
-                            let Some(_session) = session_borrow.as_ref() else { return; };
-                            // Find tuner block index and update its stream data
-                            let compact_blocks = cw.get_compact_blocks();
-                            for i in 0..compact_blocks.row_count() {
-                                if let Some(mut item) = compact_blocks.row_data(i) {
-                                    if item.effect_type == "utility" {
+                        let compact_blocks = cw.get_compact_blocks();
+                        for i in 0..compact_blocks.row_count() {
+                            if let Some(mut item) = compact_blocks.row_data(i) {
+                                if item.effect_type == "utility" {
+                                    if let Some(ref reading) = reading {
+                                        let in_tune_f = if reading.in_tune { 1.0 } else { 0.0 };
                                         item.stream_data = BlockStreamData {
                                             active: true,
                                             stream_kind: "tuner".into(),
                                             entries: ModelRc::from(Rc::new(VecModel::from(vec![
                                                 BlockStreamEntry {
                                                     key: "note".into(),
-                                                    value: 0.0,
+                                                    value: in_tune_f,
                                                     text: reading.note.clone().unwrap_or_default().into(),
                                                 },
                                                 BlockStreamEntry {
@@ -2448,13 +2445,19 @@ pub fn run_desktop_app(
                                                 },
                                                 BlockStreamEntry {
                                                     key: "Hz".into(),
-                                                    value: reading.frequency.unwrap_or(0.0),
+                                                    value: in_tune_f,
                                                     text: format!("{:.0}", reading.frequency.unwrap_or(0.0)).into(),
                                                 },
                                             ]))),
                                         };
-                                        compact_blocks.set_row_data(i, item);
+                                    } else {
+                                        item.stream_data = BlockStreamData {
+                                            active: false,
+                                            stream_kind: "".into(),
+                                            entries: ModelRc::default(),
+                                        };
                                     }
+                                    compact_blocks.set_row_data(i, item);
                                 }
                             }
                         }
@@ -4044,10 +4047,11 @@ pub fn run_desktop_app(
                             };
                             if let Some(reading) = runtime.poll_tuner_reading() {
                                 log::trace!("[tuner-stream] note={:?} freq={:?} cents={:?}", reading.note, reading.frequency, reading.cents_off);
+                                let in_tune_f = if reading.in_tune { 1.0 } else { 0.0 };
                                 let entries = vec![
                                     BlockStreamEntry {
                                         key: "note".into(),
-                                        value: 0.0,
+                                        value: in_tune_f,
                                         text: reading.note.unwrap_or_default().into(),
                                     },
                                     BlockStreamEntry {
@@ -4057,19 +4061,20 @@ pub fn run_desktop_app(
                                     },
                                     BlockStreamEntry {
                                         key: "frequency".into(),
-                                        value: reading.frequency.unwrap_or(0.0),
+                                        value: in_tune_f,
                                         text: format!("{:.1} Hz", reading.frequency.unwrap_or(0.0)).into(),
-                                    },
-                                    BlockStreamEntry {
-                                        key: "in_tune".into(),
-                                        value: if reading.in_tune { 1.0 } else { 0.0 },
-                                        text: if reading.in_tune { "IN TUNE".into() } else { "".into() },
                                     },
                                 ];
                                 win.set_block_stream_data(BlockStreamData {
                                     active: true,
                                     stream_kind: "tuner".into(),
                                     entries: ModelRc::from(Rc::new(VecModel::from(entries))),
+                                });
+                            } else {
+                                win.set_block_stream_data(BlockStreamData {
+                                    active: false,
+                                    stream_kind: "".into(),
+                                    entries: ModelRc::default(),
                                 });
                             }
                         },

--- a/crates/adapter-gui/ui/pages/block_panel_editor.slint
+++ b/crates/adapter-gui/ui/pages/block_panel_editor.slint
@@ -972,7 +972,7 @@ export component BlockPanelEditor inherits Rectangle {
         x: 0;
         y: 0;
         width: parent.width;
-        height: parent.height * 0.52;
+        height: parent.height * 0.40;
         background: #0a0c10;
 
         // Render entries in a centered layout
@@ -997,7 +997,7 @@ export component BlockPanelEditor inherits Rectangle {
             Text {
                 x: 0; y: 14px; width: parent.width; height: parent.height - 40px;
                 text: entry.text;
-                color: entry.value > 0.5 && entry.key == "in_tune" ? #29df85 : #f3f6fb;
+                color: entry.value > 0.5 ? #29df85 : #f3f6fb;
                 font-size: entry.text.character-count <= 3 ? 42px : 20px;
                 font-weight: 900;
                 horizontal-alignment: center;

--- a/crates/adapter-gui/ui/pages/compact_chain_view.slint
+++ b/crates/adapter-gui/ui/pages/compact_chain_view.slint
@@ -515,7 +515,7 @@ component CompactBlockRow inherits Rectangle {
             Text {
                 x: 0; y: 14px; width: parent.width; height: parent.height - 32px;
                 text: entry.text;
-                color: entry.value > 0.5 && entry.key == "in_tune" ? #29df85 : root.block-data.panel-text;
+                color: entry.value > 0.5 ? #29df85 : root.block-data.panel-text;
                 font-size: entry.text.character-count <= 3 ? 28px : 14px;
                 font-weight: 900;
                 horizontal-alignment: center;

--- a/crates/engine/src/runtime.rs
+++ b/crates/engine/src/runtime.rs
@@ -246,18 +246,12 @@ impl ChainRuntimeState {
         // Run detection outside any lock (takes ~1ms, fine for UI thread)
         let reading = detect_pitch(&samples, self.sample_rate);
 
-        // Store for next poll if no detection
+        // Update cached reading (clear on silence so UI doesn't show stale data)
         if let Ok(mut tr) = self.tuner_reading.try_lock() {
-            if reading.frequency.is_some() {
-                *tr = reading.clone();
-            }
+            *tr = reading.clone();
         }
 
-        if reading.frequency.is_some() { Some(reading) } else {
-            self.tuner_reading.try_lock().ok().and_then(|r| {
-                if r.frequency.is_some() { Some(r.clone()) } else { None }
-            })
-        }
+        if reading.frequency.is_some() { Some(reading) } else { None }
     }
 }
 


### PR DESCRIPTION
## Summary
- Tuner display no longer freezes on last detected note when guitar stops playing
- Removed `in_tune` as separate empty column — note and frequency turn green when in tune
- Reduced stream display area from 52% to 40% so reference knob is closer to tuner readings
- Compact chain view now clears tuner data on silence (was stuck showing last reading)

Closes #37

## Test plan
- [x] `cargo build` — zero warnings
- [ ] Manual: play guitar → readings update live → stop playing → display clears
- [ ] Manual: check compact chain view shows tuner readings
- [ ] Manual: note turns green when in tune (within ±5 cents)