### PR TITLE
feat(filter): native Guitar EQ block with low-cut and high-cut controls

### DIFF
--- a/assets/blocks/metadata/en-US.yaml
+++ b/assets/blocks/metadata/en-US.yaml
@@ -56,6 +56,10 @@ plugins:
     description: "Three-band EQ with low, mid, and high controls mapped to ±24 dB."
     license: "Proprietary - OpenRig"
     homepage: "https://github.com/jpfaria/OpenRig"
+  native_guitar_eq:
+    description: "Guitar EQ — cuts low-end rumble below 80Hz and high-frequency fizz above 8kHz. Two independent controls let you dial in how much of each cut to apply."
+    license: "Proprietary - OpenRig"
+    homepage: "https://github.com/jpfaria/OpenRig"
   ibanez_ts9:
     description: "Classic Ibanez Tube Screamer overdrive with drive, tone, and level controls."
     license: "Proprietary - OpenRig"

--- a/assets/blocks/metadata/pt-BR.yaml
+++ b/assets/blocks/metadata/pt-BR.yaml
@@ -56,6 +56,10 @@ plugins:
     description: "EQ de três bandas com controles de grave, médio e agudo (±24 dB)."
     license: "Proprietário - OpenRig"
     homepage: "https://github.com/jpfaria/OpenRig"
+  native_guitar_eq:
+    description: "Guitar EQ — corta o grave abaixo de 80Hz e o agudo acima de 8kHz. Dois controles independentes permitem ajustar a intensidade de cada corte."
+    license: "Proprietário - OpenRig"
+    homepage: "https://github.com/jpfaria/OpenRig"
   ibanez_ts9:
     description: "Tube Screamer clássico da Ibanez com controles de drive, tone e level."
     license: "Proprietário - OpenRig"

--- a/crates/block-filter/src/native_guitar_eq.rs
+++ b/crates/block-filter/src/native_guitar_eq.rs
@@ -1,0 +1,101 @@
+use anyhow::{Error, Result};
+use crate::registry::FilterModelDefinition;
+use crate::FilterBackendKind;
+use block_core::param::{
+    float_parameter, required_f32, ModelParameterSchema, ParameterSet, ParameterUnit,
+};
+use block_core::{AudioChannelLayout, BlockProcessor, BiquadFilter, BiquadKind, ModelAudioMode, MonoProcessor};
+
+pub const MODEL_ID: &str = "native_guitar_eq";
+pub const DISPLAY_NAME: &str = "Guitar EQ";
+
+pub fn model_schema() -> ModelParameterSchema {
+    ModelParameterSchema {
+        effect_type: "filter".to_string(),
+        model: MODEL_ID.to_string(),
+        display_name: DISPLAY_NAME.to_string(),
+        audio_mode: ModelAudioMode::DualMono,
+        parameters: vec![
+            float_parameter(
+                "low_cut",
+                "Low Cut",
+                None,
+                Some(100.0),
+                0.0,
+                100.0,
+                1.0,
+                ParameterUnit::Percent,
+            ),
+            float_parameter(
+                "high_cut",
+                "High Cut",
+                None,
+                Some(100.0),
+                0.0,
+                100.0,
+                1.0,
+                ParameterUnit::Percent,
+            ),
+        ],
+    }
+}
+
+pub struct GuitarEq {
+    low_shelf: BiquadFilter,
+    high_shelf: BiquadFilter,
+}
+
+impl GuitarEq {
+    pub fn new(low_cut_pct: f32, high_cut_pct: f32, sample_rate: f32) -> Self {
+        let low_gain_db = -(low_cut_pct / 100.0) * 12.0;
+        let high_gain_db = -(high_cut_pct / 100.0) * 12.0;
+        Self {
+            low_shelf: BiquadFilter::new(BiquadKind::LowShelf, 80.0, low_gain_db, 0.707, sample_rate),
+            high_shelf: BiquadFilter::new(BiquadKind::HighShelf, 8000.0, high_gain_db, 0.707, sample_rate),
+        }
+    }
+}
+
+impl MonoProcessor for GuitarEq {
+    fn process_sample(&mut self, input: f32) -> f32 {
+        let x = self.low_shelf.process(input);
+        self.high_shelf.process(x)
+    }
+}
+
+pub fn build_processor(params: &ParameterSet, sample_rate: f32) -> Result<Box<dyn MonoProcessor>> {
+    let low_cut = required_f32(params, "low_cut").map_err(Error::msg)?;
+    let high_cut = required_f32(params, "high_cut").map_err(Error::msg)?;
+    Ok(Box::new(GuitarEq::new(low_cut, high_cut, sample_rate)))
+}
+
+fn schema() -> Result<ModelParameterSchema> {
+    Ok(model_schema())
+}
+
+fn build(
+    params: &ParameterSet,
+    sample_rate: f32,
+    layout: AudioChannelLayout,
+) -> Result<BlockProcessor> {
+    match layout {
+        AudioChannelLayout::Mono => {
+            Ok(BlockProcessor::Mono(build_processor(params, sample_rate)?))
+        }
+        AudioChannelLayout::Stereo => anyhow::bail!(
+            "filter model '{}' is mono-only and cannot build native stereo processing",
+            MODEL_ID
+        ),
+    }
+}
+
+pub const MODEL_DEFINITION: FilterModelDefinition = FilterModelDefinition {
+    id: MODEL_ID,
+    display_name: DISPLAY_NAME,
+    brand: "",
+    backend_kind: FilterBackendKind::Native,
+    schema,
+    build,
+    supported_instruments: block_core::GUITAR_ACOUSTIC_BASS,
+    knob_layout: &[],
+};

