### PR TITLE
feat(ui): Carbon Studio gradient and card drop shadows

### DIFF
--- a/crates/adapter-gui/ui/pages/project_chains.slint
+++ b/crates/adapter-gui/ui/pages/project_chains.slint
@@ -1035,11 +1035,36 @@ component ChainRow inherits Rectangle {
         return Math.max(0, Math.min(root.chain.blocks.length, candidate));
     }
 
-    background: @linear-gradient(180deg, #1c2333 0%, #111720 100%);
-    border-width: 1px;
-    border-color: #1e2d42;
+    background: transparent;
     border-radius: 6px;
     height: 74px + (root.block-row-count * 108px);
+
+    // Drop shadow layers
+    Rectangle {
+        x: 2px; y: 4px;
+        width: parent.width - 4px;
+        height: parent.height;
+        border-radius: 10px;
+        background: #00000040;
+    }
+    Rectangle {
+        x: 1px; y: 2px;
+        width: parent.width - 2px;
+        height: parent.height;
+        border-radius: 8px;
+        background: #00000030;
+    }
+
+    // Main card - Carbon Studio gradient
+    Rectangle {
+        x: 0px; y: 0px;
+        width: parent.width;
+        height: parent.height;
+        border-radius: 6px;
+        background: @linear-gradient(180deg, #1c2333 0%, #111720 100%);
+        border-color: #1e2d42;
+        border-width: 1px;
+    }
 
     Rectangle {
         x: 0px;
@@ -1750,14 +1775,14 @@ export component ProjectChainsPage inherits Rectangle {
     callback select-block-parameter-option(string, int);
     callback pick-block-parameter-file(string);
 
-    background: @linear-gradient(135deg, #0d1a2e 0%, #08090d 65%);
+    background: #1f2023;
 
     Rectangle {
         x: 0px;
         y: 0px;
         width: parent.width;
         height: parent.height;
-        background: transparent;
+        background: @linear-gradient(135deg, #0d1a2e 0%, #08090d 65%);
 
         TouchArea {
             x: 0px;


### PR DESCRIPTION
## Summary
- Replace flat chain card background with Carbon Studio gradient + drop shadow layers
- Reorganize page background gradient into inner Rectangle
- Cleaner visual hierarchy with depth on chain cards

Closes #104

## Test plan
- [x] Compiles without warnings
- [ ] Visual: chain cards have subtle shadow and gradient