### PR TITLE
feat(filter): EQ Paramétrico 8 bandas (#121)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,7 +154,7 @@ OpenRig é um pedalboard virtual para músicos. O usuário monta sua cadeia de e
 | **Reverb** | Ambiência e simulação de espaço | 19 | Hall, Plate Foundation, Room, Spring (native); Dragonfly Hall/Room/Plate/Early, CAPS Plate/X2/Scape, TAP Reflector/Reverberator, MDA Ambience, MVerb, B Reverb, Roomy, Shiroverb, Floaty (LV2) |
 | **Modulation** | Chorus, flanger, tremolo, vibrato | 16 | Classic/Stereo/Ensemble Chorus, Sine Tremolo, Vibrato (native); TAP Chorus/Flanger/Tremolo/Rotary, MDA Leslie/RingMod/ThruZero, FOMP CS Chorus/Phaser, CAPS Phaser II, Harmless, Larynx (LV2) |
 | **Dynamics** | Compressor e gate | 9 | Studio Clean Compressor, Noise Gate, Brick Wall Limiter (native); TAP DeEsser/Dynamics/Limiter, ZamComp, ZamGate, ZaMultiComp (LV2) |
-| **Filter** | EQ e moldagem tonal | 12 | Three Band EQ, Guitar EQ (native); TAP Equalizer/BW, ZamEQ2, ZamGEQ31, CAPS AutoFilter, FOMP Auto-Wah, MOD HPF/LPF, Filta, Mud (LV2) |
+| **Filter** | EQ e moldagem tonal | 13 | Three Band EQ, Guitar EQ, 8-Band Parametric EQ (native); TAP Equalizer/BW, ZamEQ2, ZamGEQ31, CAPS AutoFilter, FOMP Auto-Wah, MOD HPF/LPF, Filta, Mud (LV2) |
 | **Wah** | Pedal wah-wah | 2 | Cry Classic (native); GxQuack (LV2) |
 | **Utility** | Ferramentas | 2 | Chromatic Tuner, Spectrum Analyzer (native) |
 | **Body** | Ressonância de corpo acústico | 114 | Martin (45), Taylor (30), Gibson (10), Yamaha (5), Guild (4), Takamine (4), Cort (4), Emerald (2), Rainsong (2), Lowden (2) + outros boutique (IR) |
@@ -166,7 +166,7 @@ OpenRig é um pedalboard virtual para músicos. O usuário monta sua cadeia de e
 | **Output** | Saída de áudio (device + channels) | — | standard |
 | **Insert** | Loop de efeito externo (send/return) | — | external_loop |
 
-**Total: 361+ modelos em 16 tipos de bloco processadores (5 backends: Native 34, NAM 89, IR 127, LV2 105, VST3 6).**
+**Total: 362+ modelos em 16 tipos de bloco processadores (5 backends: Native 35, NAM 89, IR 127, LV2 105, VST3 6).**
 
 ### Parâmetros comuns
 
@@ -176,7 +176,8 @@ OpenRig é um pedalboard virtual para músicos. O usuário monta sua cadeia de e
 - **Reverb**: room_size, damping, mix (0-100%)
 - **Compressor**: threshold, ratio, attack_ms, release_ms, makeup_gain, mix
 - **Gate**: threshold, attack_ms, release_ms
-- **EQ**: low, mid, high (0-100% → -24dB a +24dB)
+- **EQ (Three Band / Guitar EQ)**: low, mid, high (0-100% → -24dB a +24dB)
+- **8-Band Parametric EQ** (`eq_eight_band_parametric`): por banda — `band{N}_enabled` (bool), `band{N}_type` (peak/low_shelf/high_shelf/low_pass/high_pass/notch), `band{N}_freq` (20–20000 Hz), `band{N}_gain` (-24/+24 dB), `band{N}_q` (0.1–10). Freqs padrão: 62/125/250/500/1k/2k/4k/8kHz. Suporta todos os instrumentos. DualMono.
 - **Gain pedals**: drive, tone, level
 - **Volume**: volume (0-100%), mute (on/off)
 - **Tuner**: reference_hz (400-480Hz, default 440)

--- a/crates/block-core/src/lib.rs
+++ b/crates/block-core/src/lib.rs
@@ -296,6 +296,7 @@ pub enum BiquadKind {
     HighShelf,
     HighPass,
     LowPass,
+    Notch,
 }
 
 impl BiquadFilter {
@@ -360,6 +361,17 @@ impl BiquadFilter {
                     (1.0 - cos_w0) / 2.0,
                     1.0 - cos_w0,
                     (1.0 - cos_w0) / 2.0,
+                    1.0 + alpha,
+                    -2.0 * cos_w0,
+                    1.0 - alpha,
+                )
+            }
+            BiquadKind::Notch => {
+                let alpha = sin_w0 / (2.0 * q.max(0.01));
+                (
+                    1.0,
+                    -2.0 * cos_w0,
+                    1.0,
                     1.0 + alpha,
                     -2.0 * cos_w0,
                     1.0 - alpha,

--- a/crates/block-filter/src/native_eq_eight_band.rs
+++ b/crates/block-filter/src/native_eq_eight_band.rs
@@ -1,0 +1,182 @@
+use anyhow::{Error, Result};
+use crate::registry::FilterModelDefinition;
+use crate::FilterBackendKind;
+use block_core::param::{
+    bool_parameter, curve_editor_parameter, enum_parameter, required_bool, required_f32,
+    required_string, CurveEditorRole, ModelParameterSchema, ParameterSet, ParameterUnit,
+};
+use block_core::{BiquadFilter, BiquadKind, ModelAudioMode, MonoProcessor};
+
+pub const MODEL_ID: &str = "eq_eight_band_parametric";
+pub const DISPLAY_NAME: &str = "8-Band Parametric EQ";
+
+const BAND_TYPES: &[(&str, &str)] = &[
+    ("peak", "Peak"),
+    ("low_shelf", "Low Shelf"),
+    ("high_shelf", "High Shelf"),
+    ("low_pass", "Low Pass"),
+    ("high_pass", "High Pass"),
+    ("notch", "Notch"),
+];
+
+struct BandDefault {
+    freq: f32,
+    gain: f32,
+    q: f32,
+    band_type: &'static str,
+}
+
+const BAND_DEFAULTS: [BandDefault; 8] = [
+    BandDefault { freq: 62.0, gain: 0.0, q: 1.0, band_type: "peak" },
+    BandDefault { freq: 125.0, gain: 0.0, q: 1.0, band_type: "peak" },
+    BandDefault { freq: 250.0, gain: 0.0, q: 1.0, band_type: "peak" },
+    BandDefault { freq: 500.0, gain: 0.0, q: 1.0, band_type: "peak" },
+    BandDefault { freq: 1000.0, gain: 0.0, q: 1.0, band_type: "peak" },
+    BandDefault { freq: 2000.0, gain: 0.0, q: 1.0, band_type: "peak" },
+    BandDefault { freq: 4000.0, gain: 0.0, q: 1.0, band_type: "peak" },
+    BandDefault { freq: 8000.0, gain: 0.0, q: 1.0, band_type: "peak" },
+];
+
+pub fn model_schema() -> ModelParameterSchema {
+    let mut parameters = Vec::new();
+
+    for (i, defaults) in BAND_DEFAULTS.iter().enumerate() {
+        let n = i + 1;
+        let group = format!("Band {n}");
+
+        parameters.push(bool_parameter(
+            &format!("band{n}_enabled"),
+            "Enabled",
+            Some(&group),
+            Some(true),
+        ));
+        parameters.push(enum_parameter(
+            &format!("band{n}_type"),
+            "Type",
+            Some(&group),
+            Some(defaults.band_type),
+            BAND_TYPES,
+        ));
+        parameters.push(curve_editor_parameter(
+            &format!("band{n}_freq"),
+            "Freq",
+            Some(&group),
+            CurveEditorRole::X,
+            Some(defaults.freq),
+            20.0,
+            20000.0,
+            1.0,
+            ParameterUnit::Hertz,
+        ));
+        parameters.push(curve_editor_parameter(
+            &format!("band{n}_gain"),
+            "Gain",
+            Some(&group),
+            CurveEditorRole::Y,
+            Some(defaults.gain),
+            -24.0,
+            24.0,
+            0.1,
+            ParameterUnit::Decibels,
+        ));
+        parameters.push(curve_editor_parameter(
+            &format!("band{n}_q"),
+            "Q",
+            Some(&group),
+            CurveEditorRole::Width,
+            Some(defaults.q),
+            0.1,
+            10.0,
+            0.01,
+            ParameterUnit::None,
+        ));
+    }
+
+    ModelParameterSchema {
+        effect_type: "filter".to_string(),
+        model: MODEL_ID.to_string(),
+        display_name: DISPLAY_NAME.to_string(),
+        audio_mode: ModelAudioMode::DualMono,
+        parameters,
+    }
+}
+
+pub struct EightBandParametricEq {
+    filters: Vec<BiquadFilter>,
+    enabled: [bool; 8],
+}
+
+impl MonoProcessor for EightBandParametricEq {
+    fn process_sample(&mut self, input: f32) -> f32 {
+        let mut x = input;
+        for (filter, &en) in self.filters.iter_mut().zip(self.enabled.iter()) {
+            if en {
+                x = filter.process(x);
+            }
+        }
+        x
+    }
+}
+
+fn parse_band_kind(band_type: &str) -> Result<BiquadKind> {
+    match band_type {
+        "peak" => Ok(BiquadKind::Peak),
+        "low_shelf" => Ok(BiquadKind::LowShelf),
+        "high_shelf" => Ok(BiquadKind::HighShelf),
+        "low_pass" => Ok(BiquadKind::LowPass),
+        "high_pass" => Ok(BiquadKind::HighPass),
+        "notch" => Ok(BiquadKind::Notch),
+        other => anyhow::bail!("unknown band type '{}'", other),
+    }
+}
+
+pub fn build_processor(params: &ParameterSet, sample_rate: f32) -> Result<Box<dyn MonoProcessor>> {
+    let mut filters = Vec::with_capacity(8);
+    let mut enabled = [true; 8];
+
+    for i in 0..8usize {
+        let n = i + 1;
+        let en = required_bool(params, &format!("band{n}_enabled")).map_err(Error::msg)?;
+        let band_type = required_string(params, &format!("band{n}_type")).map_err(Error::msg)?;
+        let freq = required_f32(params, &format!("band{n}_freq")).map_err(Error::msg)?;
+        let gain = required_f32(params, &format!("band{n}_gain")).map_err(Error::msg)?;
+        let q = required_f32(params, &format!("band{n}_q")).map_err(Error::msg)?;
+
+        let kind = parse_band_kind(&band_type)?;
+        filters.push(BiquadFilter::new(kind, freq, gain, q, sample_rate));
+        enabled[i] = en;
+    }
+
+    Ok(Box::new(EightBandParametricEq { filters, enabled }))
+}
+
+fn schema() -> Result<ModelParameterSchema> {
+    Ok(model_schema())
+}
+
+fn build(
+    params: &ParameterSet,
+    sample_rate: f32,
+    layout: block_core::AudioChannelLayout,
+) -> Result<block_core::BlockProcessor> {
+    match layout {
+        block_core::AudioChannelLayout::Mono => {
+            Ok(block_core::BlockProcessor::Mono(build_processor(params, sample_rate)?))
+        }
+        block_core::AudioChannelLayout::Stereo => anyhow::bail!(
+            "filter model '{}' is mono-only and cannot build native stereo processing",
+            MODEL_ID
+        ),
+    }
+}
+
+pub const MODEL_DEFINITION: FilterModelDefinition = FilterModelDefinition {
+    id: MODEL_ID,
+    display_name: DISPLAY_NAME,
+    brand: "",
+    backend_kind: FilterBackendKind::Native,
+    schema,
+    build,
+    supported_instruments: block_core::ALL_INSTRUMENTS,
+    knob_layout: &[],
+};

--- a/docs/user-guide/blocks-reference.md
+++ b/docs/user-guide/blocks-reference.md
@@ -739,8 +739,9 @@ Filter blocks shape the frequency spectrum of the signal using equalization and 
 
 | Model Name        | Brand | Backend | Description                    |
 |-------------------|-------|---------|--------------------------------|
-| Three Band EQ     | --    | Native  | 3-band parametric EQ           |
-| Guitar EQ         | --    | Native  | Low-cut + high-cut EQ for guitar |
+| Three Band EQ          | --    | Native  | 3-band parametric EQ                       |
+| Guitar EQ              | --    | Native  | Low-cut + high-cut EQ for guitar           |
+| 8-Band Parametric EQ   | --    | Native  | 8 independent bands, full parametric control |
 | TAP Equalizer     | TAP   | LV2     | Parametric EQ                  |
 | TAP Equalizer/BW  | TAP   | LV2     | Butterworth EQ                 |
 | ZamEQ2            | ZAM   | LV2     | 2-band parametric EQ           |
@@ -768,6 +769,56 @@ Cuts the two frequency ranges known to cause noise and mud in guitar signals. Ea
 |-----------|---------|---------------|------------------------------------------------------|
 | low_cut   | 0--100% | 0 to -12 dB   | Low-shelf cut below 80 Hz (rumble, stage noise, mud) |
 | high_cut  | 0--100% | 0 to -12 dB   | High-shelf cut above 8 kHz (hiss, pick fizz)         |
+
+### Parameters -- 8-Band Parametric EQ
+
+Eight independent biquad filter stages in cascade. Each band is separately configurable. Default frequencies: 62, 125, 250, 500, 1k, 2k, 4k, 8kHz (all Peak, 0 dB).
+
+Each band `{N}` (1–8) exposes five parameters:
+
+| Parameter        | Type   | Range          | Default | Description                                        |
+|------------------|--------|----------------|---------|----------------------------------------------------|
+| `band{N}_enabled`| bool   | on/off         | on      | Bypass this band when off                          |
+| `band{N}_type`   | enum   | see below      | peak    | Filter shape                                       |
+| `band{N}_freq`   | float  | 20–20000 Hz    | *       | Center / corner frequency                          |
+| `band{N}_gain`   | float  | -24 to +24 dB  | 0       | Boost or cut (ignored by LP/HP/Notch)              |
+| `band{N}_q`      | float  | 0.1–10         | 1.0     | Bandwidth / resonance (higher = narrower)          |
+
+Band types:
+
+| Value        | Name        | Description                               |
+|--------------|-------------|-------------------------------------------|
+| `peak`       | Peak        | Bell-shaped boost or cut                  |
+| `low_shelf`  | Low Shelf   | Boost/cut all frequencies below `freq`    |
+| `high_shelf` | High Shelf  | Boost/cut all frequencies above `freq`    |
+| `low_pass`   | Low Pass    | Attenuates frequencies above `freq`       |
+| `high_pass`  | High Pass   | Attenuates frequencies below `freq`       |
+| `notch`      | Notch       | Narrow cut at `freq` (gain ignored)       |
+
+Example YAML:
+
+```yaml
+- type: filter
+  model: eq_eight_band_parametric
+  enabled: true
+  params:
+    band1_enabled: true
+    band1_type: high_pass
+    band1_freq: 80.0
+    band1_gain: 0.0
+    band1_q: 0.707
+    band2_enabled: true
+    band2_type: low_shelf
+    band2_freq: 200.0
+    band2_gain: 3.0
+    band2_q: 0.707
+    band3_enabled: true
+    band3_type: peak
+    band3_freq: 500.0
+    band3_gain: -2.0
+    band3_q: 2.0
+    # bands 4–8 follow the same pattern
+```
 
 ---
 
@@ -893,7 +944,7 @@ The NAM Loader block is a generic Neural Amp Modeler capture loader that allows 
 | Reverb      | 19      | Native, LV2              |
 | Modulation  | 16      | Native, LV2              |
 | Dynamics    | 9       | Native, LV2              |
-| Filter      | 11      | Native, LV2              |
+| Filter      | 13      | Native, LV2              |
 | Wah         | 2       | Native, LV2              |
 | Utility     | 2       | Native                   |
 | Pitch       | 4       | LV2                      |
@@ -901,6 +952,6 @@ The NAM Loader block is a generic Neural Amp Modeler capture loader that allows 
 | Full Rig    | 12      | NAM                      |
 | IR Loader   | 1       | Native                   |
 | NAM Loader  | 1       | NAM                      |
-| **Total**   | **329** |                          |
+| **Total**   | **331** |                          |
 
 > Gain includes 2 Native models, 43 NAM captures, and 46 LV2 plugins (including 33 Guitarix models). NAM captures reproduce specific hardware settings at capture time; parameters are fixed per capture variant rather than continuously variable.


### PR DESCRIPTION
Implementa o bloco `eq_eight_band_parametric` com 8 bandas independentes, cada uma configurável com tipo de filtro, frequência, gain, Q e bypass individual. Adiciona suporte ao filtro Notch no BiquadKind. Inclui documentação completa no CLAUDE.md e docs/user-guide.

Closes #121

Generated with [Claude Code](https://claude.ai/code)