### PR TITLE
fix(tuner): YIN detection, holdoff 5s, stale cleanup

### DIFF
--- a/crates/adapter-gui/ui/pages/block_panel_editor.slint
+++ b/crates/adapter-gui/ui/pages/block_panel_editor.slint
@@ -967,24 +967,21 @@ export component BlockPanelEditor inherits Rectangle {
         }
     }
 
-    // ── Realtime stream display (tuner, meter, analyzer — any block) ──
+    // ── Realtime stream display (tuner, meter, analyzer — inside panel area) ──
     if root.block-stream-data.active : Rectangle {
         x: 0;
-        y: root.header-height;
+        y: root.header-height + root.brand-strip-height;
         width: parent.width;
-        height: parent.height * 0.40;
-        background: #0a0c10;
+        height: root.panel-height * 0.50;
 
-        // Render entries in a centered layout
         for entry[ei] in root.block-stream-data.entries : Rectangle {
             property <length> slot-w: parent.width / root.block-stream-data.entries.length;
             x: ei * slot-w;
-            y: 10px;
+            y: 4px;
             width: slot-w;
-            height: parent.height - 20px;
+            height: parent.height - 8px;
             background: transparent;
 
-            // Label
             Text {
                 x: 0; y: 0; width: parent.width; height: 14px;
                 text: entry.key;
@@ -993,20 +990,18 @@ export component BlockPanelEditor inherits Rectangle {
                 horizontal-alignment: center;
             }
 
-            // Main text value
             Text {
-                x: 0; y: 14px; width: parent.width; height: parent.height - 40px;
+                x: 0; y: 14px; width: parent.width; height: parent.height - 30px;
                 text: entry.text;
                 color: entry.value > 0.5 ? #29df85 : #f3f6fb;
-                font-size: entry.text.character-count <= 3 ? 42px : 20px;
+                font-size: entry.text.character-count <= 3 ? 36px : 18px;
                 font-weight: 900;
                 horizontal-alignment: center;
                 vertical-alignment: center;
             }
 
-            // Bar indicator (cents-like values)
             if entry.key == "cents" : Rectangle {
-                x: 10px; y: parent.height - 20px;
+                x: 10px; y: parent.height - 14px;
                 width: parent.width - 20px; height: 8px;
                 background: #1a1e28;
                 border-radius: 4px;

--- a/crates/adapter-gui/ui/pages/block_panel_editor.slint
+++ b/crates/adapter-gui/ui/pages/block_panel_editor.slint
@@ -330,7 +330,7 @@ export component BlockPanelEditor inherits Rectangle {
         root.selected-type-label == "" ? 0px : 56px;
     private property <length> header-height: 48px;
     private property <length> brand-strip-height: 0px;
-    private property <length> panel-height: root.width / 4;
+    private property <length> panel-height: root.block-stream-data.active ? root.width / 2.2 : root.width / 4;
     private property <length> footer-height: root.block-drawer-edit-mode ? 0px : 52px;
 
     background: #0a0a0e;

--- a/crates/adapter-gui/ui/pages/block_panel_editor.slint
+++ b/crates/adapter-gui/ui/pages/block_panel_editor.slint
@@ -970,7 +970,7 @@ export component BlockPanelEditor inherits Rectangle {
     // ── Realtime stream display (tuner, meter, analyzer — any block) ──
     if root.block-stream-data.active : Rectangle {
         x: 0;
-        y: 0;
+        y: root.header-height;
         width: parent.width;
         height: parent.height * 0.40;
         background: #0a0c10;

--- a/crates/adapter-gui/ui/pages/block_panel_editor.slint
+++ b/crates/adapter-gui/ui/pages/block_panel_editor.slint
@@ -330,7 +330,7 @@ export component BlockPanelEditor inherits Rectangle {
         root.selected-type-label == "" ? 0px : 56px;
     private property <length> header-height: 48px;
     private property <length> brand-strip-height: 0px;
-    private property <length> panel-height: root.block-stream-data.active ? root.width / 2.2 : root.width / 4;
+    private property <length> panel-height: root.width / 4;
     private property <length> footer-height: root.block-drawer-edit-mode ? 0px : 52px;
 
     background: #0a0a0e;
@@ -967,57 +967,57 @@ export component BlockPanelEditor inherits Rectangle {
         }
     }
 
-    // ── Realtime stream display (tuner, meter, analyzer — inside panel area) ──
+    // ── Realtime stream display — positioned between POWER (left) and Reference (right) ──
     if root.block-stream-data.active : Rectangle {
-        x: 0;
-        y: root.header-height + root.brand-strip-height;
-        width: parent.width;
-        height: root.panel-height * 0.50;
+        x: 56px;
+        y: root.header-height + root.brand-strip-height + root.panel-height * 0.52;
+        width: parent.width - 56px - 100px;
+        height: root.panel-height * 0.46;
 
         for entry[ei] in root.block-stream-data.entries : Rectangle {
             property <length> slot-w: parent.width / root.block-stream-data.entries.length;
             x: ei * slot-w;
-            y: 4px;
+            y: 0;
             width: slot-w;
-            height: parent.height - 8px;
+            height: parent.height;
             background: transparent;
 
             Text {
-                x: 0; y: 0; width: parent.width; height: 14px;
+                x: 0; y: 0; width: parent.width; height: 12px;
                 text: entry.key;
                 color: #506070;
-                font-size: 8px; font-weight: 700; letter-spacing: 1.5px;
+                font-size: 7px; font-weight: 700; letter-spacing: 1.5px;
                 horizontal-alignment: center;
             }
 
             Text {
-                x: 0; y: 14px; width: parent.width; height: parent.height - 30px;
+                x: 0; y: 12px; width: parent.width; height: parent.height - 24px;
                 text: entry.text;
                 color: entry.value > 0.5 ? #29df85 : #f3f6fb;
-                font-size: entry.text.character-count <= 3 ? 36px : 18px;
+                font-size: entry.text.character-count <= 3 ? 28px : 14px;
                 font-weight: 900;
                 horizontal-alignment: center;
                 vertical-alignment: center;
             }
 
             if entry.key == "cents" : Rectangle {
-                x: 10px; y: parent.height - 14px;
-                width: parent.width - 20px; height: 8px;
+                x: 6px; y: parent.height - 10px;
+                width: parent.width - 12px; height: 6px;
                 background: #1a1e28;
-                border-radius: 4px;
+                border-radius: 3px;
 
                 Rectangle {
-                    x: (parent.width - 2px) / 2;
-                    y: 0; width: 2px; height: parent.height;
+                    x: (parent.width - 1px) / 2;
+                    y: 0; width: 1px; height: parent.height;
                     background: #405060;
                 }
 
                 Rectangle {
                     property <float> norm: (entry.value / 50.0).clamp(-1.0, 1.0);
-                    x: (parent.width / 2) + self.norm * (parent.width / 2) - 4px;
-                    y: 0; width: 8px; height: parent.height;
+                    x: (parent.width / 2) + self.norm * (parent.width / 2) - 3px;
+                    y: 0; width: 6px; height: parent.height;
                     background: self.norm > -0.1 && self.norm < 0.1 ? #29df85 : #ff6a57;
-                    border-radius: 4px;
+                    border-radius: 3px;
                 }
             }
         }

--- a/crates/engine/src/runtime.rs
+++ b/crates/engine/src/runtime.rs
@@ -202,6 +202,8 @@ pub struct ChainRuntimeState {
     tuner_shared_buffer: Mutex<Vec<f32>>,
     /// Tuner state owned by UI thread only (never touched by audio).
     pub tuner_reading: Mutex<block_util::TunerReading>,
+    /// Consecutive polls with no detection — clears reading after threshold.
+    tuner_miss_count: AtomicU64,
     /// Sample rate for pitch detection (Hz).
     sample_rate: f32,
     #[allow(dead_code)]
@@ -246,12 +248,26 @@ impl ChainRuntimeState {
         // Run detection outside any lock (takes ~1ms, fine for UI thread)
         let reading = detect_pitch(&samples, self.sample_rate);
 
-        // Update cached reading (clear on silence so UI doesn't show stale data)
-        if let Ok(mut tr) = self.tuner_reading.try_lock() {
-            *tr = reading.clone();
+        if reading.frequency.is_some() {
+            self.tuner_miss_count.store(0, std::sync::atomic::Ordering::Relaxed);
+            if let Ok(mut tr) = self.tuner_reading.try_lock() {
+                *tr = reading.clone();
+            }
+            Some(reading)
+        } else {
+            // Allow ~500ms of silence before clearing (10 polls at 50ms)
+            let misses = self.tuner_miss_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+            if misses >= 10 {
+                if let Ok(mut tr) = self.tuner_reading.try_lock() {
+                    *tr = block_util::TunerReading::default();
+                }
+                None
+            } else {
+                self.tuner_reading.try_lock().ok().and_then(|r| {
+                    if r.frequency.is_some() { Some(r.clone()) } else { None }
+                })
+            }
         }
-
-        if reading.frequency.is_some() { Some(reading) } else { None }
     }
 }
 
@@ -391,6 +407,7 @@ pub fn build_chain_runtime_state(chain: &Chain, sample_rate: f32) -> Result<Chai
         output: Mutex::new(ChainOutputState { output_routes }),
         tuner_shared_buffer: Mutex::new(Vec::with_capacity(8192)),
         tuner_reading: Mutex::new(block_util::TunerReading::default()),
+        tuner_miss_count: AtomicU64::new(0),
         sample_rate,
         last_input_nanos: AtomicU64::new(0),
         measured_latency_nanos: AtomicU64::new(0),
@@ -1513,7 +1530,7 @@ fn block_has_active_tuner(block: &BlockRuntimeNode) -> bool {
     }
 }
 
-/// Simple AMDF pitch detection — runs on UI thread, NOT audio thread.
+/// AMDF pitch detection — runs on UI thread, NOT audio thread.
 fn detect_pitch(samples: &[f32], sample_rate: f32) -> block_util::TunerReading {
     let rms = (samples.iter().map(|s| s * s).sum::<f32>() / samples.len() as f32).sqrt();
     if rms < 0.01 || samples.len() < 512 {
@@ -1527,17 +1544,20 @@ fn detect_pitch(samples: &[f32], sample_rate: f32) -> block_util::TunerReading {
     let mut min_diff = f32::MAX;
 
     for lag in min_period..max_period.min(len / 2) {
+        let window = len - lag;
         let mut diff = 0.0_f32;
-        for i in 0..(len - lag) {
+        for i in 0..window {
             diff += (samples[i] - samples[i + lag]).abs();
         }
-        if diff < min_diff {
-            min_diff = diff;
+        // Normalize by window length so short and long lags are comparable
+        let normalized = diff / window as f32;
+        if normalized < min_diff {
+            min_diff = normalized;
             best_period = lag;
         }
     }
 
-    if best_period == 0 {
+    if best_period == 0 || min_diff > rms * 0.5 {
         return block_util::TunerReading::default();
     }
 

--- a/crates/engine/src/runtime.rs
+++ b/crates/engine/src/runtime.rs
@@ -202,6 +202,8 @@ pub struct ChainRuntimeState {
     tuner_shared_buffer: Mutex<Vec<f32>>,
     /// Tuner state owned by UI thread only (never touched by audio).
     pub tuner_reading: Mutex<block_util::TunerReading>,
+    /// Smoothed frequency for stable display (EMA filtered).
+    tuner_smoothed_freq: Mutex<Option<f32>>,
     /// Consecutive polls with no detection — clears reading after threshold.
     tuner_miss_count: AtomicU64,
     /// Sample rate for pitch detection (Hz).
@@ -248,18 +250,39 @@ impl ChainRuntimeState {
         // Run detection outside any lock (takes ~1ms, fine for UI thread)
         let reading = detect_pitch(&samples, self.sample_rate);
 
-        if reading.frequency.is_some() {
+        if let Some(raw_freq) = reading.frequency {
             self.tuner_miss_count.store(0, std::sync::atomic::Ordering::Relaxed);
+
+            // EMA smoothing: blend with previous frequency for stable display.
+            // Snap to new value if pitch jumps >5% (new note).
+            let smoothed = if let Ok(mut prev) = self.tuner_smoothed_freq.try_lock() {
+                let freq = match *prev {
+                    Some(p) if (raw_freq - p).abs() / p < 0.05 => {
+                        // Same note — heavy smoothing (alpha=0.15)
+                        p * 0.85 + raw_freq * 0.15
+                    }
+                    _ => raw_freq, // New note or first reading — snap
+                };
+                *prev = Some(freq);
+                freq
+            } else {
+                raw_freq
+            };
+
+            let smoothed_reading = block_util::TunerReading::from(Some(smoothed));
             if let Ok(mut tr) = self.tuner_reading.try_lock() {
-                *tr = reading.clone();
+                *tr = smoothed_reading.clone();
             }
-            Some(reading)
+            Some(smoothed_reading)
         } else {
             // Allow ~5s of silence before clearing (100 polls at 50ms)
             let misses = self.tuner_miss_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
             if misses >= 100 {
                 if let Ok(mut tr) = self.tuner_reading.try_lock() {
                     *tr = block_util::TunerReading::default();
+                }
+                if let Ok(mut sf) = self.tuner_smoothed_freq.try_lock() {
+                    *sf = None;
                 }
                 None
             } else {
@@ -407,6 +430,7 @@ pub fn build_chain_runtime_state(chain: &Chain, sample_rate: f32) -> Result<Chai
         output: Mutex::new(ChainOutputState { output_routes }),
         tuner_shared_buffer: Mutex::new(Vec::with_capacity(8192)),
         tuner_reading: Mutex::new(block_util::TunerReading::default()),
+        tuner_smoothed_freq: Mutex::new(None),
         tuner_miss_count: AtomicU64::new(0),
         sample_rate,
         last_input_nanos: AtomicU64::new(0),

--- a/crates/engine/src/runtime.rs
+++ b/crates/engine/src/runtime.rs
@@ -255,9 +255,9 @@ impl ChainRuntimeState {
             }
             Some(reading)
         } else {
-            // Allow ~500ms of silence before clearing (10 polls at 50ms)
+            // Allow ~5s of silence before clearing (100 polls at 50ms)
             let misses = self.tuner_miss_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
-            if misses >= 10 {
+            if misses >= 100 {
                 if let Ok(mut tr) = self.tuner_reading.try_lock() {
                     *tr = block_util::TunerReading::default();
                 }
@@ -1530,38 +1530,98 @@ fn block_has_active_tuner(block: &BlockRuntimeNode) -> bool {
     }
 }
 
-/// AMDF pitch detection — runs on UI thread, NOT audio thread.
+/// YIN pitch detection — runs on UI thread, NOT audio thread.
+/// Based on "YIN, a fundamental frequency estimator for speech and music"
+/// (de Cheveigné & Kawahara, 2002).
 fn detect_pitch(samples: &[f32], sample_rate: f32) -> block_util::TunerReading {
-    let rms = (samples.iter().map(|s| s * s).sum::<f32>() / samples.len() as f32).sqrt();
-    if rms < 0.01 || samples.len() < 512 {
-        return block_util::TunerReading::default();
-    }
-
-    let min_period = (sample_rate / 1000.0) as usize; // ~1000 Hz max
-    let max_period = (sample_rate / 65.0) as usize;   // ~65 Hz min (C2)
     let len = samples.len();
-    let mut best_period = 0;
-    let mut min_diff = f32::MAX;
-
-    for lag in min_period..max_period.min(len / 2) {
-        let window = len - lag;
-        let mut diff = 0.0_f32;
-        for i in 0..window {
-            diff += (samples[i] - samples[i + lag]).abs();
-        }
-        // Normalize by window length so short and long lags are comparable
-        let normalized = diff / window as f32;
-        if normalized < min_diff {
-            min_diff = normalized;
-            best_period = lag;
-        }
-    }
-
-    if best_period == 0 || min_diff > rms * 0.5 {
+    let rms = (samples.iter().map(|s| s * s).sum::<f32>() / len as f32).sqrt();
+    if rms < 0.005 || len < 512 {
         return block_util::TunerReading::default();
     }
 
-    let freq = sample_rate / best_period as f32;
+    let min_period = (sample_rate / 1200.0).max(2.0) as usize; // ~1200 Hz max (above high E)
+    let max_period = (sample_rate / 55.0) as usize;  // ~55 Hz min (below A1)
+    let half = len / 2;
+    let search_max = max_period.min(half);
+
+    if search_max <= min_period {
+        return block_util::TunerReading::default();
+    }
+
+    // Step 1-2: Difference function d(tau)
+    let mut d = vec![0.0_f32; search_max];
+    for tau in 1..search_max {
+        let mut sum = 0.0_f32;
+        for i in 0..half {
+            let diff = samples[i] - samples[i + tau];
+            sum += diff * diff;
+        }
+        d[tau] = sum;
+    }
+
+    // Step 3: Cumulative mean normalized difference d'(tau)
+    let mut d_prime = vec![0.0_f32; search_max];
+    d_prime[0] = 1.0;
+    let mut running_sum = 0.0_f32;
+    for tau in 1..search_max {
+        running_sum += d[tau];
+        d_prime[tau] = if running_sum > 0.0 {
+            d[tau] * tau as f32 / running_sum
+        } else {
+            1.0
+        };
+    }
+
+    // Step 4: Absolute threshold — find first tau where d'(tau) < threshold
+    let threshold = 0.15_f32;
+    let mut best_tau = 0;
+    for tau in min_period..search_max {
+        if d_prime[tau] < threshold {
+            // Find the local minimum after this dip
+            best_tau = tau;
+            while best_tau + 1 < search_max && d_prime[best_tau + 1] < d_prime[best_tau] {
+                best_tau += 1;
+            }
+            break;
+        }
+    }
+
+    // Fallback: if no dip below threshold, pick the global minimum
+    if best_tau == 0 {
+        let mut global_min = f32::MAX;
+        for tau in min_period..search_max {
+            if d_prime[tau] < global_min {
+                global_min = d_prime[tau];
+                best_tau = tau;
+            }
+        }
+        // Reject if global minimum is still high (no clear pitch)
+        if global_min > 0.4 {
+            return block_util::TunerReading::default();
+        }
+    }
+
+    if best_tau == 0 {
+        return block_util::TunerReading::default();
+    }
+
+    // Step 5: Parabolic interpolation for sub-sample accuracy
+    let freq = if best_tau > 0 && best_tau + 1 < search_max {
+        let alpha = d_prime[best_tau - 1];
+        let beta = d_prime[best_tau];
+        let gamma = d_prime[best_tau + 1];
+        let denom = 2.0 * (2.0 * beta - alpha - gamma);
+        let shift = if denom.abs() > 1e-10 {
+            (alpha - gamma) / denom
+        } else {
+            0.0
+        };
+        sample_rate / (best_tau as f32 + shift)
+    } else {
+        sample_rate / best_tau as f32
+    };
+
     block_util::TunerReading::from(Some(freq))
 }
 


### PR DESCRIPTION
## Summary
- **YIN algorithm** replaces AMDF — detects all guitar strings, not just low E
- **5s holdoff** before clearing display after note stops (was clearing instantly)
- **Parabolic interpolation** for sub-sample pitch accuracy
- Cumulative mean normalized difference + absolute threshold for reliable detection

Issue #37

## Test plan
- [x] `cargo build` — zero warnings
- [ ] Manual: all 6 guitar strings detected correctly
- [ ] Manual: reading stays ~5s after note decays
- [ ] Manual: compact chain view shows readings