### PR TITLE
fix(424): strip emoji from external manifest labels (Windows tofu)

### DIFF
--- a/crates/project/src/block/dispatch.rs
+++ b/crates/project/src/block/dispatch.rs
@@ -29,6 +29,7 @@ use domain::value_objects::ParameterValue;
 
 use crate::param::{BlockParameterDescriptor, ModelParameterSchema, ParameterSet};
 
+use super::manifest_labels::sanitize_label;
 use super::types::{AudioBlockKind, BlockAudioDescriptor, CoreBlock, NamBlock};
 
 pub fn normalize_block_params(
@@ -161,7 +162,11 @@ fn grid_parameter_to_spec(
     parameter: &plugin_loader::manifest::GridParameter,
 ) -> block_core::param::ParameterSpec {
     use plugin_loader::manifest::ParameterValue;
-    let label = parameter.display_name.as_deref().unwrap_or(&parameter.name);
+    // Sanitise the axis name so emojis baked into third-party manifests
+    // (issue #424 — Bogner Ecstasy) don't tofu in the BlockEditorPanel
+    // header; raw `parameter.name` stays untouched as the lookup key.
+    let raw_label = parameter.display_name.as_deref().unwrap_or(&parameter.name);
+    let label = sanitize_label(raw_label);
     let all_numeric = parameter
         .values
         .iter()
@@ -185,7 +190,7 @@ fn grid_parameter_to_spec(
         };
         block_core::param::float_parameter(
             &parameter.name,
-            label,
+            &label,
             None,
             Some(default as f32),
             min as f32,
@@ -206,26 +211,31 @@ fn grid_parameter_to_spec(
             ParameterValue::Bool(b) => Some(*b),
             _ => None,
         });
-        return block_core::param::bool_parameter(&parameter.name, label, None, default);
+        return block_core::param::bool_parameter(&parameter.name, &label, None, default);
     } else {
+        // (raw_value, sanitised_label) pairs — the value is the lookup
+        // key into `captures[].values` and the user's persisted
+        // `ParameterSet`, so it must round-trip byte-for-byte. Only the
+        // displayed label is cleaned of emoji (issue #424).
         let options: Vec<(String, String)> = parameter
             .values
             .iter()
             .map(|value| {
-                let s = match value {
+                let raw = match value {
                     ParameterValue::Text(t) => t.clone(),
                     ParameterValue::Number(n) => n.to_string(),
                     ParameterValue::Bool(b) => b.to_string(),
                 };
-                (s.clone(), s)
+                let display = sanitize_label(&raw);
+                (raw, display)
             })
             .collect();
         let option_refs: Vec<(&str, &str)> = options
             .iter()
-            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .map(|(value, display)| (value.as_str(), display.as_str()))
             .collect();
         let default = options.first().map(|(k, _)| k.as_str());
-        block_core::param::enum_parameter(&parameter.name, label, None, default, &option_refs)
+        block_core::param::enum_parameter(&parameter.name, &label, None, default, &option_refs)
     }
 }
 
@@ -537,6 +547,83 @@ mod tests {
             "NAM schema must NOT include `output_db` (loudness lives in manifest); \
              got params: {:?}",
             specs.iter().map(|s| &s.path).collect::<Vec<_>>()
+        );
+    }
+
+    fn nam_package_with_emoji_labels() -> LoadedPackage {
+        // Real-world Bogner Ecstasy capture grid — `display_name` and
+        // every `Text` value carry a leading emoji. Reproduces the
+        // tofu/black-square symptom from issue #424.
+        LoadedPackage {
+            root: PathBuf::from("/fake"),
+            manifest: PluginManifest {
+                manifest_version: 1,
+                id: "nam_bogner_ecstasy".into(),
+                display_name: "Bogner Ecstasy".into(),
+                author: None,
+                description: None,
+                inspired_by: None,
+                brand: None,
+                thumbnail: None,
+                photo: None,
+                screenshot: None,
+                brand_logo: None,
+                license: None,
+                homepage: None,
+                sources: None,
+                output_gain_db: None,
+                block_type: BlockType::Amp,
+                backend: Backend::Nam {
+                    parameters: vec![GridParameter {
+                        name: "cabinet".into(),
+                        display_name: Some("📦 Cabinet".into()),
+                        values: vec![
+                            ParameterValue::Text("✋ 4X12".into()),
+                            ParameterValue::Text("🔥 2X12".into()),
+                        ],
+                    }],
+                    captures: vec![],
+                },
+            },
+        }
+    }
+
+    #[test]
+    fn nam_grid_parameter_label_strips_emoji_for_ui() {
+        // Issue #424: shipped fonts (Bebas Neue, Inter, Permanent
+        // Marker, …) carry no emoji glyphs; macOS cascades to Apple
+        // Color Emoji, Windows / Linux do not, so emojis render as
+        // tofu in the BlockEditorPanel selectors.
+        let pkg = nam_package_with_emoji_labels();
+        let specs = synthesize_parameters_from_manifest(&pkg);
+        let cabinet = specs
+            .iter()
+            .find(|s| s.path == "cabinet")
+            .expect("cabinet axis must be in synthesized schema");
+        assert_eq!(
+            cabinet.label, "Cabinet",
+            "axis display_name must be emoji-free for UI rendering"
+        );
+        let block_core::param::ParameterDomain::Enum { options } = &cabinet.domain else {
+            panic!(
+                "text-valued grid axis must become an enum, got {:?}",
+                cabinet.domain
+            );
+        };
+        let labels: Vec<&str> = options.iter().map(|o| o.label.as_str()).collect();
+        assert_eq!(
+            labels,
+            vec!["4X12", "2X12"],
+            "option labels must be emoji-free; raw values stay for capture lookup"
+        );
+        // Pinned: storage-side values keep the original strings so
+        // `resolve_capture` can still match user selections to the
+        // manifest's `captures[].values`.
+        let values: Vec<&str> = options.iter().map(|o| o.value.as_str()).collect();
+        assert_eq!(
+            values,
+            vec!["✋ 4X12", "🔥 2X12"],
+            "raw values must be preserved for capture lookup / persistence"
         );
     }
 }

