### PR TITLE
fix(platform): prevent Scarlett USB disconnect on Orange Pi (issue #225)

### DIFF
--- a/crates/infra-cpal/src/lib.rs
+++ b/crates/infra-cpal/src/lib.rs
@@ -416,6 +416,18 @@ fn read_card_channels(card: &str) -> (u32, u32) {
 #[cfg(all(target_os = "linux", feature = "jack"))]
 fn configure_alsa_mixer(card: &UsbAudioCard) {
     log::info!("configure_alsa_mixer: card {} ({})", card.card_num, card.display_name);
+
+    // Focusrite Scarlett (and likely other USB audio interfaces with vendor firmware)
+    // send a USB notification (0x20000000) in response to ANY amixer write — even
+    // simple volume controls. The RK3588 xHCI controller mishandles this notification
+    // and resets the USB device. Skip amixer entirely for these devices; their settings
+    // persist in NVRAM and can be configured once via the vendor app.
+    let name_lower = card.display_name.to_lowercase();
+    if name_lower.contains("scarlett") || name_lower.contains("focusrite") {
+        log::info!("configure_alsa_mixer: skipping amixer for Focusrite Scarlett (NVRAM settings)");
+        return;
+    }
+
     let c = &card.card_num;
 
     // Set all volume controls to 100%. Only touches controls named "volume" —


### PR DESCRIPTION
## Summary

- Restore `has_new_devices()` call in health_timer lost during module refactor
- Skip `configure_alsa_mixer` for Focusrite Scarlett — any amixer write triggers firmware notification `0x20000000` on RK3588 xHCI, causing USB disconnect loop

## Root cause

`38cbb23a` removed the Scarlett-specific amixer guard. Any write to Scarlett mixer controls (even volume) sends `scarlett2_notify 0x20000000` which the RK3588 xHCI mishandles as a USB reset. Fix detects "scarlett"/"focusrite" in `display_name` and skips `configure_alsa_mixer` entirely.

Closes #225