### PR TITLE
fix: restore 2D vector icons for Input, Output, Insert and VST3 blocks

### DIFF
--- a/crates/adapter-gui/ui/assets/vst3-plugin.svg
+++ b/crates/adapter-gui/ui/assets/vst3-plugin.svg
@@ -1,9 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256" fill="none">
-  <!-- Plug prongs -->
-  <line x1="104" y1="68" x2="104" y2="116" stroke="#E8E8E8" stroke-width="14" stroke-linecap="round"/>
-  <line x1="152" y1="68" x2="152" y2="116" stroke="#E8E8E8" stroke-width="14" stroke-linecap="round"/>
-  <!-- Plug body -->
-  <rect x="80" y="116" width="96" height="64" rx="14" stroke="#E8E8E8" stroke-width="12"/>
-  <!-- Cable -->
-  <line x1="128" y1="180" x2="128" y2="212" stroke="#E8E8E8" stroke-width="14" stroke-linecap="round"/>
+  <line x1="104" y1="68" x2="104" y2="116" stroke="currentColor" stroke-width="14" stroke-linecap="round"/>
+  <line x1="152" y1="68" x2="152" y2="116" stroke="currentColor" stroke-width="14" stroke-linecap="round"/>
+  <rect x="80" y="116" width="96" height="64" rx="14" stroke="currentColor" stroke-width="12"/>
+  <line x1="128" y1="180" x2="128" y2="212" stroke="currentColor" stroke-width="14" stroke-linecap="round"/>
 </svg>

--- a/crates/adapter-gui/ui/components/effect_type_icon.slint
+++ b/crates/adapter-gui/ui/components/effect_type_icon.slint
@@ -1,30 +1,13 @@
 // Single source of truth for effect type → icon mapping.
 // Use this component everywhere instead of duplicating the ternary chain.
-// Photo-based icons (input, output, insert, vst3) are NOT colorized.
 
 export component EffectTypeIcon inherits Rectangle {
     in property <string> icon-kind;
     in property <color> tint: #ffffff;
 
-    // Photo/detailed icons — no colorize tint
-    property <bool> is-photo-icon: root.icon-kind == "input"
-        || root.icon-kind == "output"
-        || root.icon-kind == "insert"
-        || root.icon-kind == "vst3";
-
     background: transparent;
 
-    if root.is-photo-icon : Image {
-        width: 100%;
-        height: 100%;
-        source: root.icon-kind == "input" ? @image-url("../assets/connector-input.png")
-            : root.icon-kind == "output" ? @image-url("../assets/connector-output.png")
-            : root.icon-kind == "insert" ? @image-url("../assets/insert-pedalboard.png")
-            : @image-url("../assets/vst3-pedal.png");
-        image-fit: contain;
-    }
-
-    if !root.is-photo-icon : Image {
+    Image {
         width: 100%;
         height: 100%;
         source: root.icon-kind == "preamp" ? @image-url("../assets/amp-head.svg")
@@ -43,6 +26,10 @@ export component EffectTypeIcon inherits Rectangle {
             : root.icon-kind == "utility" ? @image-url("../assets/util.svg")
             : root.icon-kind == "nam" ? @image-url("../assets/nam.svg")
             : root.icon-kind == "pitch" ? @image-url("../assets/pitch.svg")
+            : root.icon-kind == "input" ? @image-url("../assets/input_arrow.svg")
+            : root.icon-kind == "output" ? @image-url("../assets/output_arrow.svg")
+            : root.icon-kind == "insert" ? @image-url("../assets/insert_loop.svg")
+            : root.icon-kind == "vst3" ? @image-url("../assets/vst3-plugin.svg")
             : @image-url("../assets/gear.svg");
         image-fit: contain;
         colorize: root.tint;

--- a/crates/adapter-gui/ui/pages/project_chains.slint
+++ b/crates/adapter-gui/ui/pages/project_chains.slint
@@ -629,24 +629,22 @@ component ChainEndpointChip inherits Rectangle {
     height: 72px;
     background: transparent;
 
-    // Connector photo (XLR female for input, P10 jack for output)
     Image {
-        x: root.is-input ? (parent.width - 56px) / 2 : 0px;
-        y: root.is-input ? 2px : 16px;
-        width: root.is-input ? 56px : 72px;
-        height: root.is-input ? 52px : 36px;
+        x: (parent.width - 48px) / 2;
+        y: 4px;
+        width: 48px;
+        height: 48px;
         source: root.is-input
-            ? @image-url("../assets/connector-input.png")
-            : @image-url("../assets/connector-output.png");
+            ? @image-url("../assets/input_arrow.svg")
+            : @image-url("../assets/output_arrow.svg");
         image-fit: contain;
-        image-rendering: smooth;
-        opacity: hover-area.has-hover ? 1.0 : 0.85;
+        colorize: hover-area.has-hover ? #d0e4f8 : #5a8aab;
     }
 
     // Label
     Text {
         x: 4px;
-        y: root.is-input ? 54px : 48px;
+        y: 54px;
         width: parent.width - 8px;
         height: 16px;
         text: root.label;


### PR DESCRIPTION
Restores the 2D vector icons that were accidentally replaced with 3D photo images in commits 0205dfcb/b69b5249.

- `EffectTypeIcon`: remove photo-icon branch; input/output/insert/vst3 now use original SVG icons
- `ChainEndpointChip`: replace connector photos with input_arrow.svg / output_arrow.svg
- `vst3-plugin.svg`: replace hardcoded colors with currentColor

Closes #270

Generated with [Claude Code](https://claude.ai/code)