### PR TITLE
feat(ui): adaptive window sizing for small screens

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,8 @@ OpenRig é um pedalboard virtual para músicos. O usuário monta sua cadeia de e
 - **Settings** — dispositivos de áudio (input/output), sample rate, buffer size
 - **Chain Editor** — nome da chain, instrumento, I/O blocks (Input/Output como blocos na cadeia)
 
+**Tamanhos de janela:** Janela principal iniciada em 1100×620px (lógicos) para caber em telas de ~1300×700px (notebooks Windows). Tamanhos mínimos no Slint permitem redimensionamento livre.
+
 ### Tipos de bloco e para que servem
 
 | Tipo | O que faz | Total | Modelos (resumo) |

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -461,21 +461,10 @@ pub fn run_desktop_app(
         if needs_audio_settings { list_output_device_descriptors().unwrap_or_default() } else { Vec::new() }
     ));
     let window = AppWindow::new().map_err(|error| anyhow!(error.to_string()))?;
-    {
-        let scale = window.window().scale_factor() as f32;
-        // Get screen size from environment or use reasonable defaults
-        let screen_w_str = std::env::var("SCREEN_WIDTH").unwrap_or_default();
-        let screen_h_str = std::env::var("SCREEN_HEIGHT").unwrap_or_default();
-        let (screen_w, screen_h) = if let (Ok(w), Ok(h)) = (screen_w_str.parse::<f32>(), screen_h_str.parse::<f32>()) {
-            (w / scale, h / scale)
-        } else {
-            // Default to common monitor sizes
-            (1920.0 / scale, 1080.0 / scale)
-        };
-        let w = (screen_w * 0.85).clamp(860.0, 1400.0);
-        let h = (screen_h * 0.80).clamp(540.0, 860.0);
-        window.window().set_size(slint::WindowSize::Logical(slint::LogicalSize { width: w, height: h }));
-    }
+    window.window().set_size(slint::WindowSize::Logical(slint::LogicalSize {
+        width: 1100.0,
+        height: 620.0,
+    }));
     let project_settings_window =
         ProjectSettingsWindow::new().map_err(|error| anyhow!(error.to_string()))?;
     let chain_editor_window: Rc<RefCell<Option<ChainEditorWindow>>> =

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -461,6 +461,21 @@ pub fn run_desktop_app(
         if needs_audio_settings { list_output_device_descriptors().unwrap_or_default() } else { Vec::new() }
     ));
     let window = AppWindow::new().map_err(|error| anyhow!(error.to_string()))?;
+    {
+        let scale = window.window().scale_factor() as f32;
+        // Get screen size from environment or use reasonable defaults
+        let screen_w_str = std::env::var("SCREEN_WIDTH").unwrap_or_default();
+        let screen_h_str = std::env::var("SCREEN_HEIGHT").unwrap_or_default();
+        let (screen_w, screen_h) = if let (Ok(w), Ok(h)) = (screen_w_str.parse::<f32>(), screen_h_str.parse::<f32>()) {
+            (w / scale, h / scale)
+        } else {
+            // Default to common monitor sizes
+            (1920.0 / scale, 1080.0 / scale)
+        };
+        let w = (screen_w * 0.85).clamp(860.0, 1400.0);
+        let h = (screen_h * 0.80).clamp(540.0, 860.0);
+        window.window().set_size(slint::WindowSize::Logical(slint::LogicalSize { width: w, height: h }));
+    }
     let project_settings_window =
         ProjectSettingsWindow::new().map_err(|error| anyhow!(error.to_string()))?;
     let chain_editor_window: Rc<RefCell<Option<ChainEditorWindow>>> =

