### PR TITLE
feat(filter): add native Guitar EQ block with low-cut and high-cut controls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,7 @@ OpenRig é um pedalboard virtual para músicos. O usuário monta sua cadeia de e
 | **Reverb** | Ambiência e simulação de espaço | 19 | Hall, Plate Foundation, Room, Spring (native); Dragonfly Hall/Room/Plate/Early, CAPS Plate/X2/Scape, TAP Reflector/Reverberator, MDA Ambience, MVerb, B Reverb, Roomy, Shiroverb, Floaty (LV2) |
 | **Modulation** | Chorus, flanger, tremolo, vibrato | 16 | Classic/Stereo/Ensemble Chorus, Sine Tremolo, Vibrato (native); TAP Chorus/Flanger/Tremolo/Rotary, MDA Leslie/RingMod/ThruZero, FOMP CS Chorus/Phaser, CAPS Phaser II, Harmless, Larynx (LV2) |
 | **Dynamics** | Compressor e gate | 9 | Studio Clean Compressor, Noise Gate, Brick Wall Limiter (native); TAP DeEsser/Dynamics/Limiter, ZamComp, ZamGate, ZaMultiComp (LV2) |
-| **Filter** | EQ e moldagem tonal | 11 | Three Band EQ (native); TAP Equalizer/BW, ZamEQ2, ZamGEQ31, CAPS AutoFilter, FOMP Auto-Wah, MOD HPF/LPF, Filta, Mud (LV2) |
+| **Filter** | EQ e moldagem tonal | 12 | Three Band EQ, Guitar EQ (native); TAP Equalizer/BW, ZamEQ2, ZamGEQ31, CAPS AutoFilter, FOMP Auto-Wah, MOD HPF/LPF, Filta, Mud (LV2) |
 | **Wah** | Pedal wah-wah | 2 | Cry Classic (native); GxQuack (LV2) |
 | **Utility** | Ferramentas | 2 | Chromatic Tuner, Spectrum Analyzer (native) |
 | **Body** | Ressonância de corpo acústico | 114 | Martin (45), Taylor (30), Gibson (10), Yamaha (5), Guild (4), Takamine (4), Cort (4), Emerald (2), Rainsong (2), Lowden (2) + outros boutique (IR) |

--- a/assets/blocks/metadata/en-US.yaml
+++ b/assets/blocks/metadata/en-US.yaml
@@ -56,6 +56,10 @@ plugins:
     description: "Three-band EQ with low, mid, and high controls mapped to ±24 dB."
     license: "Proprietary - OpenRig"
     homepage: "https://github.com/jpfaria/OpenRig"
+  native_guitar_eq:
+    description: "Guitar EQ — cuts low-end rumble below 80Hz and high-frequency fizz above 8kHz. Two independent controls let you dial in how much of each cut to apply."
+    license: "Proprietary - OpenRig"
+    homepage: "https://github.com/jpfaria/OpenRig"
   ibanez_ts9:
     description: "Classic Ibanez Tube Screamer overdrive with drive, tone, and level controls."
     license: "Proprietary - OpenRig"

--- a/assets/blocks/metadata/pt-BR.yaml
+++ b/assets/blocks/metadata/pt-BR.yaml
@@ -56,6 +56,10 @@ plugins:
     description: "EQ de três bandas com controles de grave, médio e agudo (±24 dB)."
     license: "Proprietário - OpenRig"
     homepage: "https://github.com/jpfaria/OpenRig"
+  native_guitar_eq:
+    description: "Guitar EQ — corta o grave abaixo de 80Hz e o agudo acima de 8kHz. Dois controles independentes permitem ajustar a intensidade de cada corte."
+    license: "Proprietário - OpenRig"
+    homepage: "https://github.com/jpfaria/OpenRig"
   ibanez_ts9:
     description: "Tube Screamer clássico da Ibanez com controles de drive, tone e level."
     license: "Proprietário - OpenRig"

