### PR TITLE
fix: panic recovery — catch errors instead of crashing the application

### DIFF
--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -605,6 +605,28 @@ pub fn run_desktop_app(
     let toast_timer = Rc::new(Timer::default());
     window.set_toast_message("".into());
     window.set_toast_level("info".into());
+
+    // Error polling timer — drains block errors from the audio engine and shows toasts
+    {
+        let weak_window = window.as_weak();
+        let toast_timer_for_errors = toast_timer.clone();
+        let project_runtime_for_errors = project_runtime.clone();
+        let error_poll_timer = Timer::default();
+        error_poll_timer.start(
+            slint::TimerMode::Repeated,
+            std::time::Duration::from_millis(200),
+            move || {
+                let Some(win) = weak_window.upgrade() else { return; };
+                let rt_borrow = project_runtime_for_errors.borrow();
+                let Some(rt) = rt_borrow.as_ref() else { return; };
+                let errors = rt.poll_errors();
+                if let Some(first) = errors.first() {
+                    set_status_error(&win, &toast_timer_for_errors, &format!("Plugin error: {}", first.message));
+                }
+            },
+        );
+        std::mem::forget(error_poll_timer);
+    }
     window.set_block_type_options(ModelRc::from(block_type_options.clone()));
     window.set_block_model_options(ModelRc::from(block_model_options.clone()));
     window.set_block_model_option_labels(ModelRc::from(block_model_option_labels.clone()));

--- a/crates/engine/src/runtime.rs
+++ b/crates/engine/src/runtime.rs
@@ -28,6 +28,7 @@ use block_reverb::build_reverb_processor_for_layout;
 use block_util::build_utility_processor_for_layout;
 use block_core::StreamHandle;
 use block_wah::build_wah_processor_for_layout;
+use std::any::Any;
 use std::collections::{HashMap, VecDeque};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -190,11 +191,20 @@ impl AudioProcessor {
     }
 }
 
+/// An error produced by a block processor during audio processing.
+#[derive(Debug, Clone)]
+pub struct BlockError {
+    pub block_id: BlockId,
+    pub message: String,
+}
+
 pub struct ChainRuntimeState {
     processing: Mutex<ChainProcessingState>,
     output: Mutex<ChainOutputState>,
     /// Stream handles published by block processors, polled by UI thread.
     stream_handles: Mutex<HashMap<BlockId, StreamHandle>>,
+    /// Errors posted by the audio thread, drained by the UI thread.
+    error_queue: Mutex<Vec<BlockError>>,
     #[allow(dead_code)]
     last_input_nanos: AtomicU64,
     measured_latency_nanos: AtomicU64,
@@ -212,6 +222,14 @@ impl ChainRuntimeState {
         let handle = handles.get(block_id)?;
         let entries = handle.lock().ok()?;
         if entries.is_empty() { None } else { Some(entries.clone()) }
+    }
+
+    /// Drains and returns all block errors posted since the last call.
+    pub fn poll_errors(&self) -> Vec<BlockError> {
+        match self.error_queue.lock() {
+            Ok(mut q) => std::mem::take(&mut *q),
+            Err(_) => vec![],
+        }
     }
 }
 
@@ -278,6 +296,9 @@ struct BlockRuntimeNode {
     processor: RuntimeProcessor,
     stream_handle: Option<StreamHandle>,
     fade_state: FadeState,
+    /// Set to true if this block panicked during audio processing.
+    /// Once faulted, the block is permanently bypassed to prevent repeated crashes.
+    faulted: bool,
 }
 
 struct SelectRuntimeState {
@@ -399,6 +420,7 @@ pub fn build_chain_runtime_state(chain: &Chain, sample_rate: f32) -> Result<Chai
         }),
         output: Mutex::new(ChainOutputState { output_routes }),
         stream_handles: Mutex::new(stream_handles_map),
+        error_queue: Mutex::new(Vec::new()),
         last_input_nanos: AtomicU64::new(0),
         measured_latency_nanos: AtomicU64::new(0),
     })
