### PR TITLE
feat(block-cab): add TONE3000 IR cab captures

### DIFF
--- a/crates/block-cab/src/ir_evil_chug_blackstar_prs.rs
+++ b/crates/block-cab/src/ir_evil_chug_blackstar_prs.rs
@@ -1,0 +1,102 @@
+use anyhow::{anyhow, bail, Result};
+use ir::{build_mono_ir_processor_from_wav, IrAsset};
+use crate::registry::CabModelDefinition;
+use crate::CabBackendKind;
+use block_core::param::{enum_parameter, required_string, ModelParameterSchema, ParameterSet};
+use block_core::{AudioChannelLayout, ModelAudioMode, BlockProcessor};
+
+pub const MODEL_ID: &str = "evil_chug_blackstar_prs";
+pub const DISPLAY_NAME: &str = "Evil Chug (Blackstar + PRS)";
+const BRAND: &str = "blackstar";
+
+macro_rules! capture {
+    ($p1:literal, $ir_file:literal) => {
+        EvilChugCapture { capture: $p1, ir_file: $ir_file }
+    };
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EvilChugCapture {
+    pub capture: &'static str,
+    pub ir_file: &'static str,
+}
+
+pub const CAPTURES: &[EvilChugCapture] = &[
+    capture!("evil_chug_1","cabs/evil_chug_blackstar_prs/evil_chug_1.wav"),
+    capture!("evil_chug_2","cabs/evil_chug_blackstar_prs/evil_chug_2.wav"),
+    capture!("evil_chug_3","cabs/evil_chug_blackstar_prs/evil_chug_3.wav"),
+];
+
+pub fn model_schema() -> ModelParameterSchema {
+    ModelParameterSchema {
+        effect_type: "cab".to_string(),
+        model: MODEL_ID.to_string(),
+        display_name: DISPLAY_NAME.to_string(),
+        audio_mode: ModelAudioMode::DualMono,
+        parameters: vec![enum_parameter(
+            "capture",
+            "Capture",
+            Some("Cab"),
+            Some("evil_chug_1"),
+            &[
+                ("evil_chug_1","Evil Chug 1"),
+                ("evil_chug_2","Evil Chug 2"),
+                ("evil_chug_3","Evil Chug 3"),
+            ],
+        )],
+    }
+}
+
+pub fn build_processor_for_model(
+    params: &ParameterSet,
+    sample_rate: f32,
+    layout: AudioChannelLayout,
+) -> Result<BlockProcessor> {
+    match layout {
+        AudioChannelLayout::Mono => {
+            let capture = resolve_capture(params)?;
+            let wav_path = ir::resolve_ir_capture(capture.ir_file)?;
+            let ir = IrAsset::load_from_wav(&wav_path)?;
+            if ir.channel_count() != 1 {
+                bail!("cab model '{}' capture '{}' must be mono, got {} channels", MODEL_ID, capture.capture, ir.channel_count());
+            }
+            Ok(BlockProcessor::Mono(build_mono_ir_processor_from_wav(&wav_path, sample_rate)?))
+        }
+        AudioChannelLayout::Stereo => bail!("cab model '{}' currently expects mono processor layout", MODEL_ID),
+    }
+}
+
+fn schema() -> Result<ModelParameterSchema> { Ok(model_schema()) }
+
+fn build(params: &ParameterSet, sample_rate: f32, layout: AudioChannelLayout) -> Result<BlockProcessor> {
+    build_processor_for_model(params, sample_rate, layout)
+}
+
+pub const MODEL_DEFINITION: CabModelDefinition = CabModelDefinition {
+    id: MODEL_ID,
+    display_name: DISPLAY_NAME,
+    brand: BRAND,
+    backend_kind: CabBackendKind::Ir,
+    schema,
+    validate: validate_params,
+    asset_summary,
+    build,
+    supported_instruments: block_core::GUITAR_BASS,
+    knob_layout: &[],
+};
+
+pub fn validate_params(params: &ParameterSet) -> Result<()> {
+    resolve_capture(params).map(|_| ())
+}
+
+pub fn asset_summary(params: &ParameterSet) -> Result<String> {
+    let capture = resolve_capture(params)?;
+    Ok(format!("asset_id='{}'", capture.ir_file))
+}
+
+fn resolve_capture(params: &ParameterSet) -> Result<&'static EvilChugCapture> {
+    let requested = required_string(params, "capture").map_err(anyhow::Error::msg)?;
+    CAPTURES.iter()
+        .find(|c| c.capture == requested)
+        .ok_or_else(|| anyhow!("cab model '{}' does not support capture '{}'", MODEL_ID, requested))
+}