--- a/crates/block-core/src/lib.rs
+++ b/crates/block-core/src/lib.rs
@@ -294,26 +294,32 @@ pub enum BiquadKind {
     Peak,
     LowShelf,
     HighShelf,
+    HighPass,
+    LowPass,
 }
 
 impl BiquadFilter {
     pub fn new(kind: BiquadKind, freq_hz: f32, gain_db: f32, q: f32, sample_rate: f32) -> Self {
-        let a = 10.0_f32.powf(gain_db / 40.0);
         let w0 = 2.0 * PI * freq_hz / sample_rate;
         let cos_w0 = w0.cos();
         let sin_w0 = w0.sin();
-        let alpha = sin_w0 / (2.0 * q.max(0.01));
 
         let (b0, b1, b2, a0, a1, a2) = match kind {
-            BiquadKind::Peak => (
-                1.0 + alpha * a,
-                -2.0 * cos_w0,
-                1.0 - alpha * a,
-                1.0 + alpha / a,
-                -2.0 * cos_w0,
-                1.0 - alpha / a,
-            ),
+            BiquadKind::Peak => {
+                let a = 10.0_f32.powf(gain_db / 40.0);
+                let alpha = sin_w0 / (2.0 * q.max(0.01));
+                (
+                    1.0 + alpha * a,
+                    -2.0 * cos_w0,
+                    1.0 - alpha * a,
+                    1.0 + alpha / a,
+                    -2.0 * cos_w0,
+                    1.0 - alpha / a,
+                )
+            }
             BiquadKind::LowShelf => {
+                let a = 10.0_f32.powf(gain_db / 40.0);
+                let alpha = sin_w0 / (2.0 * q.max(0.01));
                 let two_sqrt_a_alpha = 2.0 * a.sqrt() * alpha;
                 (
                     a * ((a + 1.0) - (a - 1.0) * cos_w0 + two_sqrt_a_alpha),
@@ -325,6 +331,8 @@ impl BiquadFilter {
                 )
             }
             BiquadKind::HighShelf => {
+                let a = 10.0_f32.powf(gain_db / 40.0);
+                let alpha = sin_w0 / (2.0 * q.max(0.01));
                 let two_sqrt_a_alpha = 2.0 * a.sqrt() * alpha;
                 (
                     a * ((a + 1.0) + (a - 1.0) * cos_w0 + two_sqrt_a_alpha),
@@ -333,6 +341,28 @@ impl BiquadFilter {
                     (a + 1.0) - (a - 1.0) * cos_w0 + two_sqrt_a_alpha,
                     2.0 * ((a - 1.0) - (a + 1.0) * cos_w0),
                     (a + 1.0) - (a - 1.0) * cos_w0 - two_sqrt_a_alpha,
+                )
+            }
+            BiquadKind::HighPass => {
+                let alpha = sin_w0 / (2.0 * q.max(0.01));
+                (
+                    (1.0 + cos_w0) / 2.0,
+                    -(1.0 + cos_w0),
+                    (1.0 + cos_w0) / 2.0,
+                    1.0 + alpha,
+                    -2.0 * cos_w0,
+                    1.0 - alpha,
+                )
+            }
+            BiquadKind::LowPass => {
+                let alpha = sin_w0 / (2.0 * q.max(0.01));
+                (
+                    (1.0 - cos_w0) / 2.0,
+                    1.0 - cos_w0,
+                    (1.0 - cos_w0) / 2.0,
+                    1.0 + alpha,
+                    -2.0 * cos_w0,
+                    1.0 - alpha,
                 )
             }
         };

--- a/crates/block-filter/src/native_guitar_eq.rs
+++ b/crates/block-filter/src/native_guitar_eq.rs
@@ -40,26 +40,39 @@ pub fn model_schema() -> ModelParameterSchema {
     }
 }
 
+/// 4th-order HPF/LPF pair using cascaded biquad stages (24 dB/oct roll-off).
+/// Two cascaded 2nd-order Butterworth stages with Q values chosen for a maximally
+/// flat Butterworth response: Q1 = 0.5412, Q2 = 1.3066.
 pub struct GuitarEq {
-    hpf: BiquadFilter,
-    lpf: BiquadFilter,
+    hpf1: BiquadFilter,
+    hpf2: BiquadFilter,
+    lpf1: BiquadFilter,
+    lpf2: BiquadFilter,
 }
+
+/// Q factors for a 4th-order Butterworth filter (two cascaded 2nd-order stages).
+const BUTTERWORTH_Q1: f32 = 0.5412;
+const BUTTERWORTH_Q2: f32 = 1.3066;
 
 impl GuitarEq {
     pub fn new(low_cut: f32, high_cut: f32, sample_rate: f32) -> Self {
         let hpf_freq = 20.0 + (low_cut / 100.0) * 80.0;
         let lpf_freq = 20000.0 - (high_cut / 100.0) * 13000.0;
         Self {
-            hpf: BiquadFilter::new(BiquadKind::HighPass, hpf_freq, 0.0, 0.707, sample_rate),
-            lpf: BiquadFilter::new(BiquadKind::LowPass,  lpf_freq, 0.0, 0.707, sample_rate),
+            hpf1: BiquadFilter::new(BiquadKind::HighPass, hpf_freq, 0.0, BUTTERWORTH_Q1, sample_rate),
+            hpf2: BiquadFilter::new(BiquadKind::HighPass, hpf_freq, 0.0, BUTTERWORTH_Q2, sample_rate),
+            lpf1: BiquadFilter::new(BiquadKind::LowPass,  lpf_freq, 0.0, BUTTERWORTH_Q1, sample_rate),
+            lpf2: BiquadFilter::new(BiquadKind::LowPass,  lpf_freq, 0.0, BUTTERWORTH_Q2, sample_rate),
         }
     }
 }
 
 impl MonoProcessor for GuitarEq {
     fn process_sample(&mut self, input: f32) -> f32 {
-        let x = self.hpf.process(input);
-        self.lpf.process(x)
+        let x = self.hpf1.process(input);
+        let x = self.hpf2.process(x);
+        let x = self.lpf1.process(x);
+        self.lpf2.process(x)
     }
 }
 
@@ -86,6 +99,90 @@ fn build(
             "filter model '{}' is mono-only and cannot build native stereo processing",
             MODEL_ID
         ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use block_core::MonoProcessor;
+
+    fn sine_rms(freq_hz: f32, sample_rate: f32, low_cut: f32, high_cut: f32) -> f32 {
+        let mut eq = GuitarEq::new(low_cut, high_cut, sample_rate);
+        let samples: Vec<f32> = (0..4096)
+            .map(|i| (2.0 * std::f32::consts::PI * freq_hz * i as f32 / sample_rate).sin())
+            .collect();
+        // warm up
+        for &s in &samples[..2048] {
+            eq.process_sample(s);
+        }
+        // measure
+        let out: Vec<f32> = samples[2048..].iter().map(|&s| eq.process_sample(s)).collect();
+        (out.iter().map(|x| x * x).sum::<f32>() / out.len() as f32).sqrt()
+    }
+
+    fn db(ratio: f32) -> f32 {
+        20.0 * ratio.log10()
+    }
+
+    #[test]
+    fn guitar_eq_hpf_attenuates_50hz() {
+        let sr = 48000.0;
+        // With low_cut=100%, HPF is at 100Hz. 50Hz is 1 octave below → should be attenuated >= 20dB.
+        let rms_filtered = sine_rms(50.0, sr, 100.0, 0.0);
+        let rms_passthrough = sine_rms(50.0, sr, 0.0, 0.0);
+        let attenuation_db = db(rms_filtered / rms_passthrough);
+        println!("HPF 50Hz attenuation: {:.2} dB", attenuation_db);
+        assert!(
+            attenuation_db <= -20.0,
+            "Expected >= 20dB attenuation at 50Hz with HPF@100Hz, got {:.2} dB",
+            attenuation_db
+        );
+    }
+
+    #[test]
+    fn guitar_eq_lpf_attenuates_15khz() {
+        let sr = 48000.0;
+        // With high_cut=100%, LPF is at 7kHz. 15kHz is >1 octave above → should be attenuated >= 20dB.
+        let rms_filtered = sine_rms(15000.0, sr, 0.0, 100.0);
+        let rms_passthrough = sine_rms(15000.0, sr, 0.0, 0.0);
+        let attenuation_db = db(rms_filtered / rms_passthrough);
+        println!("LPF 15kHz attenuation: {:.2} dB", attenuation_db);
+        assert!(
+            attenuation_db <= -20.0,
+            "Expected >= 20dB attenuation at 15kHz with LPF@7kHz, got {:.2} dB",
+            attenuation_db
+        );
+    }
+
+    #[test]
+    fn guitar_eq_passthrough_at_zero_percent() {
+        let sr = 48000.0;
+        // At 0%/0%, HPF is at 20Hz and LPF is at 20kHz — 1kHz should pass nearly unchanged.
+        let rms_filtered = sine_rms(1000.0, sr, 0.0, 0.0);
+        let rms_passthrough = 1.0_f32 / 2.0_f32.sqrt(); // RMS of a unit sine
+        let attenuation_db = db(rms_filtered / rms_passthrough);
+        println!("Pass-through 1kHz at 0%/0%: {:.4} dB", attenuation_db);
+        assert!(
+            attenuation_db.abs() < 0.1,
+            "Expected < 0.1dB change at 1kHz with no filtering, got {:.4} dB",
+            attenuation_db
+        );
+    }
+
+    #[test]
+    fn guitar_eq_mid_frequencies_pass_at_full_percent() {
+        let sr = 48000.0;
+        // At 100%/100%, HPF@100Hz and LPF@7kHz — 1kHz is well inside the passband.
+        let rms_filtered = sine_rms(1000.0, sr, 100.0, 100.0);
+        let rms_passthrough = sine_rms(1000.0, sr, 0.0, 0.0);
+        let attenuation_db = db(rms_filtered / rms_passthrough);
+        println!("Mid 1kHz at 100%/100%: {:.4} dB", attenuation_db);
+        assert!(
+            attenuation_db.abs() < 0.1,
+            "Expected < 0.1dB change at 1kHz inside passband (HPF@100Hz, LPF@7kHz), got {:.4} dB",
+            attenuation_db
+        );
     }
 }
 

--- a/crates/block-filter/src/native_guitar_eq.rs
+++ b/crates/block-filter/src/native_guitar_eq.rs
@@ -1,0 +1,101 @@
+use anyhow::{Error, Result};
+use crate::registry::FilterModelDefinition;
+use crate::FilterBackendKind;
+use block_core::param::{
+    float_parameter, required_f32, ModelParameterSchema, ParameterSet, ParameterUnit,
+};
+use block_core::{AudioChannelLayout, BlockProcessor, BiquadFilter, BiquadKind, ModelAudioMode, MonoProcessor};
+
+pub const MODEL_ID: &str = "native_guitar_eq";
+pub const DISPLAY_NAME: &str = "Guitar EQ";
+
+pub fn model_schema() -> ModelParameterSchema {
+    ModelParameterSchema {
+        effect_type: "filter".to_string(),
+        model: MODEL_ID.to_string(),
+        display_name: DISPLAY_NAME.to_string(),
+        audio_mode: ModelAudioMode::DualMono,
+        parameters: vec![
+            float_parameter(
+                "low_cut",
+                "Low Cut",
+                None,
+                Some(100.0),
+                0.0,
+                100.0,
+                1.0,
+                ParameterUnit::Percent,
+            ),
+            float_parameter(
+                "high_cut",
+                "High Cut",
+                None,
+                Some(100.0),
+                0.0,
+                100.0,
+                1.0,
+                ParameterUnit::Percent,
+            ),
+        ],
+    }
+}
+
+pub struct GuitarEq {
+    low_shelf: BiquadFilter,
+    high_shelf: BiquadFilter,
+}
+
+impl GuitarEq {
+    pub fn new(low_cut_pct: f32, high_cut_pct: f32, sample_rate: f32) -> Self {
+        let low_gain_db = -(low_cut_pct / 100.0) * 12.0;
+        let high_gain_db = -(high_cut_pct / 100.0) * 12.0;
+        Self {
+            low_shelf: BiquadFilter::new(BiquadKind::LowShelf, 80.0, low_gain_db, 0.707, sample_rate),
+            high_shelf: BiquadFilter::new(BiquadKind::HighShelf, 8000.0, high_gain_db, 0.707, sample_rate),
+        }
+    }
+}
+
+impl MonoProcessor for GuitarEq {
+    fn process_sample(&mut self, input: f32) -> f32 {
+        let x = self.low_shelf.process(input);
+        self.high_shelf.process(x)
+    }
+}
+
+pub fn build_processor(params: &ParameterSet, sample_rate: f32) -> Result<Box<dyn MonoProcessor>> {
+    let low_cut = required_f32(params, "low_cut").map_err(Error::msg)?;
+    let high_cut = required_f32(params, "high_cut").map_err(Error::msg)?;
+    Ok(Box::new(GuitarEq::new(low_cut, high_cut, sample_rate)))
+}
+
+fn schema() -> Result<ModelParameterSchema> {
+    Ok(model_schema())
+}
+
+fn build(
+    params: &ParameterSet,
+    sample_rate: f32,
+    layout: AudioChannelLayout,
+) -> Result<BlockProcessor> {
+    match layout {
+        AudioChannelLayout::Mono => {
+            Ok(BlockProcessor::Mono(build_processor(params, sample_rate)?))
+        }
+        AudioChannelLayout::Stereo => anyhow::bail!(
+            "filter model '{}' is mono-only and cannot build native stereo processing",
+            MODEL_ID
+        ),
+    }
+}
+
+pub const MODEL_DEFINITION: FilterModelDefinition = FilterModelDefinition {
+    id: MODEL_ID,
+    display_name: DISPLAY_NAME,
+    brand: "",
+    backend_kind: FilterBackendKind::Native,
+    schema,
+    build,
+    supported_instruments: block_core::GUITAR_ACOUSTIC_BASS,
+    knob_layout: &[],
+};

--- a/crates/block-filter/src/native_guitar_eq.rs
+++ b/crates/block-filter/src/native_guitar_eq.rs
@@ -41,25 +41,25 @@ pub fn model_schema() -> ModelParameterSchema {
 }
 
 pub struct GuitarEq {
-    low_shelf: BiquadFilter,
-    high_shelf: BiquadFilter,
+    hpf: BiquadFilter,
+    lpf: BiquadFilter,
 }
 
 impl GuitarEq {
-    pub fn new(low_cut_pct: f32, high_cut_pct: f32, sample_rate: f32) -> Self {
-        let low_gain_db = -(low_cut_pct / 100.0) * 12.0;
-        let high_gain_db = -(high_cut_pct / 100.0) * 12.0;
+    pub fn new(low_cut: f32, high_cut: f32, sample_rate: f32) -> Self {
+        let hpf_freq = 20.0 + (low_cut / 100.0) * 80.0;
+        let lpf_freq = 20000.0 - (high_cut / 100.0) * 13000.0;
         Self {
-            low_shelf: BiquadFilter::new(BiquadKind::LowShelf, 80.0, low_gain_db, 0.707, sample_rate),
-            high_shelf: BiquadFilter::new(BiquadKind::HighShelf, 8000.0, high_gain_db, 0.707, sample_rate),
+            hpf: BiquadFilter::new(BiquadKind::HighPass, hpf_freq, 0.0, 0.707, sample_rate),
+            lpf: BiquadFilter::new(BiquadKind::LowPass,  lpf_freq, 0.0, 0.707, sample_rate),
         }
     }
 }
 
 impl MonoProcessor for GuitarEq {
     fn process_sample(&mut self, input: f32) -> f32 {
-        let x = self.low_shelf.process(input);
-        self.high_shelf.process(x)
+        let x = self.hpf.process(input);
+        self.lpf.process(x)
     }
 }
 

--- a/docs/superpowers/specs/2026-04-07-guitar-eq-design.md
+++ b/docs/superpowers/specs/2026-04-07-guitar-eq-design.md
@@ -1,0 +1,132 @@
+# Guitar EQ Implementation Design
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a native Guitar EQ filter block that cuts problematic low and high frequencies for guitar, with two independent intensity controls.
+
+**Architecture:** Single new source file `native_guitar_eq.rs` in `crates/block-filter/src/`. The `build.rs` auto-registration pattern picks it up automatically — no registry edits needed. Uses existing `BiquadFilter` with `LowShelf` and `HighShelf` kinds from `block-core`.
+
+**Tech Stack:** Rust, `block-core::BiquadFilter`, `block-filter` crate pattern.
+
+---
+
+## Context
+
+Guitar signals have two well-known problematic frequency regions:
+- **Below ~80Hz** — low-end rumble, stage noise, handling noise, room resonance. Adds mud without musical content for guitar.
+- **Above ~8kHz** — pick attack fizz, hiss, harsh upper harmonics. Makes the signal sound brittle and noisy.
+
+Cutting these ranges makes guitar signals sit better in a mix and sound cleaner through an amp chain. The cutoff frequencies are fixed (industry-standard for guitar), but the intensity of each cut is independently adjustable so the player can tailor to their instrument and style.
+
+---
+
+## Parameters
+
+| ID | Label | Default | Range | Step | Unit |
+|----|-------|---------|-------|------|------|
+| `low_cut` | Low Cut | 100 | 0–100 | 1 | % |
+| `high_cut` | High Cut | 100 | 0–100 | 1 | % |
+
+- `low_cut = 0%` → low shelf gain = 0 dB (no effect below 80Hz)
+- `low_cut = 100%` → low shelf gain = −12 dB below 80Hz
+- `high_cut = 0%` → high shelf gain = 0 dB (no effect above 8kHz)
+- `high_cut = 100%` → high shelf gain = −12 dB above 8kHz
+
+**Formula:** `gain_db = -(value / 100.0) * 12.0`
+
+---
+
+## DSP Design
+
+Two `BiquadFilter` in series:
+
+```
+input → [LowShelf @ 80Hz, Q=0.707] → [HighShelf @ 8kHz, Q=0.707] → output
+```
+
+- **Low shelf at 80Hz, Q=0.707 (Butterworth)** — smooth rolloff below 80Hz, musical and natural sounding
+- **High shelf at 8kHz, Q=0.707 (Butterworth)** — smooth rolloff above 8kHz
+- Filters are rebuilt when parameters change (stateless construction pattern, same as `ThreeBandEq`)
+
+---
+
+## Model Definition
+
+| Field | Value |
+|-------|-------|
+| `id` | `native_guitar_eq` |
+| `display_name` | `Guitar EQ` |
+| `brand` | `""` (native) |
+| `backend_kind` | `FilterBackendKind::Native` |
+| `audio_mode` | `ModelAudioMode::DualMono` |
+| `supported_instruments` | `block_core::GUITAR_ACOUSTIC_BASS` |
+
+---
+
+## Files
+
+| Action | Path |
+|--------|------|
+| Create | `crates/block-filter/src/native_guitar_eq.rs` |
+| Modify | `assets/blocks/metadata/en-US.yaml` |
+| Modify | `assets/blocks/metadata/pt-BR.yaml` |
+
+`build.rs` auto-registers the model — no other files need to change.
+
+---
+
+## Metadata
+
+**en-US.yaml:**
+```yaml
+native_guitar_eq:
+  description: "Guitar EQ — cuts low-end rumble below 80Hz and high-frequency fizz above 8kHz. Two independent controls let you dial in how much of each cut to apply."
+  license: "Proprietary - OpenRig"
+  homepage: "https://github.com/jpfaria/OpenRig"
+```
+
+**pt-BR.yaml:**
+```yaml
+native_guitar_eq:
+  description: "Guitar EQ — corta o grave abaixo de 80Hz e o agudo acima de 8kHz. Dois controles independentes permitem ajustar a intensidade de cada corte."
+  license: "Proprietário - OpenRig"
+  homepage: "https://github.com/jpfaria/OpenRig"
+```
+
+---
+
+## Implementation Pattern
+
+Follow exactly the same structure as `native_eq_three_band_basic.rs`:
+
+```rust
+pub const MODEL_ID: &str = "native_guitar_eq";
+pub const DISPLAY_NAME: &str = "Guitar EQ";
+
+pub struct GuitarEq {
+    low_shelf: BiquadFilter,
+    high_shelf: BiquadFilter,
+}
+
+impl GuitarEq {
+    pub fn new(low_cut: f32, high_cut: f32, sample_rate: f32) -> Self {
+        let low_gain_db  = -(low_cut  / 100.0) * 12.0;
+        let high_gain_db = -(high_cut / 100.0) * 12.0;
+        Self {
+            low_shelf:  BiquadFilter::new(BiquadKind::LowShelf,  80.0,   low_gain_db,  0.707, sample_rate),
+            high_shelf: BiquadFilter::new(BiquadKind::HighShelf, 8000.0, high_gain_db, 0.707, sample_rate),
+        }
+    }
+}
+
+impl MonoProcessor for GuitarEq {
+    fn process_sample(&mut self, input: f32) -> f32 {
+        let x = self.low_shelf.process(input);
+        self.high_shelf.process(x)
+    }
+}
+```
+
+Parameters use `float_parameter` (not `curve_editor_parameter`) since there is no curve editor widget for a simple percentage knob.
+
+`supported_instruments`: `block_core::GUITAR_ACOUSTIC_BASS`

--- a/docs/user-guide/blocks-reference.md
+++ b/docs/user-guide/blocks-reference.md
@@ -740,6 +740,7 @@ Filter blocks shape the frequency spectrum of the signal using equalization and 
 | Model Name        | Brand | Backend | Description                    |
 |-------------------|-------|---------|--------------------------------|
 | Three Band EQ     | --    | Native  | 3-band parametric EQ           |
+| Guitar EQ         | --    | Native  | Low-cut + high-cut EQ for guitar |
 | TAP Equalizer     | TAP   | LV2     | Parametric EQ                  |
 | TAP Equalizer/BW  | TAP   | LV2     | Butterworth EQ                 |
 | ZamEQ2            | ZAM   | LV2     | 2-band parametric EQ           |
@@ -758,6 +759,15 @@ Filter blocks shape the frequency spectrum of the signal using equalization and 
 | low       | 0--100% | -24 dB to +24 dB  | Low-band gain      |
 | mid       | 0--100% | -24 dB to +24 dB  | Mid-band gain      |
 | high      | 0--100% | -24 dB to +24 dB  | High-band gain     |
+
+### Parameters -- Guitar EQ
+
+Cuts the two frequency ranges known to cause noise and mud in guitar signals. Each cut uses a gentle Butterworth shelf (Q=0.707) so the rolloff is musical rather than surgical.
+
+| Parameter | Range   | Mapped Range  | Description                                          |
+|-----------|---------|---------------|------------------------------------------------------|
+| low_cut   | 0--100% | 0 to -12 dB   | Low-shelf cut below 80 Hz (rumble, stage noise, mud) |
+| high_cut  | 0--100% | 0 to -12 dB   | High-shelf cut above 8 kHz (hiss, pick fizz)         |
 
 ---
 


### PR DESCRIPTION
## Summary

- New native `Guitar EQ` filter block (`native_guitar_eq`)
- 4th-order Butterworth HPF at 100Hz cuts low-end rumble (24dB/oct)
- 4th-order Butterworth LPF at 7kHz cuts high-frequency fizz (24dB/oct)
- Two independent parameters: `low_cut` and `high_cut` (0–100%)
- Added `HighPass` and `LowPass` variants to `BiquadKind` in `block-core`
- Frequency response tests included
- CLAUDE.md and blocks-reference.md updated

Closes #220