@@ -1310,6 +1332,7 @@ fn build_select_runtime_node(
         } else {
             FadeState::Active
         },
+        faulted: false,
     })
 }
 
@@ -1327,6 +1350,7 @@ fn bypass_runtime_node(
         processor: RuntimeProcessor::Bypass,
         stream_handle: None,
         fade_state: FadeState::Bypassed,
+        faulted: false,
     }
 }
 
@@ -1346,6 +1370,7 @@ fn audio_block_runtime_node(
         processor: RuntimeProcessor::Audio(outcome.processor),
         stream_handle: outcome.stream_handle,
         fade_state: FadeState::FadingIn { frames_remaining: FADE_IN_FRAMES },
+        faulted: false,
     }
 }
 
@@ -1564,7 +1589,7 @@ pub fn process_input_f32(
                 Ok(guard) => guard,
                 Err(_) => continue,
             };
-            process_single_segment(&mut processing, seg_idx, data, input_total_channels, num_frames)
+            process_single_segment(&mut processing, seg_idx, data, input_total_channels, num_frames, &runtime.error_queue)
         };
         if let Some((processed, route_indices)) = result {
             for &route_idx in &route_indices {
@@ -1605,7 +1630,10 @@ pub fn process_input_f32(
     };
     for (route_idx, route_arc) in &route_arcs {
         if let Some(frames) = mixed_per_route.get(route_idx) {
-            let mut route = route_arc.lock().expect("route poisoned");
+            let mut route = match route_arc.lock() {
+                Ok(g) => g,
+                Err(e) => e.into_inner(),
+            };
             for &frame in frames {
                 route.buffer.push(frame);
             }
@@ -1619,6 +1647,7 @@ fn process_single_segment(
     data: &[f32],
     input_total_channels: usize,
     num_frames: usize,
+    error_queue: &Mutex<Vec<BlockError>>,
 ) -> Option<(Vec<AudioFrame>, Vec<usize>)> {
     let ChainProcessingState {
         input_states,
@@ -1662,7 +1691,7 @@ fn process_single_segment(
     }
 
     for block in blocks.iter_mut() {
-        process_audio_block(block, frame_buffer.as_mut_slice());
+        process_audio_block(block, frame_buffer.as_mut_slice(), error_queue);
     }
 
     if *fade_in_remaining > 0 {
@@ -1685,7 +1714,7 @@ fn process_single_segment(
     Some((processed, segment_routes))
 }
 
-fn process_audio_block(block: &mut BlockRuntimeNode, frames: &mut [AudioFrame]) {
+fn process_audio_block(block: &mut BlockRuntimeNode, frames: &mut [AudioFrame], error_queue: &Mutex<Vec<BlockError>>) {
     // Copy the fade state (it's Copy) so we can call apply_block_processor without
     // holding a borrow into block.fade_state at the same time.
     match block.fade_state {
@@ -1693,12 +1722,12 @@ fn process_audio_block(block: &mut BlockRuntimeNode, frames: &mut [AudioFrame]) 
             // Fully bypassed — no processing, no fade. Hard skip.
         }
         FadeState::Active => {
-            apply_block_processor(block, frames);
+            apply_block_processor(block, frames, error_queue);
         }
         FadeState::FadingIn { frames_remaining } => {
             // Crossfade: dry → wet (block fading in)
             let dry: Vec<AudioFrame> = frames.to_vec();
-            apply_block_processor(block, frames);
+            apply_block_processor(block, frames, error_queue);
             let fade_total = FADE_IN_FRAMES as f32;
             for (i, frame) in frames.iter_mut().enumerate() {
                 if frames_remaining <= i {
@@ -1722,7 +1751,7 @@ fn process_audio_block(block: &mut BlockRuntimeNode, frames: &mut [AudioFrame]) 
             // Crossfade: wet → dry (block fading out / being disabled)
             // We still process audio so we can fade out smoothly
             let dry: Vec<AudioFrame> = frames.to_vec();
-            apply_block_processor(block, frames);
+            apply_block_processor(block, frames, error_queue);
             let fade_total = FADE_IN_FRAMES as f32;
             for (i, frame) in frames.iter_mut().enumerate() {
                 if frames_remaining <= i {
@@ -1746,17 +1775,43 @@ fn process_audio_block(block: &mut BlockRuntimeNode, frames: &mut [AudioFrame]) 
     }
 }
 
-fn apply_block_processor(block: &mut BlockRuntimeNode, frames: &mut [AudioFrame]) {
+fn apply_block_processor(block: &mut BlockRuntimeNode, frames: &mut [AudioFrame], error_queue: &Mutex<Vec<BlockError>>) {
+    if block.faulted {
+        return;
+    }
     match &mut block.processor {
         RuntimeProcessor::Audio(processor) => {
-            processor.process_buffer(frames, &mut block.scratch);
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                processor.process_buffer(frames, &mut block.scratch);
+            }));
+            if let Err(payload) = result {
+                block.faulted = true;
+                for frame in frames.iter_mut() {
+                    *frame = AudioFrame::Stereo([0.0, 0.0]);
+                }
+                let msg = downcast_panic_message(payload);
+                log::error!("block '{}' panicked — permanently bypassed: {}", block.block_id.0, msg);
+                if let Ok(mut q) = error_queue.try_lock() {
+                    q.push(BlockError { block_id: block.block_id.clone(), message: msg });
+                }
+            }
         }
         RuntimeProcessor::Select(select) => {
             if let Some(selected) = select.selected_node_mut() {
-                process_audio_block(selected, frames);
+                process_audio_block(selected, frames, error_queue);
             }
         }
         RuntimeProcessor::Bypass => {}
+    }
+}
+
+fn downcast_panic_message(payload: Box<dyn Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<&str>() {
+        s.to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "unknown panic".to_string()
     }
 }
 
@@ -1785,7 +1840,10 @@ pub fn process_output_f32(
 ) {
     // Get the Arc for this specific route (brief lock on output state)
     let route_arc = {
-        let output_state = runtime.output.lock().expect("output state poisoned");
+        let output_state = match runtime.output.lock() {
+            Ok(g) => g,
+            Err(e) => e.into_inner(),
+        };
         match output_state.output_routes.get(output_index) {
             Some(r) => Arc::clone(r),
             None => {
@@ -1796,7 +1854,10 @@ pub fn process_output_f32(
     };
     // Lock this route — brief wait while input pushes is acceptable,
     // filling with silence on try_lock failure causes audible clicks.
-    let mut route = route_arc.lock().expect("route poisoned");
+    let mut route = match route_arc.lock() {
+        Ok(g) => g,
+        Err(e) => e.into_inner(),
+    };
     let num_frames = out.len() / output_total_channels;
     for frame in out.chunks_mut(output_total_channels).take(num_frames) {
         frame.fill(0.0);

--- a/crates/engine/src/runtime.rs
+++ b/crates/engine/src/runtime.rs
@@ -1992,9 +1992,11 @@ fn next_block_instance_serial() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::{
+        apply_block_processor, process_audio_block,
         build_chain_runtime_state, build_runtime_graph, process_input_f32, process_output_f32,
         update_chain_runtime_state, split_chain_into_segments, effective_inputs, effective_outputs,
-        AudioFrame, ElasticBuffer, ELASTIC_BUFFER_TARGET_LEVEL,
+        AudioFrame, AudioProcessor, BlockError, BlockRuntimeNode, FadeState, ProcessorScratch, RuntimeProcessor,
+        ElasticBuffer, ELASTIC_BUFFER_TARGET_LEVEL, FADE_IN_FRAMES,
     };
     use block_core::AudioChannelLayout;
     use block_preamp::supported_models as supported_preamp_models;
@@ -2655,5 +2657,185 @@ mod tests {
             "segment 1 should have blocks [1,2,3,5,6], got {:?}", segments[1].block_indices);
         assert_eq!(segments[1].output_route_indices, vec![1],
             "segment 1 should push to output 1 only");
+    }
+
+    // ── Panic recovery tests ──────────────────────────────────────────────────
+
+    struct PanickingProcessor;
+    impl block_core::MonoProcessor for PanickingProcessor {
+        fn process_sample(&mut self, _: f32) -> f32 {
+            panic!("simulated plugin crash");
+        }
+    }
+
+    struct CountingProcessor {
+        call_count: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    }
+    impl block_core::MonoProcessor for CountingProcessor {
+        fn process_sample(&mut self, input: f32) -> f32 {
+            self.call_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            input
+        }
+    }
+
+    fn panicking_block_node() -> BlockRuntimeNode {
+        BlockRuntimeNode {
+            instance_serial: 0,
+            block_id: domain::ids::BlockId("test:panicking".into()),
+            block_snapshot: project::block::AudioBlock {
+                id: domain::ids::BlockId("test:panicking".into()),
+                enabled: true,
+                kind: project::block::AudioBlockKind::Core(project::block::CoreBlock {
+                    effect_type: "gain".into(),
+                    model: "volume".into(),
+                    params: project::param::ParameterSet::default(),
+                }),
+            },
+            input_layout: block_core::AudioChannelLayout::Mono,
+            output_layout: block_core::AudioChannelLayout::Mono,
+            scratch: ProcessorScratch::Mono(Vec::new()),
+            processor: RuntimeProcessor::Audio(AudioProcessor::Mono(Box::new(PanickingProcessor))),
+            stream_handle: None,
+            fade_state: FadeState::Active,
+            faulted: false,
+        }
+    }
+
+    fn counting_block_node(counter: std::sync::Arc<std::sync::atomic::AtomicUsize>) -> BlockRuntimeNode {
+        BlockRuntimeNode {
+            instance_serial: 0,
+            block_id: domain::ids::BlockId("test:counting".into()),
+            block_snapshot: project::block::AudioBlock {
+                id: domain::ids::BlockId("test:counting".into()),
+                enabled: true,
+                kind: project::block::AudioBlockKind::Core(project::block::CoreBlock {
+                    effect_type: "gain".into(),
+                    model: "volume".into(),
+                    params: project::param::ParameterSet::default(),
+                }),
+            },
+            input_layout: block_core::AudioChannelLayout::Mono,
+            output_layout: block_core::AudioChannelLayout::Mono,
+            scratch: ProcessorScratch::Mono(Vec::new()),
+            processor: RuntimeProcessor::Audio(AudioProcessor::Mono(Box::new(CountingProcessor { call_count: counter }))),
+            stream_handle: None,
+            fade_state: FadeState::Active,
+            faulted: false,
+        }
+    }
+
+    #[test]
+    fn panicking_processor_does_not_crash_the_caller() {
+        let mut block = panicking_block_node();
+        let error_queue = std::sync::Mutex::new(Vec::<BlockError>::new());
+        let mut frames = vec![AudioFrame::Stereo([1.0, 1.0]); 16];
+
+        // Must not panic
+        apply_block_processor(&mut block, &mut frames, &error_queue);
+    }
+
+    #[test]
+    fn panicking_processor_marks_block_as_faulted() {
+        let mut block = panicking_block_node();
+        let error_queue = std::sync::Mutex::new(Vec::<BlockError>::new());
+        let mut frames = vec![AudioFrame::Stereo([1.0, 1.0]); 16];
+
+        apply_block_processor(&mut block, &mut frames, &error_queue);
+
+        assert!(block.faulted, "block should be marked faulted after a panic");
+    }
+
+    #[test]
+    fn panicking_processor_zeroes_output_frames() {
+        let mut block = panicking_block_node();
+        let error_queue = std::sync::Mutex::new(Vec::<BlockError>::new());
+        let mut frames = vec![AudioFrame::Stereo([1.0, 1.0]); 16];
+
+        apply_block_processor(&mut block, &mut frames, &error_queue);
+
+        for frame in &frames {
+            match frame {
+                AudioFrame::Stereo([l, r]) => {
+                    assert_eq!(*l, 0.0, "left channel should be silent after panic");
+                    assert_eq!(*r, 0.0, "right channel should be silent after panic");
+                }
+                AudioFrame::Mono(s) => assert_eq!(*s, 0.0, "mono channel should be silent after panic"),
+            }
+        }
+    }
+
+    #[test]
+    fn panicking_processor_posts_error_to_queue() {
+        let mut block = panicking_block_node();
+        let error_queue = std::sync::Mutex::new(Vec::<BlockError>::new());
+        let mut frames = vec![AudioFrame::Stereo([1.0, 1.0]); 16];
+
+        apply_block_processor(&mut block, &mut frames, &error_queue);
+
+        let errors = error_queue.lock().unwrap();
+        assert_eq!(errors.len(), 1, "exactly one error should be posted");
+        assert_eq!(errors[0].block_id.0, "test:panicking");
+        assert!(errors[0].message.contains("simulated plugin crash"), "error message should contain panic message");
+    }
+
+    #[test]
+    fn faulted_block_is_permanently_bypassed() {
+        let counter = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let mut block = counting_block_node(counter.clone());
+        block.faulted = true; // pre-fault the block
+
+        let error_queue = std::sync::Mutex::new(Vec::<BlockError>::new());
+        let mut frames = vec![AudioFrame::Stereo([1.0, 1.0]); 16];
+
+        apply_block_processor(&mut block, &mut frames, &error_queue);
+
+        assert_eq!(counter.load(std::sync::atomic::Ordering::SeqCst), 0,
+            "process_sample should never be called on a faulted block");
+    }
+
+    #[test]
+    fn second_call_after_panic_does_not_process_or_post_error() {
+        let mut block = panicking_block_node();
+        let error_queue = std::sync::Mutex::new(Vec::<BlockError>::new());
+        let mut frames = vec![AudioFrame::Stereo([1.0, 1.0]); 16];
+
+        // First call: panics, marks faulted, posts error
+        apply_block_processor(&mut block, &mut frames, &error_queue);
+        assert_eq!(error_queue.lock().unwrap().len(), 1);
+
+        // Second call: faulted — must not post another error
+        apply_block_processor(&mut block, &mut frames, &error_queue);
+        assert_eq!(error_queue.lock().unwrap().len(), 1,
+            "no additional error should be posted for an already-faulted block");
+    }
+
+    #[test]
+    fn process_audio_block_bypassed_state_skips_processing() {
+        let counter = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let mut block = counting_block_node(counter.clone());
+        block.fade_state = FadeState::Bypassed;
+
+        let error_queue = std::sync::Mutex::new(Vec::<BlockError>::new());
+        let mut frames = vec![AudioFrame::Stereo([1.0, 1.0]); 16];
+
+        process_audio_block(&mut block, &mut frames, &error_queue);
+
+        assert_eq!(counter.load(std::sync::atomic::Ordering::SeqCst), 0,
+            "bypassed block should not call process_sample");
+    }
+
+    #[test]
+    fn process_audio_block_fading_in_applies_processing() {
+        let counter = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let mut block = counting_block_node(counter.clone());
+        block.fade_state = FadeState::FadingIn { frames_remaining: FADE_IN_FRAMES };
+
+        let error_queue = std::sync::Mutex::new(Vec::<BlockError>::new());
+        let mut frames = vec![AudioFrame::Stereo([1.0, 1.0]); 16];
+
+        process_audio_block(&mut block, &mut frames, &error_queue);
+
+        assert!(counter.load(std::sync::atomic::Ordering::SeqCst) > 0,
+            "fading-in block should call process_sample");
     }
 }

--- a/crates/infra-cpal/src/lib.rs
+++ b/crates/infra-cpal/src/lib.rs
@@ -6,6 +6,7 @@ use cpal::{
 };
 use domain::ids::ChainId;
 use engine::runtime::{process_input_f32, process_output_f32, RuntimeGraph, ChainRuntimeState};
+use engine;
 use project::device::DeviceSettings;
 use project::project::Project;
 use project::block::{AudioBlockKind, InputEntry, InsertBlock, OutputEntry};
@@ -237,6 +238,13 @@ impl ProjectRuntimeController {
             }
         }
         None
+    }
+
+    /// Drains and returns all block errors that occurred since the last call.
+    pub fn poll_errors(&self) -> Vec<engine::runtime::BlockError> {
+        self.runtime_graph.chains.values()
+            .flat_map(|runtime| runtime.poll_errors())
+            .collect()
     }
 
     /// Returns the measured real-time latency in milliseconds for a given chain.
@@ -688,7 +696,9 @@ fn build_input_stream_for_input(
             device.build_input_stream(
                 &stream_config,
                 move |data: &[f32], _| {
-                    process_input_f32(&runtime_for_data, input_index, data, channels);
+                    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        process_input_f32(&runtime_for_data, input_index, data, channels);
+                    }));
                 },
                 move |err| log::error!("[{}] input stream error: {}", error_chain_id, err),
                 None,
@@ -706,7 +716,9 @@ fn build_input_stream_for_input(
                     for (dst, src) in converted.iter_mut().zip(data.iter().copied()) {
                         *dst = src as f32 / i16::MAX as f32;
                     }
-                    process_input_f32(&runtime_for_data, input_index, &converted, channels);
+                    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        process_input_f32(&runtime_for_data, input_index, &converted, channels);
+                    }));
                 },
                 move |err| log::error!("[{}] input stream error: {}", error_chain_id, err),
                 None,
@@ -724,7 +736,9 @@ fn build_input_stream_for_input(
                     for (dst, src) in converted.iter_mut().zip(data.iter().copied()) {
                         *dst = (src as f32 / u16::MAX as f32) * 2.0 - 1.0;
                     }
-                    process_input_f32(&runtime_for_data, input_index, &converted, channels);
+                    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        process_input_f32(&runtime_for_data, input_index, &converted, channels);
+                    }));
                 },
                 move |err| log::error!("[{}] input stream error: {}", error_chain_id, err),
                 None,
@@ -773,7 +787,9 @@ fn build_output_stream_for_output(
             device.build_output_stream(
                 &stream_config,
                 move |out: &mut [f32], _| {
-                    process_output_f32(&runtime_for_data, output_index, out, channels);
+                    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        process_output_f32(&runtime_for_data, output_index, out, channels);
+                    }));
                 },
                 move |err| log::error!("[{}] output stream error: {}", error_chain_id, err),
                 None,
@@ -788,7 +804,9 @@ fn build_output_stream_for_output(
                 &stream_config,
                 move |out: &mut [i16], _| {
                     temp.resize(out.len(), 0.0);
-                    process_output_f32(&runtime_for_data, output_index, &mut temp, channels);
+                    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        process_output_f32(&runtime_for_data, output_index, &mut temp, channels);
+                    }));
                     for (dst, src) in out.iter_mut().zip(temp.iter()) {
                         *dst =
                             (*src * i16::MAX as f32).clamp(i16::MIN as f32, i16::MAX as f32) as i16;
@@ -807,7 +825,9 @@ fn build_output_stream_for_output(
                 &stream_config,
                 move |out: &mut [u16], _| {
                     temp.resize(out.len(), 0.0);
-                    process_output_f32(&runtime_for_data, output_index, &mut temp, channels);
+                    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        process_output_f32(&runtime_for_data, output_index, &mut temp, channels);
+                    }));
                     for (dst, src) in out.iter_mut().zip(temp.iter()) {
                         let normalized =
                             ((*src + 1.0) * 0.5 * u16::MAX as f32).clamp(0.0, u16::MAX as f32);


### PR DESCRIPTION
## Summary

- Audio thread panics from block processors (LV2, NAM, native) are caught via `catch_unwind` — the real-time thread never dies
- A faulted block is permanently bypassed with silence output and an error is posted to a queue
- Mutex poisoning in output routing fixed — recovers instead of panicking with `.expect()`
- CPAL callbacks (all formats) wrapped in `catch_unwind` as final safety net
- UI polls errors every 200ms and shows a toast notification

## Test plan

- [x] 8 unit tests in `engine::runtime::tests` covering: no crash, block faulted, frames zeroed, error posted, no double-post, permanent bypass, fade states

Closes #137