### PR TITLE
fix(blocks): correct supported_instruments for all models

### DIFF
--- a/crates/block-dyn/src/lv2_tap_deesser.rs
+++ b/crates/block-dyn/src/lv2_tap_deesser.rs
@@ -75,5 +75,5 @@ fn build(params: &ParameterSet, sample_rate: f32, layout: AudioChannelLayout) ->
 pub const MODEL_DEFINITION: DynModelDefinition = DynModelDefinition {
     id: MODEL_ID, display_name: DISPLAY_NAME, brand: BRAND,
     backend_kind: DynBackendKind::Lv2, schema, build,
-    supported_instruments: block_core::ALL_INSTRUMENTS, knob_layout: &[],
+    supported_instruments: &[block_core::INST_VOICE, block_core::INST_ACOUSTIC_GUITAR], knob_layout: &[],
 };

--- a/crates/block-full-rig/src/nam_fender_bassman_1971.rs
+++ b/crates/block-full-rig/src/nam_fender_bassman_1971.rs
@@ -102,6 +102,6 @@ pub const MODEL_DEFINITION: FullRigModelDefinition = FullRigModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_ACOUSTIC_BASS,
     knob_layout: &[],
 };

--- a/crates/block-full-rig/src/nam_fender_deluxe_reverb_65.rs
+++ b/crates/block-full-rig/src/nam_fender_deluxe_reverb_65.rs
@@ -89,6 +89,6 @@ pub const MODEL_DEFINITION: FullRigModelDefinition = FullRigModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_ACOUSTIC_BASS,
     knob_layout: &[],
 };

--- a/crates/block-full-rig/src/nam_fender_super_reverb_1977.rs
+++ b/crates/block-full-rig/src/nam_fender_super_reverb_1977.rs
@@ -89,6 +89,6 @@ pub const MODEL_DEFINITION: FullRigModelDefinition = FullRigModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_ACOUSTIC_BASS,
     knob_layout: &[],
 };

--- a/crates/block-full-rig/src/nam_vox_ac30.rs
+++ b/crates/block-full-rig/src/nam_vox_ac30.rs
@@ -86,6 +86,6 @@ pub const MODEL_DEFINITION: FullRigModelDefinition = FullRigModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_ACOUSTIC_BASS,
     knob_layout: &[],
 };

--- a/crates/block-full-rig/src/nam_vox_ac30_1961_fawn_ef86.rs
+++ b/crates/block-full-rig/src/nam_vox_ac30_1961_fawn_ef86.rs
@@ -59,6 +59,6 @@ pub const MODEL_DEFINITION: FullRigModelDefinition = FullRigModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_ACOUSTIC_BASS,
     knob_layout: &[],
 };

