### PR TITLE
feat(vst3): IComponentHandler, GUI parameter sync and multi-instance support

### DIFF
--- a/crates/engine/src/runtime.rs
+++ b/crates/engine/src/runtime.rs
@@ -1206,15 +1206,31 @@ fn build_core_block_runtime_node(
                     Some((id, (pct / 100.0).clamp(0.0, 1.0) as f64))
                 })
                 .collect();
-            // Register a param channel so the GUI can push knob changes to this processor.
-            let param_channel = vst3_host::register_vst3_channel(model);
+            // Load the plugin once so we can extract the controller and library
+            // Arc before building the processor. This allows the GUI to reuse
+            // the same IEditController instead of creating a second instance
+            // (which fails for plugins like ValhallaSupermassive).
+            const VST3_BLOCK_SIZE: usize = 512;
+            let plugin = vst3_host::Vst3Plugin::load(
+                &bundle_path, &uid, sample_rate as f64, 2, VST3_BLOCK_SIZE, &vst3_params,
+            ).map_err(|e| anyhow!("VST3 load failed for '{}': {}", model, e))?;
+            // Register GUI context: shared controller + library Arc + param channel.
+            let param_channel = vst3_host::register_vst3_gui_context(
+                model,
+                plugin.controller_clone(),
+                plugin.library_arc(),
+            );
+            // Wrap in Option so we can move the plugin out of the FnMut closure
+            // (VST3 MonoToStereo schema guarantees the closure is called exactly once).
+            let mut plugin_opt = Some(plugin);
             Ok(audio_block_runtime_node(
                 block,
                 input_layout,
                 build_audio_processor_for_model(chain, block_core::EFFECT_TYPE_VST3, model, input_layout, |layout| {
-                    vst3_host::build_vst3_processor_with_channel(
-                        &bundle_path, &uid, sample_rate as f64, layout, &vst3_params, param_channel.clone(),
-                    ).map_err(|e| anyhow!("{}", e))
+                    let p = plugin_opt.take().ok_or_else(|| anyhow!("VST3 plugin consumed twice"))?;
+                    Ok(vst3_host::build_vst3_processor_from_plugin(
+                        p, layout, param_channel.clone(),
+                    ))
                 })?,
             ))
         }