--- a/crates/block-cab/src/ir_g12m_greenback_2x12.rs
+++ b/crates/block-cab/src/ir_g12m_greenback_2x12.rs
@@ -25,9 +25,10 @@ pub struct G12mGreenback2x12Capture {
 }
 
 pub const CAPTURES: &[G12mGreenback2x12Capture] = &[
-    capture!("sm57_dark", "cabs/g12m_greenback_2x12/sm57_dark.wav"),
-    capture!("sm57_dark_2", "cabs/g12m_greenback_2x12/sm57_dark_2.wav"),
-    capture!("sm57_fat", "cabs/g12m_greenback_2x12/sm57_fat.wav"),
+    capture!("sm57_dark",  "cabs/g12m_greenback_2x12/sm57_dark.wav"),
+    capture!("sm57_dark_2","cabs/g12m_greenback_2x12/sm57_dark_2.wav"),
+    capture!("sm57_fat",   "cabs/g12m_greenback_2x12/sm57_fat.wav"),
+    capture!("oc818",      "cabs/g12m_greenback_2x12/oc818.wav"),
 ];
 
 pub fn model_schema() -> ModelParameterSchema {
@@ -42,9 +43,10 @@ pub fn model_schema() -> ModelParameterSchema {
             Some("Cab"),
             Some("sm57_dark"),
             &[
-                ("sm57_dark", "SM57 Dark"),
-                ("sm57_dark_2", "SM57 Dark 2"),
-                ("sm57_fat", "SM57 Fat"),
+                ("sm57_dark",  "SM57 Dark"),
+                ("sm57_dark_2","SM57 Dark 2"),
+                ("sm57_fat",   "SM57 Fat"),
+                ("oc818",      "OC818"),
             ],
         )],
     }

