### PR TITLE
feat: refresh device list when USB audio interface is plugged in

### DIFF
--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -9,8 +9,8 @@ const SELECT_SELECTED_BLOCK_ID: &str = "__select.selected_block_id";
 use application::validate::validate_project;
 use domain::ids::{BlockId, DeviceId, ChainId};
 use infra_cpal::{
-    invalidate_device_cache, list_input_device_descriptors, list_output_device_descriptors,
-    AudioDeviceDescriptor, ProjectRuntimeController,
+    has_new_devices, invalidate_device_cache, list_input_device_descriptors,
+    list_output_device_descriptors, AudioDeviceDescriptor, ProjectRuntimeController,
 };
 use infra_filesystem::{
     AppConfig, FilesystemStorage, GuiAudioDeviceSettings, GuiAudioSettings, RecentProjectEntry,
@@ -730,19 +730,31 @@ pub fn run_desktop_app(
 
     // Audio health check timer — detects device disconnects (JACK server
     // down on Linux, CoreAudio device removed on macOS) and auto-reconnects
-    // when the backend becomes available again.
+    // when the backend becomes available again. Also detects USB audio
+    // interfaces plugged in after app start and refreshes the device lists.
     {
         let weak_window = window.as_weak();
         let toast_timer_health = toast_timer.clone();
         let runtime_health = project_runtime.clone();
         let session_health = project_session.clone();
         let disconnected = Rc::new(RefCell::new(false));
+        let input_opts_health = chain_input_device_options.clone();
+        let output_opts_health = chain_output_device_options.clone();
         let health_timer = Timer::default();
         health_timer.start(
             slint::TimerMode::Repeated,
             std::time::Duration::from_secs(2),
             move || {
                 let Some(win) = weak_window.upgrade() else { return; };
+
+                // Hotplug detection: refresh device lists when new interfaces appear.
+                if has_new_devices() {
+                    invalidate_device_cache();
+                    refresh_input_devices(&input_opts_health);
+                    refresh_output_devices(&output_opts_health);
+                    log::info!("health timer: new audio device detected, device list refreshed");
+                }
+
                 let mut rt_borrow = runtime_health.borrow_mut();
                 let Some(rt) = rt_borrow.as_mut() else { return; };
                 if !rt.is_running() {

--- a/crates/infra-cpal/src/lib.rs
+++ b/crates/infra-cpal/src/lib.rs
@@ -1428,6 +1428,56 @@ pub fn invalidate_device_cache() {
     log::info!("device descriptor cache invalidated");
 }
 
+// ── Hotplug detection ────────────────────────────────────────────────────────
+// Cheap device count used by the health timer to detect plug-in events without
+// running a full enumeration (no ALSA PCM probe, no JACK client connection).
+
+static LAST_KNOWN_DEVICE_COUNT: Mutex<Option<usize>> = Mutex::new(None);
+
+/// Returns `true` when the audio device count has increased since the last
+/// call, indicating that a new interface was plugged in.
+///
+/// Intentionally cheap — no ALSA probing, no JACK connection. Call from a
+/// periodic UI timer; on `true` follow up with `invalidate_device_cache()` and
+/// a full device-list refresh.
+pub fn has_new_devices() -> bool {
+    let current = count_devices_cheap();
+    let mut guard = LAST_KNOWN_DEVICE_COUNT.lock().unwrap();
+    match *guard {
+        None => {
+            *guard = Some(current);
+            false
+        }
+        Some(prev) if current > prev => {
+            *guard = Some(current);
+            log::info!("has_new_devices: count {} → {}", prev, current);
+            true
+        }
+        Some(prev) => {
+            if current != prev {
+                *guard = Some(current);
+            }
+            false
+        }
+    }
+}
+
+/// Count audio devices cheaply — no ALSA PCM probing, no JACK client.
+fn count_devices_cheap() -> usize {
+    #[cfg(all(target_os = "linux", feature = "jack"))]
+    {
+        // Pure /proc/asound/cards read — safe, no PCM open, no JACK connection.
+        return detect_all_usb_audio_cards().len();
+    }
+    #[allow(unreachable_code)]
+    {
+        let host = select_host_for_enumeration();
+        let input = host.input_devices().map(|it| it.count()).unwrap_or(0);
+        let output = host.output_devices().map(|it| it.count()).unwrap_or(0);
+        input + output
+    }
+}
+
 /// Returns true if the JACK server is currently running.
 /// Fast, non-blocking check — safe to call from the UI thread.
 #[cfg(all(target_os = "linux", feature = "jack"))]


### PR DESCRIPTION
Fixes the device list not updating when a USB audio interface is plugged in while OpenRig is running.

Closes #272

Generated with [Claude Code](https://claude.ai/code)