### PR TITLE
feat(gui): show app version in launcher screen

### DIFF
--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -480,6 +480,7 @@ pub fn run_desktop_app(
     let insert_return_channels = Rc::new(VecModel::from(Vec::<ChannelOptionItem>::new()));
     let block_editor_window =
         BlockEditorWindow::new().map_err(|error| anyhow!(error.to_string()))?;
+    window.set_app_version(env!("CARGO_PKG_VERSION").into());
     window.set_show_project_launcher(true);
     window.set_show_project_setup(false);
     window.set_show_project_chains(false);

--- a/crates/adapter-gui/ui/app-window.slint
+++ b/crates/adapter-gui/ui/app-window.slint
@@ -537,6 +537,7 @@ export component AppWindow inherits Window {
     icon: @image-url("assets/openrig-logomark.svg");
     default-font-family: "Cooper Hewitt";
     default-font-size: 13px;
+    in property <string> app-version;
     in property <bool> show-project-launcher;
     in property <bool> show-project-setup;
     in property <bool> show-project-chains;
@@ -660,6 +661,7 @@ export component AppWindow inherits Window {
     if !touch-optimized : DesktopMain {
         width: 100%;
         height: 100%;
+        app-version: root.app-version;
         show-project-launcher: root.show-project-launcher;
         show-project-setup: root.show-project-setup;
         show-project-chains: root.show-project-chains;

--- a/crates/adapter-gui/ui/desktop_main.slint
+++ b/crates/adapter-gui/ui/desktop_main.slint
@@ -4,6 +4,7 @@ import { ChannelOptionItem, DeviceSelectionItem, ProjectChainItem, RecentProject
 import { ProjectLauncherPage, ProjectSetupPage, ProjectSettingsPage, ProjectChainsPage, ChainEditorPage } from "pages/pages.slint";
 
 export component DesktopMain inherits Rectangle {
+    in property <string> app-version;
     in property <bool> show-project-launcher;
     in property <bool> show-project-setup;
     in property <bool> show-project-chains;
@@ -122,6 +123,7 @@ export component DesktopMain inherits Rectangle {
     if root.show-project-launcher : ProjectLauncherPage {
         width: parent.width;
         height: parent.height;
+        app-version: root.app-version;
         recent-projects: root.recent-projects;
         recent-project-search: root.recent-project-search;
         status-message: root.status-message;

--- a/crates/adapter-gui/ui/pages/project_launcher.slint
+++ b/crates/adapter-gui/ui/pages/project_launcher.slint
@@ -207,6 +207,7 @@ export component ProjectLauncherPage inherits Rectangle {
     in property <[RecentProjectItem]> recent-projects;
     in-out property <string> status-message;
     in-out property <string> recent-project-search;
+    in property <string> app-version;
     callback open-project-file();
     callback create-project-file();
     callback open-recent-project(int);
@@ -297,6 +298,18 @@ export component ProjectLauncherPage inherits Rectangle {
         width: parent.width - 48px;
         height: 1px;
         background: #34383f;
+    }
+
+    if root.app-version != "" : Text {
+        x: 0px;
+        y: parent.height - 20px;
+        width: parent.width - 16px;
+        height: 20px;
+        text: "v" + root.app-version;
+        color: #4a5060;
+        font-size: 10px;
+        horizontal-alignment: right;
+        vertical-alignment: center;
     }
 
     Rectangle {


### PR DESCRIPTION
## Summary

- Adds `app-version` property piped from `AppWindow` → `DesktopMain` → `ProjectLauncherPage`
- Sets the version via `env!("CARGO_PKG_VERSION")` at startup
- Renders as small muted text (`v1.2.3`) at the bottom-right of the launcher screen

Closes #233