--- a/crates/block-cab/src/ir_g12m_greenback_multi_mic.rs
+++ b/crates/block-cab/src/ir_g12m_greenback_multi_mic.rs
@@ -1,0 +1,108 @@
+use anyhow::{anyhow, bail, Result};
+use ir::{build_mono_ir_processor_from_wav, IrAsset};
+use crate::registry::CabModelDefinition;
+use crate::CabBackendKind;
+use block_core::param::{enum_parameter, required_string, ModelParameterSchema, ParameterSet};
+use block_core::{AudioChannelLayout, ModelAudioMode, BlockProcessor};
+
+pub const MODEL_ID: &str = "g12m_greenback_multi_mic";
+pub const DISPLAY_NAME: &str = "G12M Greenback Multi-Mic";
+const BRAND: &str = "";
+
+macro_rules! capture {
+    ($p1:literal, $ir_file:literal) => {
+        G12mGreenbackMultiMicCapture { capture: $p1, ir_file: $ir_file }
+    };
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct G12mGreenbackMultiMicCapture {
+    pub capture: &'static str,
+    pub ir_file: &'static str,
+}
+
+pub const CAPTURES: &[G12mGreenbackMultiMicCapture] = &[
+    capture!("sm57",  "cabs/g12m_greenback_multi_mic/sm57.wav"),
+    capture!("lct441","cabs/g12m_greenback_multi_mic/lct441.wav"),
+    capture!("mc834", "cabs/g12m_greenback_multi_mic/mc834.wav"),
+    capture!("m160",  "cabs/g12m_greenback_multi_mic/m160.wav"),
+    capture!("oc818", "cabs/g12m_greenback_multi_mic/oc818.wav"),
+    capture!("cc8",   "cabs/g12m_greenback_multi_mic/cc8.wav"),
+];
+
+pub fn model_schema() -> ModelParameterSchema {
+    ModelParameterSchema {
+        effect_type: "cab".to_string(),
+        model: MODEL_ID.to_string(),
+        display_name: DISPLAY_NAME.to_string(),
+        audio_mode: ModelAudioMode::DualMono,
+        parameters: vec![enum_parameter(
+            "mic",
+            "Mic",
+            Some("Cab"),
+            Some("sm57"),
+            &[
+                ("sm57",  "SM57"),
+                ("lct441","LCT 441"),
+                ("mc834", "MC 834"),
+                ("m160",  "M160"),
+                ("oc818", "OC818"),
+                ("cc8",   "CC8"),
+            ],
+        )],
+    }
+}
+
+pub fn build_processor_for_model(
+    params: &ParameterSet,
+    sample_rate: f32,
+    layout: AudioChannelLayout,
+) -> Result<BlockProcessor> {
+    match layout {
+        AudioChannelLayout::Mono => {
+            let capture = resolve_capture(params)?;
+            let wav_path = ir::resolve_ir_capture(capture.ir_file)?;
+            let ir = IrAsset::load_from_wav(&wav_path)?;
+            if ir.channel_count() != 1 {
+                bail!("cab model '{}' capture '{}' must be mono, got {} channels", MODEL_ID, capture.capture, ir.channel_count());
+            }
+            Ok(BlockProcessor::Mono(build_mono_ir_processor_from_wav(&wav_path, sample_rate)?))
+        }
+        AudioChannelLayout::Stereo => bail!("cab model '{}' currently expects mono processor layout", MODEL_ID),
+    }
+}
+
+fn schema() -> Result<ModelParameterSchema> { Ok(model_schema()) }
+
+fn build(params: &ParameterSet, sample_rate: f32, layout: AudioChannelLayout) -> Result<BlockProcessor> {
+    build_processor_for_model(params, sample_rate, layout)
+}
+
+pub const MODEL_DEFINITION: CabModelDefinition = CabModelDefinition {
+    id: MODEL_ID,
+    display_name: DISPLAY_NAME,
+    brand: BRAND,
+    backend_kind: CabBackendKind::Ir,
+    schema,
+    validate: validate_params,
+    asset_summary,
+    build,
+    supported_instruments: block_core::GUITAR_BASS,
+    knob_layout: &[],
+};
+
+pub fn validate_params(params: &ParameterSet) -> Result<()> {
+    resolve_capture(params).map(|_| ())
+}
+
+pub fn asset_summary(params: &ParameterSet) -> Result<String> {
+    let capture = resolve_capture(params)?;
+    Ok(format!("asset_id='{}'", capture.ir_file))
+}
+
+fn resolve_capture(params: &ParameterSet) -> Result<&'static G12mGreenbackMultiMicCapture> {
+    let requested = required_string(params, "mic").map_err(anyhow::Error::msg)?;
+    CAPTURES.iter()
+        .find(|c| c.capture == requested)
+        .ok_or_else(|| anyhow!("cab model '{}' does not support mic '{}'", MODEL_ID, requested))
+}

