### PR TITLE
fix(414): hover tooltip resolve display_name for NAM disk-packages

### DIFF
--- a/crates/project/src/catalog.rs
+++ b/crates/project/src/catalog.rs
@@ -437,10 +437,29 @@ pub fn model_stream_kind(effect_type: &str, model_id: &str) -> &'static str {
     }
 }
 
+/// Look up a disk-package by effect_type + model_id, applying the same
+/// `effect_type → BlockType` mapping the catalog uses for `supported_block_models`.
+/// Returns `None` if the effect_type has no disk-package support or the
+/// model_id isn't a disk-package id. Issue #414.
+fn disk_package_for(
+    effect_type: &str,
+    model_id: &str,
+) -> Option<&'static plugin_loader::discover::LoadedPackage> {
+    let block_type = block_type_for_effect_type(effect_type)?;
+    plugin_loader::registry::packages_for(block_type)
+        .into_iter()
+        .find(|p| p.manifest.id == model_id)
+}
+
 /// Returns the display name for a model, or empty string if not found.
-pub fn model_display_name(effect_type: &str, model_id: &str) -> &'static str {
+///
+/// Native models resolve via the per-effect `block_*::display_name`; disk-package
+/// models (NAM/IR/LV2/VST3) fall back to the plugin_loader registry so the
+/// hover tooltip, plugin-info window and block editor header all show the right
+/// name. Issue #414.
+pub fn model_display_name(effect_type: &str, model_id: &str) -> String {
     use block_core::*;
-    match effect_type {
+    let native: &'static str = match effect_type {
         EFFECT_TYPE_UTILITY => block_util::util_display_name(model_id),
         EFFECT_TYPE_GAIN => block_gain::gain_display_name(model_id),
         EFFECT_TYPE_AMP => block_amp::amp_display_name(model_id),
@@ -458,13 +477,21 @@ pub fn model_display_name(effect_type: &str, model_id: &str) -> &'static str {
         EFFECT_TYPE_NAM => block_nam::nam_display_name(model_id),
         EFFECT_TYPE_IR => block_ir::ir_display_name(model_id),
         _ => "",
+    };
+    if !native.is_empty() {
+        return native.to_string();
     }
+    disk_package_for(effect_type, model_id)
+        .map(|p| p.manifest.display_name.clone())
+        .unwrap_or_default()
 }
 
 /// Returns the brand for a model, or empty string if not found.
-pub fn model_brand(effect_type: &str, model_id: &str) -> &'static str {
+///
+/// Native first, then disk-package `manifest.brand`. Issue #414.
+pub fn model_brand(effect_type: &str, model_id: &str) -> String {
     use block_core::*;
-    match effect_type {
+    let native: &'static str = match effect_type {
         EFFECT_TYPE_UTILITY => block_util::util_brand(model_id),
         EFFECT_TYPE_GAIN => block_gain::gain_brand(model_id),
         EFFECT_TYPE_AMP => block_amp::amp_model_visual(model_id)
@@ -484,14 +511,23 @@ pub fn model_brand(effect_type: &str, model_id: &str) -> &'static str {
         EFFECT_TYPE_NAM => block_nam::nam_brand(model_id),
         EFFECT_TYPE_IR => block_ir::ir_brand(model_id),
         _ => "",
+    };
+    if !native.is_empty() {
+        return native.to_string();
     }
+    disk_package_for(effect_type, model_id)
+        .and_then(|p| p.manifest.brand.clone())
+        .unwrap_or_default()
 }
 
 /// Returns the type label for a model (e.g. "NATIVE", "NAM", "LV2", "IR"),
 /// or empty string if not found.