--- a/crates/adapter-gui/ui/app-window.slint
+++ b/crates/adapter-gui/ui/app-window.slint
@@ -24,10 +24,10 @@ export component ProjectSettingsWindow inherits Window {
     callback update-project-sample-rate(int, string);
     callback update-project-buffer-size(int, string);
     title: "OpenRig · Configurar projeto";
-    min-width: 980px;
-    min-height: 680px;
-    preferred-width: 1160px;
-    preferred-height: 760px;
+    min-width: 860px;
+    min-height: 540px;
+    preferred-width: 1100px;
+    preferred-height: 640px;
     background: #040708;
 
     ProjectSettingsPage {
@@ -70,10 +70,10 @@ export component ChainEditorWindow inherits Window {
     callback cancel-chain();
     callback select-instrument(int);
     title: "OpenRig · Configurar chain";
-    min-width: 980px;
-    min-height: 680px;
-    preferred-width: 1160px;
-    preferred-height: 760px;
+    min-width: 860px;
+    min-height: 540px;
+    preferred-width: 1100px;
+    preferred-height: 640px;
     background: #040708;
 
     ChainEditorPage {
@@ -115,10 +115,10 @@ export component ChainInputWindow inherits Window {
     callback save();
     callback cancel();
     title: "OpenRig · Entrada da chain";
-    min-width: 720px;
-    min-height: 620px;
-    preferred-width: 860px;
-    preferred-height: 720px;
+    min-width: 680px;
+    min-height: 500px;
+    preferred-width: 820px;
+    preferred-height: 620px;
     background: #040708;
 
     ChainEndpointEditorPage {
@@ -155,10 +155,10 @@ export component ChainOutputWindow inherits Window {
     callback save();
     callback cancel();
     title: "OpenRig · Saída da chain";
-    min-width: 720px;
-    min-height: 620px;
-    preferred-width: 860px;
-    preferred-height: 720px;
+    min-width: 680px;
+    min-height: 500px;
+    preferred-width: 820px;
+    preferred-height: 620px;
     background: #040708;
 
     ChainEndpointEditorPage {
@@ -196,10 +196,10 @@ export component ChainInputGroupsWindow inherits Window {
     callback toggle-enabled();
     callback delete-block();
     title: "OpenRig \u{00B7} Entradas da chain";
-    min-width: 720px;
-    min-height: 620px;
-    preferred-width: 860px;
-    preferred-height: 720px;
+    min-width: 680px;
+    min-height: 500px;
+    preferred-width: 820px;
+    preferred-height: 620px;
     background: #040708;
 
     ChainIoGroupsPage {
@@ -237,10 +237,10 @@ export component ChainOutputGroupsWindow inherits Window {
     callback toggle-enabled();
     callback delete-block();
     title: "OpenRig \u{00B7} Sa\u{00ED}das da chain";
-    min-width: 720px;
-    min-height: 620px;
-    preferred-width: 860px;
-    preferred-height: 720px;
+    min-width: 680px;
+    min-height: 500px;
+    preferred-width: 820px;
+    preferred-height: 620px;
     background: #040708;
 
     ChainIoGroupsPage {
@@ -293,10 +293,10 @@ export component ChainInsertWindow inherits Window {
     callback cancel();
 
     title: "OpenRig \u{00B7} Configurar Insert";
-    min-width: 720px;
-    min-height: 720px;
-    preferred-width: 860px;
-    preferred-height: 820px;
+    min-width: 680px;
+    min-height: 580px;
+    preferred-width: 820px;
+    preferred-height: 720px;
     background: #040708;
 
     ChainInsertEditorPage {
@@ -399,11 +399,11 @@ export component BlockEditorWindow inherits Window {
 
     title: root.block-window-title;
     min-width: panel-width;
-    min-height: root.use-panel-editor ? eq-extra-height : 760px;
+    min-height: root.use-panel-editor ? eq-extra-height : 640px;
     max-width: panel-width;
-    max-height: root.use-panel-editor ? eq-extra-height : 760px;
+    max-height: root.use-panel-editor ? eq-extra-height : 640px;
     preferred-width: panel-width;
-    preferred-height: root.use-panel-editor ? eq-extra-height : 760px;
+    preferred-height: root.use-panel-editor ? eq-extra-height : 640px;
     background: #040708;
 
     // Amp head: visual panel editor
@@ -486,10 +486,10 @@ export component CompactChainViewWindow inherits Window {
     default-font-family: "Cooper Hewitt";
     default-font-size: 13px;
     title: "OpenRig \u{00B7} Chain";
-    min-width: 900px;
-    min-height: 300px;
-    preferred-width: 1100px;
-    preferred-height: 500px;
+    min-width: 800px;
+    min-height: 260px;
+    preferred-width: 1000px;
+    preferred-height: 460px;
     background: #0a0c10;
 
     in property <string> chain-title;
@@ -653,10 +653,10 @@ export component AppWindow inherits Window {
     callback save-chain();
     callback cancel-chain();
     title: "OpenRig";
-    min-width: 980px;
-    min-height: 680px;
-    preferred-width: 1160px;
-    preferred-height: 760px;
+    min-width: 860px;
+    min-height: 540px;
+    preferred-width: 1100px;
+    preferred-height: 640px;
     background: #040708;
     if !touch-optimized : DesktopMain {
         width: 100%;


### PR DESCRIPTION
Reduces window sizes to fit ~1300×700px screens (common on Windows notebooks) and prevents oversized windows on 4K displays.

**Changes:**
- Reduced `min-*` and `preferred-*` sizes on all 10 Window components in `app-window.slint`
- Main window now opens at 1100×620px logical pixels (fits 1300×700 with OS chrome)
- Min-height reduced from 680px → 540px (allows user to resize smaller)

Closes #240