--- a/crates/block-cab/src/ir_mesa_os_4x12_v30.rs
+++ b/crates/block-cab/src/ir_mesa_os_4x12_v30.rs
@@ -25,14 +25,15 @@ pub struct MesaOs4x12V30Capture {
 }
 
 pub const CAPTURES: &[MesaOs4x12V30Capture] = &[
-    capture!("at2020_1", "cabs/mesa_os_4x12_v30/at2020_1.wav"),
-    capture!("at2020_2", "cabs/mesa_os_4x12_v30/at2020_2.wav"),
+    capture!("at2020_1",         "cabs/mesa_os_4x12_v30/at2020_1.wav"),
+    capture!("at2020_2",         "cabs/mesa_os_4x12_v30/at2020_2.wav"),
     capture!("room_left_at2020", "cabs/mesa_os_4x12_v30/room_left_at2020.wav"),
-    capture!("room_right_at2020", "cabs/mesa_os_4x12_v30/room_right_at2020.wav"),
-    capture!("sm57_1", "cabs/mesa_os_4x12_v30/sm57_1.wav"),
-    capture!("sm57_2", "cabs/mesa_os_4x12_v30/sm57_2.wav"),
-    capture!("sm58_1", "cabs/mesa_os_4x12_v30/sm58_1.wav"),
-    capture!("sm58_2", "cabs/mesa_os_4x12_v30/sm58_2.wav"),
+    capture!("room_right_at2020","cabs/mesa_os_4x12_v30/room_right_at2020.wav"),
+    capture!("sm57_1",           "cabs/mesa_os_4x12_v30/sm57_1.wav"),
+    capture!("sm57_2",           "cabs/mesa_os_4x12_v30/sm57_2.wav"),
+    capture!("sm57_m160_mix",    "cabs/mesa_os_4x12_v30/sm57_m160_mix.wav"),
+    capture!("sm58_1",           "cabs/mesa_os_4x12_v30/sm58_1.wav"),
+    capture!("sm58_2",           "cabs/mesa_os_4x12_v30/sm58_2.wav"),
 ];
 
 pub fn model_schema() -> ModelParameterSchema {
@@ -47,14 +48,15 @@ pub fn model_schema() -> ModelParameterSchema {
             Some("Cab"),
             Some("at2020_1"),
             &[
-                ("at2020_1", "AT2020 1"),
-                ("at2020_2", "AT2020 2"),
+                ("at2020_1",         "AT2020 1"),
+                ("at2020_2",         "AT2020 2"),
                 ("room_left_at2020", "Room Left AT2020"),
-                ("room_right_at2020", "Room Right AT2020"),
-                ("sm57_1", "SM57 1"),
-                ("sm57_2", "SM57 2"),
-                ("sm58_1", "SM58 1"),
-                ("sm58_2", "SM58 2"),
+                ("room_right_at2020","Room Right AT2020"),
+                ("sm57_1",           "SM57 1"),
+                ("sm57_2",           "SM57 2"),
+                ("sm57_m160_mix",    "SM57 + M160 Mix"),
+                ("sm58_1",           "SM58 1"),
+                ("sm58_2",           "SM58 2"),
             ],
         )],
     }

