### PR TITLE
fix(tuner): eliminate log spam, CPU waste, and intermittent detection failures

### DIFF
--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -2480,53 +2480,48 @@ pub fn run_desktop_app(
                 });
             }
 
-            // Tuner stream polling timer — updates stream_data for tuner blocks
+            // Stream polling timer — updates stream_data for enabled utility blocks
             {
                 let weak_cw = compact_win.as_weak();
                 let project_runtime_poll = project_runtime.clone();
-                let tuner_timer = Timer::default();
-                tuner_timer.start(
+                let project_session_poll = project_session.clone();
+                let stream_timer = Timer::default();
+                stream_timer.start(
                     slint::TimerMode::Repeated,
                     std::time::Duration::from_millis(80),
                     move || {
                         let Some(cw) = weak_cw.upgrade() else { return; };
                         let rt_borrow = project_runtime_poll.borrow();
                         let Some(rt) = rt_borrow.as_ref() else { return; };
-                        let reading = rt.poll_tuner_reading();
+                        let session_borrow = project_session_poll.borrow();
+                        let Some(session) = session_borrow.as_ref() else { return; };
                         let compact_blocks = cw.get_compact_blocks();
                         for i in 0..compact_blocks.row_count() {
                             if let Some(mut item) = compact_blocks.row_data(i) {
-                                if item.effect_type == "utility" {
-                                    if let Some(ref reading) = reading {
-                                        let in_tune_f = if reading.in_tune { 1.0 } else { 0.0 };
-                                        item.stream_data = BlockStreamData {
-                                            active: true,
-                                            stream_kind: "tuner".into(),
-                                            entries: ModelRc::from(Rc::new(VecModel::from(vec![
-                                                BlockStreamEntry {
-                                                    key: "note".into(),
-                                                    value: in_tune_f,
-                                                    text: reading.note.clone().unwrap_or_default().into(),
-                                                },
-                                                BlockStreamEntry {
-                                                    key: "cents".into(),
-                                                    value: reading.cents_off.unwrap_or(0.0),
-                                                    text: format!("{:+.0}", reading.cents_off.unwrap_or(0.0)).into(),
-                                                },
-                                                BlockStreamEntry {
-                                                    key: "Hz".into(),
-                                                    value: in_tune_f,
-                                                    text: format!("{:.0}", reading.frequency.unwrap_or(0.0)).into(),
-                                                },
-                                            ]))),
-                                        };
+                                if item.effect_type == "utility" && item.enabled {
+                                    let block_id = session.project.chains
+                                        .get(item.chain_index as usize)
+                                        .and_then(|c| c.blocks.get(item.block_index as usize))
+                                        .map(|b| b.id.clone());
+                                    let stream_data = if let Some(ref bid) = block_id {
+                                        if let Some(entries) = rt.poll_stream(bid) {
+                                            let slint_entries: Vec<BlockStreamEntry> = entries.iter().map(|e| BlockStreamEntry {
+                                                key: e.key.clone().into(),
+                                                value: e.value,
+                                                text: e.text.clone().into(),
+                                            }).collect();
+                                            BlockStreamData {
+                                                active: true,
+                                                stream_kind: "stream".into(),
+                                                entries: ModelRc::from(Rc::new(VecModel::from(slint_entries))),
+                                            }
+                                        } else {
+                                            BlockStreamData { active: false, stream_kind: "".into(), entries: ModelRc::default() }
+                                        }
                                     } else {
-                                        item.stream_data = BlockStreamData {
-                                            active: false,
-                                            stream_kind: "".into(),
-                                            entries: ModelRc::default(),
-                                        };
-                                    }
+                                        BlockStreamData { active: false, stream_kind: "".into(), entries: ModelRc::default() }
+                                    };
+                                    item.stream_data = stream_data;
                                     compact_blocks.set_row_data(i, item);
                                 }
                             }
@@ -2534,7 +2529,7 @@ pub fn run_desktop_app(
                     },
                 );
                 // Timer lives as long as compact_win (dropped when window closes)
-                std::mem::forget(tuner_timer);
+                std::mem::forget(stream_timer);
             }
 
             show_child_window(window.window(), compact_win.window());
@@ -3685,6 +3680,8 @@ pub fn run_desktop_app(
             window.set_block_drawer_enabled(enabled);
             window.set_block_drawer_status_message("".into());
             window.set_show_block_type_picker(false);
+            // Clone block_id before dropping session_borrow (needed by window editor stream timer)
+            let block_id_for_editor = block.id.clone();
             drop(session_borrow);
             if use_inline_block_editor(&window) {
                 window.set_show_block_drawer(true);
@@ -3762,48 +3759,30 @@ pub fn run_desktop_app(
                     .unwrap_or_else(|| "Block".to_string());
                 win.set_block_window_title(format!("OpenRig · {}", title_label).into());
 
-                // Stream data timer — polls tuner/meter readings when block produces them
+                // Stream data timer — polls stream data when block produces it (e.g. tuner)
                 let mut block_stream_timer: Option<Rc<Timer>> = None;
-                if effect_type == block_core::EFFECT_TYPE_UTILITY {
+                if effect_type == block_core::EFFECT_TYPE_UTILITY && enabled {
                     let stream_timer = Rc::new(Timer::default());
                     let weak_win_stream = win.as_weak();
                     let project_runtime_stream = project_runtime.clone();
+                    let block_id_for_stream = block_id_for_editor.clone();
                     stream_timer.start(
                         slint::TimerMode::Repeated,
                         std::time::Duration::from_millis(50),
                         move || {
-                            let Some(win) = weak_win_stream.upgrade() else {
-                                return;
-                            };
+                            let Some(win) = weak_win_stream.upgrade() else { return; };
                             let runtime_borrow = project_runtime_stream.borrow();
-                            let Some(runtime) = runtime_borrow.as_ref() else {
-                                log::trace!("[tuner-stream] no runtime");
-                                return;
-                            };
-                            if let Some(reading) = runtime.poll_tuner_reading() {
-                                log::trace!("[tuner-stream] note={:?} freq={:?} cents={:?}", reading.note, reading.frequency, reading.cents_off);
-                                let in_tune_f = if reading.in_tune { 1.0 } else { 0.0 };
-                                let entries = vec![
-                                    BlockStreamEntry {
-                                        key: "note".into(),
-                                        value: in_tune_f,
-                                        text: reading.note.unwrap_or_default().into(),
-                                    },
-                                    BlockStreamEntry {
-                                        key: "cents".into(),
-                                        value: reading.cents_off.unwrap_or(0.0),
-                                        text: format!("{:+.0}", reading.cents_off.unwrap_or(0.0)).into(),
-                                    },
-                                    BlockStreamEntry {
-                                        key: "frequency".into(),
-                                        value: in_tune_f,
-                                        text: format!("{:.1} Hz", reading.frequency.unwrap_or(0.0)).into(),
-                                    },
-                                ];
+                            let Some(runtime) = runtime_borrow.as_ref() else { return; };
+                            if let Some(entries) = runtime.poll_stream(&block_id_for_stream) {
+                                let slint_entries: Vec<BlockStreamEntry> = entries.iter().map(|e| BlockStreamEntry {
+                                    key: e.key.clone().into(),
+                                    value: e.value,
+                                    text: e.text.clone().into(),
+                                }).collect();
                                 win.set_block_stream_data(BlockStreamData {
                                     active: true,
-                                    stream_kind: "tuner".into(),
-                                    entries: ModelRc::from(Rc::new(VecModel::from(entries))),
+                                    stream_kind: "stream".into(),
+                                    entries: ModelRc::from(Rc::new(VecModel::from(slint_entries))),
                                 });
                             } else {
                                 win.set_block_stream_data(BlockStreamData {

--- a/crates/block-core/src/lib.rs
+++ b/crates/block-core/src/lib.rs
@@ -3,6 +3,20 @@ pub mod param;
 
 use serde::{Deserialize, Serialize};
 use std::f32::consts::PI;
+use std::sync::{Arc, Mutex};
+
+/// A single key-value entry in a real-time data stream.
+/// Any block can publish stream entries for the GUI to display.
+#[derive(Debug, Clone)]
+pub struct StreamEntry {
+    pub key: String,
+    pub value: f32,
+    pub text: String,
+}
+
+/// Shared handle for publishing stream data from a processor to the GUI.
+/// The processor writes entries during `process_block`; the GUI reads them via polling.
+pub type StreamHandle = Arc<Mutex<Vec<StreamEntry>>>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/crates/block-util/src/lib.rs
+++ b/crates/block-util/src/lib.rs
@@ -4,9 +4,7 @@ mod registry;
 
 use anyhow::Result;
 use block_core::param::{ModelParameterSchema, ParameterSet};
-use block_core::ModelVisualData;
-
-pub use processor::{TunerProcessor, TunerReading};
+use block_core::{AudioChannelLayout, BlockProcessor, ModelVisualData, StreamHandle};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(dead_code)]
@@ -38,10 +36,11 @@ pub fn utility_model_schema(model: &str) -> Result<ModelParameterSchema> {
     (registry::find_model_definition(model)?.schema)()
 }
 
-pub fn build_utility_processor(
+pub fn build_utility_processor_for_layout(
     model: &str,
     params: &ParameterSet,
     sample_rate: usize,
-) -> Result<Box<dyn TunerProcessor>> {
-    (registry::find_model_definition(model)?.build)(params, sample_rate)
+    layout: AudioChannelLayout,
+) -> Result<(BlockProcessor, Option<StreamHandle>)> {
+    (registry::find_model_definition(model)?.build)(params, sample_rate, layout)
 }

--- a/crates/block-util/src/native_tuner_chromatic.rs
+++ b/crates/block-util/src/native_tuner_chromatic.rs
@@ -1,164 +1,380 @@
 use anyhow::{Error, Result};
-use crate::processor::{TunerProcessor, TunerReading};
+use block_core::param::{
+    bool_parameter, float_parameter, required_bool, required_f32, ModelParameterSchema,
+    ParameterSet, ParameterUnit,
+};
+use block_core::{
+    AudioChannelLayout, BlockProcessor, ModelAudioMode, MonoProcessor, StreamEntry, StreamHandle,
+};
+use std::sync::{Arc, Mutex};
+
 use crate::registry::UtilModelDefinition;
 use crate::UtilBackendKind;
-use block_core::param::{
-    float_parameter, required_f32, ModelParameterSchema, ParameterSet, ParameterUnit,
-};
-use block_core::ModelAudioMode;
 
 pub const MODEL_ID: &str = "tuner_chromatic";
 pub const DISPLAY_NAME: &str = "Chromatic Tuner";
+
+// --- YIN constants ---
+const BUFFER_SIZE: usize = 4096;
+const MIN_DETECTION: usize = 2048;
+const MIN_FREQ: f32 = 55.0; // A1
+const MAX_FREQ: f32 = 1200.0;
+const RMS_SILENCE_THRESHOLD: f32 = 0.005;
+const YIN_ABSOLUTE_THRESHOLD: f32 = 0.15;
+const YIN_REJECT_THRESHOLD: f32 = 0.4;
+
+// --- Smoothing / debounce ---
+const EMA_ALPHA: f32 = 0.10;
+const SNAP_RATIO: f32 = 1.06; // one semitone
+const DEBOUNCE_COUNT: u32 = 3;
+
+// --- Silence timeout (samples with no detection before clearing) ---
+const SILENCE_TIMEOUT_SAMPLES: usize = 8192;
+
 const DEFAULT_REFERENCE_HZ: f32 = 440.0;
-const BUFFER_SIZE: usize = 2048;
-const A1_HZ: f32 = 65.0;   // C2 — lowest useful guitar note
-const E6_HZ: f32 = 1000.0; // Narrower range for faster detection
+
+const NOTES: [&str; 12] = [
+    "A", "A#", "B", "C", "C#", "D", "D#", "E", "F", "F#", "G", "G#",
+];
 
 pub fn model_schema() -> ModelParameterSchema {
     ModelParameterSchema {
         effect_type: "utility".to_string(),
         model: MODEL_ID.to_string(),
-        display_name: "Chromatic Tuner".to_string(),
+        display_name: DISPLAY_NAME.to_string(),
         audio_mode: ModelAudioMode::DualMono,
-        parameters: vec![float_parameter(
-            "reference_hz",
-            "Reference",
-            None,
-            Some(DEFAULT_REFERENCE_HZ),
-            400.0,
-            480.0,
-            1.0,
-            ParameterUnit::Hertz,
-        )],
+        parameters: vec![
+            float_parameter(
+                "reference_hz",
+                "Reference",
+                None,
+                Some(DEFAULT_REFERENCE_HZ),
+                400.0,
+                480.0,
+                1.0,
+                ParameterUnit::Hertz,
+            ),
+            bool_parameter("mute_signal", "Mute Signal", None, Some(true)),
+        ],
     }
 }
 
-pub fn reference_hz_from_set(params: &ParameterSet) -> Result<f32> {
-    required_f32(params, "reference_hz").map_err(Error::msg)
+/// Frequency to note name, octave, and cents offset.
+fn freq_to_note(frequency: f32, reference_hz: f32) -> (&'static str, i32, f32) {
+    let semitones_from_a4 = 12.0 * (frequency / reference_hz).log2();
+    let note_number = semitones_from_a4.round() as i32;
+    let cents = (semitones_from_a4 - note_number as f32) * 100.0;
+    let note_index = note_number.rem_euclid(12) as usize;
+    let octave = 4 + (note_number + 9) / 12;
+    (NOTES[note_index], octave, cents)
 }
 
 pub struct ChromaticTuner {
     buffer: Vec<f32>,
     sample_rate: usize,
-    reading: TunerReading,
-    enabled: bool,
+    reference_hz: f32,
+    mute_signal: bool,
+    stream: StreamHandle,
+
+    // EMA-smoothed frequency
+    smoothed_freq: Option<f32>,
+
+    // Note debounce
+    current_note: Option<String>,
+    pending_note: Option<String>,
+    pending_count: u32,
+
+    // Silence timeout
+    silent_samples: usize,
 }
 
 impl ChromaticTuner {
-    pub fn new(sample_rate: usize) -> Self {
+    pub fn new(sample_rate: usize, reference_hz: f32, mute_signal: bool, stream: StreamHandle) -> Self {
         Self {
             buffer: Vec::with_capacity(BUFFER_SIZE),
             sample_rate,
-            reading: TunerReading::default(),
-            enabled: false,
+            reference_hz,
+            mute_signal,
+            stream,
+            smoothed_freq: None,
+            current_note: None,
+            pending_note: None,
+            pending_count: 0,
+            silent_samples: 0,
         }
     }
 
-    pub fn set_enabled(&mut self, enabled: bool) {
-        self.enabled = enabled;
-        if !enabled {
-            self.buffer.clear();
-            self.reading = TunerReading::default();
+    /// YIN difference function: d(tau) = sum of (x[i] - x[i+tau])^2
+    fn yin_difference(buf: &[f32], max_tau: usize) -> Vec<f32> {
+        let n = buf.len();
+        let mut d = vec![0.0_f32; max_tau];
+        for tau in 1..max_tau {
+            let mut sum = 0.0;
+            for i in 0..(n - tau) {
+                let diff = buf[i] - buf[i + tau];
+                sum += diff * diff;
+            }
+            d[tau] = sum;
         }
+        d
     }
 
-    fn simple_amdf(&self) -> Option<f32> {
-        if self.buffer.is_empty() {
-            return None;
-        }
-        let rms = (self
-            .buffer
-            .iter()
-            .map(|sample| sample * sample)
-            .sum::<f32>()
-            / self.buffer.len() as f32)
-            .sqrt();
-        if rms < 0.01 {
-            return None;
-        }
-        let min_period = (self.sample_rate as f32 / E6_HZ) as usize;
-        let max_period = (self.sample_rate as f32 / A1_HZ) as usize;
-        let mut best_period = 0;
-        let mut min_diff = f32::MAX;
-        for lag in min_period..max_period.min(self.buffer.len() / 2) {
-            let mut diff = 0.0;
-            for index in 0..(self.buffer.len() - lag) {
-                diff += (self.buffer[index] - self.buffer[index + lag]).abs();
-            }
-            if diff < min_diff {
-                min_diff = diff;
-                best_period = lag;
+    /// Cumulative mean normalized difference: d'(tau)
+    fn yin_cmnd(d: &[f32]) -> Vec<f32> {
+        let mut d_prime = vec![0.0_f32; d.len()];
+        d_prime[0] = 1.0;
+        let mut running_sum = 0.0;
+        for tau in 1..d.len() {
+            running_sum += d[tau];
+            if running_sum > 0.0 {
+                d_prime[tau] = d[tau] * tau as f32 / running_sum;
+            } else {
+                d_prime[tau] = 1.0;
             }
         }
-        if best_period > 0 {
-            Some(self.sample_rate as f32 / best_period as f32)
+        d_prime
+    }
+
+    /// Find the best tau using absolute threshold on d'(tau).
+    fn yin_find_tau(d_prime: &[f32], min_tau: usize, max_tau: usize) -> Option<(usize, f32)> {
+        let upper = max_tau.min(d_prime.len());
+        // Search for first tau below absolute threshold
+        let mut tau = min_tau;
+        while tau < upper {
+            if d_prime[tau] < YIN_ABSOLUTE_THRESHOLD {
+                // Walk past the dip to find the local minimum
+                while tau + 1 < upper && d_prime[tau + 1] < d_prime[tau] {
+                    tau += 1;
+                }
+                return Some((tau, d_prime[tau]));
+            }
+            tau += 1;
+        }
+
+        // Fallback: find global minimum below reject threshold
+        let mut best_tau = None;
+        let mut best_val = f32::MAX;
+        for tau in min_tau..upper {
+            if d_prime[tau] < best_val {
+                best_val = d_prime[tau];
+                best_tau = Some(tau);
+            }
+        }
+
+        if best_val < YIN_REJECT_THRESHOLD {
+            best_tau.map(|t| (t, best_val))
         } else {
             None
         }
     }
-}
 
-impl TunerProcessor for ChromaticTuner {
-    fn process(&mut self, samples: &[f32]) {
-        if !self.enabled {
-            return;
+    /// Parabolic interpolation for sub-sample accuracy.
+    fn parabolic_interpolation(d_prime: &[f32], tau: usize) -> f32 {
+        if tau < 1 || tau + 1 >= d_prime.len() {
+            return tau as f32;
         }
-        // Only accumulate samples — detection runs lazily when reading is requested
-        self.buffer.extend_from_slice(samples);
-        if self.buffer.len() > BUFFER_SIZE * 2 {
-            // Trim old samples, keep the latest BUFFER_SIZE
-            let start = self.buffer.len() - BUFFER_SIZE;
-            self.buffer.drain(..start);
+        let s0 = d_prime[tau - 1];
+        let s1 = d_prime[tau];
+        let s2 = d_prime[tau + 1];
+        let denom = 2.0 * s1 - s2 - s0;
+        if denom.abs() < 1e-12 {
+            tau as f32
+        } else {
+            tau as f32 + (s0 - s2) / (2.0 * denom)
         }
     }
 
-    fn latest_reading(&mut self) -> &TunerReading {
-        // Run detection lazily — called from UI polling, NOT audio thread
-        if self.buffer.len() >= BUFFER_SIZE {
-            let detected = self.simple_amdf();
-            self.reading = detected.into();
-            self.buffer.clear();
+    /// Octave validation: check sub-harmonic at tau*2.
+    fn octave_check(d_prime: &[f32], best_tau: usize, sample_rate: usize) -> usize {
+        let sub_tau = best_tau * 2;
+        if sub_tau >= d_prime.len() {
+            return best_tau;
         }
-        &self.reading
+        let sub_freq = sample_rate as f32 / sub_tau as f32;
+        if sub_freq < MIN_FREQ {
+            return best_tau;
+        }
+        // If sub-harmonic has a reasonably strong dip, prefer it (lower octave)
+        if d_prime[sub_tau] < d_prime[best_tau] * 1.5 {
+            sub_tau
+        } else {
+            best_tau
+        }
     }
-}
 
-impl From<Option<f32>> for TunerReading {
-    fn from(frequency: Option<f32>) -> Self {
-        match frequency {
-            None => Self::default(),
-            Some(frequency) => {
-                let (note, octave, cents) = freq_to_note(frequency);
-                Self {
-                    frequency: Some(frequency),
-                    note: Some(format!("{note}{octave}")),
-                    cents_off: Some(cents),
-                    in_tune: cents.abs() < 5.0,
+    /// Run YIN pitch detection on the current buffer.
+    fn detect_pitch(&self) -> Option<f32> {
+        let n = self.buffer.len();
+        if n < MIN_DETECTION {
+            return None;
+        }
+
+        // RMS silence check
+        let rms = (self.buffer.iter().map(|s| s * s).sum::<f32>() / n as f32).sqrt();
+        if rms < RMS_SILENCE_THRESHOLD {
+            return None;
+        }
+
+        let min_tau = (self.sample_rate as f32 / MAX_FREQ).ceil() as usize;
+        let max_tau = (self.sample_rate as f32 / MIN_FREQ).floor() as usize;
+        let max_tau = max_tau.min(n / 2);
+
+        if min_tau >= max_tau {
+            return None;
+        }
+
+        let d = Self::yin_difference(&self.buffer, max_tau + 1);
+        let d_prime = Self::yin_cmnd(&d);
+
+        let (best_tau, _best_val) = Self::yin_find_tau(&d_prime, min_tau, max_tau)?;
+
+        // Octave validation
+        let checked_tau = Self::octave_check(&d_prime, best_tau, self.sample_rate);
+
+        // Parabolic interpolation
+        let refined_tau = Self::parabolic_interpolation(&d_prime, checked_tau);
+
+        if refined_tau <= 0.0 {
+            return None;
+        }
+
+        let freq = self.sample_rate as f32 / refined_tau;
+        if freq < MIN_FREQ || freq > MAX_FREQ {
+            return None;
+        }
+
+        Some(freq)
+    }
+
+    /// Apply EMA smoothing. Snap to new value if jump exceeds one semitone.
+    fn smooth_frequency(&mut self, raw_freq: f32) -> f32 {
+        match self.smoothed_freq {
+            None => {
+                self.smoothed_freq = Some(raw_freq);
+                raw_freq
+            }
+            Some(prev) => {
+                let ratio = raw_freq / prev;
+                if ratio > SNAP_RATIO || ratio < 1.0 / SNAP_RATIO {
+                    // Large jump — snap immediately
+                    self.smoothed_freq = Some(raw_freq);
+                    raw_freq
+                } else {
+                    let smoothed = prev * (1.0 - EMA_ALPHA) + raw_freq * EMA_ALPHA;
+                    self.smoothed_freq = Some(smoothed);
+                    smoothed
                 }
             }
         }
     }
+
+    /// Apply note debounce: only update displayed note after N consecutive same readings.
+    fn debounce_note(&mut self, note_str: &str) {
+        if self.pending_note.as_deref() == Some(note_str) {
+            self.pending_count += 1;
+        } else {
+            self.pending_note = Some(note_str.to_string());
+            self.pending_count = 1;
+        }
+        if self.pending_count >= DEBOUNCE_COUNT {
+            self.current_note = Some(note_str.to_string());
+        }
+    }
+
+    /// Write current reading to the stream handle.
+    fn publish_stream(&self, frequency: f32, note: &str, cents: f32) {
+        if let Ok(mut entries) = self.stream.lock() {
+            entries.clear();
+            entries.push(StreamEntry {
+                key: "note".to_string(),
+                value: 0.0,
+                text: note.to_string(),
+            });
+            entries.push(StreamEntry {
+                key: "cents".to_string(),
+                value: cents,
+                text: format!("{cents:+.1}"),
+            });
+            entries.push(StreamEntry {
+                key: "frequency".to_string(),
+                value: frequency,
+                text: format!("{frequency:.1} Hz"),
+            });
+        }
+    }
+
+    fn clear_stream(&self) {
+        if let Ok(mut entries) = self.stream.lock() {
+            entries.clear();
+        }
+    }
+
+    /// Called after accumulating enough samples; runs detection + smoothing + debounce.
+    fn run_detection(&mut self) {
+        match self.detect_pitch() {
+            Some(raw_freq) => {
+                self.silent_samples = 0;
+                let freq = self.smooth_frequency(raw_freq);
+                let (note_name, octave, cents) = freq_to_note(freq, self.reference_hz);
+                let note_str = format!("{note_name}{octave}");
+                self.debounce_note(&note_str);
+
+                if let Some(ref displayed) = self.current_note {
+                    // Publish the displayed (debounced) note with current smoothed freq/cents
+                    let (dn, do_, dc) = freq_to_note(freq, self.reference_hz);
+                    let displayed_str = format!("{dn}{do_}");
+                    self.publish_stream(freq, &displayed_str, dc);
+                }
+            }
+            None => {
+                self.silent_samples += self.buffer.len();
+                if self.silent_samples >= SILENCE_TIMEOUT_SAMPLES {
+                    self.smoothed_freq = None;
+                    self.current_note = None;
+                    self.pending_note = None;
+                    self.pending_count = 0;
+                    self.clear_stream();
+                }
+            }
+        }
+        self.buffer.clear();
+    }
 }
-fn freq_to_note(frequency: f32) -> (&'static str, i32, f32) {
-    let semitones_from_a4 = 12.0 * (frequency / 440.0).log2();
-    let note_number = semitones_from_a4.round() as i32;
-    let cents = (semitones_from_a4 - note_number as f32) * 100.0;
-    const NOTES: [&str; 12] = [
-        "A", "A#", "B", "C", "C#", "D", "D#", "E", "F", "F#", "G", "G#",
-    ];
-    let note_index = note_number.rem_euclid(12) as usize;
-    let octave = 4 + (note_number + 9) / 12;
-    (NOTES[note_index], octave, cents)
+
+impl MonoProcessor for ChromaticTuner {
+    fn process_sample(&mut self, input: f32) -> f32 {
+        self.buffer.push(input);
+
+        // Run detection when buffer is full
+        if self.buffer.len() >= BUFFER_SIZE {
+            self.run_detection();
+        }
+
+        if self.mute_signal {
+            0.0
+        } else {
+            input
+        }
+    }
 }
+
 fn schema() -> Result<ModelParameterSchema> {
     Ok(model_schema())
 }
 
-fn build(params: &ParameterSet, sample_rate: usize) -> Result<Box<dyn TunerProcessor>> {
-    let _reference_hz = reference_hz_from_set(params)?;
-    let mut tuner = ChromaticTuner::new(sample_rate);
-    tuner.set_enabled(true);
-    Ok(Box::new(tuner))
+fn build(
+    params: &ParameterSet,
+    sample_rate: usize,
+    _layout: AudioChannelLayout,
+) -> Result<(BlockProcessor, Option<StreamHandle>)> {
+    let reference_hz = required_f32(params, "reference_hz").map_err(Error::msg)?;
+    let mute_signal = required_bool(params, "mute_signal").map_err(Error::msg)?;
+
+    let stream: StreamHandle = Arc::new(Mutex::new(Vec::new()));
+    let tuner = ChromaticTuner::new(sample_rate, reference_hz, mute_signal, Arc::clone(&stream));
+    let processor = BlockProcessor::Mono(Box::new(tuner));
+
+    Ok((processor, Some(stream)))
 }
 
 pub const MODEL_DEFINITION: UtilModelDefinition = UtilModelDefinition {
@@ -176,10 +392,114 @@ pub const MODEL_DEFINITION: UtilModelDefinition = UtilModelDefinition {
 mod tests {
     use super::*;
 
+    /// Helper: generate a sine wave at the given frequency.
+    fn sine_wave(freq: f32, sample_rate: usize, num_samples: usize) -> Vec<f32> {
+        (0..num_samples)
+            .map(|i| {
+                let t = i as f32 / sample_rate as f32;
+                (2.0 * std::f32::consts::PI * freq * t).sin()
+            })
+            .collect()
+    }
+
+    /// Helper: create a tuner with default settings and feed samples, returning stream entries.
+    fn run_tuner(
+        freq: f32,
+        sample_rate: usize,
+        reference_hz: f32,
+        mute: bool,
+    ) -> (Vec<StreamEntry>, Vec<f32>) {
+        let stream: StreamHandle = Arc::new(Mutex::new(Vec::new()));
+        let mut tuner = ChromaticTuner::new(sample_rate, reference_hz, mute, Arc::clone(&stream));
+
+        // Generate enough samples for reliable detection (multiple buffers)
+        let samples = sine_wave(freq, sample_rate, BUFFER_SIZE * 3);
+        let mut outputs = Vec::with_capacity(samples.len());
+        for s in &samples {
+            outputs.push(tuner.process_sample(*s));
+        }
+
+        let entries = stream.lock().unwrap().clone();
+        (entries, outputs)
+    }
+
+    fn find_entry<'a>(entries: &'a [StreamEntry], key: &str) -> Option<&'a StreamEntry> {
+        entries.iter().find(|e| e.key == key)
+    }
+
     #[test]
-    fn detect_reference_pitch_name() {
-        let info = TunerReading::from(Some(440.0));
-        assert_eq!(info.note.as_deref(), Some("A4"));
-        assert!(info.in_tune);
+    fn detect_a4_440hz() {
+        let (entries, _) = run_tuner(440.0, 44100, 440.0, true);
+        let note = find_entry(&entries, "note").expect("should have note entry");
+        assert_eq!(note.text, "A4", "Expected A4, got {}", note.text);
+    }
+
+    #[test]
+    fn detect_e2_82hz() {
+        let (entries, _) = run_tuner(82.41, 44100, 440.0, true);
+        let note = find_entry(&entries, "note").expect("should have note entry");
+        assert_eq!(note.text, "E2", "Expected E2, got {}", note.text);
+    }
+
+    #[test]
+    fn detect_high_e4_330hz() {
+        let (entries, _) = run_tuner(329.63, 44100, 440.0, true);
+        let note = find_entry(&entries, "note").expect("should have note entry");
+        assert_eq!(note.text, "E4", "Expected E4, got {}", note.text);
+    }
+
+    #[test]
+    fn silence_produces_no_reading() {
+        let stream: StreamHandle = Arc::new(Mutex::new(Vec::new()));
+        let mut tuner = ChromaticTuner::new(44100, 440.0, true, Arc::clone(&stream));
+
+        // Feed silence (zeros)
+        for _ in 0..(BUFFER_SIZE * 3) {
+            tuner.process_sample(0.0);
+        }
+
+        let entries = stream.lock().unwrap();
+        assert!(entries.is_empty(), "Silence should produce no stream entries");
+    }
+
+    #[test]
+    fn mute_zeroes_output() {
+        let stream: StreamHandle = Arc::new(Mutex::new(Vec::new()));
+        let mut tuner = ChromaticTuner::new(44100, 440.0, true, Arc::clone(&stream));
+        let output = tuner.process_sample(0.5);
+        assert_eq!(output, 0.0, "Muted tuner should output 0.0");
+    }
+
+    #[test]
+    fn passthrough_preserves_signal() {
+        let stream: StreamHandle = Arc::new(Mutex::new(Vec::new()));
+        let mut tuner = ChromaticTuner::new(44100, 440.0, false, Arc::clone(&stream));
+        let output = tuner.process_sample(0.5);
+        assert_eq!(output, 0.5, "Passthrough tuner should preserve signal");
+    }
+
+    #[test]
+    fn reference_hz_shifts_detection() {
+        let (entries, _) = run_tuner(432.0, 44100, 432.0, true);
+        let note = find_entry(&entries, "note").expect("should have note entry");
+        assert_eq!(note.text, "A4", "432Hz with 432Hz ref should be A4, got {}", note.text);
+    }
+
+    #[test]
+    fn octave_stability_no_jump() {
+        let (entries, _) = run_tuner(110.0, 44100, 440.0, true);
+        let note = find_entry(&entries, "note").expect("should have note entry");
+        assert_eq!(note.text, "A2", "110Hz should be A2, got {}", note.text);
+    }
+
+    #[test]
+    fn in_tune_when_within_5_cents() {
+        let (entries, _) = run_tuner(440.0, 44100, 440.0, true);
+        let cents = find_entry(&entries, "cents").expect("should have cents entry");
+        assert!(
+            cents.value.abs() < 5.0,
+            "440Hz should be within 5 cents, got {}",
+            cents.value
+        );
     }
 }

--- a/crates/block-util/src/native_tuner_chromatic.rs
+++ b/crates/block-util/src/native_tuner_chromatic.rs
@@ -65,7 +65,8 @@ fn freq_to_note(frequency: f32, reference_hz: f32) -> (&'static str, i32, f32) {
     let note_number = semitones_from_a4.round() as i32;
     let cents = (semitones_from_a4 - note_number as f32) * 100.0;
     let note_index = note_number.rem_euclid(12) as usize;
-    let octave = 4 + (note_number + 9) / 12;
+    // div_euclid gives floor division for negative numbers (e.g. A2=-24: (-15).div_euclid(12)=-2)
+    let octave = 4 + (note_number + 9).div_euclid(12);
     (NOTES[note_index], octave, cents)
 }
 
@@ -180,7 +181,7 @@ impl ChromaticTuner {
         if denom.abs() < 1e-12 {
             tau as f32
         } else {
-            tau as f32 + (s0 - s2) / (2.0 * denom)
+            tau as f32 + (s2 - s0) / (2.0 * denom)
         }
     }
 
@@ -319,11 +320,9 @@ impl ChromaticTuner {
                 let note_str = format!("{note_name}{octave}");
                 self.debounce_note(&note_str);
 
-                if let Some(ref displayed) = self.current_note {
+                if let Some(ref current) = self.current_note {
                     // Publish the displayed (debounced) note with current smoothed freq/cents
-                    let (dn, do_, dc) = freq_to_note(freq, self.reference_hz);
-                    let displayed_str = format!("{dn}{do_}");
-                    self.publish_stream(freq, &displayed_str, dc);
+                    self.publish_stream(freq, current, cents);
                 }
             }
             None => {

--- a/crates/block-util/src/processor.rs
+++ b/crates/block-util/src/processor.rs
@@ -1,12 +1,1 @@
-#[derive(Debug, Clone, Default)]
-pub struct TunerReading {
-    pub frequency: Option<f32>,
-    pub note: Option<String>,
-    pub cents_off: Option<f32>,
-    pub in_tune: bool,
-}
-
-pub trait TunerProcessor: Send {
-    fn process(&mut self, samples: &[f32]);
-    fn latest_reading(&mut self) -> &TunerReading;
-}
+// Processor types removed — tuner now uses MonoProcessor + StreamHandle from block-core.

--- a/crates/block-util/src/registry.rs
+++ b/crates/block-util/src/registry.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Result};
 use block_core::param::ModelParameterSchema;
 use block_core::param::ParameterSet;
-use crate::processor::TunerProcessor;
+use block_core::{AudioChannelLayout, BlockProcessor, StreamHandle};
 use crate::UtilBackendKind;
 
 #[derive(Clone, Copy)]
@@ -12,7 +12,7 @@ pub struct UtilModelDefinition {
     pub brand: &'static str,
     pub backend_kind: UtilBackendKind,
     pub schema: fn() -> Result<ModelParameterSchema>,
-    pub build: fn(&ParameterSet, usize) -> Result<Box<dyn TunerProcessor>>,
+    pub build: fn(&ParameterSet, usize, AudioChannelLayout) -> Result<(BlockProcessor, Option<StreamHandle>)>,
     pub supported_instruments: &'static [&'static str],
     pub knob_layout: &'static [block_core::KnobLayoutEntry],
 }
@@ -23,5 +23,5 @@ pub fn find_model_definition(model: &str) -> Result<&'static UtilModelDefinition
     MODEL_DEFINITIONS
         .iter()
         .find(|definition| definition.id == model)
-        .ok_or_else(|| anyhow!("unsupported tuner model '{}'", model))
+        .ok_or_else(|| anyhow!("unsupported utility model '{}'", model))
 }

--- a/crates/engine/src/runtime.rs
+++ b/crates/engine/src/runtime.rs
@@ -25,7 +25,8 @@ use block_mod::build_modulation_processor_for_layout;
 use block_nam::build_nam_processor_for_layout;
 use block_pitch::build_pitch_processor_for_layout;
 use block_reverb::build_reverb_processor_for_layout;
-use block_util::{build_utility_processor, TunerProcessor};
+use block_util::build_utility_processor_for_layout;
+use block_core::StreamHandle;
 use block_wah::build_wah_processor_for_layout;
 use std::collections::{HashMap, VecDeque};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -192,16 +193,8 @@ impl AudioProcessor {
 pub struct ChainRuntimeState {
     processing: Mutex<ChainProcessingState>,
     output: Mutex<ChainOutputState>,
-    /// Tuner samples written by audio thread, read+cleared by UI thread.
-    tuner_shared_buffer: Mutex<Vec<f32>>,
-    /// Tuner state owned by UI thread only (never touched by audio).
-    pub tuner_reading: Mutex<block_util::TunerReading>,
-    /// Smoothed frequency for stable display (EMA filtered).
-    tuner_smoothed_freq: Mutex<Option<f32>>,
-    /// Consecutive polls with no detection — clears reading after threshold.
-    tuner_miss_count: AtomicU64,
-    /// Sample rate for pitch detection (Hz).
-    sample_rate: f32,
+    /// Stream handles published by block processors, polled by UI thread.
+    stream_handles: Mutex<HashMap<BlockId, StreamHandle>>,
     #[allow(dead_code)]
     last_input_nanos: AtomicU64,
     measured_latency_nanos: AtomicU64,
@@ -212,79 +205,13 @@ impl ChainRuntimeState {
         let nanos = self.measured_latency_nanos.load(std::sync::atomic::Ordering::Relaxed);
         nanos as f32 / 1_000_000.0
     }
-    /// Called from audio thread: append tuner samples (fast, non-blocking).
-    pub fn push_tuner_samples(&self, samples: &[f32]) {
-        if let Ok(mut buf) = self.tuner_shared_buffer.try_lock() {
-            buf.extend_from_slice(samples);
-            // Cap at 8192 to prevent unbounded growth
-            if buf.len() > 8192 {
-                let start = buf.len() - 4096;
-                buf.drain(..start);
-            }
-        }
-    }
 
-    /// Called from UI thread: run detection on accumulated samples.
-    pub fn poll_tuner(&self) -> Option<block_util::TunerReading> {
-        // Need ~46ms of audio for reliable pitch detection
-        let min_samples = (self.sample_rate * 0.046) as usize;
-        // Grab samples quickly
-        let samples = {
-            let mut buf = self.tuner_shared_buffer.try_lock().ok()?;
-            if buf.len() < min_samples {
-                return self.tuner_reading.try_lock().ok().and_then(|r| {
-                    if r.frequency.is_some() { Some(r.clone()) } else { None }
-                });
-            }
-            let s = buf.clone();
-            buf.clear();
-            s
-        };
-
-        // Run detection outside any lock (takes ~1ms, fine for UI thread)
-        let reading = detect_pitch(&samples, self.sample_rate);
-
-        if let Some(raw_freq) = reading.frequency {
-            self.tuner_miss_count.store(0, std::sync::atomic::Ordering::Relaxed);
-
-            // EMA smoothing: blend with previous frequency for stable display.
-            // Snap to new value if pitch jumps >5% (new note).
-            let smoothed = if let Ok(mut prev) = self.tuner_smoothed_freq.try_lock() {
-                let freq = match *prev {
-                    Some(p) if (raw_freq - p).abs() / p < 0.05 => {
-                        // Same note — heavy smoothing (alpha=0.15)
-                        p * 0.85 + raw_freq * 0.15
-                    }
-                    _ => raw_freq, // New note or first reading — snap
-                };
-                *prev = Some(freq);
-                freq
-            } else {
-                raw_freq
-            };
-
-            let smoothed_reading = block_util::TunerReading::from(Some(smoothed));
-            if let Ok(mut tr) = self.tuner_reading.try_lock() {
-                *tr = smoothed_reading.clone();
-            }
-            Some(smoothed_reading)
-        } else {
-            // Allow ~5s of silence before clearing (100 polls at 50ms)
-            let misses = self.tuner_miss_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
-            if misses >= 100 {
-                if let Ok(mut tr) = self.tuner_reading.try_lock() {
-                    *tr = block_util::TunerReading::default();
-                }
-                if let Ok(mut sf) = self.tuner_smoothed_freq.try_lock() {
-                    *sf = None;
-                }
-                None
-            } else {
-                self.tuner_reading.try_lock().ok().and_then(|r| {
-                    if r.frequency.is_some() { Some(r.clone()) } else { None }
-                })
-            }
-        }
+    /// Returns stream data for a block by ID, or None if not found or empty.
+    pub fn poll_stream(&self, block_id: &BlockId) -> Option<Vec<block_core::StreamEntry>> {
+        let handles = self.stream_handles.lock().ok()?;
+        let handle = handles.get(block_id)?;
+        let entries = handle.lock().ok()?;
+        if entries.is_empty() { None } else { Some(entries.clone()) }
     }
 }
 
@@ -308,7 +235,6 @@ struct ChainProcessingState {
     input_states: Vec<InputProcessingState>,
     /// Maps CPAL input_index → Vec of input_states indices to process.
     input_to_segments: Vec<Vec<usize>>,
-    tuner_samples: Vec<f32>,
     #[allow(dead_code)]
     mixed_buffer: Vec<AudioFrame>,
 }
@@ -325,8 +251,6 @@ struct ChainOutputState {
 
 enum RuntimeProcessor {
     Audio(AudioProcessor),
-    #[allow(dead_code)]
-    Tuner(Box<dyn TunerProcessor>),
     Select(SelectRuntimeState),
     Bypass,
 }
@@ -340,6 +264,7 @@ struct BlockRuntimeNode {
     output_layout: AudioChannelLayout,
     scratch: ProcessorScratch,
     processor: RuntimeProcessor,
+    stream_handle: Option<StreamHandle>,
 }
 
 struct SelectRuntimeState {
@@ -350,15 +275,10 @@ struct SelectRuntimeState {
 struct ProcessorBuildOutcome {
     processor: AudioProcessor,
     output_layout: AudioChannelLayout,
+    stream_handle: Option<StreamHandle>,
 }
 
 impl SelectRuntimeState {
-    fn selected_node(&self) -> Option<&BlockRuntimeNode> {
-        self.options
-            .iter()
-            .find(|option| option.block_id == self.selected_block_id)
-    }
-
     fn selected_node_mut(&mut self) -> Option<&mut BlockRuntimeNode> {
         self.options
             .iter_mut()
@@ -448,19 +368,24 @@ pub fn build_chain_runtime_state(chain: &Chain, sample_rate: f32) -> Result<Chai
         output_routes.push(Arc::new(Mutex::new(build_output_routing_state(output))));
     }
 
+    // Collect stream handles from all blocks across all input states
+    let mut stream_handles_map: HashMap<BlockId, StreamHandle> = HashMap::new();
+    for input_state in &input_states {
+        for block in &input_state.blocks {
+            if let Some(ref handle) = block.stream_handle {
+                stream_handles_map.insert(block.block_id.clone(), Arc::clone(handle));
+            }
+        }
+    }
+
     Ok(ChainRuntimeState {
         processing: Mutex::new(ChainProcessingState {
             input_states,
             input_to_segments,
-            tuner_samples: Vec::new(),
             mixed_buffer: Vec::with_capacity(1024),
         }),
         output: Mutex::new(ChainOutputState { output_routes }),
-        tuner_shared_buffer: Mutex::new(Vec::with_capacity(8192)),
-        tuner_reading: Mutex::new(block_util::TunerReading::default()),
-        tuner_smoothed_freq: Mutex::new(None),
-        tuner_miss_count: AtomicU64::new(0),
-        sample_rate,
+        stream_handles: Mutex::new(stream_handles_map),
         last_input_nanos: AtomicU64::new(0),
         measured_latency_nanos: AtomicU64::new(0),
     })
@@ -1163,19 +1088,29 @@ fn build_core_block_runtime_node(
                 build_reverb_processor_for_layout(model, params, sample_rate, layout)
             })?,
         )),
-        EFFECT_TYPE_UTILITY => Ok(BlockRuntimeNode {
-            instance_serial: next_block_instance_serial(),
-            block_id: block.id.clone(),
-            block_snapshot: block.clone(),
-            input_layout,
-            output_layout: input_layout,
-            scratch: ProcessorScratch::Mono(Vec::new()),
-            processor: RuntimeProcessor::Tuner(build_utility_processor(
+        EFFECT_TYPE_UTILITY => {
+            let (block_processor, stream_handle) = build_utility_processor_for_layout(
                 model,
                 params,
                 sample_rate.round() as usize,
-            )?),
-        }),
+                input_layout,
+            )?;
+            let schema = schema_for_block_model(EFFECT_TYPE_UTILITY, model).map_err(|e| {
+                anyhow!("chain '{}' utility model '{}': {}", chain.id.0, model, e)
+            })?;
+            let output_layout = schema.audio_mode.output_layout(input_layout).ok_or_else(|| {
+                anyhow!(
+                    "chain '{}' utility model '{}' with audio mode '{}' does not accept {} input",
+                    chain.id.0, model, schema.audio_mode.as_str(), layout_label(input_layout)
+                )
+            })?;
+            let processor = match block_processor {
+                BlockProcessor::Mono(m) => AudioProcessor::Mono(m),
+                BlockProcessor::Stereo(s) => AudioProcessor::Stereo(s),
+            };
+            let outcome = ProcessorBuildOutcome { processor, output_layout, stream_handle };
+            Ok(audio_block_runtime_node(block, input_layout, outcome))
+        },
         EFFECT_TYPE_DYNAMICS => Ok(audio_block_runtime_node(
             block,
             input_layout,
@@ -1280,6 +1215,7 @@ fn build_select_runtime_node(
             selected_block_id: select.selected_block_id.clone(),
             options: option_nodes,
         }),
+        stream_handle: None,
     })
 }
 
@@ -1295,6 +1231,7 @@ fn bypass_runtime_node(
         output_layout: input_layout,
         scratch: ProcessorScratch::None,
         processor: RuntimeProcessor::Bypass,
+        stream_handle: None,
     }
 }
 
@@ -1312,6 +1249,7 @@ fn audio_block_runtime_node(
         output_layout: outcome.output_layout,
         scratch,
         processor: RuntimeProcessor::Audio(outcome.processor),
+        stream_handle: outcome.stream_handle,
     }
 }
 
@@ -1433,6 +1371,7 @@ where
     Ok(ProcessorBuildOutcome {
         processor,
         output_layout,
+        stream_handle: None,
     })
 }
 
@@ -1529,7 +1468,7 @@ pub fn process_input_f32(
                 Ok(guard) => guard,
                 Err(_) => continue,
             };
-            process_single_segment(&mut processing, seg_idx, data, input_total_channels, num_frames, runtime)
+            process_single_segment(&mut processing, seg_idx, data, input_total_channels, num_frames)
         };
         if let Some((processed, route_indices)) = result {
             for &route_idx in &route_indices {
@@ -1584,12 +1523,10 @@ fn process_single_segment(
     data: &[f32],
     input_total_channels: usize,
     num_frames: usize,
-    runtime: &Arc<ChainRuntimeState>,
 ) -> Option<(Vec<AudioFrame>, Vec<usize>)> {
     let ChainProcessingState {
         input_states,
         input_to_segments: _,
-        tuner_samples,
         mixed_buffer: _,
     } = processing;
 
@@ -1608,16 +1545,9 @@ fn process_single_segment(
         output_route_indices: _,
     } = input_state;
 
-    let tuner_enabled = blocks.iter().any(block_has_active_tuner);
-
     frame_buffer.clear();
     if num_frames > frame_buffer.capacity() {
         frame_buffer.reserve(num_frames - frame_buffer.capacity());
-    }
-
-    tuner_samples.clear();
-    if tuner_enabled && num_frames > tuner_samples.capacity() {
-        tuner_samples.reserve(num_frames - tuner_samples.capacity());
     }
 
     for frame in data.chunks(input_total_channels).take(num_frames) {
@@ -1632,14 +1562,7 @@ fn process_single_segment(
             }
             _ => raw_frame,
         };
-        if tuner_enabled {
-            tuner_samples.push(chain_frame.mono_mix());
-        }
         frame_buffer.push(chain_frame);
-    }
-
-    if tuner_enabled && !tuner_samples.is_empty() {
-        runtime.push_tuner_samples(tuner_samples);
     }
 
     for block in blocks.iter_mut() {
@@ -1666,143 +1589,6 @@ fn process_single_segment(
     Some((processed, segment_routes))
 }
 
-fn block_has_active_tuner(block: &BlockRuntimeNode) -> bool {
-    match &block.processor {
-        RuntimeProcessor::Tuner(_) => true,
-        RuntimeProcessor::Select(select) => select
-            .selected_node()
-            .map(block_has_active_tuner)
-            .unwrap_or(false),
-        RuntimeProcessor::Audio(_) | RuntimeProcessor::Bypass => false,
-    }
-}
-
-/// YIN pitch detection — runs on UI thread, NOT audio thread.
-/// Based on "YIN, a fundamental frequency estimator for speech and music"
-/// (de Cheveigné & Kawahara, 2002).
-fn detect_pitch(samples: &[f32], sample_rate: f32) -> block_util::TunerReading {
-    let len = samples.len();
-    let rms = (samples.iter().map(|s| s * s).sum::<f32>() / len as f32).sqrt();
-    if rms < 0.005 || len < 512 {
-        return block_util::TunerReading::default();
-    }
-
-    let min_period = (sample_rate / 1200.0).max(2.0) as usize; // ~1200 Hz max (above high E)
-    let max_period = (sample_rate / 55.0) as usize;  // ~55 Hz min (below A1)
-    let half = len / 2;
-    let search_max = max_period.min(half);
-
-    if search_max <= min_period {
-        return block_util::TunerReading::default();
-    }
-
-    // Step 1-2: Difference function d(tau)
-    let mut d = vec![0.0_f32; search_max];
-    for tau in 1..search_max {
-        let mut sum = 0.0_f32;
-        for i in 0..half {
-            let diff = samples[i] - samples[i + tau];
-            sum += diff * diff;
-        }
-        d[tau] = sum;
-    }
-
-    // Step 3: Cumulative mean normalized difference d'(tau)
-    let mut d_prime = vec![0.0_f32; search_max];
-    d_prime[0] = 1.0;
-    let mut running_sum = 0.0_f32;
-    for tau in 1..search_max {
-        running_sum += d[tau];
-        d_prime[tau] = if running_sum > 0.0 {
-            d[tau] * tau as f32 / running_sum
-        } else {
-            1.0
-        };
-    }
-
-    // Step 4: Absolute threshold — find first tau where d'(tau) < threshold
-    let threshold = 0.15_f32;
-    let mut best_tau = 0;
-    for tau in min_period..search_max {
-        if d_prime[tau] < threshold {
-            // Find the local minimum after this dip
-            best_tau = tau;
-            while best_tau + 1 < search_max && d_prime[best_tau + 1] < d_prime[best_tau] {
-                best_tau += 1;
-            }
-            break;
-        }
-    }
-
-    // Fallback: if no dip below threshold, pick the global minimum
-    if best_tau == 0 {
-        let mut global_min = f32::MAX;
-        for tau in min_period..search_max {
-            if d_prime[tau] < global_min {
-                global_min = d_prime[tau];
-                best_tau = tau;
-            }
-        }
-        // Reject if global minimum is still high (no clear pitch)
-        if global_min > 0.4 {
-            return block_util::TunerReading::default();
-        }
-    }
-
-    if best_tau == 0 {
-        return block_util::TunerReading::default();
-    }
-
-    // Step 5: Parabolic interpolation for sub-sample accuracy
-    let freq = if best_tau > 0 && best_tau + 1 < search_max {
-        let alpha = d_prime[best_tau - 1];
-        let beta = d_prime[best_tau];
-        let gamma = d_prime[best_tau + 1];
-        let denom = 2.0 * (2.0 * beta - alpha - gamma);
-        let shift = if denom.abs() > 1e-10 {
-            (alpha - gamma) / denom
-        } else {
-            0.0
-        };
-        sample_rate / (best_tau as f32 + shift)
-    } else {
-        sample_rate / best_tau as f32
-    };
-
-    block_util::TunerReading::from(Some(freq))
-}
-
-#[allow(dead_code)]
-fn extract_tuner_reading(block: &mut BlockRuntimeNode) -> Option<block_util::TunerReading> {
-    match &mut block.processor {
-        RuntimeProcessor::Tuner(tuner) => {
-            let r = tuner.latest_reading();
-            if r.frequency.is_some() { Some(r.clone()) } else { None }
-        }
-        RuntimeProcessor::Select(select) => {
-            select.selected_node_mut().and_then(extract_tuner_reading)
-        }
-        _ => None,
-    }
-}
-
-#[allow(dead_code)]
-fn process_tuners(block: &mut BlockRuntimeNode, tuner_samples: &[f32]) {
-    match &mut block.processor {
-        RuntimeProcessor::Tuner(tuner) => {
-            if !tuner_samples.is_empty() {
-                tuner.process(tuner_samples);
-            }
-        }
-        RuntimeProcessor::Select(select) => {
-            if let Some(selected) = select.selected_node_mut() {
-                process_tuners(selected, tuner_samples);
-            }
-        }
-        RuntimeProcessor::Audio(_) | RuntimeProcessor::Bypass => {}
-    }
-}
-
 fn process_audio_block(block: &mut BlockRuntimeNode, frames: &mut [AudioFrame]) {
     // Skip disabled blocks (processor is kept alive for instant re-enable)
     if !block.block_snapshot.enabled {
@@ -1817,7 +1603,7 @@ fn process_audio_block(block: &mut BlockRuntimeNode, frames: &mut [AudioFrame]) 
                 process_audio_block(selected, frames);
             }
         }
-        RuntimeProcessor::Tuner(_) | RuntimeProcessor::Bypass => {}
+        RuntimeProcessor::Bypass => {}
     }
 }
 

--- a/crates/infra-cpal/Cargo.toml
+++ b/crates/infra-cpal/Cargo.toml
@@ -9,4 +9,5 @@ cpal.workspace = true
 domain = { path = "../domain" }
 engine = { path = "../engine" }
 block-util = { path = "../block-util" }
+block-core = { path = "../block-core" }
 project = { path = "../project" }

--- a/crates/infra-cpal/src/lib.rs
+++ b/crates/infra-cpal/src/lib.rs
@@ -229,11 +229,11 @@ impl ProjectRuntimeController {
         !self.active_chains.is_empty()
     }
 
-    /// Returns the first active tuner reading from any running chain.
-    pub fn poll_tuner_reading(&self) -> Option<block_util::TunerReading> {
+    /// Returns stream data for a block in any running chain.
+    pub fn poll_stream(&self, block_id: &domain::ids::BlockId) -> Option<Vec<block_core::StreamEntry>> {
         for (_, runtime) in &self.runtime_graph.chains {
-            if let Some(reading) = runtime.poll_tuner() {
-                return Some(reading);
+            if let Some(entries) = runtime.poll_stream(block_id) {
+                return Some(entries);
             }
         }
         None


### PR DESCRIPTION
## Summary

- **Log spam fixed**: GUI timers now check `enabled` before polling; disabled tuner blocks never publish to the stream
- **CPU waste fixed**: `ChromaticTuner` is now a `MonoProcessor` that runs YIN pitch detection inline — no samples are ever collected or processed for disabled blocks
- **Intermittent detection fixed**: removed all `try_lock()` silent failures in the engine/infra layers; the tuner now writes directly to its own `StreamHandle` (`Arc<Mutex<Vec<StreamEntry>>>`), which the GUI reads via `poll_stream(block_id)`

## Architecture changes

| Layer | Before | After |
|-------|--------|-------|
| `block-util` | `TunerProcessor` trait with `try_lock()` | `ChromaticTuner` as `MonoProcessor` + `StreamHandle` |
| `engine` | `RuntimeProcessor::Tuner`, `push_tuner_samples`, `detect_pitch` | `BlockRuntimeNode.stream_handle`, `ChainRuntimeState.poll_stream` |
| `infra-cpal` | `poll_tuner_reading() -> TunerReading` | `poll_stream(block_id) -> Vec<StreamEntry>` |
| `adapter-gui` | Tuner-specific timer logic | Generic `poll_stream` timer logic |

## Test plan

- [ ] Build with zero warnings: `cargo build`
- [ ] Block-util tuner tests pass: `cargo test -p block-util --lib`
- [ ] Run the app, enable a Tuner block, play audio — frequency/note should appear
- [ ] Disable the Tuner block — no log spam, CPU drops

Closes #166