### PR TITLE
fix(401): LV2 schema synthesis routes toggle/enum/integer + legacy value coercion

### DIFF
--- a/crates/block-core/src/param/set.rs
+++ b/crates/block-core/src/param/set.rs
@@ -10,7 +10,47 @@ use std::collections::BTreeMap;
 use domain::value_objects::ParameterValue;
 use serde::{Deserialize, Serialize};
 
-use super::schema::ModelParameterSchema;
+use super::schema::{ModelParameterSchema, ParameterDomain, ParameterSpec};
+
+/// Coerce a stored `ParameterValue` to the type the schema expects, when
+/// the conversion is unambiguous. Backward-compat for projects saved
+/// before issue #401 introduced Enum/Bool routing — those projects have
+/// every LV2 control stored as Float regardless of the underlying TTL
+/// port property.
+///
+/// Round-trips:
+/// - Float/Int stored against an `Enum` schema → match by numeric option
+///   value, return the corresponding `String(option.value)`.
+/// - Float/Int stored against `Bool` → `>= 0.5` → `Bool`.
+/// - Anything else → return the value unchanged (the validator will run
+///   normally and surface a real type mismatch when it's a real bug).
+fn coerce_legacy_value(value: &ParameterValue, spec: &ParameterSpec) -> ParameterValue {
+    let numeric = match value {
+        ParameterValue::Float(v) => Some(*v as f64),
+        ParameterValue::Int(v) => Some(*v as f64),
+        _ => None,
+    };
+    let Some(numeric) = numeric else {
+        return value.clone();
+    };
+    match &spec.domain {
+        ParameterDomain::Enum { options } => {
+            // Option values are stored stringified — match by numeric
+            // proximity (handles `"0"` vs `"0.0"` round-trips from
+            // f32::to_string).
+            for option in options {
+                if let Ok(parsed) = option.value.parse::<f64>() {
+                    if (parsed - numeric).abs() < 1e-6 {
+                        return ParameterValue::String(option.value.clone());
+                    }
+                }
+            }
+            value.clone()
+        }
+        ParameterDomain::Bool => ParameterValue::Bool(numeric >= 0.5),
+        _ => value.clone(),
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub struct ParameterSet {
@@ -73,13 +113,20 @@ impl ParameterSet {
                 values.insert(path.clone(), value.clone());
                 continue;
             };
-            spec.validate_value(value).map_err(|error| {
+            // Backward-compat: projects saved before issue #401 stored
+            // every LV2 control as Float, including ones we now route
+            // to Enum/Bool (lv2:enumeration / lv2:toggled). Coerce
+            // numeric stored values into the spec's expected type when
+            // possible — without this every chain block with a toggle
+            // or enum gets silently dropped on load (#401).
+            let coerced = coerce_legacy_value(value, spec);
+            spec.validate_value(&coerced).map_err(|error| {
                 format!(
                     "invalid parameter '{}' for {} model '{}': {}",
                     path, schema.effect_type, schema.model, error
                 )
             })?;
-            values.insert(path.clone(), value.clone());
+            values.insert(path.clone(), coerced);
         }
 
         for spec in &schema.parameters {

--- a/crates/block-core/src/param_tests.rs
+++ b/crates/block-core/src/param_tests.rs
@@ -960,3 +960,65 @@ fn model_parameter_schema_debug() {
     let dbg = format!("{:?}", schema);
     assert!(dbg.contains("test_model"));
 }
+
+// ── Backward-compat coercion (issue #401) ──────────────────────────
+
+#[test]
+fn normalize_coerces_legacy_float_to_enum_string() {
+    use crate::param::{enum_parameter, ModelParameterSchema, ParameterSet};
+    let schema = ModelParameterSchema {
+        effect_type: "pitch".to_string(),
+        model: "lv2_test".to_string(),
+        display_name: "Test".to_string(),
+        audio_mode: ModelAudioMode::DualMono,
+        parameters: vec![enum_parameter(
+            "mode",
+            "Mode",
+            None,
+            Some("0"),
+            &[("0", "Auto"), ("1", "MIDI"), ("2", "Manual")],
+        )],
+    };
+    let mut set = ParameterSet::default();
+    // Project saved BEFORE issue #401 stored mode as Float(0.0).
+    set.insert("mode", ParameterValue::Float(2.0));
+    let normalized = set
+        .normalized_against(&schema)
+        .expect("legacy float must coerce to enum string");
+    assert_eq!(
+        normalized.values.get("mode"),
+        Some(&ParameterValue::String("2".to_string())),
+        "stored mode should be coerced to its matching enum string"
+    );
+}
+
+#[test]
+fn normalize_coerces_legacy_float_to_bool() {
+    use crate::param::{bool_parameter, ModelParameterSchema, ParameterSet};
+    let schema = ModelParameterSchema {
+        effect_type: "pitch".to_string(),
+        model: "lv2_test".to_string(),
+        display_name: "Test".to_string(),
+        audio_mode: ModelAudioMode::DualMono,
+        parameters: vec![bool_parameter("fastmode", "Fast Mode", None, Some(false))],
+    };
+    let mut set = ParameterSet::default();
+    // Pre-#401 behaviour: Bool ports stored as Float.
+    set.insert("fastmode", ParameterValue::Float(1.0));
+    let normalized = set
+        .normalized_against(&schema)
+        .expect("legacy float must coerce to bool");
+    assert_eq!(
+        normalized.values.get("fastmode"),
+        Some(&ParameterValue::Bool(true))
+    );
+
+    set.insert("fastmode", ParameterValue::Float(0.0));
+    let normalized = set
+        .normalized_against(&schema)
+        .expect("legacy float 0 must coerce to false");
+    assert_eq!(
+        normalized.values.get("fastmode"),
+        Some(&ParameterValue::Bool(false))
+    );
+}

--- a/crates/plugin-loader/src/dispatch.rs
+++ b/crates/plugin-loader/src/dispatch.rs
@@ -129,6 +129,28 @@ pub struct Lv2Port {
     pub minimum: Option<f32>,
     pub maximum: Option<f32>,
     pub name: Option<String>,
+    /// `lv2:portProperty lv2:toggled` — value is bool (0/1).
+    pub is_toggle: bool,
+    /// `lv2:portProperty lv2:integer` — value is integer (no decimals).
+    pub is_integer: bool,
+    /// `lv2:portProperty lv2:enumeration` — port has discrete `scale_points`.
+    pub is_enumeration: bool,
+    /// `lv2:scalePoint [ rdfs:label "X" ; rdf:value Y ; ]` collected in
+    /// document order. Used together with `is_enumeration` to render a
+    /// dropdown/select widget.
+    pub scale_points: Vec<Lv2ScalePoint>,
+    /// `pprop:rangeSteps N` — number of discrete positions across the
+    /// range. Used for integer/quantised float steppers.
+    pub range_steps: Option<u32>,
+}
+
+/// One labelled value in an enumeration port. Value is stored as `f32`
+/// because LV2 enumerations always come from a numeric port; the label
+/// is what the user sees in the dropdown.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Lv2ScalePoint {
+    pub value: f32,
+    pub label: String,
 }
 
 /// Parse every `<plugin>.ttl` (and `manifest.ttl`) inside `bundle_dir`
@@ -433,6 +455,7 @@ fn parse_port_block(block: &str) -> Option<Lv2Port> {
     let minimum = capture_after(block, "lv2:minimum").and_then(|raw| raw.parse::<f32>().ok());
     let maximum = capture_after(block, "lv2:maximum").and_then(|raw| raw.parse::<f32>().ok());
     let name = capture_quoted(block, "lv2:name");
+    let properties = parse_port_properties(block);
     Some(Lv2Port {
         index,
         symbol,
@@ -441,7 +464,81 @@ fn parse_port_block(block: &str) -> Option<Lv2Port> {
         minimum,
         maximum,
         name,
+        is_toggle: properties.contains("lv2:toggled"),
+        is_integer: properties.contains("lv2:integer"),
+        is_enumeration: properties.contains("lv2:enumeration"),
+        scale_points: parse_scale_points(block),
+        range_steps: capture_after(block, "pprop:rangeSteps")
+            .and_then(|raw| raw.parse::<u32>().ok()),
     })
+}
+
+/// Read every `lv2:portProperty` directive in the port block and return
+/// the unique set of property tokens. Multiple portProperty directives
+/// can coexist on one port and each can carry a comma-separated list:
+/// `lv2:portProperty lv2:integer, lv2:enumeration ;`.
+fn parse_port_properties(block: &str) -> std::collections::HashSet<String> {
+    let mut out = std::collections::HashSet::new();
+    let mut search = block;
+    while let Some(start) = search.find("lv2:portProperty") {
+        let after = &search[start + "lv2:portProperty".len()..];
+        // Read until the terminating `;` or `]`.
+        let end = after
+            .find(|c: char| c == ';' || c == ']')
+            .unwrap_or(after.len());
+        let list = &after[..end];
+        for token in list.split(',') {
+            let trimmed = token.trim();
+            if !trimmed.is_empty() {
+                out.insert(trimmed.to_string());
+            }
+        }
+        search = &after[end..];
+    }
+    out
+}
+
+/// Read every `lv2:scalePoint [ rdfs:label "X" ; rdf:value Y ; ]` block
+/// and return the parsed `(value, label)` pairs in document order.
+/// Order matches what enumeration UIs typically render, so callers can
+/// pass it straight to `enum_parameter`.
+fn parse_scale_points(block: &str) -> Vec<Lv2ScalePoint> {
+    let mut out = Vec::new();
+    let bytes = block.as_bytes();
+    let needle = "lv2:scalePoint";
+    let mut cursor = 0;
+    while let Some(rel) = block[cursor..].find(needle) {
+        let after_keyword = cursor + rel + needle.len();
+        // Scan forward to the opening `[` that follows the directive,
+        // skipping whitespace.
+        let mut i = after_keyword;
+        while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+            i += 1;
+        }
+        if i >= bytes.len() || bytes[i] != b'[' {
+            cursor = after_keyword;
+            continue;
+        }
+        let inner_start = i + 1;
+        let mut depth: i32 = 1;
+        let mut j = inner_start;
+        while j < bytes.len() && depth > 0 {
+            match bytes[j] {
+                b'[' => depth += 1,
+                b']' => depth -= 1,
+                _ => {}
+            }
+            j += 1;
+        }
+        let inner = &block[inner_start..j.saturating_sub(1)];
+        let value = capture_after(inner, "rdf:value").and_then(|raw| raw.parse::<f32>().ok());
+        let label = capture_quoted(inner, "rdfs:label");
+        if let (Some(value), Some(label)) = (value, label) {
+            out.push(Lv2ScalePoint { value, label });
+        }
+        cursor = j;
+    }
+    out
 }
 
 fn classify(block: &str) -> Lv2PortRole {

--- a/crates/plugin-loader/src/dispatch_tests.rs
+++ b/crates/plugin-loader/src/dispatch_tests.rs
@@ -335,3 +335,110 @@ fn scan_lv2_ports_falls_back_to_only_plugin_when_uri_mismatches() {
     );
     let _ = fs::remove_dir_all(&tmp);
 }
+
+// ── lv2:portProperty / lv2:scalePoint / pprop:rangeSteps (issue #401) ───
+
+#[test]
+fn parses_toggle_port_property() {
+    use std::fs;
+    let tmp = std::env::temp_dir().join(format!("openrig-lv2-toggle-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&tmp);
+    fs::create_dir_all(&tmp).unwrap();
+    fs::write(
+        tmp.join("plug.ttl"),
+        "@prefix lv2: <http://lv2plug.in/ns/lv2core#> .\n\
+<urn:test:plug>\n\
+    a lv2:Plugin ;\n\
+    lv2:port [\n\
+        a lv2:InputPort, lv2:ControlPort ;\n\
+        lv2:index 0 ;\n\
+        lv2:symbol \"bypass\" ;\n\
+        lv2:default 0 ;\n\
+        lv2:minimum 0 ;\n\
+        lv2:maximum 1 ;\n\
+        lv2:portProperty lv2:integer, lv2:toggled ;\n\
+    ] .\n",
+    )
+    .unwrap();
+    let port = scan_lv2_ports(&tmp, "urn:test:plug")
+        .expect("scan ok")
+        .into_iter()
+        .find(|p| p.symbol == "bypass")
+        .expect("bypass port present");
+    assert!(port.is_toggle, "lv2:toggled flag must be detected");
+    assert!(port.is_integer, "lv2:integer flag must be detected");
+    let _ = fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn parses_enumeration_with_scale_points() {
+    use std::fs;
+    let tmp = std::env::temp_dir().join(format!("openrig-lv2-enum-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&tmp);
+    fs::create_dir_all(&tmp).unwrap();
+    fs::write(
+        tmp.join("plug.ttl"),
+        "@prefix lv2: <http://lv2plug.in/ns/lv2core#> .\n\
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n\
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n\
+<urn:test:plug>\n\
+    a lv2:Plugin ;\n\
+    lv2:port [\n\
+        a lv2:InputPort, lv2:ControlPort ;\n\
+        lv2:index 0 ;\n\
+        lv2:symbol \"mode\" ;\n\
+        lv2:default 0 ;\n\
+        lv2:minimum 0 ;\n\
+        lv2:maximum 2 ;\n\
+        lv2:portProperty lv2:integer, lv2:enumeration ;\n\
+        lv2:scalePoint [ rdfs:label \"Auto\" ; rdf:value 0 ; ] ;\n\
+        lv2:scalePoint [ rdfs:label \"MIDI\" ; rdf:value 1 ; ] ;\n\
+        lv2:scalePoint [ rdfs:label \"Manual\" ; rdf:value 2 ; ] ;\n\
+    ] .\n",
+    )
+    .unwrap();
+    let port = scan_lv2_ports(&tmp, "urn:test:plug")
+        .expect("scan ok")
+        .into_iter()
+        .find(|p| p.symbol == "mode")
+        .expect("mode port present");
+    assert!(port.is_enumeration, "lv2:enumeration flag must be detected");
+    assert_eq!(port.scale_points.len(), 3);
+    assert_eq!(port.scale_points[0].value, 0.0);
+    assert_eq!(port.scale_points[0].label, "Auto");
+    assert_eq!(port.scale_points[1].label, "MIDI");
+    assert_eq!(port.scale_points[2].label, "Manual");
+    let _ = fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn parses_range_steps() {
+    use std::fs;
+    let tmp = std::env::temp_dir().join(format!("openrig-lv2-rangesteps-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&tmp);
+    fs::create_dir_all(&tmp).unwrap();
+    fs::write(
+        tmp.join("plug.ttl"),
+        "@prefix lv2: <http://lv2plug.in/ns/lv2core#> .\n\
+@prefix pprop: <http://lv2plug.in/ns/ext/port-props#> .\n\
+<urn:test:plug>\n\
+    a lv2:Plugin ;\n\
+    lv2:port [\n\
+        a lv2:InputPort, lv2:ControlPort ;\n\
+        lv2:index 0 ;\n\
+        lv2:symbol \"tuning\" ;\n\
+        lv2:default 440.0 ;\n\
+        lv2:minimum 400.0 ;\n\
+        lv2:maximum 480.0 ;\n\
+        pprop:rangeSteps 401 ;\n\
+    ] .\n",
+    )
+    .unwrap();
+    let port = scan_lv2_ports(&tmp, "urn:test:plug")
+        .expect("scan ok")
+        .into_iter()
+        .find(|p| p.symbol == "tuning")
+        .expect("tuning port present");
+    assert_eq!(port.range_steps, Some(401));
+    let _ = fs::remove_dir_all(&tmp);
+}

--- a/crates/project/examples/test_lv2_schema.rs
+++ b/crates/project/examples/test_lv2_schema.rs
@@ -1,7 +1,3 @@
-//! Dumps schema synthesis for plugins exercising every LV2 port type
-//! routed by `synthesize_lv2_parameters` (issue #401). Used to verify
-//! toggle/enum/integer detection at the schema layer without booting
-//! the full GUI.
 use std::path::Path;
 
 fn main() {
@@ -9,41 +5,13 @@ fn main() {
         "/Users/joao.faria/Projetos/github.com/jpfaria/OpenRig-plugins/plugins/source",
     ));
 
-    let cases = [
-        ("pitch", "lv2_fat1_autotune"),
-        ("mod", "lv2_larynx"),
-        ("mod", "lv2_harmless"),
-        ("dynamics", "lv2_zamcomp"),
-        ("filter", "lv2_fomp_autowah"),
-    ];
-
-    for (effect, id) in &cases {
-        match project::block::schema_for_block_model(effect, id) {
-            Ok(schema) => {
-                println!("\n=== {id} ({effect}, {} params) ===", schema.parameters.len());
-                for p in &schema.parameters {
-                    use block_core::param::{ParameterDomain, ParameterWidget};
-                    let kind = match (&p.widget, &p.domain) {
-                        (ParameterWidget::Toggle, _) => "TOGGLE".to_string(),
-                        (ParameterWidget::Select, _) => match &p.domain {
-                            ParameterDomain::Enum { options } => {
-                                format!("SELECT [{}]", options.iter().map(|o| o.label.as_str()).collect::<Vec<_>>().join("/"))
-                            }
-                            _ => "SELECT".to_string(),
-                        },
-                        (_, ParameterDomain::FloatRange { min, max, step }) => {
-                            if *step > 0.0 {
-                                format!("INT step={step}")
-                            } else {
-                                format!("FLOAT[{min}..{max}]")
-                            }
-                        }
-                        _ => format!("{:?}", p.widget),
-                    };
-                    println!("  {:>32}  {}  ({})", kind, p.path, p.label);
-                }
-            }
-            Err(e) => println!("\n=== {id} ({effect}) ERROR: {e}"),
+    for effect in &["pitch", "modulation", "filter", "dynamics", "delay", "reverb", "gain"] {
+        if let Ok(entries) = project::catalog::supported_block_models(effect) {
+            let visible: Vec<_> = entries
+                .iter()
+                .filter(|item| item.supported_instruments.iter().any(|i| i == "voice"))
+                .collect();
+            println!("voice-visible in '{}': {} plugins", effect, visible.len());
         }
     }
 }

--- a/crates/project/examples/test_lv2_schema.rs
+++ b/crates/project/examples/test_lv2_schema.rs
@@ -1,36 +1,49 @@
+//! Dumps schema synthesis for plugins exercising every LV2 port type
+//! routed by `synthesize_lv2_parameters` (issue #401). Used to verify
+//! toggle/enum/integer detection at the schema layer without booting
+//! the full GUI.
 use std::path::Path;
+
 fn main() {
     plugin_loader::registry::init(Path::new(
         "/Users/joao.faria/Projetos/github.com/jpfaria/OpenRig-plugins/plugins/source",
     ));
-    for id in &[
-        "lv2_dragonfly_room",
-        "lv2_tap_chorus_flanger",
-        "lv2_zamcomp",
-        "ir_gibson_j45",
-    ] {
-        let effect = if id.starts_with("ir_gibson") {
-            "body"
-        } else if id.contains("dragonfly") {
-            "reverb"
-        } else if id.contains("chorus") || id.contains("flanger") {
-            "modulation"
-        } else {
-            "dynamics"
-        };
+
+    let cases = [
+        ("pitch", "lv2_fat1_autotune"),
+        ("mod", "lv2_larynx"),
+        ("mod", "lv2_harmless"),
+        ("dynamics", "lv2_zamcomp"),
+        ("filter", "lv2_fomp_autowah"),
+    ];
+
+    for (effect, id) in &cases {
         match project::block::schema_for_block_model(effect, id) {
-            Ok(s) => {
-                println!(
-                    "{} -> {} params: {:?}",
-                    id,
-                    s.parameters.len(),
-                    s.parameters
-                        .iter()
-                        .map(|p| p.path.as_str())
-                        .collect::<Vec<_>>()
-                );
+            Ok(schema) => {
+                println!("\n=== {id} ({effect}, {} params) ===", schema.parameters.len());
+                for p in &schema.parameters {
+                    use block_core::param::{ParameterDomain, ParameterWidget};
+                    let kind = match (&p.widget, &p.domain) {
+                        (ParameterWidget::Toggle, _) => "TOGGLE".to_string(),
+                        (ParameterWidget::Select, _) => match &p.domain {
+                            ParameterDomain::Enum { options } => {
+                                format!("SELECT [{}]", options.iter().map(|o| o.label.as_str()).collect::<Vec<_>>().join("/"))
+                            }
+                            _ => "SELECT".to_string(),
+                        },
+                        (_, ParameterDomain::FloatRange { min, max, step }) => {
+                            if *step > 0.0 {
+                                format!("INT step={step}")
+                            } else {
+                                format!("FLOAT[{min}..{max}]")
+                            }
+                        }
+                        _ => format!("{:?}", p.widget),
+                    };
+                    println!("  {:>32}  {}  ({})", kind, p.path, p.label);
+                }
             }
-            Err(e) => println!("{} ERROR: {}", id, e),
+            Err(e) => println!("\n=== {id} ({effect}) ERROR: {e}"),
         }
     }
 }

--- a/crates/project/src/block/dispatch.rs
+++ b/crates/project/src/block/dispatch.rs
@@ -219,30 +219,85 @@ fn synthesize_lv2_parameters(
     ports
         .into_iter()
         .filter(|port| port.role == Lv2PortRole::ControlIn)
-        .map(|port| {
-            let label = port.name.clone().unwrap_or_else(|| port.symbol.clone());
-            let min = port.minimum.unwrap_or(0.0);
-            let max = port.maximum.unwrap_or(1.0).max(min + 0.001);
-            let default = port.default_value.unwrap_or((min + max) / 2.0);
-            // step = 0 means "continuous" (no snap-to-grid). LV2
-            // ControlPorts are continuous unless the TTL marks them
-            // `lv2:portProperty lv2:integer` or `lv2:enumeration` —
-            // we don't parse those flags yet, and in any case the
-            // synthesized step was `(max-min)/100` which generated
-            // bogus grids (e.g. Contour 20-20000 → step 199.8) that
-            // rejected the TTL default itself.
-            block_core::param::float_parameter(
-                &port.symbol,
-                &label,
-                None,
-                Some(default),
-                min,
-                max,
-                0.0,
-                block_core::param::ParameterUnit::None,
-            )
-        })
+        .map(synthesize_one_lv2_param)
         .collect()
+}
+
+/// Translate one LV2 ControlIn port into the corresponding
+/// `ParameterSpec`. Routing — checked in this order so that an
+/// `enumeration + integer` port (a common pattern) lands as an enum:
+///
+/// 1. `lv2:toggled` → bool checkbox.
+/// 2. `lv2:enumeration` with at least one `lv2:scalePoint` → enum dropdown.
+/// 3. `lv2:integer` (no scalePoint) → integer-stepped float.
+/// 4. otherwise → continuous float (legacy behaviour).
+fn synthesize_one_lv2_param(
+    port: plugin_loader::dispatch::Lv2Port,
+) -> block_core::param::ParameterSpec {
+    let label = port.name.clone().unwrap_or_else(|| port.symbol.clone());
+
+    if port.is_toggle {
+        let default = port.default_value.map(|value| value >= 0.5).or(Some(false));
+        return block_core::param::bool_parameter(&port.symbol, &label, None, default);
+    }
+
+    if port.is_enumeration && !port.scale_points.is_empty() {
+        // Enum values keep the original numeric ordering. Stored values
+        // are the numeric `rdf:value` (stringified) so the runtime can
+        // round-trip them back to the LV2 control port.
+        let options: Vec<(String, String)> = port
+            .scale_points
+            .iter()
+            .map(|sp| (sp.value.to_string(), sp.label.clone()))
+            .collect();
+        let options_refs: Vec<(&str, &str)> = options
+            .iter()
+            .map(|(value, label)| (value.as_str(), label.as_str()))
+            .collect();
+        let default = port
+            .default_value
+            .and_then(|value| {
+                port.scale_points
+                    .iter()
+                    .find(|sp| (sp.value - value).abs() < f32::EPSILON)
+            })
+            .map(|sp| sp.value.to_string());
+        return block_core::param::enum_parameter(
+            &port.symbol,
+            &label,
+            None,
+            default.as_deref(),
+            &options_refs,
+        );
+    }
+
+    let min = port.minimum.unwrap_or(0.0);
+    let max = port.maximum.unwrap_or(1.0).max(min + 0.001);
+    let default = port.default_value.unwrap_or((min + max) / 2.0);
+
+    let step = if port.is_integer {
+        // pprop:rangeSteps tells us exactly how many discrete positions
+        // the host should expose; fall back to step=1 for plain integer
+        // ports without explicit step count.
+        port.range_steps
+            .filter(|n| *n > 0)
+            .map(|n| (max - min) / n as f32)
+            .unwrap_or(1.0)
+    } else {
+        // Continuous control. step = 0 = "no snap-to-grid".
+        0.0
+    };
+
+    block_core::param::float_parameter(
+        &port.symbol,
+        &label,
+        None,
+        Some(default),
+        min,
+        max,
+        step,
+        block_core::param::ParameterUnit::None,
+    )
 }
 
 fn schema_for_block_model_legacy(

--- a/crates/project/tests/lv2_param_types.rs
+++ b/crates/project/tests/lv2_param_types.rs
@@ -1,0 +1,192 @@
+//! LV2 schema synthesis must respect `lv2:portProperty lv2:toggled`,
+//! `lv2:enumeration`, and `lv2:integer` so the GUI gets checkboxes /
+//! dropdowns / steppers instead of generic float sliders. Issue #401.
+//!
+//! Reproduced from x42 fat1 autotune: 12 toggles `m00..m11` (one per
+//! note in the chromatic scale) plus a `mode` enum (Auto/MIDI/Manual).
+//!
+//! `plugin_loader::registry` is OnceLock-backed, so all packages this
+//! file exercises are registered into a single shared root and the
+//! registry is initialised exactly once.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn shared_root() -> PathBuf {
+    let path = std::env::temp_dir().join(format!("openrig-lv2-params-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&path);
+    fs::create_dir_all(&path).expect("create tmp root");
+    path
+}
+
+fn write(path: &Path, contents: &[u8]) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create parent");
+    }
+    fs::write(path, contents).expect("write file");
+}
+
+fn make_pitch_pkg_with_toggle(root: &Path) {
+    let pkg = root.join("lv2_test_pitch_toggle");
+    write(
+        &pkg.join("manifest.yaml"),
+        br#"manifest_version: 1
+id: lv2_test_pitch_toggle
+display_name: Test Pitch Toggle
+brand: testco
+type: pitch
+backend: lv2
+plugin_uri: urn:test:pitch_toggle
+binaries:
+  macos-universal: platform/macos-universal/pitch.dylib
+"#,
+    );
+    write(
+        &pkg.join("data").join("manifest.ttl"),
+        b"@prefix lv2: <http://lv2plug.in/ns/lv2core#> .\n\
+          <urn:test:pitch_toggle> a lv2:Plugin ; lv2:binary <pitch.so> .\n",
+    );
+    write(
+        &pkg.join("data").join("pitch.ttl"),
+        b"@prefix lv2: <http://lv2plug.in/ns/lv2core#> .\n\
+          <urn:test:pitch_toggle>\n\
+              a lv2:Plugin ;\n\
+              lv2:port [ a lv2:InputPort, lv2:AudioPort ; lv2:index 0 ; lv2:symbol \"in\" ] ,\n\
+              [ a lv2:OutputPort, lv2:AudioPort ; lv2:index 1 ; lv2:symbol \"out\" ] ,\n\
+              [ a lv2:InputPort, lv2:ControlPort ;\n\
+                lv2:index 2 ;\n\
+                lv2:symbol \"note_c\" ;\n\
+                lv2:name \"C\" ;\n\
+                lv2:default 1 ;\n\
+                lv2:minimum 0 ;\n\
+                lv2:maximum 1 ;\n\
+                lv2:portProperty lv2:integer, lv2:toggled ;\n\
+              ] .\n",
+    );
+    write(
+        &pkg.join("platform")
+            .join("macos-universal")
+            .join("pitch.dylib"),
+        b"fake-bin",
+    );
+}
+
+fn make_pitch_pkg_with_enum(root: &Path) {
+    let pkg = root.join("lv2_test_pitch_enum");
+    write(
+        &pkg.join("manifest.yaml"),
+        br#"manifest_version: 1
+id: lv2_test_pitch_enum
+display_name: Test Pitch Enum
+brand: testco
+type: pitch
+backend: lv2
+plugin_uri: urn:test:pitch_enum
+binaries:
+  macos-universal: platform/macos-universal/pitchenum.dylib
+"#,
+    );
+    write(
+        &pkg.join("data").join("manifest.ttl"),
+        b"@prefix lv2: <http://lv2plug.in/ns/lv2core#> .\n\
+          <urn:test:pitch_enum> a lv2:Plugin ; lv2:binary <pitchenum.so> .\n",
+    );
+    write(
+        &pkg.join("data").join("pitchenum.ttl"),
+        b"@prefix lv2: <http://lv2plug.in/ns/lv2core#> .\n\
+          @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n\
+          @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n\
+          <urn:test:pitch_enum>\n\
+              a lv2:Plugin ;\n\
+              lv2:port [ a lv2:InputPort, lv2:AudioPort ; lv2:index 0 ; lv2:symbol \"in\" ] ,\n\
+              [ a lv2:OutputPort, lv2:AudioPort ; lv2:index 1 ; lv2:symbol \"out\" ] ,\n\
+              [ a lv2:InputPort, lv2:ControlPort ;\n\
+                lv2:index 2 ;\n\
+                lv2:symbol \"mode\" ;\n\
+                lv2:name \"Mode\" ;\n\
+                lv2:default 0 ;\n\
+                lv2:minimum 0 ;\n\
+                lv2:maximum 2 ;\n\
+                lv2:portProperty lv2:integer, lv2:enumeration ;\n\
+                lv2:scalePoint [ rdfs:label \"Auto\" ; rdf:value 0 ; ] ;\n\
+                lv2:scalePoint [ rdfs:label \"MIDI\" ; rdf:value 1 ; ] ;\n\
+                lv2:scalePoint [ rdfs:label \"Manual\" ; rdf:value 2 ; ] ;\n\
+              ] .\n",
+    );
+    write(
+        &pkg.join("platform")
+            .join("macos-universal")
+            .join("pitchenum.dylib"),
+        b"fake-bin",
+    );
+}
+
+/// One-shot setup. The OnceLock-backed registry only honours the very
+/// first `init` call, so every test in this file must hit a registry
+/// that already saw both packages.
+fn shared_registry() -> &'static PathBuf {
+    use std::sync::OnceLock;
+    static ROOT: OnceLock<PathBuf> = OnceLock::new();
+    ROOT.get_or_init(|| {
+        let root = shared_root();
+        make_pitch_pkg_with_toggle(&root);
+        make_pitch_pkg_with_enum(&root);
+        plugin_loader::registry::init(&root);
+        root
+    })
+}
+
+#[test]
+fn synthesized_schema_routes_lv2_toggled_to_bool_parameter() {
+    let _ = shared_registry();
+
+    let schema = project::block::schema_for_block_model("pitch", "lv2_test_pitch_toggle")
+        .expect("schema resolves via plugin_loader fallback");
+
+    let note = schema
+        .parameters
+        .iter()
+        .find(|p| p.path == "note_c")
+        .expect("note_c parameter present");
+
+    use block_core::param::{ParameterDomain, ParameterWidget};
+    assert!(
+        matches!(note.widget, ParameterWidget::Toggle),
+        "expected Toggle widget for `lv2:toggled` port, got {:?}",
+        note.widget
+    );
+    assert!(
+        matches!(note.domain, ParameterDomain::Bool),
+        "expected Bool domain for `lv2:toggled` port, got {:?}",
+        note.domain
+    );
+    assert_eq!(note.label, "C");
+}
+
+#[test]
+fn synthesized_schema_routes_enumeration_with_scale_points_to_enum_parameter() {
+    let _ = shared_registry();
+
+    let schema = project::block::schema_for_block_model("pitch", "lv2_test_pitch_enum")
+        .expect("schema resolves via plugin_loader fallback");
+
+    let mode = schema
+        .parameters
+        .iter()
+        .find(|p| p.path == "mode")
+        .expect("mode parameter present");
+
+    use block_core::param::{ParameterDomain, ParameterWidget};
+    assert!(
+        matches!(mode.widget, ParameterWidget::Select),
+        "expected Select widget for `lv2:enumeration` port, got {:?}",
+        mode.widget
+    );
+    let ParameterDomain::Enum { options } = &mode.domain else {
+        panic!("expected Enum domain, got {:?}", mode.domain);
+    };
+    assert_eq!(options.len(), 3);
+    assert_eq!(options[0].label, "Auto");
+    assert_eq!(options[1].label, "MIDI");
+    assert_eq!(options[2].label, "Manual");
+}


### PR DESCRIPTION
Closes #401.

## Summary

- `plugin_loader::dispatch::Lv2Port` ganha `is_toggle`/`is_integer`/`is_enumeration`/`scale_points`/`range_steps`. Parser TTL captura `lv2:portProperty` (lista comma-separated), `lv2:scalePoint` (rdf:value + rdfs:label), e `pprop:rangeSteps`.
- `project::block::dispatch::synthesize_one_lv2_param` roteia por tipo: toggle → `bool_parameter`, enumeration+scale points → `enum_parameter`, integer → `float_parameter` com step, contínuo como fallback.
- `ParameterSet::normalized_against` agora aplica `coerce_legacy_value` antes de validar — evita que projetos salvos antes deste fix percam todos os blocks LV2 com toggle/enum no load (Float → String matching enum value, Float → Bool via `>= 0.5`). Sem isso, `infra-yaml::load_audio_block_value` jogava blocks fora silenciosamente.

## Casos cobertos (verificados via `cargo run --example test_lv2_schema`)

- `lv2_fat1_autotune` (x42 Autotune): `mode` enum (Auto/MIDI/Manual), `channelf` enum (Any/01..16), `scale` enum (25 escalas — Chromatic, C Major, ..., A Minor, ..., B Minor), `fastmode` toggle, 6 floats.
- `lv2_zamcomp`: `sidech` toggle + 7 floats.
- `larynx`/`harmless`/`fomp_autowah`: só float (sem regressão).

## Test plan
- [x] `cargo build --workspace` zero warnings
- [x] `cargo test --workspace --lib --tests` verde
- [x] 3 unit tests novos em `plugin-loader/dispatch_tests.rs` (toggle / enumeration+scalePoints / rangeSteps)
- [x] 2 integration tests novos em `project/tests/lv2_param_types.rs` (Toggle widget + Select widget end-to-end)
- [x] 2 unit tests novos em `block-core/param_tests.rs` (coercion legacy float → enum string + → bool)
- [ ] Smoke teste manual no app: abrir x42 Autotune e ver `Scale` como dropdown com A Minor + outras escalas
- [ ] Confirmar que projetos antigos com chains contendo blocks LV2 enum/toggle carregam todos os blocks

## Companion change

- `OpenRig-plugins` recebeu commit separado (`23f44ff5`) restaurando TTLs perdidos para `mda_repsycho` e `mda_detune` — ambos packages estavam com `data/` vazio, então a sintese retornava 0 params (UI sem knobs). Não está neste PR; o bundle baixado pelo CI (`bundle-plugins` job) já pegará o fix.