### PR TITLE
fix(425): bundles de packaging dropam binários de outros OS

### DIFF
--- a/crates/engine/src/runtime_state.rs
+++ b/crates/engine/src/runtime_state.rs
@@ -490,9 +490,7 @@ pub(crate) fn lock_recover<'a, T>(
     name: &'static str,
 ) -> std::sync::MutexGuard<'a, T> {
     mutex.lock().unwrap_or_else(|poisoned| {
-        log::error!(
-            "{name} mutex was poisoned by a prior panic — recovering and continuing"
-        );
+        log::error!("{name} mutex was poisoned by a prior panic — recovering and continuing");
         poisoned.into_inner()
     })
 }

--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -98,6 +98,27 @@ cp -r assets                               "$S/usr/share/openrig/assets"
 # registry::init_many scans this path plus the user-writable root.
 if [ -d plugins/source ]; then
     cp -r plugins/source "$S/usr/share/openrig/plugins"
+    # Each LV2 plugin carries platform/{linux-x86_64,linux-aarch64,
+    # macos-*,windows-*} binaries — Linux package só carrega .so do
+    # arch alvo. Drop o que sobra (issue #425):
+    #   - sempre: macos-*, windows-*
+    #   - x86_64 build: também linux-aarch64
+    #   - aarch64 build: também linux-x86_64
+    dropped_dirs=0
+    drop_patterns=("macos-*" "windows-*")
+    if [ "$ARCH" = "x86_64" ]; then
+        drop_patterns+=("linux-aarch64")
+    elif [ "$ARCH" = "aarch64" ]; then
+        drop_patterns+=("linux-x86_64")
+    fi
+    for pattern in "${drop_patterns[@]}"; do
+        while IFS= read -r dir; do
+            rm -rf "$dir"
+            dropped_dirs=$((dropped_dirs + 1))
+        done < <(find "$S/usr/share/openrig/plugins" -type d -path "*/platform/$pattern" 2>/dev/null)
+    done
+    PLUGIN_COUNT=$(find "$S/usr/share/openrig/plugins" -name 'manifest.yaml' | wc -l | tr -d ' ')
+    echo "    bundled plugins ($PLUGIN_COUNT package(s)); dropped $dropped_dirs non-${ARCH} platform dirs"
 else
     echo "WARN: plugins/source/ not found — run OpenRig-plugins's pack_plugins or check out the plugin tree first"
 fi

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -78,8 +78,18 @@ cp -r assets                   "$APP/Contents/Resources/assets"
 # OpenRig — registry::init falls back to the user root only.
 if [ -d plugins/source ]; then
     cp -r plugins/source "$APP/Contents/Resources/plugins"
+    # Each LV2 plugin carries platform/{linux-*,macos-*,windows-*}
+    # binaries — macOS .app só carrega .dylib, então .so/.dll são MB
+    # inúteis. Drop tudo que não é macOS (issue #425).
+    dropped_dirs=0
+    for pattern in "linux-*" "windows-*"; do
+        while IFS= read -r dir; do
+            rm -rf "$dir"
+            dropped_dirs=$((dropped_dirs + 1))
+        done < <(find "$APP/Contents/Resources/plugins" -type d -path "*/platform/$pattern" 2>/dev/null)
+    done
     PLUGIN_COUNT=$(find "$APP/Contents/Resources/plugins" -name 'manifest.yaml' | wc -l | tr -d ' ')
-    echo "    bundled plugins ($PLUGIN_COUNT package(s))"
+    echo "    bundled plugins ($PLUGIN_COUNT package(s)); dropped $dropped_dirs non-macOS platform dirs"
 else
     echo "    NOTE: plugins/source/ not found — .app ships without bundled plugins"
 fi

--- a/scripts/package-windows.ps1
+++ b/scripts/package-windows.ps1
@@ -99,8 +99,23 @@ try {
     # the user-writable root.
     if (Test-Path "plugins\source") {
         Copy-Item -Recurse "plugins\source" "$stageDir\plugins"
+        # Each LV2 plugin carries platform/{linux-x86_64,linux-aarch64,
+        # macos-universal,windows-x86_64} binaries — Windows installer só
+        # carrega .dll, então .so/.dylib são MB inúteis. Drop tudo que
+        # não é Windows (issue #425).
+        $droppedDirs = 0
+        $droppedBytes = 0
+        foreach ($pattern in @("linux-*", "macos-*")) {
+            Get-ChildItem -Path "$stageDir\plugins" -Recurse -Directory -Filter $pattern -ErrorAction SilentlyContinue |
+                Where-Object { $_.Parent.Name -eq "platform" } |
+                ForEach-Object {
+                    $droppedBytes += (Get-ChildItem $_.FullName -Recurse -File -ErrorAction SilentlyContinue | Measure-Object -Property Length -Sum).Sum
+                    $droppedDirs++
+                    Remove-Item -Recurse -Force $_.FullName
+                }
+        }
         $count = (Get-ChildItem -Recurse -Filter "manifest.yaml" "$stageDir\plugins").Count
-        Write-Host ("    bundled plugins ({0} package(s))" -f $count)
+        Write-Host ("    bundled plugins ({0} package(s)); dropped {1} non-Windows platform dirs ({2:N1} MB)" -f $count, $droppedDirs, ($droppedBytes / 1MB))
     } else {
         Write-Host "    NOTE: plugins\source\ not found — bundle ships without plugins"
     }


### PR DESCRIPTION
Resolve #425.

## Mudança

Cada plugin LV2 traz `platform/{linux-x86_64,linux-aarch64,macos-universal,windows-x86_64}` com binários nativos. Os 3 scripts de packaging copiavam tudo. Agora cada um filtra:

| Script | Mantém | Dropa |
|---|---|---|
| `package-windows.ps1` | `windows-*` | `linux-*`, `macos-*` |
| `package-macos.sh` | `macos-*` | `linux-*`, `windows-*` |
| `package-linux.sh` (arch=x86_64) | `linux-x86_64` | `linux-aarch64`, `macos-*`, `windows-*` |
| `package-linux.sh` (arch=aarch64) | `linux-aarch64` | `linux-x86_64`, `macos-*`, `windows-*` |

## Efeito esperado

- `.msi` Windows: ~80 MB menor (so + dylib removidos).
- `.dmg`/`.app` macOS: menor.
- `.deb`/`.rpm`/`.AppImage` Linux: menor.

Plus log do bundle agora mostra quantas pastas foram droppadas, útil pra debug no CI.

## Não resolve

Plugins LV2 que não TÊM `.dll` Windows compilado (issue #426 — escopo separado).

## Test plan

- [x] Sintaxe bash dos 2 scripts shell OK (`bash -n`).
- [ ] Build no CI: Windows job confirma `.msi` menor + log "dropped N non-Windows platform dirs".
- [ ] Mesmo pra macOS e Linux (x86_64 e aarch64).