--- a/crates/block-cab/src/ir_mesa_standard_4x12_v30.rs
+++ b/crates/block-cab/src/ir_mesa_standard_4x12_v30.rs
@@ -1,0 +1,100 @@
+use anyhow::{anyhow, bail, Result};
+use ir::{build_mono_ir_processor_from_wav, IrAsset};
+use crate::registry::CabModelDefinition;
+use crate::CabBackendKind;
+use block_core::param::{enum_parameter, required_string, ModelParameterSchema, ParameterSet};
+use block_core::{AudioChannelLayout, ModelAudioMode, BlockProcessor};
+
+pub const MODEL_ID: &str = "mesa_standard_4x12_v30";
+pub const DISPLAY_NAME: &str = "Standard 4x12 V30";
+const BRAND: &str = "mesa";
+
+macro_rules! capture {
+    ($p1:literal, $ir_file:literal) => {
+        MesaStandard4x12V30Capture { capture: $p1, ir_file: $ir_file }
+    };
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MesaStandard4x12V30Capture {
+    pub capture: &'static str,
+    pub ir_file: &'static str,
+}
+
+pub const CAPTURES: &[MesaStandard4x12V30Capture] = &[
+    capture!("sm57","cabs/mesa_standard_4x12_v30/sm57.wav"),
+    capture!("sm58","cabs/mesa_standard_4x12_v30/sm58.wav"),
+];
+
+pub fn model_schema() -> ModelParameterSchema {
+    ModelParameterSchema {
+        effect_type: "cab".to_string(),
+        model: MODEL_ID.to_string(),
+        display_name: DISPLAY_NAME.to_string(),
+        audio_mode: ModelAudioMode::DualMono,
+        parameters: vec![enum_parameter(
+            "mic",
+            "Mic",
+            Some("Cab"),
+            Some("sm57"),
+            &[
+                ("sm57","SM57"),
+                ("sm58","SM58"),
+            ],
+        )],
+    }
+}
+
+pub fn build_processor_for_model(
+    params: &ParameterSet,
+    sample_rate: f32,
+    layout: AudioChannelLayout,
+) -> Result<BlockProcessor> {
+    match layout {
+        AudioChannelLayout::Mono => {
+            let capture = resolve_capture(params)?;
+            let wav_path = ir::resolve_ir_capture(capture.ir_file)?;
+            let ir = IrAsset::load_from_wav(&wav_path)?;
+            if ir.channel_count() != 1 {
+                bail!("cab model '{}' capture '{}' must be mono, got {} channels", MODEL_ID, capture.capture, ir.channel_count());
+            }
+            Ok(BlockProcessor::Mono(build_mono_ir_processor_from_wav(&wav_path, sample_rate)?))
+        }
+        AudioChannelLayout::Stereo => bail!("cab model '{}' currently expects mono processor layout", MODEL_ID),
+    }
+}
+
+fn schema() -> Result<ModelParameterSchema> { Ok(model_schema()) }
+
+fn build(params: &ParameterSet, sample_rate: f32, layout: AudioChannelLayout) -> Result<BlockProcessor> {
+    build_processor_for_model(params, sample_rate, layout)
+}
+
+pub const MODEL_DEFINITION: CabModelDefinition = CabModelDefinition {
+    id: MODEL_ID,
+    display_name: DISPLAY_NAME,
+    brand: BRAND,
+    backend_kind: CabBackendKind::Ir,
+    schema,
+    validate: validate_params,
+    asset_summary,
+    build,
+    supported_instruments: block_core::GUITAR_BASS,
+    knob_layout: &[],
+};
+
+pub fn validate_params(params: &ParameterSet) -> Result<()> {
+    resolve_capture(params).map(|_| ())
+}
+
+pub fn asset_summary(params: &ParameterSet) -> Result<String> {
+    let capture = resolve_capture(params)?;
+    Ok(format!("asset_id='{}'", capture.ir_file))
+}
+
+fn resolve_capture(params: &ParameterSet) -> Result<&'static MesaStandard4x12V30Capture> {
+    let requested = required_string(params, "mic").map_err(anyhow::Error::msg)?;
+    CAPTURES.iter()
+        .find(|c| c.capture == requested)
+        .ok_or_else(|| anyhow!("cab model '{}' does not support mic '{}'", MODEL_ID, requested))
+}

--- a/crates/block-cab/src/ir_roland_jc_120_cab.rs
+++ b/crates/block-cab/src/ir_roland_jc_120_cab.rs
@@ -1,0 +1,61 @@
+use anyhow::{bail, Result};
+use ir::build_mono_ir_processor_from_wav;
+use crate::registry::CabModelDefinition;
+use crate::CabBackendKind;
+use block_core::param::{ModelParameterSchema, ParameterSet};
+use block_core::{AudioChannelLayout, ModelAudioMode, BlockProcessor};
+
+pub const MODEL_ID: &str = "roland_jc_120_cab";
+pub const DISPLAY_NAME: &str = "JC-120 Cab";
+const BRAND: &str = "roland";
+
+const IR_FILE: &str = "cabs/roland_jc_120_cab/sm57_md421_mix.wav";
+
+pub fn model_schema() -> ModelParameterSchema {
+    ModelParameterSchema {
+        effect_type: "cab".to_string(),
+        model: MODEL_ID.to_string(),
+        display_name: DISPLAY_NAME.to_string(),
+        audio_mode: ModelAudioMode::DualMono,
+        parameters: vec![],
+    }
+}
+
+pub fn build_processor_for_model(
+    _params: &ParameterSet,
+    sample_rate: f32,
+    layout: AudioChannelLayout,
+) -> Result<BlockProcessor> {
+    match layout {
+        AudioChannelLayout::Mono => {
+            let wav_path = ir::resolve_ir_capture(IR_FILE)?;
+            Ok(BlockProcessor::Mono(build_mono_ir_processor_from_wav(&wav_path, sample_rate)?))
+        }
+        AudioChannelLayout::Stereo => bail!("cab model '{}' currently expects mono processor layout", MODEL_ID),
+    }
+}
+
+fn schema() -> Result<ModelParameterSchema> { Ok(model_schema()) }
+
+fn build(params: &ParameterSet, sample_rate: f32, layout: AudioChannelLayout) -> Result<BlockProcessor> {
+    build_processor_for_model(params, sample_rate, layout)
+}
+
+pub const MODEL_DEFINITION: CabModelDefinition = CabModelDefinition {
+    id: MODEL_ID,
+    display_name: DISPLAY_NAME,
+    brand: BRAND,
+    backend_kind: CabBackendKind::Ir,
+    schema,
+    validate: validate_params,
+    asset_summary,
+    build,
+    supported_instruments: block_core::ALL_INSTRUMENTS,
+    knob_layout: &[],
+};
+
+pub fn validate_params(_params: &ParameterSet) -> Result<()> { Ok(()) }
+
+pub fn asset_summary(_params: &ParameterSet) -> Result<String> {
+    Ok(format!("asset_id='{}'", IR_FILE))
+}

