### PR TITLE
fix(422): enumerar audio devices via mesmo host que streaming usa (ASIO no Windows)

### DIFF
--- a/crates/infra-cpal/src/host.rs
+++ b/crates/infra-cpal/src/host.rs
@@ -65,12 +65,20 @@ pub(crate) fn jack_server_is_running() -> bool {
 /// Select the CPAL audio host for device enumeration (non-JACK path only).
 ///
 /// On Linux+JACK this function does not exist — all enumeration goes through
-/// /proc/asound and the jack crate. On other platforms, caches a default host
-/// once so repeated enumerations share the same host instance.
+/// /proc/asound and the jack crate. On other platforms, caches a host once
+/// so repeated enumerations share the same instance.
+///
+/// Reusa exatamente `create_host` (a fn que o streaming usa) em vez de
+/// `cpal::default_host`: o picker e o streaming PRECISAM enxergar o mesmo
+/// conjunto de devices, senão a UI lista o que o WASAPI vê e o stream
+/// abre o que o ASIO vê — devices exclusivos do ASIO (Scarlett 2i2 4th Gen
+/// em modo exclusive, RME, etc.) somem do picker no Windows (issue #422).
+/// macOS/Linux-sem-JACK não têm ASIO, então `create_host` cai no
+/// `cpal::default_host` igual antes.
 #[cfg(not(all(target_os = "linux", feature = "jack")))]
 pub(crate) fn select_host_for_enumeration() -> &'static cpal::Host {
     static ENUM_HOST: OnceLock<cpal::Host> = OnceLock::new();
-    ENUM_HOST.get_or_init(cpal::default_host)
+    ENUM_HOST.get_or_init(create_host)
 }
 
 /// Returns true when the given host is the ASIO host on Windows.


### PR DESCRIPTION
Resolve #422.

## Bug

`crates/infra-cpal/src/host.rs` tinha duas funções pra escolher o host CPAL:

- `create_host()` → no Windows tenta **ASIO** primeiro (Scarlett 4th Gen, RME, etc.) e cai pra WASAPI se ASIO não está disponível.
- `select_host_for_enumeration()` → **sempre** `cpal::default_host()` = WASAPI no Windows.

O picker de áudio (UI thread) usava `select_host_for_enumeration`, o streaming usava `create_host`. Devices que aparecem só no ASIO (Scarlett 2i2 4th Gen em modo exclusive, qualquer interface RME, etc.) sumiam do picker mesmo com ASIO disponível.

## Fix

`select_host_for_enumeration` reusa exatamente `create_host`. Mesmo conjunto de devices entre enumeração e streaming.

## Sem efeito fora do Windows

`create_host` em macOS/Linux-sem-JACK cai direto em `cpal::default_host()` — mesmo comportamento de antes.

## Test plan

- [ ] Windows: rebuild via workflow, instalar `.msi`, abrir picker, Scarlett 2i2 4th Gen aparece.
- [x] macOS: build local limpo, picker continua listando Scarlett (Mac não tem ASIO, fall-through pro `default_host` se mantém).
- [ ] Linux (não-JACK): se rodar, picker continua igual.