### PR TITLE
fix(tuner): show tuner widget immediately without waiting for signal

### DIFF
--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -2649,21 +2649,31 @@ pub fn run_desktop_app(
                         let compact_blocks = cw.get_compact_blocks();
                         for i in 0..compact_blocks.row_count() {
                             if let Some(mut item) = compact_blocks.row_data(i) {
-                                if item.effect_type == "utility" && item.enabled {
-                                    let bid = domain::ids::BlockId(item.block_id.to_string());
-                                    let stream_data = if let Some(entries) = rt.poll_stream(&bid) {
-                                        let slint_entries: Vec<BlockStreamEntry> = entries.iter().map(|e| BlockStreamEntry {
-                                            key: e.key.clone().into(),
-                                            value: e.value,
-                                            text: e.text.clone().into(),
-                                            peak: e.peak,
-                                        }).collect();
-                                        BlockStreamData {
-                                            active: true,
-                                            stream_kind: project::catalog::model_stream_kind(item.effect_type.as_str(), item.model_id.as_str()).into(),
-                                            entries: ModelRc::from(Rc::new(VecModel::from(slint_entries))),
+                                if item.effect_type == "utility" {
+                                    let stream_data = if item.enabled {
+                                        let bid = domain::ids::BlockId(item.block_id.to_string());
+                                        let kind: slint::SharedString = project::catalog::model_stream_kind(item.effect_type.as_str(), item.model_id.as_str()).into();
+                                        if let Some(entries) = rt.poll_stream(&bid) {
+                                            let slint_entries: Vec<BlockStreamEntry> = entries.iter().map(|e| BlockStreamEntry {
+                                                key: e.key.clone().into(),
+                                                value: e.value,
+                                                text: e.text.clone().into(),
+                                                peak: e.peak,
+                                            }).collect();
+                                            BlockStreamData {
+                                                active: true,
+                                                stream_kind: kind,
+                                                entries: ModelRc::from(Rc::new(VecModel::from(slint_entries))),
+                                            }
+                                        } else {
+                                            BlockStreamData {
+                                                active: false,
+                                                stream_kind: kind,
+                                                entries: ModelRc::default(),
+                                            }
                                         }
                                     } else {
+                                        // Disabled utility block — clear stream so parameters become visible
                                         BlockStreamData { active: false, stream_kind: "".into(), entries: ModelRc::default() }
                                     };
                                     item.stream_data = stream_data;
@@ -4009,7 +4019,7 @@ pub fn run_desktop_app(
                                 }
                                 win.set_block_stream_data(BlockStreamData {
                                     active: false,
-                                    stream_kind: "".into(),
+                                    stream_kind: kind.clone(),
                                     entries: ModelRc::default(),
                                 });
                             }

--- a/crates/adapter-gui/ui/pages/block_panel_editor.slint
+++ b/crates/adapter-gui/ui/pages/block_panel_editor.slint
@@ -974,11 +974,21 @@ export component BlockPanelEditor inherits Rectangle {
     }
 
     // ── Realtime stream display — positioned between POWER (left) and Reference (right) ──
-    if root.block-stream-data.active && root.block-stream-data.stream-kind != "spectrum" : Rectangle {
+    if root.block-stream-data.stream-kind != "" && root.block-stream-data.stream-kind != "spectrum" : Rectangle {
         x: 56px;
         y: root.header-height + root.brand-strip-height + root.panel-height * 0.52;
         width: parent.width - 56px - 100px;
         height: root.panel-height * 0.46;
+
+        // Waiting for signal — shown until pitch is detected
+        if !root.block-stream-data.active : Text {
+            x: 0; y: 0; width: parent.width; height: parent.height;
+            text: "–";
+            color: #3a4050;
+            font-size: 28px; font-weight: 900;
+            horizontal-alignment: center;
+            vertical-alignment: center;
+        }
 
         for entry[ei] in root.block-stream-data.entries : Rectangle {
             property <length> slot-w: parent.width / root.block-stream-data.entries.length;

--- a/crates/adapter-gui/ui/pages/compact_chain_view.slint
+++ b/crates/adapter-gui/ui/pages/compact_chain_view.slint
@@ -346,7 +346,7 @@ component CompactBlockRow inherits Rectangle {
 
     // ── All parameters (HorizontalLayout, right-aligned, when no knob overlays and no stream data) ──
     HorizontalLayout {
-        visible: root.block-data.knob-overlays.length == 0 && !root.block-data.stream-data.active && !root.block-data.has-external-gui;
+        visible: root.block-data.knob-overlays.length == 0 && root.block-data.stream-data.stream-kind == "" && !root.block-data.has-external-gui;
         alignment: end;
         spacing: 4px;
         padding-right: 8px;
@@ -472,12 +472,22 @@ component CompactBlockRow inherits Rectangle {
     }
 
     // ── Stream data display (tuner readings, meter, etc.) ──
-    if root.block-data.stream-data.active && root.block-data.stream-data.stream-kind != "spectrum" : Rectangle {
+    if root.block-data.stream-data.stream-kind != "" && root.block-data.stream-data.stream-kind != "spectrum" : Rectangle {
         x: 470px;
         y: 4px;
         width: parent.width - 510px;
         height: parent.height - 8px;
         background: transparent;
+
+        // Waiting for signal — shown until pitch is detected
+        if !root.block-data.stream-data.active : Text {
+            x: 0; y: 0; width: parent.width; height: parent.height;
+            text: "–";
+            color: #3a4050;
+            font-size: 28px; font-weight: 900;
+            horizontal-alignment: center;
+            vertical-alignment: center;
+        }
 
         for entry[ei] in root.block-data.stream-data.entries : Rectangle {
             property <length> slot-w: parent.width / root.block-data.stream-data.entries.length;

--- a/crates/adapter-gui/ui/pages/project_chains.slint
+++ b/crates/adapter-gui/ui/pages/project_chains.slint
@@ -1536,6 +1536,9 @@ export component BlockEditorPanel inherits Rectangle {
         && root.block-drawer-selected-type-index < root.block-type-options.length
         && root.block-type-options[root.block-drawer-selected-type-index].icon_kind == "preamp";
 
+    // True when a tuner (or other non-spectrum stream) is the active block — show stream area even while silent
+    property <bool> has-tuner-stream: root.block-stream-data.stream-kind != "" && root.block-stream-data.stream-kind != "spectrum";
+
     property <bool> is-vst3:
         root.block-drawer-selected-type-index >= 0
         && root.block-drawer-selected-type-index < root.block-type-options.length
@@ -1694,7 +1697,7 @@ export component BlockEditorPanel inherits Rectangle {
         }
 
         // ── Stream display (tuner, spectrum) — for non-preamp utility blocks ──
-        if !root.is-preamp && root.block-stream-data.active && root.block-stream-data.stream-kind != "spectrum" : Rectangle {
+        if !root.is-preamp && root.has-tuner-stream : Rectangle {
             x: 20px;
             y: 142px;
             width: parent.width - 40px;
@@ -1703,6 +1706,16 @@ export component BlockEditorPanel inherits Rectangle {
             border-radius: 8px;
             border-width: 1px;
             border-color: #2d3340;
+
+            // Waiting for signal — shown until pitch is detected
+            if !root.block-stream-data.active : Text {
+                x: 0; y: 0; width: parent.width; height: parent.height;
+                text: "–";
+                color: #3a4050;
+                font-size: 52px; font-weight: 900;
+                horizontal-alignment: center;
+                vertical-alignment: center;
+            }
 
             for entry[ei] in root.block-stream-data.entries : Rectangle {
                 property <length> slot-w: parent.width / root.block-stream-data.entries.length;
@@ -1784,9 +1797,9 @@ export component BlockEditorPanel inherits Rectangle {
 
         if !root.is-preamp && root.curve-editor-points.length == 0 && root.multi-slider-points.length == 0 : ScrollView {
             x: 20px;
-            y: root.block-stream-data.active ? 354px : 138px;
+            y: root.has-tuner-stream || (root.block-stream-data.active && root.block-stream-data.stream-kind == "spectrum") ? 354px : 138px;
             width: parent.width - 40px;
-            height: root.block-stream-data.active ? (parent.height - 374px) : (parent.height - 158px);
+            height: root.has-tuner-stream || (root.block-stream-data.active && root.block-stream-data.stream-kind == "spectrum") ? (parent.height - 374px) : (parent.height - 158px);
             viewport-width: self.width;
             viewport-height: root.block-parameter-items.length * 96px;
 


### PR DESCRIPTION
## Summary

- Tuner (and other stream-based utility blocks) was invisible until pitch was detected — on interfaces with low input or at startup, `active` never became `true` so the widget never appeared
- Root cause: `stream_kind` was cleared to `""` when no entries, so the Slint condition `active && stream_kind != "spectrum"` never passed
- Fix: keep `stream_kind` set even when no entries; Slint now shows the container when `stream_kind != ""`, with a `–` placeholder until signal is detected
- Compact view also fixed: disabled utility blocks reset `stream_kind` to `""` so parameter knobs stay visible when the block is powered off

## Test plan

- [ ] Open tuner block — widget should appear immediately with `–` placeholder
- [ ] Play a note — note name and cents should appear
- [ ] Mute guitar — widget returns to `–` placeholder
- [ ] Disable (power off) tuner in compact view — parameter knobs should become visible
- [ ] Re-enable tuner — stream area should reappear

Closes #237