--- a/crates/project/src/vst3_editor.rs
+++ b/crates/project/src/vst3_editor.rs
@@ -16,25 +16,34 @@ pub fn init_vst3_catalog(sample_rate: f64) {
 
 /// Open the native editor window for the VST3 plugin identified by `model_id`.
 ///
-/// Reuses the `IEditController` from the audio processor (via the registered
-/// `Vst3GuiContext`) instead of loading a second plugin instance. This avoids
-/// failures with plugins like ValhallaSupermassive that reject multiple instances.
-///
-/// Returns an error if the plugin has not been loaded by the audio engine yet
-/// (i.e. there is no registered GUI context for `model_id`).
+/// Strategy:
+/// 1. If the audio engine has already built this plugin (registered a
+///    `Vst3GuiContext`), reuse its `IEditController`. This avoids creating a
+///    second plugin instance, which fails for plugins like ValhallaSupermassive.
+/// 2. Otherwise fall back to loading a fresh instance. This works for plugins
+///    that allow multiple instances (Cloud Seed, Cocoa Delay, …) and lets the
+///    user open the GUI before the engine has started.
 ///
 /// Must be called on the main/UI thread (macOS AppKit requirement).
-pub fn open_vst3_editor(model_id: &str, _sample_rate: f64) -> Result<Box<dyn PluginEditorHandle>> {
+pub fn open_vst3_editor(model_id: &str, sample_rate: f64) -> Result<Box<dyn PluginEditorHandle>> {
     let entry = vst3_host::find_vst3_plugin(model_id)
         .ok_or_else(|| anyhow::anyhow!("VST3 plugin '{}' not found in catalog", model_id))?;
 
-    let gui_context = vst3_host::lookup_vst3_gui_context(model_id)
-        .ok_or_else(|| anyhow::anyhow!(
-            "VST3 plugin '{}' is not loaded in the audio engine yet — \
-             add it to a chain first",
-            model_id
-        ))?;
+    if let Some(gui_context) = vst3_host::lookup_vst3_gui_context(model_id) {
+        // Engine already loaded this plugin — reuse the existing controller.
+        log::debug!("VST3 editor: reusing engine controller for '{}'", model_id);
+        let handle = vst3_host::open_vst3_editor_window(entry.display_name, gui_context)?;
+        return Ok(Box::new(handle));
+    }
 
-    let handle = vst3_host::open_vst3_editor_window(entry.display_name, gui_context)?;
+    // Fallback: load a standalone instance (no param-channel communication).
+    log::debug!("VST3 editor: no engine context for '{}', loading standalone instance", model_id);
+    let uid = vst3_host::resolve_uid_for_model(model_id)?;
+    let handle = vst3_host::open_vst3_editor_window_standalone(
+        &entry.info.bundle_path,
+        &uid,
+        entry.display_name,
+        sample_rate,
+    )?;
     Ok(Box::new(handle))
 }

--- a/crates/project/src/vst3_editor.rs
+++ b/crates/project/src/vst3_editor.rs
@@ -16,27 +16,25 @@ pub fn init_vst3_catalog(sample_rate: f64) {
 
 /// Open the native editor window for the VST3 plugin identified by `model_id`.
 ///
-/// Loads a separate plugin instance dedicated to the GUI. Resolves the UID
-/// lazily if the plugin lacks `moduleinfo.json`. Returns a handle that keeps
-/// the window alive; drop it to close.
+/// Reuses the `IEditController` from the audio processor (via the registered
+/// `Vst3GuiContext`) instead of loading a second plugin instance. This avoids
+/// failures with plugins like ValhallaSupermassive that reject multiple instances.
+///
+/// Returns an error if the plugin has not been loaded by the audio engine yet
+/// (i.e. there is no registered GUI context for `model_id`).
 ///
 /// Must be called on the main/UI thread (macOS AppKit requirement).
-pub fn open_vst3_editor(model_id: &str, sample_rate: f64) -> Result<Box<dyn PluginEditorHandle>> {
-    let uid = vst3_host::resolve_uid_for_model(model_id)?;
+pub fn open_vst3_editor(model_id: &str, _sample_rate: f64) -> Result<Box<dyn PluginEditorHandle>> {
     let entry = vst3_host::find_vst3_plugin(model_id)
         .ok_or_else(|| anyhow::anyhow!("VST3 plugin '{}' not found in catalog", model_id))?;
 
-    // Look up the param channel registered by the audio processor (if any).
-    // This connects GUI knob movements → audio thread via the lock-free queue.
-    let param_channel = vst3_host::lookup_vst3_channel(model_id);
+    let gui_context = vst3_host::lookup_vst3_gui_context(model_id)
+        .ok_or_else(|| anyhow::anyhow!(
+            "VST3 plugin '{}' is not loaded in the audio engine yet — \
+             add it to a chain first",
+            model_id
+        ))?;
 
-    let handle = vst3_host::open_vst3_editor_window(
-        &entry.info.bundle_path,
-        &uid,
-        entry.display_name,
-        sample_rate,
-        param_channel,
-    )?;
-
+    let handle = vst3_host::open_vst3_editor_window(entry.display_name, gui_context)?;
     Ok(Box::new(handle))
 }

--- a/crates/vst3/src/editor.rs
+++ b/crates/vst3/src/editor.rs
@@ -1,19 +1,19 @@
 //! VST3 editor window: opens the plugin's native GUI in a separate OS window.
 //!
-//! Calls `IEditController::createView("editor")` to get an `IPlugView`, then
-//! creates a native window and embeds the view in it.
+//! Reuses the `IEditController` from the audio processor (via `Vst3GuiContext`)
+//! instead of loading a second plugin instance. This avoids failures with
+//! plugins like ValhallaSupermassive that reject multiple instances.
 //!
 //! Must be called on the main/UI thread (macOS AppKit requirement).
 
 use anyhow::{bail, Result};
-use std::path::Path;
-use vst3::Steinberg::Vst::{IConnectionPointTrait, IEditControllerTrait, ViewType};
+use std::sync::Arc;
+use vst3::Steinberg::Vst::{IEditControllerTrait, ViewType};
 use vst3::Steinberg::{IPlugViewTrait, ViewRect, kResultOk};
 use vst3::ComPtr;
 
 use crate::component_handler::ComponentHandler;
-use crate::host::Vst3Plugin;
-use crate::param_channel::Vst3ParamChannel;
+use crate::param_registry::Vst3GuiContext;
 
 impl block_core::PluginEditorHandle for Vst3EditorHandle {}
 
@@ -23,7 +23,10 @@ impl block_core::PluginEditorHandle for Vst3EditorHandle {}
 /// all resources. On macOS it also releases the NSWindow.
 pub struct Vst3EditorHandle {
     view: ComPtr<vst3::Steinberg::IPlugView>,
-    _plugin: Box<Vst3Plugin>,
+    /// Keeps the plugin dylib alive while the editor is open.
+    _library: Arc<libloading::Library>,
+    /// Keeps the controller alive so `view.removed()` can call back into it.
+    _controller: ComPtr<vst3::Steinberg::Vst::IEditController>,
     /// Keep the ComponentHandler alive for as long as the editor is open.
     /// The plugin holds a raw pointer to this; dropping it before the plugin
     /// is done would cause a use-after-free.
@@ -40,53 +43,37 @@ impl Drop for Vst3EditorHandle {
     }
 }
 
-/// Open the native editor window for the VST3 plugin identified by
-/// `bundle_path` + `uid`.
+/// Open the native editor window for the VST3 plugin, reusing the existing
+/// `IEditController` from the audio processor.
 ///
-/// Loads a separate plugin instance dedicated to the GUI (not the audio
-/// processor). The audio processor is unaffected.
+/// `plugin_name` is used only for the window title.
+/// `gui_context` carries the shared controller, library handle, and param channel.
 ///
 /// Returns a `Vst3EditorHandle` that keeps the window alive. Drop it to close.
 pub fn open_vst3_editor_window(
-    bundle_path: &Path,
-    uid: &[u8; 16],
     plugin_name: &str,
-    sample_rate: f64,
-    param_channel: Option<Vst3ParamChannel>,
+    gui_context: Vst3GuiContext,
 ) -> Result<Vst3EditorHandle> {
-    // Load a lightweight plugin instance (2ch, small block) just for the GUI.
-    let plugin = Vst3Plugin::load(bundle_path, uid, sample_rate, 2, 512, &[])?;
-
-    // Standard VST3 host requirement: connect component ↔ controller via
-    // IConnectionPoint so the controller can query component state before
-    // creating its view. Many plugins return null from createView otherwise.
-    unsafe {
-        use vst3::Steinberg::Vst::IConnectionPoint;
-        if let Some(comp_cp) = plugin.component().cast::<IConnectionPoint>() {
-            if let Some(ctrl_cp) = plugin.controller().cast::<IConnectionPoint>() {
-                let _ = comp_cp.connect(ctrl_cp.as_ptr());
-                let _ = ctrl_cp.connect(comp_cp.as_ptr());
-                log::debug!("VST3 editor: IConnectionPoint connected");
-            }
-        }
-    }
+    let controller = gui_context.controller;
+    let library = gui_context.library;
+    let param_channel = gui_context.param_channel;
 
     // Register the component handler so parameter changes from the native GUI
     // reach the audio processor via the param channel.
-    let component_handler = param_channel.map(|ch| {
-        let wrapper = ComponentHandler::new(ch).into_com_ptr();
+    let component_handler = {
+        let wrapper = ComponentHandler::new(param_channel).into_com_ptr();
         unsafe {
             use vst3::Steinberg::Vst::IComponentHandler;
             if let Some(com_ref) = wrapper.as_com_ref::<IComponentHandler>() {
-                let _ = plugin.controller().setComponentHandler(com_ref.as_ptr());
+                let _ = controller.setComponentHandler(com_ref.as_ptr());
                 log::debug!("VST3 editor: IComponentHandler registered");
             }
         }
-        wrapper
-    });
+        Some(wrapper)
+    };
 
     // Get IPlugView from the controller.
-    let view_ptr = unsafe { plugin.controller().createView(ViewType::kEditor) };
+    let view_ptr = unsafe { controller.createView(ViewType::kEditor) };
     if view_ptr.is_null() {
         bail!("plugin '{}' returned null IPlugView (no GUI)", plugin_name);
     }
@@ -125,7 +112,8 @@ pub fn open_vst3_editor_window(
 
         return Ok(Vst3EditorHandle {
             view,
-            _plugin: Box::new(plugin),
+            _library: library,
+            _controller: controller,
             _component_handler: component_handler,
             _ns_window: ns_window,
         });

--- a/crates/vst3/src/editor.rs
+++ b/crates/vst3/src/editor.rs
@@ -30,9 +30,10 @@ pub struct Vst3EditorHandle {
     /// Keeps the controller alive so `view.removed()` can call back into it.
     _controller: ComPtr<vst3::Steinberg::Vst::IEditController>,
     /// Keep the ComponentHandler alive for as long as the editor is open.
-    /// The plugin holds a raw pointer to this; dropping it before the plugin
-    /// is done would cause a use-after-free.
     _component_handler: Option<vst3::ComWrapper<ComponentHandler>>,
+    /// In standalone mode (no engine running) the entire plugin instance must
+    /// stay alive because the component must remain active for the view to work.
+    _standalone_plugin: Option<Box<Vst3Plugin>>,
     #[cfg(target_os = "macos")]
     _ns_window: macos::OwnedNsWindow,
 }
@@ -117,6 +118,7 @@ pub fn open_vst3_editor_window(
             _library: library,
             _controller: controller,
             _component_handler: component_handler,
+            _standalone_plugin: None,
             _ns_window: ns_window,
         });
     }
@@ -148,23 +150,68 @@ pub fn open_vst3_editor_window_standalone(
             if let Some(ctrl_cp) = plugin.controller().cast::<IConnectionPoint>() {
                 let _ = comp_cp.connect(ctrl_cp.as_ptr());
                 let _ = ctrl_cp.connect(comp_cp.as_ptr());
+                log::debug!("VST3 standalone editor: IConnectionPoint connected");
             }
         }
     }
 
-    // No param channel — engine not running, so no audio-thread communication.
     let library = plugin.library_arc();
     let controller = plugin.controller_clone();
-    // Keep the plugin alive via the library Arc and controller clone.
-    // The Vst3Plugin itself is not needed beyond this point.
-    drop(plugin);
 
-    let ctx = Vst3GuiContext {
-        param_channel: crate::param_channel::vst3_param_channel(),
-        controller,
-        library,
+    // No param channel — engine not running.
+    let component_handler = {
+        let wrapper = ComponentHandler::new(crate::param_channel::vst3_param_channel()).into_com_ptr();
+        unsafe {
+            use vst3::Steinberg::Vst::IComponentHandler;
+            if let Some(com_ref) = wrapper.as_com_ref::<IComponentHandler>() {
+                let _ = controller.setComponentHandler(com_ref.as_ptr());
+            }
+        }
+        Some(wrapper)
     };
-    open_vst3_editor_window(plugin_name, ctx)
+
+    let view_ptr = unsafe { controller.createView(ViewType::kEditor) };
+    if view_ptr.is_null() {
+        bail!("plugin '{}' returned null IPlugView (no GUI)", plugin_name);
+    }
+    let view: ComPtr<vst3::Steinberg::IPlugView> =
+        unsafe { ComPtr::from_raw_unchecked(view_ptr) };
+
+    #[cfg(target_os = "macos")]
+    {
+        use vst3::Steinberg::kPlatformTypeNSView;
+        let res = unsafe { view.isPlatformTypeSupported(kPlatformTypeNSView) };
+        if res != kResultOk {
+            bail!("plugin '{}' does not support NSView GUI (result={})", plugin_name, res);
+        }
+
+        let mut rect = ViewRect { left: 0, top: 0, right: 800, bottom: 600 };
+        unsafe { view.getSize(&mut rect) };
+        let width = (rect.right - rect.left).max(200) as f64;
+        let height = (rect.bottom - rect.top).max(100) as f64;
+
+        let ns_window = macos::create_editor_window(plugin_name, width, height)?;
+        let ns_view = ns_window.content_view();
+
+        let res = unsafe { view.attached(ns_view, kPlatformTypeNSView) };
+        if res != kResultOk {
+            bail!("IPlugView::attached failed (result={})", res);
+        }
+
+        ns_window.show(plugin_name);
+
+        return Ok(Vst3EditorHandle {
+            view,
+            _library: library,
+            _controller: controller,
+            _component_handler: component_handler,
+            _standalone_plugin: Some(Box::new(plugin)),
+            _ns_window: ns_window,
+        });
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    bail!("VST3 editor window not yet supported on this platform")
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/vst3/src/editor.rs
+++ b/crates/vst3/src/editor.rs
@@ -7,12 +7,14 @@
 //! Must be called on the main/UI thread (macOS AppKit requirement).
 
 use anyhow::{bail, Result};
+use std::path::Path;
 use std::sync::Arc;
 use vst3::Steinberg::Vst::{IEditControllerTrait, ViewType};
 use vst3::Steinberg::{IPlugViewTrait, ViewRect, kResultOk};
 use vst3::ComPtr;
 
 use crate::component_handler::ComponentHandler;
+use crate::host::Vst3Plugin;
 use crate::param_registry::Vst3GuiContext;
 
 impl block_core::PluginEditorHandle for Vst3EditorHandle {}
@@ -121,6 +123,48 @@ pub fn open_vst3_editor_window(
 
     #[cfg(not(target_os = "macos"))]
     bail!("VST3 editor window not yet supported on this platform")
+}
+
+/// Open the editor by loading a **fresh** plugin instance.
+///
+/// Used as a fallback when no `Vst3GuiContext` exists in the registry (i.e.
+/// the audio engine has not yet built the chain). Plugins that reject multiple
+/// simultaneous instances will fail here if an audio instance is already
+/// running, but single-instance plugins (Cloud Seed, Cocoa Delay, …) work
+/// fine before the engine starts.
+pub fn open_vst3_editor_window_standalone(
+    bundle_path: &Path,
+    uid: &[u8; 16],
+    plugin_name: &str,
+    sample_rate: f64,
+) -> Result<Vst3EditorHandle> {
+    let plugin = Vst3Plugin::load(bundle_path, uid, sample_rate, 2, 512, &[])?;
+
+    // Connect component ↔ controller so createView works (many plugins require it).
+    unsafe {
+        use vst3::Steinberg::Vst::IConnectionPoint;
+        use vst3::Steinberg::Vst::IConnectionPointTrait;
+        if let Some(comp_cp) = plugin.component().cast::<IConnectionPoint>() {
+            if let Some(ctrl_cp) = plugin.controller().cast::<IConnectionPoint>() {
+                let _ = comp_cp.connect(ctrl_cp.as_ptr());
+                let _ = ctrl_cp.connect(comp_cp.as_ptr());
+            }
+        }
+    }
+
+    // No param channel — engine not running, so no audio-thread communication.
+    let library = plugin.library_arc();
+    let controller = plugin.controller_clone();
+    // Keep the plugin alive via the library Arc and controller clone.
+    // The Vst3Plugin itself is not needed beyond this point.
+    drop(plugin);
+
+    let ctx = Vst3GuiContext {
+        param_channel: crate::param_channel::vst3_param_channel(),
+        controller,
+        library,
+    };
+    open_vst3_editor_window(plugin_name, ctx)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/vst3/src/host.rs
+++ b/crates/vst3/src/host.rs
@@ -425,7 +425,23 @@ impl Vst3Plugin {
                 (ctrl, true)
             };
 
-        // 14. Apply initial parameters.
+        // 14. Connect component ↔ controller via IConnectionPoint.
+        // Required by the VST3 spec so the controller can query component
+        // state before createView is called. Many plugins return null from
+        // createView if this step is skipped.
+        unsafe {
+            use vst3::Steinberg::Vst::IConnectionPoint;
+            use vst3::Steinberg::Vst::IConnectionPointTrait;
+            if let Some(comp_cp) = component.cast::<IConnectionPoint>() {
+                if let Some(ctrl_cp) = controller.cast::<IConnectionPoint>() {
+                    let _ = comp_cp.connect(ctrl_cp.as_ptr());
+                    let _ = ctrl_cp.connect(comp_cp.as_ptr());
+                    log::debug!("VST3: IConnectionPoint connected");
+                }
+            }
+        }
+
+        // 15. Apply initial parameters.
         for &(id, normalized) in initial_params {
             let res = unsafe { controller.setParamNormalized(id, normalized) };
             if res != kResultOk {

--- a/crates/vst3/src/host.rs
+++ b/crates/vst3/src/host.rs
@@ -10,13 +10,16 @@ use std::ptr;
 use vst3::Steinberg::Vst::{
     AudioBusBuffers, AudioBusBuffers__type0, BusDirections_, BusInfo, IAudioProcessor,
     IAudioProcessorTrait, IComponent, IComponentTrait, IEditController, IEditControllerTrait,
-    MediaTypes_, ParameterInfo, ProcessData, ProcessSetup, SpeakerArr, SymbolicSampleSizes_,
+    IParameterChanges, MediaTypes_, ParameterInfo, ProcessData, ProcessSetup, SpeakerArr,
+    SymbolicSampleSizes_,
 };
 use vst3::Steinberg::{
     IPluginBaseTrait, IPluginFactory, IPluginFactoryTrait, PClassInfo, TBool, TUID,
     kResultOk,
 };
-use vst3::{ComPtr, Interface};
+use vst3::{ComPtr, ComWrapper, Interface};
+
+use crate::param_changes::HostParameterChanges;
 
 // ---------------------------------------------------------------------------
 // Public data types
@@ -460,6 +463,12 @@ impl Vst3Plugin {
     ///
     /// All slices must have length >= `n_samples`. The raw pointers in
     /// `ProcessData` are only valid for the duration of this call.
+    /// Process audio, optionally applying parameter changes to the DSP.
+    ///
+    /// `pending_params` — `(param_id, normalized_value)` pairs collected from
+    /// the GUI since the last block.  They are delivered via
+    /// `ProcessData::inputParameterChanges` so the plugin's DSP reads them
+    /// regardless of whether its controller and component share state.
     pub fn process_audio(
         &mut self,
         input_l: &mut [f32],
@@ -467,6 +476,7 @@ impl Vst3Plugin {
         output_l: &mut [f32],
         output_r: &mut [f32],
         n_samples: usize,
+        pending_params: &[(u32, f64)],
     ) {
         debug_assert!(input_l.len() >= n_samples);
         debug_assert!(input_r.len() >= n_samples);
@@ -476,12 +486,6 @@ impl Vst3Plugin {
         let n = n_samples.min(self.block_size) as i32;
 
         // Build planar channel pointer arrays.
-        // The VST3 spec requires *mut *mut f32 (array of pointers, one per channel).
-        //
-        // Safety: the channel buffers are valid for the duration of this call.
-        // We construct local arrays pointing into the provided slices and pass
-        // their addresses to the plugin. No aliasing occurs because input and
-        // output use separate arrays.
         let mut input_channels: [*mut f32; 2] =
             [input_l.as_mut_ptr(), input_r.as_mut_ptr()];
         let mut output_channels: [*mut f32; 2] =
@@ -494,9 +498,6 @@ impl Vst3Plugin {
             numChannels: num_in as i32,
             silenceFlags: 0,
             __field0: AudioBusBuffers__type0 {
-                // Safety: channelBuffers32 points to a stack-allocated array of
-                // valid f32 pointers. The plugin must not store these beyond the
-                // process() call per the VST3 spec.
                 channelBuffers32: input_channels.as_mut_ptr(),
             },
         };
@@ -508,6 +509,27 @@ impl Vst3Plugin {
             },
         };
 
+        // Build IParameterChanges COM object for any pending GUI-driven changes.
+        // Keeping this alive until after process() ensures the plugin can
+        // safely dereference the pointer during the call.
+        let param_changes_wrapper: Option<ComWrapper<HostParameterChanges>> =
+            if !pending_params.is_empty() {
+                Some(ComWrapper::new(HostParameterChanges::new(pending_params)))
+            } else {
+                None
+            };
+
+        let input_param_changes_ptr: *mut IParameterChanges = param_changes_wrapper
+            .as_ref()
+            .and_then(|w| w.as_com_ref::<IParameterChanges>())
+            .map(|r| r.as_ptr())
+            .unwrap_or(ptr::null_mut());
+
+        // Also sync the controller display state (for plugins that query it).
+        for &(id, normalized) in pending_params {
+            let _ = unsafe { self.controller.setParamNormalized(id, normalized) };
+        }
+
         let mut process_data = ProcessData {
             processMode: 0i32, // kRealtime
             symbolicSampleSize: SymbolicSampleSizes_::kSample32 as i32,
@@ -516,7 +538,7 @@ impl Vst3Plugin {
             numOutputs: 1,
             inputs: &mut input_bus,
             outputs: &mut output_bus,
-            inputParameterChanges: ptr::null_mut(),
+            inputParameterChanges: input_param_changes_ptr,
             outputParameterChanges: ptr::null_mut(),
             inputEvents: ptr::null_mut(),
             outputEvents: ptr::null_mut(),

--- a/crates/vst3/src/host.rs
+++ b/crates/vst3/src/host.rs
@@ -6,6 +6,7 @@ use anyhow::{bail, Context, Result};
 use std::ffi::{c_char, c_void, CStr};
 use std::path::Path;
 use std::ptr;
+use std::sync::Arc;
 
 use vst3::Steinberg::Vst::{
     AudioBusBuffers, AudioBusBuffers__type0, BusDirections_, BusInfo, IAudioProcessor,
@@ -168,7 +169,7 @@ pub fn bundle_binary_path(bundle_path: &Path) -> Result<std::path::PathBuf> {
 /// ensure the plugin is used only on the audio thread.
 pub struct Vst3Plugin {
     /// Keep the library alive for the lifetime of the plugin.
-    _library: libloading::Library,
+    _library: Arc<libloading::Library>,
 
     /// `IComponent` interface — controls bus routing, activation, state.
     component: ComPtr<IComponent>,
@@ -225,14 +226,14 @@ impl Vst3Plugin {
         // 2. dlopen the binary.
         // Safety: libloading loads a shared library. The returned library is
         // kept alive for the entire lifetime of `Vst3Plugin`.
-        let library = unsafe { libloading::Library::new(&binary_path) }
-            .with_context(|| format!("failed to dlopen VST3 binary: {}", binary_path.display()))?;
+        let library = Arc::new(unsafe { libloading::Library::new(&binary_path) }
+            .with_context(|| format!("failed to dlopen VST3 binary: {}", binary_path.display()))?);
 
         // 3. Get the GetPluginFactory symbol.
         // Safety: the symbol must exist and have the correct signature. This is
         // mandated by the VST3 spec for all conforming plugins.
         let get_factory: libloading::Symbol<unsafe extern "C" fn() -> *mut IPluginFactory> =
-            unsafe { library.get(b"GetPluginFactory\0") }
+            unsafe { library.as_ref().get(b"GetPluginFactory\0") }
                 .context("symbol 'GetPluginFactory' not found — not a VST3 plugin")?;
 
         let factory_raw = unsafe { get_factory() };
@@ -525,11 +526,6 @@ impl Vst3Plugin {
             .map(|r| r.as_ptr())
             .unwrap_or(ptr::null_mut());
 
-        // Also sync the controller display state (for plugins that query it).
-        for &(id, normalized) in pending_params {
-            let _ = unsafe { self.controller.setParamNormalized(id, normalized) };
-        }
-
         let mut process_data = ProcessData {
             processMode: 0i32, // kRealtime
             symbolicSampleSize: SymbolicSampleSizes_::kSample32 as i32,
@@ -597,6 +593,19 @@ impl Vst3Plugin {
     /// Access the `IComponent` interface (needed for GUI host setup: IConnectionPoint).
     pub fn component(&self) -> &ComPtr<IComponent> {
         &self.component
+    }
+
+    /// Clone the `Arc` wrapping the shared library so the GUI can keep the
+    /// dylib alive independently of the audio-thread plugin instance.
+    pub fn library_arc(&self) -> Arc<libloading::Library> {
+        self._library.clone()
+    }
+
+    /// Clone the `IEditController` COM pointer (reference-counted) so the GUI
+    /// can reuse the controller from the audio processor without creating a
+    /// second plugin instance.
+    pub fn controller_clone(&self) -> ComPtr<vst3::Steinberg::Vst::IEditController> {
+        self.controller.clone()
     }
 
     /// Enumerate all plugin classes in a bundle without fully initialising them.

--- a/crates/vst3/src/lib.rs
+++ b/crates/vst3/src/lib.rs
@@ -14,6 +14,7 @@
 mod host;
 mod processor;
 mod stereo;
+mod param_changes;
 pub mod param_channel;
 pub mod param_registry;
 pub mod component_handler;

--- a/crates/vst3/src/lib.rs
+++ b/crates/vst3/src/lib.rs
@@ -23,7 +23,7 @@ pub mod catalog;
 pub mod editor;
 
 pub use host::{Vst3Plugin, Vst3ParamInfo, Vst3PluginClass};
-pub use editor::{Vst3EditorHandle, open_vst3_editor_window};
+pub use editor::{Vst3EditorHandle, open_vst3_editor_window, open_vst3_editor_window_standalone};
 pub use processor::Vst3Processor;
 pub use stereo::StereoVst3Processor;
 pub use discovery::{Vst3PluginInfo, scan_vst3_bundle, scan_vst3_bundle_light, scan_system_vst3, system_vst3_paths, resolve_vst3_bundle};

--- a/crates/vst3/src/lib.rs
+++ b/crates/vst3/src/lib.rs
@@ -32,7 +32,7 @@ pub use catalog::{
     vst3_model_ids, vst3_model_visual, make_model_id, resolve_uid_for_model,
 };
 pub use param_channel::{Vst3ParamChannel, Vst3ParamUpdate, vst3_param_channel};
-pub use param_registry::{register_vst3_channel, lookup_vst3_channel};
+pub use param_registry::{Vst3GuiContext, register_vst3_gui_context, lookup_vst3_gui_context, lookup_vst3_channel};
 
 use anyhow::Result;
 use std::path::Path;
@@ -84,7 +84,7 @@ pub fn build_vst3_processor(
 /// knob movements in the native plugin GUI are applied to the audio processor.
 ///
 /// - `param_channel`: the `Vst3ParamChannel` previously registered via
-///   `register_vst3_channel`.  The GUI editor will push updates onto the same
+///   `register_vst3_gui_context`.  The GUI editor will push updates onto the same
 ///   `Arc`; the processor drains them before each processing block.
 pub fn build_vst3_processor_with_channel(
     bundle_path: &Path,
@@ -118,6 +118,27 @@ pub fn build_vst3_processor_with_channel(
                 params,
             )?;
             Ok(BlockProcessor::Stereo(Box::new(StereoVst3Processor::new(plugin, Some(param_channel)))))
+        }
+    }
+}
+
+/// Build a VST3 `BlockProcessor` from an already-loaded `Vst3Plugin` and a
+/// param channel.
+///
+/// Used by the engine when it needs to register the GUI context (controller +
+/// library) before constructing the processor, so the GUI can later reuse the
+/// controller without creating a second plugin instance.
+pub fn build_vst3_processor_from_plugin(
+    plugin: Vst3Plugin,
+    layout: AudioChannelLayout,
+    param_channel: Vst3ParamChannel,
+) -> BlockProcessor {
+    match layout {
+        AudioChannelLayout::Mono => {
+            BlockProcessor::Mono(Box::new(Vst3Processor::new(plugin, Some(param_channel))))
+        }
+        AudioChannelLayout::Stereo => {
+            BlockProcessor::Stereo(Box::new(StereoVst3Processor::new(plugin, Some(param_channel))))
         }
     }
 }

--- a/crates/vst3/src/param_changes.rs
+++ b/crates/vst3/src/param_changes.rs
@@ -1,0 +1,140 @@
+//! Host-side IParameterChanges / IParamValueQueue COM objects.
+//!
+//! The VST3 spec requires the host to pass parameter changes to the audio
+//! processor via `ProcessData::inputParameterChanges`.  Simply calling
+//! `IEditController::setParamNormalized` only updates the controller's display
+//! state; it does NOT reach the audio DSP for plugins with a separate
+//! component object.
+//!
+//! This module provides minimal read-only implementations that the plugin can
+//! call during `IAudioProcessor::process()`.
+
+use std::cell::Cell;
+use std::ptr;
+
+use vst3::{
+    Class, ComWrapper,
+    Steinberg::Vst::{
+        IParamValueQueue, IParamValueQueueTrait,
+        IParameterChanges, IParameterChangesTrait,
+        ParamID, ParamValue,
+    },
+    Steinberg::{kResultOk, kInvalidArgument},
+};
+
+// ---------------------------------------------------------------------------
+// IParamValueQueue — one queue per parameter
+// ---------------------------------------------------------------------------
+
+/// Single-point parameter queue: holds one (sample_offset=0, value) pair.
+pub struct HostParamValueQueue {
+    id: u32,
+    value: Cell<f64>,
+}
+
+impl HostParamValueQueue {
+    pub fn new(id: u32, value: f64) -> Self {
+        Self { id, value: Cell::new(value) }
+    }
+}
+
+// SAFETY: HostParamValueQueue is only used from the audio thread (single
+// consumer), but ComWrapper requires Send+Sync for the impl. We assert this
+// manually because Cell<f64> is !Send by default.
+unsafe impl Send for HostParamValueQueue {}
+unsafe impl Sync for HostParamValueQueue {}
+
+impl Class for HostParamValueQueue {
+    type Interfaces = (IParamValueQueue,);
+}
+
+impl IParamValueQueueTrait for HostParamValueQueue {
+    unsafe fn getParameterId(&self) -> ParamID {
+        self.id
+    }
+
+    unsafe fn getPointCount(&self) -> i32 {
+        1
+    }
+
+    #[allow(non_snake_case)]
+    unsafe fn getPoint(
+        &self,
+        index: i32,
+        sampleOffset: *mut i32,
+        value: *mut ParamValue,
+    ) -> i32 {
+        if index != 0 {
+            return kInvalidArgument;
+        }
+        *sampleOffset = 0;
+        *value = self.value.get();
+        kResultOk
+    }
+
+    #[allow(non_snake_case)]
+    unsafe fn addPoint(
+        &self,
+        _sampleOffset: i32,
+        value: ParamValue,
+        _index: *mut i32,
+    ) -> i32 {
+        // Allow the plugin to write back its current value (some plugins do this).
+        self.value.set(value);
+        kResultOk
+    }
+}
+
+// ---------------------------------------------------------------------------
+// IParameterChanges — one collection per process() call
+// ---------------------------------------------------------------------------
+
+/// Collection of per-parameter queues passed as `inputParameterChanges`.
+pub struct HostParameterChanges {
+    queues: Vec<ComWrapper<HostParamValueQueue>>,
+}
+
+impl HostParameterChanges {
+    /// Build from a slice of `(param_id, normalized_value)` pairs.
+    pub fn new(params: &[(u32, f64)]) -> Self {
+        Self {
+            queues: params
+                .iter()
+                .map(|&(id, v)| ComWrapper::new(HostParamValueQueue::new(id, v)))
+                .collect(),
+        }
+    }
+
+}
+
+unsafe impl Send for HostParameterChanges {}
+unsafe impl Sync for HostParameterChanges {}
+
+impl Class for HostParameterChanges {
+    type Interfaces = (IParameterChanges,);
+}
+
+impl IParameterChangesTrait for HostParameterChanges {
+    unsafe fn getParameterCount(&self) -> i32 {
+        self.queues.len() as i32
+    }
+
+    #[allow(non_snake_case)]
+    unsafe fn getParameterData(&self, index: i32) -> *mut IParamValueQueue {
+        self.queues
+            .get(index as usize)
+            .and_then(|q| q.as_com_ref::<IParamValueQueue>())
+            .map(|r| r.as_ptr())
+            .unwrap_or(ptr::null_mut())
+    }
+
+    #[allow(non_snake_case)]
+    unsafe fn addParameterData(
+        &self,
+        _id: *const ParamID,
+        _index: *mut i32,
+    ) -> *mut IParamValueQueue {
+        // Host-provided; plugin should not add data to our input changes.
+        ptr::null_mut()
+    }
+}

--- a/crates/vst3/src/param_registry.rs
+++ b/crates/vst3/src/param_registry.rs
@@ -57,7 +57,7 @@ pub fn register_vst3_gui_context(
             controller,
             library,
         });
-    log::info!("VST3 registry: registered context for '{}'", model_id);
+    log::debug!("VST3 registry: registered context for '{}'", model_id);
     channel
 }
 
@@ -67,18 +67,12 @@ pub fn register_vst3_gui_context(
 /// The returned context clones the COM pointer and `Arc` (cheap ref-count bumps).
 pub fn lookup_vst3_gui_context(model_id: &str) -> Option<Vst3GuiContext> {
     let guard = registry().read().expect("vst3 param registry poisoned");
-    let keys: Vec<&str> = guard.keys().map(|s| s.as_str()).collect();
-    if let Some(ctx) = guard.get(model_id) {
-        log::info!("VST3 registry: found context for '{}'", model_id);
-        Some(Vst3GuiContext {
-            param_channel: ctx.param_channel.clone(),
-            controller: ctx.controller.clone(),
-            library: ctx.library.clone(),
-        })
-    } else {
-        log::info!("VST3 registry: no context for '{}' (registered: {:?})", model_id, keys);
-        None
-    }
+    let ctx = guard.get(model_id)?;
+    Some(Vst3GuiContext {
+        param_channel: ctx.param_channel.clone(),
+        controller: ctx.controller.clone(),
+        library: ctx.library.clone(),
+    })
 }
 
 /// Backward-compatible alias: look up only the param channel.

--- a/crates/vst3/src/param_registry.rs
+++ b/crates/vst3/src/param_registry.rs
@@ -1,41 +1,82 @@
-//! Global registry that maps VST3 `model_id` → `Vst3ParamChannel`.
+//! Global registry that maps VST3 `model_id` → `Vst3GuiContext`.
 //!
-//! The engine registers a channel when it builds a `Vst3Processor`.  When the
-//! GUI opens the native editor it looks up the same channel so both ends share
-//! the same `Arc<SegQueue>`.  This avoids any direct coupling between the
-//! engine and the GUI layer.
+//! The engine registers a context (param channel + shared controller + library
+//! Arc) when it builds a `Vst3Processor`. When the GUI opens the native editor
+//! it looks up the same context so the editor reuses the existing controller
+//! instead of creating a second plugin instance (which fails for plugins like
+//! ValhallaSupermassive that reject multiple instances).
 
 use std::collections::HashMap;
-use std::sync::{OnceLock, RwLock};
+use std::sync::{Arc, OnceLock, RwLock};
+use vst3::Steinberg::Vst::IEditController;
+use vst3::ComPtr;
 
 use crate::param_channel::{vst3_param_channel, Vst3ParamChannel};
 
-static REGISTRY: OnceLock<RwLock<HashMap<String, Vst3ParamChannel>>> = OnceLock::new();
+/// Everything the GUI needs to open and drive the native editor window without
+/// creating a second plugin instance.
+pub struct Vst3GuiContext {
+    /// Lock-free queue shared between the GUI and the audio processor.
+    pub param_channel: Vst3ParamChannel,
+    /// Reference-counted pointer to the controller already held by the audio
+    /// processor. The GUI uses it to call `createView` and register
+    /// `IComponentHandler`.
+    pub controller: ComPtr<IEditController>,
+    /// Keeps the plugin dylib alive while the editor window is open, even if
+    /// the audio processor is dropped first.
+    pub library: Arc<libloading::Library>,
+}
 
-fn registry() -> &'static RwLock<HashMap<String, Vst3ParamChannel>> {
+// SAFETY: `ComPtr<IEditController>` is a reference-counted COM pointer. The
+// controller is only ever used on the main/UI thread from the editor side.
+// `Arc<libloading::Library>` is inherently Send+Sync.
+unsafe impl Send for Vst3GuiContext {}
+unsafe impl Sync for Vst3GuiContext {}
+
+static REGISTRY: OnceLock<RwLock<HashMap<String, Vst3GuiContext>>> = OnceLock::new();
+
+fn registry() -> &'static RwLock<HashMap<String, Vst3GuiContext>> {
     REGISTRY.get_or_init(|| RwLock::new(HashMap::new()))
 }
 
-/// Register a new channel for `model_id`, replacing any previous entry.
+/// Register a GUI context for `model_id`, replacing any previous entry.
 ///
-/// Returns the newly created channel so the caller can attach it to its
-/// processor instance.
-pub fn register_vst3_channel(model_id: &str) -> Vst3ParamChannel {
+/// Called by the engine after loading the plugin. Returns the newly created
+/// `Vst3ParamChannel` so the caller can attach it to its processor instance.
+pub fn register_vst3_gui_context(
+    model_id: &str,
+    controller: ComPtr<IEditController>,
+    library: Arc<libloading::Library>,
+) -> Vst3ParamChannel {
     let channel = vst3_param_channel();
     registry()
         .write()
         .expect("vst3 param registry poisoned")
-        .insert(model_id.to_string(), channel.clone());
+        .insert(model_id.to_string(), Vst3GuiContext {
+            param_channel: channel.clone(),
+            controller,
+            library,
+        });
     channel
 }
 
-/// Look up the channel previously registered for `model_id`.
+/// Look up the `Vst3GuiContext` previously registered for `model_id`.
 ///
 /// Returns `None` if no processor for this model has been built yet.
+/// The returned context clones the COM pointer and `Arc` (cheap ref-count bumps).
+pub fn lookup_vst3_gui_context(model_id: &str) -> Option<Vst3GuiContext> {
+    let guard = registry().read().expect("vst3 param registry poisoned");
+    let ctx = guard.get(model_id)?;
+    Some(Vst3GuiContext {
+        param_channel: ctx.param_channel.clone(),
+        controller: ctx.controller.clone(),
+        library: ctx.library.clone(),
+    })
+}
+
+/// Backward-compatible alias: look up only the param channel.
+///
+/// Used by `Vst3Processor` to drain the parameter queue each audio block.
 pub fn lookup_vst3_channel(model_id: &str) -> Option<Vst3ParamChannel> {
-    registry()
-        .read()
-        .expect("vst3 param registry poisoned")
-        .get(model_id)
-        .cloned()
+    lookup_vst3_gui_context(model_id).map(|c| c.param_channel)
 }

--- a/crates/vst3/src/param_registry.rs
+++ b/crates/vst3/src/param_registry.rs
@@ -57,6 +57,7 @@ pub fn register_vst3_gui_context(
             controller,
             library,
         });
+    log::info!("VST3 registry: registered context for '{}'", model_id);
     channel
 }
 
@@ -66,12 +67,18 @@ pub fn register_vst3_gui_context(
 /// The returned context clones the COM pointer and `Arc` (cheap ref-count bumps).
 pub fn lookup_vst3_gui_context(model_id: &str) -> Option<Vst3GuiContext> {
     let guard = registry().read().expect("vst3 param registry poisoned");
-    let ctx = guard.get(model_id)?;
-    Some(Vst3GuiContext {
-        param_channel: ctx.param_channel.clone(),
-        controller: ctx.controller.clone(),
-        library: ctx.library.clone(),
-    })
+    let keys: Vec<&str> = guard.keys().map(|s| s.as_str()).collect();
+    if let Some(ctx) = guard.get(model_id) {
+        log::info!("VST3 registry: found context for '{}'", model_id);
+        Some(Vst3GuiContext {
+            param_channel: ctx.param_channel.clone(),
+            controller: ctx.controller.clone(),
+            library: ctx.library.clone(),
+        })
+    } else {
+        log::info!("VST3 registry: no context for '{}' (registered: {:?})", model_id, keys);
+        None
+    }
 }
 
 /// Backward-compatible alias: look up only the param channel.

--- a/crates/vst3/src/processor.rs
+++ b/crates/vst3/src/processor.rs
@@ -46,19 +46,23 @@ impl Vst3Processor {
         self.plugin.set_param(id, normalized)
     }
 
-    /// Apply any pending parameter updates from the GUI before processing.
-    fn apply_pending_params(&self) {
+    /// Drain pending GUI parameter updates, returning them as a Vec.
+    fn drain_pending_params(&self) -> Vec<(u32, f64)> {
         if let Some(rx) = &self.param_rx {
+            let mut out = Vec::new();
             while let Some(update) = rx.pop() {
-                let _ = self.plugin.set_param(update.id, update.normalized);
+                out.push((update.id, update.normalized));
             }
+            out
+        } else {
+            Vec::new()
         }
     }
 }
 
 impl MonoProcessor for Vst3Processor {
     fn process_sample(&mut self, input: f32) -> f32 {
-        self.apply_pending_params();
+        let pending = self.drain_pending_params();
         self.buf_in_l[0] = input;
         self.buf_in_r[0] = input;
         self.plugin.process_audio(
@@ -67,12 +71,13 @@ impl MonoProcessor for Vst3Processor {
             &mut self.buf_out_l[..1],
             &mut self.buf_out_r[..1],
             1,
+            &pending,
         );
         self.buf_out_l[0]
     }
 
     fn process_block(&mut self, samples: &mut [f32]) {
-        self.apply_pending_params();
+        let pending = self.drain_pending_params();
         let mut offset = 0;
         while offset < samples.len() {
             let chunk = (samples.len() - offset).min(BLOCK_SIZE);
@@ -83,12 +88,17 @@ impl MonoProcessor for Vst3Processor {
                 self.buf_in_r[i] = v;
             }
 
+            // Pass pending params only on the first chunk; subsequent chunks
+            // get an empty slice (changes already applied by the plugin).
+            let params_for_chunk: &[(u32, f64)] = if offset == 0 { &pending } else { &[] };
+
             self.plugin.process_audio(
                 &mut self.buf_in_l[..chunk],
                 &mut self.buf_in_r[..chunk],
                 &mut self.buf_out_l[..chunk],
                 &mut self.buf_out_r[..chunk],
                 chunk,
+                params_for_chunk,
             );
 
             for i in 0..chunk {

--- a/crates/vst3/src/stereo.rs
+++ b/crates/vst3/src/stereo.rs
@@ -41,19 +41,23 @@ impl StereoVst3Processor {
         self.plugin.set_param(id, normalized)
     }
 
-    /// Apply any pending parameter updates from the GUI before processing.
-    fn apply_pending_params(&self) {
+    /// Drain pending GUI parameter updates, returning them as a Vec.
+    fn drain_pending_params(&self) -> Vec<(u32, f64)> {
         if let Some(rx) = &self.param_rx {
+            let mut out = Vec::new();
             while let Some(update) = rx.pop() {
-                let _ = self.plugin.set_param(update.id, update.normalized);
+                out.push((update.id, update.normalized));
             }
+            out
+        } else {
+            Vec::new()
         }
     }
 }
 
 impl StereoProcessor for StereoVst3Processor {
     fn process_frame(&mut self, input: [f32; 2]) -> [f32; 2] {
-        self.apply_pending_params();
+        let pending = self.drain_pending_params();
         self.buf_in_l[0] = input[0];
         self.buf_in_r[0] = input[1];
         self.plugin.process_audio(
@@ -62,12 +66,13 @@ impl StereoProcessor for StereoVst3Processor {
             &mut self.buf_out_l[..1],
             &mut self.buf_out_r[..1],
             1,
+            &pending,
         );
         [self.buf_out_l[0], self.buf_out_r[0]]
     }
 
     fn process_block(&mut self, frames: &mut [[f32; 2]]) {
-        self.apply_pending_params();
+        let pending = self.drain_pending_params();
         let mut offset = 0;
         while offset < frames.len() {
             let chunk = (frames.len() - offset).min(BLOCK_SIZE);
@@ -77,12 +82,15 @@ impl StereoProcessor for StereoVst3Processor {
                 self.buf_in_r[i] = frames[offset + i][1];
             }
 
+            let params_for_chunk: &[(u32, f64)] = if offset == 0 { &pending } else { &[] };
+
             self.plugin.process_audio(
                 &mut self.buf_in_l[..chunk],
                 &mut self.buf_in_r[..chunk],
                 &mut self.buf_out_l[..chunk],
                 &mut self.buf_out_r[..chunk],
                 chunk,
+                params_for_chunk,
             );
 
             for i in 0..chunk {


### PR DESCRIPTION
## Summary

- Implement `IComponentHandler` so knob movements in native plugin GUIs reach the audio processor via a lock-free `crossbeam_queue::SegQueue` param channel
- Pass parameter changes to DSP via `IParameterChanges`/`IParamValueQueue` in `ProcessData::inputParameterChanges` (correct VST3 mechanism, not `setParamNormalized` alone)
- Add global `Vst3GuiContext` registry (`param_channel + controller + library`) so the GUI reuses the engine's existing `IEditController` instead of creating a second plugin instance — fixes ValhallaSupermassive `createInstance failed result=-1`
- Connect `IConnectionPoint` (component ↔ controller) during `Vst3Plugin::load` so `createView` returns a valid view for all plugins
- Add standalone fallback: opens a fresh plugin instance when the audio engine hasn't built the chain yet (Cloud Seed, Cocoa Delay, etc.)
- Keep `_standalone_plugin` alive inside `Vst3EditorHandle` so `createView` works after setup

## Test plan

- [x] Open Cloud Seed GUI before engine starts (standalone path)
- [x] Open ValhallaSupermassive GUI after engine starts (shared controller path)
- [x] Open a second VST3 plugin GUI without crash
- [x] Move knob in native GUI and confirm audio is affected
- [x] `cargo build` produces zero warnings

Closes #178