--- a/docs/superpowers/specs/2026-04-07-guitar-eq-design.md
+++ b/docs/superpowers/specs/2026-04-07-guitar-eq-design.md
@@ -1,0 +1,132 @@
+# Guitar EQ Implementation Design
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a native Guitar EQ filter block that cuts problematic low and high frequencies for guitar, with two independent intensity controls.
+
+**Architecture:** Single new source file `native_guitar_eq.rs` in `crates/block-filter/src/`. The `build.rs` auto-registration pattern picks it up automatically — no registry edits needed. Uses existing `BiquadFilter` with `LowShelf` and `HighShelf` kinds from `block-core`.
+
+**Tech Stack:** Rust, `block-core::BiquadFilter`, `block-filter` crate pattern.
+
+---
+
+## Context
+
+Guitar signals have two well-known problematic frequency regions:
+- **Below ~80Hz** — low-end rumble, stage noise, handling noise, room resonance. Adds mud without musical content for guitar.
+- **Above ~8kHz** — pick attack fizz, hiss, harsh upper harmonics. Makes the signal sound brittle and noisy.
+
+Cutting these ranges makes guitar signals sit better in a mix and sound cleaner through an amp chain. The cutoff frequencies are fixed (industry-standard for guitar), but the intensity of each cut is independently adjustable so the player can tailor to their instrument and style.
+
+---
+
+## Parameters
+
+| ID | Label | Default | Range | Step | Unit |
+|----|-------|---------|-------|------|------|
+| `low_cut` | Low Cut | 100 | 0–100 | 1 | % |
+| `high_cut` | High Cut | 100 | 0–100 | 1 | % |
+
+- `low_cut = 0%` → low shelf gain = 0 dB (no effect below 80Hz)
+- `low_cut = 100%` → low shelf gain = −12 dB below 80Hz
+- `high_cut = 0%` → high shelf gain = 0 dB (no effect above 8kHz)
+- `high_cut = 100%` → high shelf gain = −12 dB above 8kHz
+
+**Formula:** `gain_db = -(value / 100.0) * 12.0`
+
+---
+
+## DSP Design
+
+Two `BiquadFilter` in series:
+
+```
+input → [LowShelf @ 80Hz, Q=0.707] → [HighShelf @ 8kHz, Q=0.707] → output
+```
+
+- **Low shelf at 80Hz, Q=0.707 (Butterworth)** — smooth rolloff below 80Hz, musical and natural sounding
+- **High shelf at 8kHz, Q=0.707 (Butterworth)** — smooth rolloff above 8kHz
+- Filters are rebuilt when parameters change (stateless construction pattern, same as `ThreeBandEq`)
+
+---
+
+## Model Definition
+
+| Field | Value |
+|-------|-------|
+| `id` | `native_guitar_eq` |
+| `display_name` | `Guitar EQ` |
+| `brand` | `""` (native) |
+| `backend_kind` | `FilterBackendKind::Native` |
+| `audio_mode` | `ModelAudioMode::DualMono` |
+| `supported_instruments` | `block_core::GUITAR_ACOUSTIC_BASS` |
+
+---
+
+## Files
+
+| Action | Path |
+|--------|------|
+| Create | `crates/block-filter/src/native_guitar_eq.rs` |
+| Modify | `assets/blocks/metadata/en-US.yaml` |
+| Modify | `assets/blocks/metadata/pt-BR.yaml` |
+
+`build.rs` auto-registers the model — no other files need to change.
+
+---
+
+## Metadata
+
+**en-US.yaml:**
+```yaml
+native_guitar_eq:
+  description: "Guitar EQ — cuts low-end rumble below 80Hz and high-frequency fizz above 8kHz. Two independent controls let you dial in how much of each cut to apply."
+  license: "Proprietary - OpenRig"
+  homepage: "https://github.com/jpfaria/OpenRig"
+```
+
+**pt-BR.yaml:**
+```yaml
+native_guitar_eq:
+  description: "Guitar EQ — corta o grave abaixo de 80Hz e o agudo acima de 8kHz. Dois controles independentes permitem ajustar a intensidade de cada corte."
+  license: "Proprietário - OpenRig"
+  homepage: "https://github.com/jpfaria/OpenRig"
+```
+
+---
+
+## Implementation Pattern
+
+Follow exactly the same structure as `native_eq_three_band_basic.rs`:
+
+```rust
+pub const MODEL_ID: &str = "native_guitar_eq";
+pub const DISPLAY_NAME: &str = "Guitar EQ";
+
+pub struct GuitarEq {
+    low_shelf: BiquadFilter,
+    high_shelf: BiquadFilter,
+}
+
+impl GuitarEq {
+    pub fn new(low_cut: f32, high_cut: f32, sample_rate: f32) -> Self {
+        let low_gain_db  = -(low_cut  / 100.0) * 12.0;
+        let high_gain_db = -(high_cut / 100.0) * 12.0;
+        Self {
+            low_shelf:  BiquadFilter::new(BiquadKind::LowShelf,  80.0,   low_gain_db,  0.707, sample_rate),
+            high_shelf: BiquadFilter::new(BiquadKind::HighShelf, 8000.0, high_gain_db, 0.707, sample_rate),
+        }
+    }
+}
+
+impl MonoProcessor for GuitarEq {
+    fn process_sample(&mut self, input: f32) -> f32 {
+        let x = self.low_shelf.process(input);
+        self.high_shelf.process(x)
+    }
+}
+```
+
+Parameters use `float_parameter` (not `curve_editor_parameter`) since there is no curve editor widget for a simple percentage knob.
+
+`supported_instruments`: `block_core::GUITAR_ACOUSTIC_BASS`


### PR DESCRIPTION
## Summary

- New native `Guitar EQ` filter block (`native_guitar_eq`)
- Low shelf at 80Hz cuts low-end rumble, stage noise and mud
- High shelf at 8kHz cuts high-frequency hiss, pick fizz and harsh harmonics
- Two independent parameters: `low_cut` and `high_cut` (0–100%), each scaling the shelf gain from 0 to −12 dB
- Q = 0.707 (Butterworth — smooth, musical rolloff)
- Zero changes to `block-core` — uses existing `BiquadFilter` with `LowShelf` + `HighShelf`
- `build.rs` auto-registration — no manual registry edits needed
- Metadata added to `en-US.yaml` and `pt-BR.yaml`

Closes #220