--- a/crates/block-cab/src/ir_vox_ac50_2x12.rs
+++ b/crates/block-cab/src/ir_vox_ac50_2x12.rs
@@ -1,0 +1,61 @@
+use anyhow::{bail, Result};
+use ir::build_mono_ir_processor_from_wav;
+use crate::registry::CabModelDefinition;
+use crate::CabBackendKind;
+use block_core::param::{ModelParameterSchema, ParameterSet};
+use block_core::{AudioChannelLayout, ModelAudioMode, BlockProcessor};
+
+pub const MODEL_ID: &str = "vox_ac50_2x12";
+pub const DISPLAY_NAME: &str = "AC50 2x12 Goodmans";
+const BRAND: &str = "vox";
+
+const IR_FILE: &str = "cabs/vox_ac50_2x12/goodmans_241.wav";
+
+pub fn model_schema() -> ModelParameterSchema {
+    ModelParameterSchema {
+        effect_type: "cab".to_string(),
+        model: MODEL_ID.to_string(),
+        display_name: DISPLAY_NAME.to_string(),
+        audio_mode: ModelAudioMode::DualMono,
+        parameters: vec![],
+    }
+}
+
+pub fn build_processor_for_model(
+    _params: &ParameterSet,
+    sample_rate: f32,
+    layout: AudioChannelLayout,
+) -> Result<BlockProcessor> {
+    match layout {
+        AudioChannelLayout::Mono => {
+            let wav_path = ir::resolve_ir_capture(IR_FILE)?;
+            Ok(BlockProcessor::Mono(build_mono_ir_processor_from_wav(&wav_path, sample_rate)?))
+        }
+        AudioChannelLayout::Stereo => bail!("cab model '{}' currently expects mono processor layout", MODEL_ID),
+    }
+}
+
+fn schema() -> Result<ModelParameterSchema> { Ok(model_schema()) }
+
+fn build(params: &ParameterSet, sample_rate: f32, layout: AudioChannelLayout) -> Result<BlockProcessor> {
+    build_processor_for_model(params, sample_rate, layout)
+}
+
+pub const MODEL_DEFINITION: CabModelDefinition = CabModelDefinition {
+    id: MODEL_ID,
+    display_name: DISPLAY_NAME,
+    brand: BRAND,
+    backend_kind: CabBackendKind::Ir,
+    schema,
+    validate: validate_params,
+    asset_summary,
+    build,
+    supported_instruments: block_core::GUITAR_BASS,
+    knob_layout: &[],
+};
+
+pub fn validate_params(_params: &ParameterSet) -> Result<()> { Ok(()) }
+
+pub fn asset_summary(_params: &ParameterSet) -> Result<String> {
+    Ok(format!("asset_id='{}'", IR_FILE))
+}


### PR DESCRIPTION
## Summary
- Installs missing WAVs for 3 existing models (fender_deluxe_reverb_oxford, mesa_os_4x12_v30, vox_ac30_blue)
- Adds new captures to 2 existing models (g12m_greenback_2x12 + oc818, mesa_os_4x12_v30 + sm57_m160_mix)
- 5 new cab models: g12m_greenback_multi_mic, evil_chug_blackstar_prs, mesa_standard_4x12_v30, roland_jc_120_cab, vox_ac50_2x12
- Bonus: Fender Frontman 15G NAMs installed for existing preamp model
- Zero warnings, full build passes

Closes #210