### PR TITLE
refactor(block-amp): move full-rig NAM models to block-amp

### DIFF
--- a/crates/block-amp/src/nam_ampeg_svt_classic.rs
+++ b/crates/block-amp/src/nam_ampeg_svt_classic.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Result};
-use crate::registry::FullRigModelDefinition;
-use crate::FullRigBackendKind;
+use crate::registry::{AmpBackendKind, AmpModelDefinition};
+
 use nam::{
     build_processor_with_assets_for_layout, model_schema_for,
     processor::{NamPluginParams, DEFAULT_PLUGIN_PARAMS},
@@ -36,7 +36,7 @@ pub const CAPTURES: &[AmpegSvtCapture] = &[
 ];
 
 pub fn model_schema() -> ModelParameterSchema {
-    let mut schema = model_schema_for("full_rig", MODEL_ID, DISPLAY_NAME, false);
+    let mut schema = model_schema_for("amp", MODEL_ID, DISPLAY_NAME, false);
     schema.parameters = vec![
         enum_parameter(
             "tone",
@@ -93,7 +93,7 @@ fn resolve_capture(params: &ParameterSet) -> Result<&'static AmpegSvtCapture> {
         .find(|c| c.params.tone == tone && c.params.mic == mic)
         .ok_or_else(|| {
             anyhow!(
-                "full-rig model '{}' does not support tone='{}' mic='{}'",
+                "amp model '{}' does not support tone='{}' mic='{}'",
                 MODEL_ID,
                 tone,
                 mic
@@ -116,11 +116,11 @@ fn build(params: &ParameterSet, sample_rate: f32, layout: AudioChannelLayout) ->
     build_processor_for_model(params, sample_rate, layout)
 }
 
-pub const MODEL_DEFINITION: FullRigModelDefinition = FullRigModelDefinition {
+pub const MODEL_DEFINITION: AmpModelDefinition = AmpModelDefinition {
     id: MODEL_ID,
     display_name: DISPLAY_NAME,
     brand: BRAND,
-    backend_kind: FullRigBackendKind::Nam,
+    backend_kind: AmpBackendKind::Nam,
     schema,
     validate: validate_params,
     asset_summary,

--- a/crates/block-amp/src/nam_dover_da50_mesa.rs
+++ b/crates/block-amp/src/nam_dover_da50_mesa.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Result};
-use crate::registry::FullRigModelDefinition;
-use crate::FullRigBackendKind;
+use crate::registry::{AmpBackendKind, AmpModelDefinition};
+
 use nam::{
     build_processor_with_assets_for_layout, model_schema_for,
     processor::{NamPluginParams, DEFAULT_PLUGIN_PARAMS},
@@ -25,7 +25,7 @@ const CAPTURES: &[DoverCapture] = &[
 ];
 
 pub fn model_schema() -> ModelParameterSchema {
-    let mut schema = model_schema_for("full_rig", MODEL_ID, DISPLAY_NAME, false);
+    let mut schema = model_schema_for("amp", MODEL_ID, DISPLAY_NAME, false);
     schema.parameters = vec![enum_parameter(
         "boost",
         "Boost",
@@ -68,7 +68,7 @@ fn resolve_capture(params: &ParameterSet) -> Result<&'static DoverCapture> {
     CAPTURES
         .iter()
         .find(|c| c.boost == boost)
-        .ok_or_else(|| anyhow!("full-rig model '{}' does not support boost='{}'", MODEL_ID, boost))
+        .ok_or_else(|| anyhow!("amp model '{}' does not support boost='{}'", MODEL_ID, boost))
 }
 
 fn schema() -> Result<ModelParameterSchema> {
@@ -79,11 +79,11 @@ fn build(params: &ParameterSet, sample_rate: f32, layout: AudioChannelLayout) ->
     build_processor_for_model(params, sample_rate, layout)
 }
 
-pub const MODEL_DEFINITION: FullRigModelDefinition = FullRigModelDefinition {
+pub const MODEL_DEFINITION: AmpModelDefinition = AmpModelDefinition {
     id: MODEL_ID,
     display_name: DISPLAY_NAME,
     brand: BRAND,
-    backend_kind: FullRigBackendKind::Nam,
+    backend_kind: AmpBackendKind::Nam,
     schema,
     validate: validate_params,
     asset_summary,

--- a/crates/block-amp/src/nam_fender_bassman_1971.rs
+++ b/crates/block-amp/src/nam_fender_bassman_1971.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Result};
-use crate::registry::FullRigModelDefinition;
-use crate::FullRigBackendKind;
+use crate::registry::{AmpBackendKind, AmpModelDefinition};
+
 use nam::{
     build_processor_with_assets_for_layout, model_schema_for,
     processor::{NamPluginParams, DEFAULT_PLUGIN_PARAMS},
@@ -32,7 +32,7 @@ const CAPTURES: &[BassmanCapture] = &[
 ];
 
 pub fn model_schema() -> ModelParameterSchema {
-    let mut schema = model_schema_for("full_rig", MODEL_ID, DISPLAY_NAME, false);
+    let mut schema = model_schema_for("amp", MODEL_ID, DISPLAY_NAME, false);
     schema.parameters = vec![enum_parameter(
         "tone",
         "Tone",
@@ -82,7 +82,7 @@ fn resolve_capture(params: &ParameterSet) -> Result<&'static BassmanCapture> {
     CAPTURES
         .iter()
         .find(|c| c.tone == tone)
-        .ok_or_else(|| anyhow!("full-rig model '{}' does not support tone='{}'", MODEL_ID, tone))
+        .ok_or_else(|| anyhow!("amp model '{}' does not support tone='{}'", MODEL_ID, tone))
 }
 
 fn schema() -> Result<ModelParameterSchema> {
@@ -93,11 +93,11 @@ fn build(params: &ParameterSet, sample_rate: f32, layout: AudioChannelLayout) ->
     build_processor_for_model(params, sample_rate, layout)
 }
 
-pub const MODEL_DEFINITION: FullRigModelDefinition = FullRigModelDefinition {
+pub const MODEL_DEFINITION: AmpModelDefinition = AmpModelDefinition {
     id: MODEL_ID,
     display_name: DISPLAY_NAME,
     brand: BRAND,
-    backend_kind: FullRigBackendKind::Nam,
+    backend_kind: AmpBackendKind::Nam,
     schema,
     validate: validate_params,
     asset_summary,

--- a/crates/block-amp/src/nam_fender_deluxe_reverb_65.rs
+++ b/crates/block-amp/src/nam_fender_deluxe_reverb_65.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Result};
-use crate::registry::FullRigModelDefinition;
-use crate::FullRigBackendKind;
+use crate::registry::{AmpBackendKind, AmpModelDefinition};
+
 use nam::{
     build_processor_with_assets_for_layout, model_schema_for,
     processor::{NamPluginParams, DEFAULT_PLUGIN_PARAMS},
@@ -8,25 +8,27 @@ use nam::{
 use block_core::param::{enum_parameter, required_string, ModelParameterSchema, ParameterSet};
 use block_core::{AudioChannelLayout, BlockProcessor};
 
-pub const MODEL_ID: &str = "vox_ac30";
-pub const DISPLAY_NAME: &str = "AC30";
-const BRAND: &str = "vox";
+pub const MODEL_ID: &str = "fender_deluxe_reverb_65";
+pub const DISPLAY_NAME: &str = "Deluxe Reverb '65";
+const BRAND: &str = "fender";
 
 pub const NAM_PLUGIN_FIXED_PARAMS: NamPluginParams = DEFAULT_PLUGIN_PARAMS;
 
-const CAPTURE_STANDARD: &str = "full_rigs/vox_ac30/vox_ac30_cab.nam";
-const CAPTURE_CLEAN_65PRINCE: &str = "full_rigs/vox_ac30/vox_ac30_clean_65prince.nam";
+const CAPTURE_SM57_ROYER: &str = "full_rigs/fender_deluxe_reverb_65/fender_drri_clean_sm57_royer.nam";
+const CAPTURE_SM57_ROYER_ROOM: &str = "full_rigs/fender_deluxe_reverb_65/fender_drri_clean_sm57_royer_room.nam";
+const CAPTURE_ROOM: &str = "full_rigs/fender_deluxe_reverb_65/fender_drri_clean_room.nam";
 
 pub fn model_schema() -> ModelParameterSchema {
-    let mut schema = model_schema_for("full_rig", MODEL_ID, DISPLAY_NAME, false);
+    let mut schema = model_schema_for("amp", MODEL_ID, DISPLAY_NAME, false);
     schema.parameters = vec![enum_parameter(
-        "character",
-        "Character",
-        Some("Amp"),
-        Some("standard"),
+        "mic",
+        "Mic",
+        Some("Cab"),
+        Some("sm57_royer"),
         &[
-            ("standard", "Standard"),
-            ("clean_65prince", "Clean 65Prince"),
+            ("sm57_royer", "SM57 + Royer R-121"),
+            ("sm57_royer_room", "SM57 + Royer R-121 + Room"),
+            ("room", "Room Only"),
         ],
     )];
     schema
@@ -57,12 +59,13 @@ pub fn asset_summary(params: &ParameterSet) -> Result<String> {
 }
 
 fn resolve_capture_path(params: &ParameterSet) -> Result<&'static str> {
-    let character = required_string(params, "character").map_err(anyhow::Error::msg)?;
-    match character.as_str() {
-        "standard" => Ok(CAPTURE_STANDARD),
-        "clean_65prince" => Ok(CAPTURE_CLEAN_65PRINCE),
+    let mic = required_string(params, "mic").map_err(anyhow::Error::msg)?;
+    match mic.as_str() {
+        "sm57_royer" => Ok(CAPTURE_SM57_ROYER),
+        "sm57_royer_room" => Ok(CAPTURE_SM57_ROYER_ROOM),
+        "room" => Ok(CAPTURE_ROOM),
         other => Err(anyhow!(
-            "full-rig model '{}' does not support character='{}'",
+            "amp model '{}' does not support mic='{}'",
             MODEL_ID,
             other
         )),
@@ -77,11 +80,11 @@ fn build(params: &ParameterSet, sample_rate: f32, layout: AudioChannelLayout) ->
     build_processor_for_model(params, sample_rate, layout)
 }
 
-pub const MODEL_DEFINITION: FullRigModelDefinition = FullRigModelDefinition {
+pub const MODEL_DEFINITION: AmpModelDefinition = AmpModelDefinition {
     id: MODEL_ID,
     display_name: DISPLAY_NAME,
     brand: BRAND,
-    backend_kind: FullRigBackendKind::Nam,
+    backend_kind: AmpBackendKind::Nam,
     schema,
     validate: validate_params,
     asset_summary,

--- a/crates/block-amp/src/nam_fender_super_reverb_1977.rs
+++ b/crates/block-amp/src/nam_fender_super_reverb_1977.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Result};
-use crate::registry::FullRigModelDefinition;
-use crate::FullRigBackendKind;
+use crate::registry::{AmpBackendKind, AmpModelDefinition};
+
 use nam::{
     build_processor_with_assets_for_layout, model_schema_for,
     processor::{NamPluginParams, DEFAULT_PLUGIN_PARAMS},
@@ -8,27 +8,27 @@ use nam::{
 use block_core::param::{enum_parameter, required_string, ModelParameterSchema, ParameterSet};
 use block_core::{AudioChannelLayout, BlockProcessor};
 
-pub const MODEL_ID: &str = "fender_deluxe_reverb_65";
-pub const DISPLAY_NAME: &str = "Deluxe Reverb '65";
+pub const MODEL_ID: &str = "fender_super_reverb_1977";
+pub const DISPLAY_NAME: &str = "Super Reverb 1977";
 const BRAND: &str = "fender";
 
 pub const NAM_PLUGIN_FIXED_PARAMS: NamPluginParams = DEFAULT_PLUGIN_PARAMS;
 
-const CAPTURE_SM57_ROYER: &str = "full_rigs/fender_deluxe_reverb_65/fender_drri_clean_sm57_royer.nam";
-const CAPTURE_SM57_ROYER_ROOM: &str = "full_rigs/fender_deluxe_reverb_65/fender_drri_clean_sm57_royer_room.nam";
-const CAPTURE_ROOM: &str = "full_rigs/fender_deluxe_reverb_65/fender_drri_clean_room.nam";
+const CAPTURE_SM57: &str = "full_rigs/fender_super_reverb_1977/fender_super_reverb_sm57.nam";
+const CAPTURE_AKG414: &str = "full_rigs/fender_super_reverb_1977/fender_super_reverb_akg414.nam";
+const CAPTURE_SM57_AKG414: &str = "full_rigs/fender_super_reverb_1977/fender_super_reverb_sm57_akg414.nam";
 
 pub fn model_schema() -> ModelParameterSchema {
-    let mut schema = model_schema_for("full_rig", MODEL_ID, DISPLAY_NAME, false);
+    let mut schema = model_schema_for("amp", MODEL_ID, DISPLAY_NAME, false);
     schema.parameters = vec![enum_parameter(
         "mic",
         "Mic",
         Some("Cab"),
-        Some("sm57_royer"),
+        Some("sm57"),
         &[
-            ("sm57_royer", "SM57 + Royer R-121"),
-            ("sm57_royer_room", "SM57 + Royer R-121 + Room"),
-            ("room", "Room Only"),
+            ("sm57", "SM57"),
+            ("akg414", "AKG 414"),
+            ("sm57_akg414", "SM57 + AKG 414"),
         ],
     )];
     schema
@@ -61,11 +61,11 @@ pub fn asset_summary(params: &ParameterSet) -> Result<String> {
 fn resolve_capture_path(params: &ParameterSet) -> Result<&'static str> {
     let mic = required_string(params, "mic").map_err(anyhow::Error::msg)?;
     match mic.as_str() {
-        "sm57_royer" => Ok(CAPTURE_SM57_ROYER),
-        "sm57_royer_room" => Ok(CAPTURE_SM57_ROYER_ROOM),
-        "room" => Ok(CAPTURE_ROOM),
+        "sm57" => Ok(CAPTURE_SM57),
+        "akg414" => Ok(CAPTURE_AKG414),
+        "sm57_akg414" => Ok(CAPTURE_SM57_AKG414),
         other => Err(anyhow!(
-            "full-rig model '{}' does not support mic='{}'",
+            "amp model '{}' does not support mic='{}'",
             MODEL_ID,
             other
         )),
@@ -80,11 +80,11 @@ fn build(params: &ParameterSet, sample_rate: f32, layout: AudioChannelLayout) ->
     build_processor_for_model(params, sample_rate, layout)
 }
 
-pub const MODEL_DEFINITION: FullRigModelDefinition = FullRigModelDefinition {
+pub const MODEL_DEFINITION: AmpModelDefinition = AmpModelDefinition {
     id: MODEL_ID,
     display_name: DISPLAY_NAME,
     brand: BRAND,
-    backend_kind: FullRigBackendKind::Nam,
+    backend_kind: AmpBackendKind::Nam,
     schema,
     validate: validate_params,
     asset_summary,

--- a/crates/block-amp/src/nam_marshall_jmp_1_full_rig.rs
+++ b/crates/block-amp/src/nam_marshall_jmp_1_full_rig.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
-use crate::registry::FullRigModelDefinition;
-use crate::FullRigBackendKind;
+use crate::registry::{AmpBackendKind, AmpModelDefinition};
+
 use nam::{
     build_processor_with_assets_for_layout, model_schema_for,
     processor::{NamPluginParams, DEFAULT_PLUGIN_PARAMS},
@@ -8,16 +8,16 @@ use nam::{
 use block_core::param::{ModelParameterSchema, ParameterSet};
 use block_core::{AudioChannelLayout, BlockProcessor};
 
-pub const MODEL_ID: &str = "vox_ac30_1961_fawn_ef86";
-pub const DISPLAY_NAME: &str = "AC30 '61 Fawn EF86";
-const BRAND: &str = "vox";
+pub const MODEL_ID: &str = "marshall_jmp_1_full_rig";
+pub const DISPLAY_NAME: &str = "JMP-1 Full Rig";
+const BRAND: &str = "marshall";
 
 pub const NAM_PLUGIN_FIXED_PARAMS: NamPluginParams = DEFAULT_PLUGIN_PARAMS;
 
-const CAPTURE_PATH: &str = "full_rigs/vox_ac30_1961_fawn_ef86/vox_ac30_1961_fawn_crunch.nam";
+const CAPTURE_PATH: &str = "full_rigs/marshall_jmp_1/jmp_1_od2_v30_full_rig.nam";
 
 pub fn model_schema() -> ModelParameterSchema {
-    model_schema_for("full_rig", MODEL_ID, DISPLAY_NAME, false)
+    model_schema_for("amp", MODEL_ID, DISPLAY_NAME, false)
 }
 
 pub fn build_processor_for_model(
@@ -50,15 +50,15 @@ fn build(params: &ParameterSet, sample_rate: f32, layout: AudioChannelLayout) ->
     build_processor_for_model(params, sample_rate, layout)
 }
 
-pub const MODEL_DEFINITION: FullRigModelDefinition = FullRigModelDefinition {
+pub const MODEL_DEFINITION: AmpModelDefinition = AmpModelDefinition {
     id: MODEL_ID,
     display_name: DISPLAY_NAME,
     brand: BRAND,
-    backend_kind: FullRigBackendKind::Nam,
+    backend_kind: AmpBackendKind::Nam,
     schema,
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::GUITAR_ACOUSTIC_BASS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-amp/src/nam_marshall_super_100_1966.rs
+++ b/crates/block-amp/src/nam_marshall_super_100_1966.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
-use crate::registry::FullRigModelDefinition;
-use crate::FullRigBackendKind;
+use crate::registry::{AmpBackendKind, AmpModelDefinition};
+
 use nam::{
     build_processor_with_assets_for_layout, model_schema_for,
     processor::{NamPluginParams, DEFAULT_PLUGIN_PARAMS},
@@ -8,16 +8,16 @@ use nam::{
 use block_core::param::{ModelParameterSchema, ParameterSet};
 use block_core::{AudioChannelLayout, BlockProcessor};
 
-pub const MODEL_ID: &str = "marshall_jmp_1_full_rig";
-pub const DISPLAY_NAME: &str = "JMP-1 Full Rig";
+pub const MODEL_ID: &str = "marshall_super_100_1966";
+pub const DISPLAY_NAME: &str = "Super 100 1966";
 const BRAND: &str = "marshall";
 
 pub const NAM_PLUGIN_FIXED_PARAMS: NamPluginParams = DEFAULT_PLUGIN_PARAMS;
 
-const CAPTURE_PATH: &str = "full_rigs/marshall_jmp_1/jmp_1_od2_v30_full_rig.nam";
+const CAPTURE_PATH: &str = "full_rigs/marshall_super_100_1966/marshall_sa100_i_edge_bal_cab.nam";
 
 pub fn model_schema() -> ModelParameterSchema {
-    model_schema_for("full_rig", MODEL_ID, DISPLAY_NAME, false)
+    model_schema_for("amp", MODEL_ID, DISPLAY_NAME, false)
 }
 
 pub fn build_processor_for_model(
@@ -50,11 +50,11 @@ fn build(params: &ParameterSet, sample_rate: f32, layout: AudioChannelLayout) ->
     build_processor_for_model(params, sample_rate, layout)
 }
 
-pub const MODEL_DEFINITION: FullRigModelDefinition = FullRigModelDefinition {
+pub const MODEL_DEFINITION: AmpModelDefinition = AmpModelDefinition {
     id: MODEL_ID,
     display_name: DISPLAY_NAME,
     brand: BRAND,
-    backend_kind: FullRigBackendKind::Nam,
+    backend_kind: AmpBackendKind::Nam,
     schema,
     validate: validate_params,
     asset_summary,

--- a/crates/block-amp/src/nam_peavey_5150_mesa_4x12.rs
+++ b/crates/block-amp/src/nam_peavey_5150_mesa_4x12.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Result};
-use crate::registry::FullRigModelDefinition;
-use crate::FullRigBackendKind;
+use crate::registry::{AmpBackendKind, AmpModelDefinition};
+
 use nam::{
     build_processor_with_assets_for_layout, model_schema_for,
     processor::{NamPluginParams, DEFAULT_PLUGIN_PARAMS},
@@ -36,7 +36,7 @@ pub const CAPTURES: &[Peavey5150Capture] = &[
 ];
 
 pub fn model_schema() -> ModelParameterSchema {
-    let mut schema = model_schema_for("full_rig", MODEL_ID, DISPLAY_NAME, false);
+    let mut schema = model_schema_for("amp", MODEL_ID, DISPLAY_NAME, false);
     schema.parameters = vec![
         enum_parameter(
             "boost",
@@ -101,7 +101,7 @@ fn resolve_capture(params: &ParameterSet) -> Result<&'static Peavey5150Capture> 
     }
 
     Err(anyhow!(
-        "full-rig model '{}' does not support boost='{}' mic='{}'",
+        "amp model '{}' does not support boost='{}' mic='{}'",
         MODEL_ID,
         boost,
         mic
@@ -123,11 +123,11 @@ fn build(params: &ParameterSet, sample_rate: f32, layout: AudioChannelLayout) ->
     build_processor_for_model(params, sample_rate, layout)
 }
 
-pub const MODEL_DEFINITION: FullRigModelDefinition = FullRigModelDefinition {
+pub const MODEL_DEFINITION: AmpModelDefinition = AmpModelDefinition {
     id: MODEL_ID,
     display_name: DISPLAY_NAME,
     brand: BRAND,
-    backend_kind: FullRigBackendKind::Nam,
+    backend_kind: AmpBackendKind::Nam,
     schema,
     validate: validate_params,
     asset_summary,

--- a/crates/block-amp/src/nam_roland_jc_120b_jazz_chorus.rs
+++ b/crates/block-amp/src/nam_roland_jc_120b_jazz_chorus.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Result};
-use crate::registry::FullRigModelDefinition;
-use crate::FullRigBackendKind;
+use crate::registry::{AmpBackendKind, AmpModelDefinition};
+
 use nam::{
     build_processor_with_assets_for_layout, model_schema_for,
     processor::{plugin_params_from_set_with_defaults, NamPluginParams},
@@ -76,7 +76,7 @@ pub const CAPTURES: &[RolandCapture] = &[
 ];
 
 pub fn model_schema() -> ModelParameterSchema {
-    let mut schema = model_schema_for("full_rig", MODEL_ID, DISPLAY_NAME, false);
+    let mut schema = model_schema_for("amp", MODEL_ID, DISPLAY_NAME, false);
     schema.parameters = vec![
         bool_parameter("bright_enabled", "Bright", Some("Rig"), Some(false)),
         bool_parameter("royer_101_enabled", "Royer 101", Some("Rig"), Some(true)),
@@ -142,11 +142,11 @@ fn build(params: &ParameterSet, sample_rate: f32, layout: AudioChannelLayout) ->
     build_processor_for_model(params, sample_rate, layout)
 }
 
-pub const MODEL_DEFINITION: FullRigModelDefinition = FullRigModelDefinition {
+pub const MODEL_DEFINITION: AmpModelDefinition = AmpModelDefinition {
     id: MODEL_ID,
     display_name: DISPLAY_NAME,
     brand: BRAND,
-    backend_kind: FullRigBackendKind::Nam,
+    backend_kind: AmpBackendKind::Nam,
     schema,
     validate: validate_params,
     asset_summary,

--- a/crates/block-amp/src/nam_synergy_drect_mesa.rs
+++ b/crates/block-amp/src/nam_synergy_drect_mesa.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Result};
-use crate::registry::FullRigModelDefinition;
-use crate::FullRigBackendKind;
+use crate::registry::{AmpBackendKind, AmpModelDefinition};
+
 use nam::{
     build_processor_with_assets_for_layout, model_schema_for,
     processor::{NamPluginParams, DEFAULT_PLUGIN_PARAMS},
@@ -8,27 +8,27 @@ use nam::{
 use block_core::param::{enum_parameter, required_string, ModelParameterSchema, ParameterSet};
 use block_core::{AudioChannelLayout, BlockProcessor};
 
-pub const MODEL_ID: &str = "fender_super_reverb_1977";
-pub const DISPLAY_NAME: &str = "Super Reverb 1977";
-const BRAND: &str = "fender";
+pub const MODEL_ID: &str = "synergy_drect_mesa";
+pub const DISPLAY_NAME: &str = "DRECT Mesa";
+const BRAND: &str = "synergy";
 
 pub const NAM_PLUGIN_FIXED_PARAMS: NamPluginParams = DEFAULT_PLUGIN_PARAMS;
 
-const CAPTURE_SM57: &str = "full_rigs/fender_super_reverb_1977/fender_super_reverb_sm57.nam";
-const CAPTURE_AKG414: &str = "full_rigs/fender_super_reverb_1977/fender_super_reverb_akg414.nam";
-const CAPTURE_SM57_AKG414: &str = "full_rigs/fender_super_reverb_1977/fender_super_reverb_sm57_akg414.nam";
+const CAPTURE_UNBOOSTED: &str = "full_rigs/synergy_drect_mesa/synergy_drect_unboosted.nam";
+const CAPTURE_OD808_SM57: &str = "full_rigs/synergy_drect_mesa/synergy_drect_od808_sm57.nam";
+const CAPTURE_SD1_SM58: &str = "full_rigs/synergy_drect_mesa/synergy_drect_sd1_sm58.nam";
 
 pub fn model_schema() -> ModelParameterSchema {
-    let mut schema = model_schema_for("full_rig", MODEL_ID, DISPLAY_NAME, false);
+    let mut schema = model_schema_for("amp", MODEL_ID, DISPLAY_NAME, false);
     schema.parameters = vec![enum_parameter(
-        "mic",
-        "Mic",
-        Some("Cab"),
-        Some("sm57"),
+        "boost",
+        "Boost",
+        Some("Amp"),
+        Some("unboosted"),
         &[
-            ("sm57", "SM57"),
-            ("akg414", "AKG 414"),
-            ("sm57_akg414", "SM57 + AKG 414"),
+            ("unboosted", "Unboosted"),
+            ("od808", "OD808"),
+            ("sd1", "SD-1"),
         ],
     )];
     schema
@@ -59,13 +59,13 @@ pub fn asset_summary(params: &ParameterSet) -> Result<String> {
 }
 
 fn resolve_capture_path(params: &ParameterSet) -> Result<&'static str> {
-    let mic = required_string(params, "mic").map_err(anyhow::Error::msg)?;
-    match mic.as_str() {
-        "sm57" => Ok(CAPTURE_SM57),
-        "akg414" => Ok(CAPTURE_AKG414),
-        "sm57_akg414" => Ok(CAPTURE_SM57_AKG414),
+    let boost = required_string(params, "boost").map_err(anyhow::Error::msg)?;
+    match boost.as_str() {
+        "unboosted" => Ok(CAPTURE_UNBOOSTED),
+        "od808" => Ok(CAPTURE_OD808_SM57),
+        "sd1" => Ok(CAPTURE_SD1_SM58),
         other => Err(anyhow!(
-            "full-rig model '{}' does not support mic='{}'",
+            "amp model '{}' does not support boost='{}'",
             MODEL_ID,
             other
         )),
@@ -80,15 +80,15 @@ fn build(params: &ParameterSet, sample_rate: f32, layout: AudioChannelLayout) ->
     build_processor_for_model(params, sample_rate, layout)
 }
 
-pub const MODEL_DEFINITION: FullRigModelDefinition = FullRigModelDefinition {
+pub const MODEL_DEFINITION: AmpModelDefinition = AmpModelDefinition {
     id: MODEL_ID,
     display_name: DISPLAY_NAME,
     brand: BRAND,
-    backend_kind: FullRigBackendKind::Nam,
+    backend_kind: AmpBackendKind::Nam,
     schema,
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::GUITAR_ACOUSTIC_BASS,
+    supported_instruments: block_core::GUITAR_BASS,
     knob_layout: &[],
 };

--- a/crates/block-amp/src/nam_vox_ac30.rs
+++ b/crates/block-amp/src/nam_vox_ac30.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Result};
-use crate::registry::FullRigModelDefinition;
-use crate::FullRigBackendKind;
+use crate::registry::{AmpBackendKind, AmpModelDefinition};
+
 use nam::{
     build_processor_with_assets_for_layout, model_schema_for,
     processor::{NamPluginParams, DEFAULT_PLUGIN_PARAMS},
@@ -8,27 +8,25 @@ use nam::{
 use block_core::param::{enum_parameter, required_string, ModelParameterSchema, ParameterSet};
 use block_core::{AudioChannelLayout, BlockProcessor};
 
-pub const MODEL_ID: &str = "synergy_drect_mesa";
-pub const DISPLAY_NAME: &str = "DRECT Mesa";
-const BRAND: &str = "synergy";
+pub const MODEL_ID: &str = "vox_ac30";
+pub const DISPLAY_NAME: &str = "AC30";
+const BRAND: &str = "vox";
 
 pub const NAM_PLUGIN_FIXED_PARAMS: NamPluginParams = DEFAULT_PLUGIN_PARAMS;
 
-const CAPTURE_UNBOOSTED: &str = "full_rigs/synergy_drect_mesa/synergy_drect_unboosted.nam";
-const CAPTURE_OD808_SM57: &str = "full_rigs/synergy_drect_mesa/synergy_drect_od808_sm57.nam";
-const CAPTURE_SD1_SM58: &str = "full_rigs/synergy_drect_mesa/synergy_drect_sd1_sm58.nam";
+const CAPTURE_STANDARD: &str = "full_rigs/vox_ac30/vox_ac30_cab.nam";
+const CAPTURE_CLEAN_65PRINCE: &str = "full_rigs/vox_ac30/vox_ac30_clean_65prince.nam";
 
 pub fn model_schema() -> ModelParameterSchema {
-    let mut schema = model_schema_for("full_rig", MODEL_ID, DISPLAY_NAME, false);
+    let mut schema = model_schema_for("amp", MODEL_ID, DISPLAY_NAME, false);
     schema.parameters = vec![enum_parameter(
-        "boost",
-        "Boost",
+        "character",
+        "Character",
         Some("Amp"),
-        Some("unboosted"),
+        Some("standard"),
         &[
-            ("unboosted", "Unboosted"),
-            ("od808", "OD808"),
-            ("sd1", "SD-1"),
+            ("standard", "Standard"),
+            ("clean_65prince", "Clean 65Prince"),
         ],
     )];
     schema
@@ -59,13 +57,12 @@ pub fn asset_summary(params: &ParameterSet) -> Result<String> {
 }
 
 fn resolve_capture_path(params: &ParameterSet) -> Result<&'static str> {
-    let boost = required_string(params, "boost").map_err(anyhow::Error::msg)?;
-    match boost.as_str() {
-        "unboosted" => Ok(CAPTURE_UNBOOSTED),
-        "od808" => Ok(CAPTURE_OD808_SM57),
-        "sd1" => Ok(CAPTURE_SD1_SM58),
+    let character = required_string(params, "character").map_err(anyhow::Error::msg)?;
+    match character.as_str() {
+        "standard" => Ok(CAPTURE_STANDARD),
+        "clean_65prince" => Ok(CAPTURE_CLEAN_65PRINCE),
         other => Err(anyhow!(
-            "full-rig model '{}' does not support boost='{}'",
+            "amp model '{}' does not support character='{}'",
             MODEL_ID,
             other
         )),
@@ -80,15 +77,15 @@ fn build(params: &ParameterSet, sample_rate: f32, layout: AudioChannelLayout) ->
     build_processor_for_model(params, sample_rate, layout)
 }
 
-pub const MODEL_DEFINITION: FullRigModelDefinition = FullRigModelDefinition {
+pub const MODEL_DEFINITION: AmpModelDefinition = AmpModelDefinition {
     id: MODEL_ID,
     display_name: DISPLAY_NAME,
     brand: BRAND,
-    backend_kind: FullRigBackendKind::Nam,
+    backend_kind: AmpBackendKind::Nam,
     schema,
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::GUITAR_BASS,
+    supported_instruments: block_core::GUITAR_ACOUSTIC_BASS,
     knob_layout: &[],
 };

--- a/crates/block-amp/src/nam_vox_ac30_1961_fawn_ef86.rs
+++ b/crates/block-amp/src/nam_vox_ac30_1961_fawn_ef86.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
-use crate::registry::FullRigModelDefinition;
-use crate::FullRigBackendKind;
+use crate::registry::{AmpBackendKind, AmpModelDefinition};
+
 use nam::{
     build_processor_with_assets_for_layout, model_schema_for,
     processor::{NamPluginParams, DEFAULT_PLUGIN_PARAMS},
@@ -8,16 +8,16 @@ use nam::{
 use block_core::param::{ModelParameterSchema, ParameterSet};
 use block_core::{AudioChannelLayout, BlockProcessor};
 
-pub const MODEL_ID: &str = "marshall_super_100_1966";
-pub const DISPLAY_NAME: &str = "Super 100 1966";
-const BRAND: &str = "marshall";
+pub const MODEL_ID: &str = "vox_ac30_1961_fawn_ef86";
+pub const DISPLAY_NAME: &str = "AC30 '61 Fawn EF86";
+const BRAND: &str = "vox";
 
 pub const NAM_PLUGIN_FIXED_PARAMS: NamPluginParams = DEFAULT_PLUGIN_PARAMS;
 
-const CAPTURE_PATH: &str = "full_rigs/marshall_super_100_1966/marshall_sa100_i_edge_bal_cab.nam";
+const CAPTURE_PATH: &str = "full_rigs/vox_ac30_1961_fawn_ef86/vox_ac30_1961_fawn_crunch.nam";
 
 pub fn model_schema() -> ModelParameterSchema {
-    model_schema_for("full_rig", MODEL_ID, DISPLAY_NAME, false)
+    model_schema_for("amp", MODEL_ID, DISPLAY_NAME, false)
 }
 
 pub fn build_processor_for_model(
@@ -50,15 +50,15 @@ fn build(params: &ParameterSet, sample_rate: f32, layout: AudioChannelLayout) ->
     build_processor_for_model(params, sample_rate, layout)
 }
 
-pub const MODEL_DEFINITION: FullRigModelDefinition = FullRigModelDefinition {
+pub const MODEL_DEFINITION: AmpModelDefinition = AmpModelDefinition {
     id: MODEL_ID,
     display_name: DISPLAY_NAME,
     brand: BRAND,
-    backend_kind: FullRigBackendKind::Nam,
+    backend_kind: AmpBackendKind::Nam,
     schema,
     validate: validate_params,
     asset_summary,
     build,
-    supported_instruments: block_core::GUITAR_BASS,
+    supported_instruments: block_core::GUITAR_ACOUSTIC_BASS,
     knob_layout: &[],
 };


### PR DESCRIPTION
## Summary
- Moves 12 NAM amp+cab captures from `block-full-rig` to `block-amp`
- `block-full-rig` is now reserved for complete rigs with effects pedals baked in
- Capture file paths (`full_rigs/...`) unchanged on disk
- Zero warnings, full build passes

Closes #208