--- a/crates/project/src/block/manifest_labels.rs
+++ b/crates/project/src/block/manifest_labels.rs
@@ -1,0 +1,58 @@
+//! Sanitisation of human-facing labels coming from external plugin
+//! manifests (NAM/IR `GridParameter`, LV2 port names, VST3 parameter
+//! display names) before they reach the Slint UI.
+//!
+//! The OpenRig UI ships a curated set of fonts (Bebas Neue, Inter,
+//! Permanent Marker, Orbitron, Cooper Hewitt, Dancing Script, Ek Mukta)
+//! plus locale-aware system faces for CJK / Devanagari. None of them
+//! carry emoji / pictograph glyphs. macOS' Slint backend cascades to
+//! Apple Color Emoji automatically; Windows / Linux do not, and emojis
+//! render as black tofu boxes (issue #424 — Bogner Ecstasy capture
+//! labels like `"✋ 4X12"` showing up as `"□ 4X12"`).
+//!
+//! Project policy (`feedback_no_font_glyphs_for_icons`): never use a
+//! glyph as an icon — always SVG. We can't rewrite third-party manifests
+//! we don't own, so we strip the offending codepoints at the seam where
+//! manifest data turns into `ParameterSpec`. The raw value strings used
+//! for capture lookup / persistence stay untouched, only the *displayed*
+//! label is cleaned.
+//!
+//! Stripped ranges are deliberately conservative — symbols / pictograph
+//! blocks that no shipped font carries — so Latin, Cyrillic, Greek,
+//! Hebrew, Arabic, Devanagari and CJK keep working untouched.
+
+/// Remove emoji / pictograph codepoints from `input` and trim the
+/// result. Returns the original (untrimmed) string when stripping
+/// would leave nothing to display, so a label that was *only* an
+/// emoji at least falls back to its raw form rather than vanishing.
+pub fn sanitize_label(input: &str) -> String {
+    let cleaned: String = input.chars().filter(|c| !is_pictograph(*c)).collect();
+    let trimmed = cleaned.trim();
+    if trimmed.is_empty() {
+        input.to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn is_pictograph(c: char) -> bool {
+    let n = c as u32;
+    // Misc Symbols + Dingbats (✋ U+270B, ★ U+2605, ☎ U+260E, …).
+    (0x2300..=0x27BF).contains(&n)
+        // Supplemental Arrows-B + Misc Mathematical Symbols-B.
+        || (0x2900..=0x29FF).contains(&n)
+        // Misc Symbols and Arrows.
+        || (0x2B00..=0x2BFF).contains(&n)
+        // Plane 1 pictographs (emoji, transport, supplemental symbols,
+        // CJK-style ideographic *symbols* — not the unified ideographs).
+        || (0x1F000..=0x1FFFF).contains(&n)
+        // Variation selectors (VS-1..16) used to switch to emoji
+        // presentation; orphaned after stripping the base codepoint.
+        || (0xFE00..=0xFE0F).contains(&n)
+        // Zero-width joiner used to compose multi-codepoint emoji.
+        || n == 0x200D
+}
+
+#[cfg(test)]
+#[path = "manifest_labels_tests.rs"]
+mod tests;

--- a/crates/project/src/block/manifest_labels_tests.rs
+++ b/crates/project/src/block/manifest_labels_tests.rs
@@ -1,0 +1,73 @@
+use super::sanitize_label;
+
+#[test]
+fn sanitize_label_strips_leading_emoji_keeps_text() {
+    // Issue #424: Bogner Ecstasy capture grid labels arrive from the
+    // third-party manifest as `"✋ 4X12"`. The emoji renders as tofu on
+    // Windows because no shipped font carries a glyph for U+270B.
+    assert_eq!(sanitize_label("✋ 4X12"), "4X12");
+}
+
+#[test]
+fn sanitize_label_strips_pictograph_keeps_text() {
+    assert_eq!(sanitize_label("📦 Cabinet"), "Cabinet");
+    assert_eq!(sanitize_label("🔥 Drive"), "Drive");
+}
+
+#[test]
+fn sanitize_label_strips_dingbats_and_misc_symbols() {
+    // ★ (U+2605) and ☎ (U+260E) are inside the Misc Symbols / Dingbats
+    // block — same tofu story as full emoji.
+    assert_eq!(sanitize_label("★ Lead"), "Lead");
+    assert_eq!(sanitize_label("☎ Phone"), "Phone");
+}
+
+#[test]
+fn sanitize_label_passes_clean_text_unchanged() {
+    assert_eq!(sanitize_label("4X12"), "4X12");
+    assert_eq!(sanitize_label("Drive A"), "Drive A");
+    // Punctuation, slashes and digits stay.
+    assert_eq!(sanitize_label("Drive/Gain"), "Drive/Gain");
+}
+
+#[test]
+fn sanitize_label_keeps_cjk_arabic_devanagari() {
+    // Pinned: stripping must not touch scripts the project ships fonts
+    // for via the locale cascade (issue #424 fix would regress JP/ZH/HI
+    // users otherwise).
+    assert_eq!(sanitize_label("輸入"), "輸入");
+    assert_eq!(sanitize_label("ドライブ"), "ドライブ");
+    assert_eq!(sanitize_label("الإدخال"), "الإدخال");
+    assert_eq!(sanitize_label("ध्वनि"), "ध्वनि");
+}
+
+#[test]
+fn sanitize_label_falls_back_to_raw_when_only_emoji() {
+    // A label that's nothing but emoji (no fallback text) is rare but
+    // legal in third-party manifests. Returning empty would render an
+    // anonymous selector position; keep the raw codepoint so the user
+    // can still tell positions apart even if they show as tofu.
+    assert_eq!(sanitize_label("✋"), "✋");
+    assert_eq!(sanitize_label("   ✋   "), "   ✋   ");
+}
+
+#[test]
+fn sanitize_label_drops_zwj_compound_emoji() {
+    // ZWJ-compound emoji like family-glyphs leave nothing renderable
+    // after the pictograph base is stripped; the leftover ZWJs would
+    // otherwise still trip up shaping.
+    let zwj = "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F466} Family";
+    assert_eq!(sanitize_label(zwj), "Family");
+}
+
+#[test]
+fn sanitize_label_drops_variation_selector_after_base() {
+    // ❤️ = U+2764 (heart, inside the Misc Symbols range we strip) +
+    // U+FE0F (variation selector forcing emoji presentation). Both go.
+    assert_eq!(sanitize_label("\u{2764}\u{FE0F} Love"), "Love");
+}
+
+#[test]
+fn sanitize_label_trims_resulting_whitespace_both_sides() {
+    assert_eq!(sanitize_label("  ✋  4X12  "), "4X12");
+}

--- a/crates/project/src/block/mod.rs
+++ b/crates/project/src/block/mod.rs
@@ -12,6 +12,7 @@
 //! working unchanged.
 
 pub mod dispatch;
+pub mod manifest_labels;
 pub mod methods;
 pub mod types;
 


### PR DESCRIPTION
## Summary

Issue #424 — Windows BlockEditorPanel renders **black tofu squares** in NAM amp grid parameter selectors (Bogner Ecstasy, etc.) because third-party manifests embed emoji codepoints (✋, 📦, …) in `GridParameter.display_name` and value labels. macOS cascades to Apple Color Emoji; Windows / Linux do not.

Fix: sanitise labels at the manifest→schema seam (`grid_parameter_to_spec`). Raw values stay byte-for-byte for capture lookup; only the displayed label loses the unrendered glyphs.

## Approach

- New module `crates/project/src/block/manifest_labels.rs` — pure `sanitize_label` helper stripping Unicode pictograph blocks (Misc Symbols, Dingbats, plane-1 pictographs, variation selectors, ZWJ).
- Wired into `dispatch.rs::grid_parameter_to_spec` for both axis name and enum option labels.
- CJK / Arabic / Devanagari preserved — outside the stripped ranges, the locale font cascade keeps owning them.
- Display-only sanitisation. Persistence keys (`ParameterSet`, `captures[].values`) stay untouched so `resolve_capture` keeps working.
- Empty-after-strip falls back to raw so a selector position never blanks out.

## Tests

- RED-then-GREEN: `nam_grid_parameter_label_strips_emoji_for_ui` reproduces Bogner Ecstasy (`📦 Cabinet`, `[✋ 4X12, 🔥 2X12]`) — confirmed failing before the fix, passing after.
- 9 unit tests in `manifest_labels_tests.rs` pin: ASCII passthrough, emoji-text, dingbats, CJK / Arabic / Devanagari preservation, ZWJ family compounds, variation-selector heart, raw fallback.

## QA gate

```
metric        base       pr     verdict
─────────────────────────────────────────
fmt              1       1    ✅ same
clippy          18      18    ✅ same
build            0       0    ✅ same
test fails       0       0    ✅ same
complexity     137     137    ✅ same
coverage     ✅ improved
```

## Test plan

- [ ] Windows: install dev.18+1 build with this fix; open chain with NAM amp containing emoji-laden grid params (Bogner Ecstasy); confirm selector labels render as plain text (e.g. `4X12` instead of `□ 4X12`).
- [ ] macOS: regression check — same Bogner chain still renders with the same option order, no missing positions, no broken capture lookup.
- [ ] Persistence round-trip: change cabinet selection on either OS → save → reload → selection survives (proves sanitisation didn't touch storage keys).