--- a/crates/block-gain/src/nam_ampeg_scr_di.rs
+++ b/crates/block-gain/src/nam_ampeg_scr_di.rs
@@ -96,6 +96,6 @@ pub const MODEL_DEFINITION: GainModelDefinition = GainModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-gain/src/nam_behringer_sf300.rs
+++ b/crates/block-gain/src/nam_behringer_sf300.rs
@@ -92,6 +92,6 @@ pub const MODEL_DEFINITION: GainModelDefinition = GainModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-gain/src/nam_bluesbreaker.rs
+++ b/crates/block-gain/src/nam_bluesbreaker.rs
@@ -63,6 +63,6 @@ pub const MODEL_DEFINITION: GainModelDefinition = GainModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-gain/src/nam_boss_ds1.rs
+++ b/crates/block-gain/src/nam_boss_ds1.rs
@@ -113,6 +113,6 @@ pub const MODEL_DEFINITION: GainModelDefinition = GainModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-gain/src/nam_boss_ds1_wampler.rs
+++ b/crates/block-gain/src/nam_boss_ds1_wampler.rs
@@ -113,6 +113,6 @@ pub const MODEL_DEFINITION: GainModelDefinition = GainModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-gain/src/nam_boss_fz1w.rs
+++ b/crates/block-gain/src/nam_boss_fz1w.rs
@@ -112,6 +112,6 @@ pub const MODEL_DEFINITION: GainModelDefinition = GainModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-gain/src/nam_boss_hm2_1986.rs
+++ b/crates/block-gain/src/nam_boss_hm2_1986.rs
@@ -98,6 +98,6 @@ pub const MODEL_DEFINITION: GainModelDefinition = GainModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-gain/src/nam_boss_hm2_mij.rs
+++ b/crates/block-gain/src/nam_boss_hm2_mij.rs
@@ -96,6 +96,6 @@ pub const MODEL_DEFINITION: GainModelDefinition = GainModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-gain/src/nam_cc_boost.rs
+++ b/crates/block-gain/src/nam_cc_boost.rs
@@ -63,6 +63,6 @@ pub const MODEL_DEFINITION: GainModelDefinition = GainModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-gain/src/nam_darkglass_alpha_omega.rs
+++ b/crates/block-gain/src/nam_darkglass_alpha_omega.rs
@@ -112,6 +112,6 @@ pub const MODEL_DEFINITION: GainModelDefinition = GainModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-gain/src/nam_darkglass_b7k.rs
+++ b/crates/block-gain/src/nam_darkglass_b7k.rs
@@ -94,6 +94,6 @@ pub const MODEL_DEFINITION: GainModelDefinition = GainModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-gain/src/nam_demonfx_be_od.rs
+++ b/crates/block-gain/src/nam_demonfx_be_od.rs
@@ -92,6 +92,6 @@ pub const MODEL_DEFINITION: GainModelDefinition = GainModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-gain/src/nam_fulltone_ocd.rs
+++ b/crates/block-gain/src/nam_fulltone_ocd.rs
@@ -110,6 +110,6 @@ pub const MODEL_DEFINITION: GainModelDefinition = GainModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-gain/src/nam_fulltone_ocd_v15.rs
+++ b/crates/block-gain/src/nam_fulltone_ocd_v15.rs
@@ -110,6 +110,6 @@ pub const MODEL_DEFINITION: GainModelDefinition = GainModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-gain/src/nam_grind.rs
+++ b/crates/block-gain/src/nam_grind.rs
@@ -63,6 +63,6 @@ pub const MODEL_DEFINITION: GainModelDefinition = GainModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-gain/src/nam_hm2.rs
+++ b/crates/block-gain/src/nam_hm2.rs
@@ -63,6 +63,6 @@ pub const MODEL_DEFINITION: GainModelDefinition = GainModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-gain/src/nam_ibanez_ts808.rs
+++ b/crates/block-gain/src/nam_ibanez_ts808.rs
@@ -85,6 +85,6 @@ pub const MODEL_DEFINITION: GainModelDefinition = GainModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-gain/src/nam_jhs_bonsai.rs
+++ b/crates/block-gain/src/nam_jhs_bonsai.rs
@@ -114,6 +114,6 @@ pub const MODEL_DEFINITION: GainModelDefinition = GainModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-gain/src/nam_klon_centaur.rs
+++ b/crates/block-gain/src/nam_klon_centaur.rs
@@ -96,6 +96,6 @@ pub const MODEL_DEFINITION: GainModelDefinition = GainModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-gain/src/nam_klone.rs
+++ b/crates/block-gain/src/nam_klone.rs
@@ -63,6 +63,6 @@ pub const MODEL_DEFINITION: GainModelDefinition = GainModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-gain/src/nam_lokajaudio_der_blend.rs
+++ b/crates/block-gain/src/nam_lokajaudio_der_blend.rs
@@ -94,6 +94,6 @@ pub const MODEL_DEFINITION: GainModelDefinition = GainModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-gain/src/nam_lokajaudio_doom_machine.rs
+++ b/crates/block-gain/src/nam_lokajaudio_doom_machine.rs
@@ -63,6 +63,6 @@ pub const MODEL_DEFINITION: GainModelDefinition = GainModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-gain/src/nam_maxon_od808.rs
+++ b/crates/block-gain/src/nam_maxon_od808.rs
@@ -104,6 +104,6 @@ pub const MODEL_DEFINITION: GainModelDefinition = GainModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-gain/src/nam_metal_zone.rs
+++ b/crates/block-gain/src/nam_metal_zone.rs
@@ -63,6 +63,6 @@ pub const MODEL_DEFINITION: GainModelDefinition = GainModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-gain/src/nam_mxr_gt_od.rs
+++ b/crates/block-gain/src/nam_mxr_gt_od.rs
@@ -88,6 +88,6 @@ pub const MODEL_DEFINITION: GainModelDefinition = GainModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-gain/src/nam_pot_boost.rs
+++ b/crates/block-gain/src/nam_pot_boost.rs
@@ -63,6 +63,6 @@ pub const MODEL_DEFINITION: GainModelDefinition = GainModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-gain/src/nam_pot_od.rs
+++ b/crates/block-gain/src/nam_pot_od.rs
@@ -63,6 +63,6 @@ pub const MODEL_DEFINITION: GainModelDefinition = GainModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-gain/src/nam_proco_rat.rs
+++ b/crates/block-gain/src/nam_proco_rat.rs
@@ -63,6 +63,6 @@ pub const MODEL_DEFINITION: GainModelDefinition = GainModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-gain/src/nam_proco_rat2.rs
+++ b/crates/block-gain/src/nam_proco_rat2.rs
@@ -92,6 +92,6 @@ pub const MODEL_DEFINITION: GainModelDefinition = GainModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-gain/src/nam_rod10_ds1.rs
+++ b/crates/block-gain/src/nam_rod10_ds1.rs
@@ -63,6 +63,6 @@ pub const MODEL_DEFINITION: GainModelDefinition = GainModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-gain/src/nam_rod10_sd1.rs
+++ b/crates/block-gain/src/nam_rod10_sd1.rs
@@ -63,6 +63,6 @@ pub const MODEL_DEFINITION: GainModelDefinition = GainModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-gain/src/nam_rr_golden_clone.rs
+++ b/crates/block-gain/src/nam_rr_golden_clone.rs
@@ -90,6 +90,6 @@ pub const MODEL_DEFINITION: GainModelDefinition = GainModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-gain/src/nam_sansamp_di_2112.rs
+++ b/crates/block-gain/src/nam_sansamp_di_2112.rs
@@ -102,6 +102,6 @@ pub const MODEL_DEFINITION: GainModelDefinition = GainModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-gain/src/nam_slammin_booster.rs
+++ b/crates/block-gain/src/nam_slammin_booster.rs
@@ -104,6 +104,6 @@ pub const MODEL_DEFINITION: GainModelDefinition = GainModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-gain/src/nam_tascam_424.rs
+++ b/crates/block-gain/src/nam_tascam_424.rs
@@ -92,6 +92,6 @@ pub const MODEL_DEFINITION: GainModelDefinition = GainModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-gain/src/nam_tc_spark.rs
+++ b/crates/block-gain/src/nam_tc_spark.rs
@@ -87,6 +87,6 @@ pub const MODEL_DEFINITION: GainModelDefinition = GainModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-gain/src/nam_tcip.rs
+++ b/crates/block-gain/src/nam_tcip.rs
@@ -63,6 +63,6 @@ pub const MODEL_DEFINITION: GainModelDefinition = GainModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-gain/src/nam_tech21_steve_harris.rs
+++ b/crates/block-gain/src/nam_tech21_steve_harris.rs
@@ -85,6 +85,6 @@ pub const MODEL_DEFINITION: GainModelDefinition = GainModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-gain/src/nam_velvet_katana.rs
+++ b/crates/block-gain/src/nam_velvet_katana.rs
@@ -96,6 +96,6 @@ pub const MODEL_DEFINITION: GainModelDefinition = GainModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-gain/src/nam_vemuram_jan_ray.rs
+++ b/crates/block-gain/src/nam_vemuram_jan_ray.rs
@@ -85,6 +85,6 @@ pub const MODEL_DEFINITION: GainModelDefinition = GainModelDefinition {
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::ALL_INSTRUMENTS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-wah/src/lv2_gx_quack.rs
+++ b/crates/block-wah/src/lv2_gx_quack.rs
@@ -107,6 +107,6 @@ pub const MODEL_DEFINITION: WahModelDefinition = WahModelDefinition {
     schema,
     validate,
     build,
-    supported_instruments: block_core::GUITAR_ACOUSTIC_BASS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };


### PR DESCRIPTION
## Summary

- **De-Esser** (`block-dyn`): `ALL_INSTRUMENTS` → `&[INST_VOICE, INST_ACOUSTIC_GUITAR]` — de-esser is for voice and acoustic guitar, not electric guitar/bass
- **Full Rig guitar amps** (`block-full-rig`, 5 models — Fender Bassman/Deluxe/Super Reverb, Vox AC30 x2): `ALL_INSTRUMENTS` → `GUITAR_ACOUSTIC_BASS` — guitar amps shouldn't appear for voice/keys chains
- **NAM gain pedals** (`block-gain`, ~41 models — TS808, BD-2, Rat, DS1, Metal Zone, etc.): `ALL_INSTRUMENTS` → `GUITAR_BASS` — overdrive/distortion pedals shouldn't appear for voice/keys/acoustic chains
- **Wah GxQuack** (`block-wah`): `GUITAR_ACOUSTIC_BASS` → `GUITAR_BASS` — wah on acoustic guitar doesn't make sense

Closes #192