### PR TITLE
fix(415): recover from poisoned chain runtime Mutex instead of aborting

### DIFF
--- a/crates/engine/src/runtime.rs
+++ b/crates/engine/src/runtime.rs
@@ -610,3 +610,7 @@ mod audio_deadline;
 #[cfg(test)]
 #[path = "audio_signal_integrity_tests.rs"]
 mod audio_signal_integrity;
+
+#[cfg(test)]
+#[path = "runtime_lock_recovery_tests.rs"]
+mod runtime_lock_recovery;

--- a/crates/engine/src/runtime_graph.rs
+++ b/crates/engine/src/runtime_graph.rs
@@ -54,8 +54,8 @@ use crate::runtime_audio_frame::ElasticBuffer;
 use crate::runtime_endpoints::{effective_inputs, effective_outputs};
 use crate::runtime_segments::split_chain_into_segments;
 use crate::runtime_state::{
-    BlockRuntimeNode, ChainProcessingState, InputCallbackScratch, InputProcessingState,
-    OutputRoutingState,
+    lock_recover, BlockRuntimeNode, ChainProcessingState, InputCallbackScratch,
+    InputProcessingState, OutputRoutingState,
 };
 
 /// Bounded capacity for the per-chain SPSC error queue. Audio-thread
@@ -354,7 +354,7 @@ pub fn update_chain_runtime_state(
 
     // Step 1: Extract existing blocks from all input states (brief lock)
     let mut existing_per_input: Vec<Vec<BlockRuntimeNode>> = {
-        let mut processing = runtime.processing.lock().expect("chain runtime poisoned");
+        let mut processing = lock_recover(&runtime.processing, "chain runtime");
         processing
             .input_states
             .iter_mut()
@@ -393,7 +393,7 @@ pub fn update_chain_runtime_state(
                     "[engine] rebuild failed for chain '{}': {e} — restoring previous state",
                     chain.id.0
                 );
-                let mut processing = runtime.processing.lock().expect("chain runtime poisoned");
+                let mut processing = lock_recover(&runtime.processing, "chain runtime");
                 for (is, old_blocks) in processing
                     .input_states
                     .iter_mut()
@@ -422,10 +422,7 @@ pub fn update_chain_runtime_state(
     // Step 2.5: Refresh stream_handles — picks up new handles from rebuilt blocks
     // (e.g. block param changed → new processor → new Arc; old Arc in map would be stale)
     {
-        let mut handles = runtime
-            .stream_handles
-            .lock()
-            .expect("stream_handles poisoned");
+        let mut handles = lock_recover(&runtime.stream_handles, "stream_handles");
         handles.clear();
         for input_state in &new_input_states {
             for block in &input_state.blocks {
@@ -438,7 +435,7 @@ pub fn update_chain_runtime_state(
 
     // Step 3: Swap in new state (brief lock)
     {
-        let mut processing = runtime.processing.lock().expect("chain runtime poisoned");
+        let mut processing = lock_recover(&runtime.processing, "chain runtime");
         processing.input_states = new_input_states;
 
         // Rebuild input_to_segments mapping from current segments

--- a/crates/engine/src/runtime_lock_recovery_tests.rs
+++ b/crates/engine/src/runtime_lock_recovery_tests.rs
@@ -1,0 +1,74 @@
+//! Tests for `lock_recover` — issue #415.
+//!
+//! The chain runtime Mutex used to be `.lock().expect("chain runtime
+//! poisoned")` at three sites in `runtime_graph.rs`. A prior panic
+//! anywhere holding that lock would poison it and the next UI-triggered
+//! rebuild (Save in Chain Input Groups) would abort the process.
+//!
+//! These tests pin the recovery behaviour: a poisoned Mutex is logged
+//! and the inner state is still returned, so a subsequent rebuild can
+//! overwrite the inconsistent state with a fresh one.
+
+use std::sync::{Arc, Mutex};
+
+use crate::runtime_state::lock_recover;
+
+#[test]
+fn lock_recover_returns_guard_when_not_poisoned() {
+    let m: Mutex<u32> = Mutex::new(42);
+    let g = lock_recover(&m, "test");
+    assert_eq!(*g, 42);
+}
+
+#[test]
+fn lock_recover_returns_inner_when_poisoned_by_prior_panic() {
+    let m: Arc<Mutex<u32>> = Arc::new(Mutex::new(7));
+
+    // Poison the lock from another thread.
+    let m_clone = Arc::clone(&m);
+    let _ = std::thread::spawn(move || {
+        let _guard = m_clone.lock().expect("not yet poisoned");
+        panic!("intentional poison for test");
+    })
+    .join();
+
+    // Sanity: the lock IS poisoned now.
+    assert!(
+        m.lock().is_err(),
+        "lock must be poisoned before exercising lock_recover"
+    );
+
+    // The fix: lock_recover returns the guard anyway.
+    let g = lock_recover(&m, "test");
+    assert_eq!(
+        *g, 7,
+        "poisoned data is still accessible — only the poison flag was set"
+    );
+}
+
+#[test]
+fn lock_recover_lets_caller_overwrite_inconsistent_state() {
+    // This mirrors what `update_chain_runtime_state` does at the swap
+    // sites (Step 1 and Step 3): take a write lock, replace the entire
+    // state. Even if a prior panic left the state inconsistent,
+    // overwriting is safe.
+    let m: Arc<Mutex<Vec<u32>>> = Arc::new(Mutex::new(vec![1, 2, 3]));
+
+    let m_clone = Arc::clone(&m);
+    let _ = std::thread::spawn(move || {
+        let mut g = m_clone.lock().expect("not yet poisoned");
+        g.clear(); // mid-write, leaving an "inconsistent" empty vec
+        panic!("intentional poison mid-write");
+    })
+    .join();
+
+    assert!(m.lock().is_err(), "must be poisoned for the regression");
+
+    {
+        let mut g = lock_recover(&m, "test");
+        *g = vec![10, 20, 30]; // wholesale replacement, as the rebuild path does
+    }
+
+    let g = lock_recover(&m, "test");
+    assert_eq!(*g, vec![10, 20, 30]);
+}

--- a/crates/engine/src/runtime_state.rs
+++ b/crates/engine/src/runtime_state.rs
@@ -445,3 +445,29 @@ impl ChainRuntimeState {
         out
     }
 }
+
+/// Acquire a `Mutex` even if a prior panic poisoned it (issue #415).
+///
+/// PoisonError is recoverable: it indicates that some other thread panicked
+/// while holding the lock, but the underlying data is still accessible.
+/// In this codebase the only writer is the chain-rebuild path, which
+/// overwrites `input_states` and `input_to_segments` wholesale, so a
+/// partially inconsistent state is healed by the very next call.
+///
+/// Aborting the process on poison is strictly worse than logging and
+/// continuing — the original panic was already reported (via `log::error!`
+/// from `apply_block_processor` or upstream).
+///
+/// Audio-thread callsites still use `try_lock` and must NOT call this —
+/// they treat `Err` (whether poison or contention) as "skip this callback".
+pub(crate) fn lock_recover<'a, T>(
+    mutex: &'a Mutex<T>,
+    name: &'static str,
+) -> std::sync::MutexGuard<'a, T> {
+    mutex.lock().unwrap_or_else(|poisoned| {
+        log::error!(
+            "{name} mutex was poisoned by a prior panic — recovering and continuing"
+        );
+        poisoned.into_inner()
+    })
+}


### PR DESCRIPTION
## Summary

Fixa o crash relatado em #415 — `chain runtime poisoned: PoisonError` ao salvar Chain Input Groups.

- Novo helper `lock_recover()` em `runtime_state.rs` que loga e retorna o guard via `PoisonError::into_inner()`.
- Os 4 sites em `runtime_graph.rs` (`.lock().expect("chain runtime poisoned")` × 3 + `stream_handles`) passam pelo helper.
- Audio thread (`runtime.rs:99`, `probe.rs:99`) mantém `try_lock` — `Err` ainda significa skip-callback (intencional, não toca audio thread).

Filosofia: `PoisonError` é recoverable. O state inconsistente é substituído pela rebuild path em si (overwrite wholesale de `input_states` / `input_to_segments`). Abortar o processo era estritamente pior do que logar e seguir.

## Test plan

- [x] 3 tests novos em `runtime_lock_recovery_tests.rs` cobrindo: passthrough não-envenenado, recovery pós-panic, overwrite wholesale.
- [x] `cargo test -p engine` verde local (208 tests).
- [ ] CI roda gate comparativo

Closes #415