### PR TITLE
fix(ci): rewrite git:// to https:// before recursive submodule checkout

### DIFF
--- a/.github/workflows/build-libs.yml
+++ b/.github/workflows/build-libs.yml
@@ -100,6 +100,9 @@ jobs:
       matrix:
         plugin: ${{ fromJson(needs.detect-changes.outputs.plugins) }}
     steps:
+      - name: Rewrite git:// URLs to https://
+        run: git config --global url."https://".insteadOf git://
+
       - uses: actions/checkout@v4
         with:
           submodules: recursive
@@ -141,6 +144,9 @@ jobs:
       matrix:
         plugin: ${{ fromJson(needs.detect-changes.outputs.plugins) }}
     steps:
+      - name: Rewrite git:// URLs to https://
+        run: git config --global url."https://".insteadOf git://
+
       - uses: actions/checkout@v4
         with:
           submodules: recursive
@@ -182,6 +188,9 @@ jobs:
       matrix:
         plugin: ${{ fromJson(needs.detect-changes.outputs.plugins) }}
     steps:
+      - name: Rewrite git:// URLs to https://
+        run: git config --global url."https://".insteadOf git://
+
       - uses: actions/checkout@v4
         with:
           submodules: recursive
@@ -222,6 +231,10 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
+      - name: Rewrite git:// URLs to https://
+        shell: bash
+        run: git config --global url."https://".insteadOf git://
+
       - uses: actions/checkout@v4
         with:
           submodules: recursive
@@ -279,6 +292,10 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
+      - name: Rewrite git:// URLs to https://
+        shell: bash
+        run: git config --global url."https://".insteadOf git://
+
       - uses: actions/checkout@v4
         with:
           submodules: recursive


### PR DESCRIPTION
## Problem

`build-libs.yml` was failing on all Linux and Windows runners with:

```
fatal: clone of 'git://github.com/DISTRHO/DPF' into submodule path 'deps/SHIRO-Plugins/dpf' failed
errno=Connection timed out
```

GitHub Actions runners block the `git://` protocol via firewall. The `SHIRO-Plugins` submodule has a nested `dpf` submodule using `git://` URLs.

## Fix

Added `git config --global url."https://".insteadOf git://` as the first step in all 5 jobs (`linux-x86_64`, `linux-aarch64`, `macos-universal`, `windows-x64`, `windows-arm64`) before `actions/checkout` runs the recursive submodule clone.

Closes #216