-pub fn model_type_label(effect_type: &str, model_id: &str) -> &'static str {
+///
+/// Native first, then `backend_label_for` on the disk-package's backend variant.
+/// Issue #414.
+pub fn model_type_label(effect_type: &str, model_id: &str) -> String {
     use block_core::*;
-    match effect_type {
+    let native: &'static str = match effect_type {
         EFFECT_TYPE_UTILITY => block_util::util_type_label(model_id),
         EFFECT_TYPE_GAIN => block_gain::gain_type_label(model_id),
         EFFECT_TYPE_AMP => block_amp::amp_model_visual(model_id)
@@ -511,7 +547,13 @@ pub fn model_type_label(effect_type: &str, model_id: &str) -> &'static str {
         EFFECT_TYPE_NAM => block_nam::nam_type_label(model_id),
         EFFECT_TYPE_IR => block_ir::ir_type_label(model_id),
         _ => "",
+    };
+    if !native.is_empty() {
+        return native.to_string();
     }
+    disk_package_for(effect_type, model_id)
+        .map(|p| backend_label_for(&p.manifest.backend).to_string())
+        .unwrap_or_default()
 }
 
 pub fn model_knob_layout(

--- a/crates/project/tests/disk_package_metadata_lookups.rs
+++ b/crates/project/tests/disk_package_metadata_lookups.rs
@@ -1,0 +1,92 @@
+//! Issue #414 — `model_display_name`, `model_brand` and `model_type_label`
+//! must resolve disk-package models (NAM/IR/LV2) via the plugin_loader
+//! registry, not just the native block_* tables. Previously they only
+//! consulted natives and returned `""` for NAM blocks, which collapsed the
+//! hover tooltip (gated by `display_name != ""`).
+
+use project::catalog::{model_brand, model_display_name, model_type_label};
+
+fn init_plugins() {
+    use std::path::PathBuf;
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let candidates = [
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("../../../../../OpenRig-plugins/plugins/source"),
+            PathBuf::from(
+                "/Users/joao.faria/Projetos/github.com/jpfaria/OpenRig-plugins/plugins/source",
+            ),
+        ];
+        let roots: Vec<PathBuf> = candidates.into_iter().filter(|p| p.is_dir()).collect();
+        if !roots.is_empty() {
+            plugin_loader::registry::init_many(&roots);
+        }
+    });
+}
+
+/// Pick the first disk-package model id from `supported_block_models(amp)`
+/// that isn't a native amp — so the test is resilient to packages being
+/// added/removed in OpenRig-plugins.
+fn first_nam_amp_id() -> String {
+    use project::catalog::supported_block_models;
+    supported_block_models("amp")
+        .expect("amp catalog")
+        .into_iter()
+        .find(|m| m.model_id.starts_with("nam_"))
+        .map(|m| m.model_id)
+        .expect("at least one NAM amp expected in OpenRig-plugins")
+}
+
+#[test]
+fn nam_amp_display_name_resolves() {
+    init_plugins();
+    let id = first_nam_amp_id();
+    let name = model_display_name("amp", &id);
+    assert!(
+        !name.is_empty(),
+        "expected non-empty display_name for NAM amp `{}` — tooltip hover relies on this",
+        id,
+    );
+}
+
+#[test]
+fn nam_amp_type_label_is_nam() {
+    init_plugins();
+    let id = first_nam_amp_id();
+    let label = model_type_label("amp", &id);
+    assert_eq!(
+        label, "NAM",
+        "NAM disk-package should report NAM type label"
+    );
+}
+
+#[test]
+fn nam_amp_brand_resolves() {
+    init_plugins();
+    let id = first_nam_amp_id();
+    let brand = model_brand("amp", &id);
+    assert!(
+        !brand.is_empty(),
+        "expected non-empty brand for NAM amp `{}` (manifest.brand)",
+        id,
+    );
+}
+
+/// Native model still resolves through its block-* registry (untouched
+/// fast path).
+#[test]
+fn native_model_display_name_unchanged() {
+    init_plugins();
+    let name = model_display_name("dynamics", "compressor_studio_clean");
+    assert!(!name.is_empty(), "native model should keep resolving");
+}
+
+/// Unknown model returns empty (no panic / no false-positive).
+#[test]
+fn unknown_model_returns_empty() {
+    init_plugins();
+    assert_eq!(model_display_name("amp", "does_not_exist_xyz"), "");
+    assert_eq!(model_brand("amp", "does_not_exist_xyz"), "");
+    assert_eq!(model_type_label("amp", "does_not_exist_xyz"), "");
+}


### PR DESCRIPTION
## Summary

`model_display_name`, `model_brand` and `model_type_label` em `project::catalog` só consultavam o registry **nativo** (block_*::display_name). Disk-package models (NAM/IR/LV2) caem fora — retornavam `""`.

A condição de visibilidade do `BlockHoverTooltip` (chain_row.slint:392) é `display_name != ""` → tooltip nunca abria em hover sobre blocos NAM.

Fix: adiciona fallback no `plugin_loader::registry` quando o lookup nativo retorna vazio. Return type passa de `&'static str` para `String` pra acomodar strings runtime do manifest.

## Test plan

- [x] `cargo test -p project --test disk_package_metadata_lookups` (5 tests verdes)
- [ ] Hover em bloco NAM (`nam_marshall_jtm45` etc.) abre tooltip com pill marrom NAM, brand, display_name e parâmetros
- [ ] Hover em bloco LV2/Native/IR continua funcionando como antes
- [ ] Bloco I/O (Input/Output/Insert) não abre tooltip (comportamento existente)