### PR TITLE
fix: cannot remove block in fullscreen mode (Orange Pi)

### DIFF
--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -6415,6 +6415,25 @@ pub fn run_desktop_app(
     }
     {
         let weak_window = window.as_weak();
+        let block_editor_draft = block_editor_draft.clone();
+        let block_editor_persist_timer = block_editor_persist_timer.clone();
+        window.on_delete_block_drawer(move || {
+            let Some(window) = weak_window.upgrade() else {
+                return;
+            };
+            block_editor_persist_timer.stop();
+            let Some(draft) = block_editor_draft.borrow().clone() else {
+                return;
+            };
+            if draft.block_index.is_none() {
+                return;
+            }
+            window.set_confirm_delete_block_name(draft.model_id.into());
+            window.set_show_confirm_delete_block(true);
+        });
+    }
+    {
+        let weak_window = window.as_weak();
         let selected_block = selected_block.clone();
         let block_editor_draft = block_editor_draft.clone();
         let block_model_options = block_model_options.clone();
@@ -6428,31 +6447,21 @@ pub fn run_desktop_app(
         let project_runtime = project_runtime.clone();
         let saved_project_snapshot = saved_project_snapshot.clone();
         let project_dirty = project_dirty.clone();
-        let block_editor_persist_timer = block_editor_persist_timer.clone();
         let weak_block_editor_window = block_editor_window.as_weak();
         let input_chain_devices = input_chain_devices.clone();
         let output_chain_devices = output_chain_devices.clone();
         let toast_timer = toast_timer.clone();
-        window.on_delete_block_drawer(move || {
+        window.on_confirm_delete_block(move || {
             let Some(window) = weak_window.upgrade() else {
                 return;
             };
-            block_editor_persist_timer.stop();
+            window.set_show_confirm_delete_block(false);
             let Some(draft) = block_editor_draft.borrow().clone() else {
                 return;
             };
             let Some(block_index) = draft.block_index else {
                 return;
             };
-            let confirmed = rfd::MessageDialog::new()
-                .set_title("Excluir bloco")
-                .set_description(format!("Excluir o bloco \"{}\"?", draft.model_id))
-                .set_buttons(rfd::MessageButtons::YesNo)
-                .set_level(rfd::MessageLevel::Warning)
-                .show();
-            if !matches!(confirmed, rfd::MessageDialogResult::Yes) {
-                return;
-            }
             log::info!("on_delete_block: chain_index={}, block_index={}, effect_type='{}', model_id='{}'", draft.chain_index, block_index, draft.effect_type, draft.model_id);
             let mut session_borrow = project_session.borrow_mut();
             let Some(session) = session_borrow.as_mut() else {
@@ -6496,6 +6505,14 @@ pub fn run_desktop_app(
             clear_status(&window, &toast_timer);
             if let Some(block_editor_window) = weak_block_editor_window.upgrade() {
                 let _ = block_editor_window.hide();
+            }
+        });
+    }
+    {
+        let weak_window = window.as_weak();
+        window.on_cancel_delete_block(move || {
+            if let Some(window) = weak_window.upgrade() {
+                window.set_show_confirm_delete_block(false);
             }
         });
     }

--- a/crates/adapter-gui/ui/app-window.slint
+++ b/crates/adapter-gui/ui/app-window.slint
@@ -788,6 +788,10 @@ export component AppWindow inherits Window {
     callback preset-picker-confirm(int);
     callback preset-picker-delete(int);
     callback preset-picker-cancel();
+    in property <bool> show-confirm-delete-block: false;
+    in property <string> confirm-delete-block-name: "";
+    callback confirm-delete-block();
+    callback cancel-delete-block();
     title: "OpenRig";
     min-width: 860px;
     min-height: 540px;
@@ -1131,6 +1135,81 @@ export component AppWindow inherits Window {
         chain-io-select-mode(index) => { root.chain-io-select-mode(index); }
         chain-io-save => { root.chain-io-save(); }
         chain-io-cancel => { root.chain-io-cancel(); }
+    }
+
+    if root.show-confirm-delete-block : Rectangle {
+        x: 0; y: 0;
+        width: root.width; height: root.height;
+        background: #000000b0;
+        TouchArea { }
+        Rectangle {
+            x: (root.width - self.width) / 2;
+            y: (root.height - self.height) / 2;
+            width: min(root.width * 0.7, 400px);
+            height: 170px;
+            background: #1e1f22;
+            border-radius: 10px;
+            drop-shadow-blur: 16px;
+            drop-shadow-offset-y: 4px;
+            drop-shadow-color: #000000c0;
+            VerticalLayout {
+                padding: 20px;
+                spacing: 12px;
+                Text {
+                    text: "Excluir bloco";
+                    font-size: 16px;
+                    color: #ffffff;
+                    font-weight: 700;
+                    horizontal-alignment: center;
+                }
+                Text {
+                    text: "Excluir \"" + root.confirm-delete-block-name + "\"?";
+                    font-size: 13px;
+                    color: #aaaaaa;
+                    horizontal-alignment: center;
+                    overflow: elide;
+                    wrap: no-wrap;
+                }
+                HorizontalLayout {
+                    spacing: 8px;
+                    Rectangle {
+                        horizontal-stretch: 1;
+                        height: 40px;
+                        border-radius: 6px;
+                        background: dlg-cancel-area.has-hover ? #444 : #2d2e32;
+                        dlg-cancel-area := TouchArea {
+                            mouse-cursor: pointer;
+                            clicked => { root.cancel-delete-block(); }
+                        }
+                        Text {
+                            text: "Cancelar";
+                            font-size: 13px;
+                            color: #aaaaaa;
+                            horizontal-alignment: center;
+                            vertical-alignment: center;
+                        }
+                    }
+                    Rectangle {
+                        horizontal-stretch: 1;
+                        height: 40px;
+                        border-radius: 6px;
+                        background: dlg-confirm-area.has-hover ? #c0392b : #e74c3c;
+                        dlg-confirm-area := TouchArea {
+                            mouse-cursor: pointer;
+                            clicked => { root.confirm-delete-block(); }
+                        }
+                        Text {
+                            text: "Excluir";
+                            font-size: 13px;
+                            color: #ffffff;
+                            font-weight: 700;
+                            horizontal-alignment: center;
+                            vertical-alignment: center;
+                        }
+                    }
+                }
+            }
+        }
     }
 
     in-out property <string> toast-message;


### PR DESCRIPTION
Substitui o popup nativo `rfd::MessageDialog` por overlay Slint inline para confirmar exclusão de bloco. O dialog nativo ficava atrás da janela fullscreen no Wayland/kiosk do Orange Pi, tornando a operação impossível.

Closes #267

Generated with [Claude Code](https://claude.ai/code)