### PR TITLE
feat(audio): ASIO support on Windows for low-latency audio

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -385,6 +385,19 @@ jobs:
           key: windows-x64-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: windows-x64-cargo-
 
+      - name: Download ASIO SDK
+        shell: pwsh
+        run: |
+          $sdk_url = "https://download.steinberg.net/sdk_downloads/asiosdk_2.3.3_2019-06-14.zip"
+          Invoke-WebRequest -Uri $sdk_url -OutFile asiosdk.zip
+          Expand-Archive -Path asiosdk.zip -DestinationPath C:\asiosdk
+          $sdk_dir = (Get-ChildItem C:\asiosdk -Directory)[0].FullName
+          "CPAL_ASIO_DIR=$sdk_dir" | Out-File -FilePath $env:GITHUB_ENV -Append
+          Write-Host "ASIO SDK: $sdk_dir"
+
+      - name: Install LLVM/clang (required by ASIO bindgen)
+        run: choco install llvm -y --no-progress
+
       - name: Build
         run: cargo build --release -p adapter-gui
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
 dirs = "6"
 thiserror = "1"
-cpal = "0.17.3"
+cpal = { version = "0.17.3", features = ["asio"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 tonic = "0.12"
 prost = "0.13"

--- a/crates/infra-cpal/src/lib.rs
+++ b/crates/infra-cpal/src/lib.rs
@@ -4,6 +4,32 @@ use cpal::{
     BufferSize, SampleFormat, Stream, StreamConfig, SupportedBufferSize, SupportedStreamConfig,
     SupportedStreamConfigRange,
 };
+
+/// Select the best available audio host.
+///
+/// On Windows: tries ASIO first (low latency, bypasses Windows mixer),
+/// falls back to WASAPI if no ASIO driver is installed.
+/// On macOS/Linux: returns the platform default (CoreAudio / ALSA).
+fn select_host() -> cpal::Host {
+    #[cfg(target_os = "windows")]
+    {
+        for host_id in cpal::available_hosts() {
+            if host_id == cpal::HostId::Asio {
+                match cpal::host_from_id(host_id) {
+                    Ok(host) => {
+                        log::info!("Audio host: ASIO");
+                        return host;
+                    }
+                    Err(e) => {
+                        log::warn!("ASIO host found but failed to initialize: {e} — falling back to WASAPI");
+                    }
+                }
+            }
+        }
+        log::info!("Audio host: WASAPI (no ASIO driver installed)");
+    }
+    cpal::default_host()
+}
 use domain::ids::ChainId;
 use engine::runtime::{process_input_f32, process_output_f32, RuntimeGraph, ChainRuntimeState};
 use engine;
@@ -76,7 +102,7 @@ pub struct ProjectRuntimeController {
 }
 pub fn list_devices() -> Result<Vec<String>> {
     log::debug!("listing all audio devices");
-    let host = cpal::default_host();
+    let host = select_host();
     let mut devices = Vec::new();
     for device in host.input_devices()? {
         let description = device.description()?;
@@ -99,7 +125,7 @@ pub fn list_devices() -> Result<Vec<String>> {
 
 pub fn list_input_device_descriptors() -> Result<Vec<AudioDeviceDescriptor>> {
     log::debug!("listing input device descriptors");
-    let host = cpal::default_host();
+    let host = select_host();
     let mut devices = Vec::new();
     for device in host.input_devices()? {
         let description = device.description()?;
@@ -115,7 +141,7 @@ pub fn list_input_device_descriptors() -> Result<Vec<AudioDeviceDescriptor>> {
 
 pub fn list_output_device_descriptors() -> Result<Vec<AudioDeviceDescriptor>> {
     log::debug!("listing output device descriptors");
-    let host = cpal::default_host();
+    let host = select_host();
     let mut devices = Vec::new();
     for device in host.output_devices()? {
         let description = device.description()?;
@@ -133,7 +159,7 @@ pub fn build_streams_for_project(
     runtime_graph: &RuntimeGraph,
 ) -> Result<Vec<Stream>> {
     log::info!("building audio streams for project");
-    let host = cpal::default_host();
+    let host = select_host();
     validate_channels_against_devices(project, &host)?;
     let mut resolved_chains = resolve_enabled_chain_audio_configs(&host, project)?;
     let mut streams = Vec::new();
@@ -171,7 +197,7 @@ impl ProjectRuntimeController {
 
     pub fn sync_project(&mut self, project: &Project) -> Result<()> {
         log::debug!("syncing project runtime with {} chains", project.chains.len());
-        let host = cpal::default_host();
+        let host = select_host();
         validate_channels_against_devices(project, &host)?;
         let mut resolved_chains = resolve_enabled_chain_audio_configs(&host, project)?;
 
@@ -208,7 +234,7 @@ impl ProjectRuntimeController {
             return Ok(());
         }
 
-        let host = cpal::default_host();
+        let host = select_host();
         validate_chain_channels_against_devices(&host, chain)?;
         let resolved = resolve_chain_audio_config(&host, project, chain)?;
         self.upsert_chain_with_resolved(chain, resolved)
@@ -278,7 +304,7 @@ impl ProjectRuntimeController {
 }
 
 pub fn resolve_project_chain_sample_rates(project: &Project) -> Result<HashMap<ChainId, f32>> {
-    let host = cpal::default_host();
+    let host = select_host();
     let mut sample_rates = HashMap::new();
 
     for chain in &project.chains {


### PR DESCRIPTION
## Summary

- Adds ASIO host selection on Windows — bypasses the Windows audio mixer entirely
- `select_host()` replaces all `cpal::default_host()` calls in `infra-cpal`
- On Windows: tries ASIO first → falls back to WASAPI automatically
- macOS/Linux: no change (CoreAudio/ALSA as before)
- CI: downloads ASIO SDK 2.3.3 (BSD license) + installs LLVM/clang for bindgen

## Expected result

Focusrite Scarlett 2i2 with Focusrite USB ASIO driver: latency drops from ~20ms (WASAPI shared) to ~3-5ms (ASIO at 128 samples).

## Test plan

- [ ] Build on Windows with `CPAL_ASIO_DIR` pointing to ASIO SDK
- [ ] Verify CI Windows build passes
- [ ] On Windows with Scarlett + Focusrite ASIO driver: confirm ASIO host is selected in logs
- [ ] On Windows without ASIO driver: confirm fallback to WASAPI in logs
- [ ] macOS/Linux: confirm build still works

Closes #235