### PR TITLE
perf(431): fast-path no qa.sh — pula cargo gates em PR sem Rust

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -85,11 +85,14 @@ jobs:
           if-no-files-found: ignore
 
       - name: Generate lcov.info for Codecov (reuses PR coverage run)
-        if: success()
+        # Pula quando qa.sh tomou o fast-path: PR sem .rs/Cargo.* não
+        # roda llvm-cov, então `target/llvm-cov-target/**/*.profraw` não
+        # existe e `cargo llvm-cov report` falha. Issue #431.
+        if: success() && hashFiles('target/llvm-cov-target/**/*.profraw') != ''
         run: cargo llvm-cov report --lcov --output-path lcov.info
 
       - name: Upload coverage to Codecov
-        if: success()
+        if: success() && hashFiles('lcov.info') != ''
         uses: codecov/codecov-action@v5
         with:
           files: lcov.info

--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -28,6 +28,7 @@
 #   QA_REFRESH_BASELINE    1 → re-extrai baseline mesmo que exista
 #   QA_COV_MARGIN          tolerância de coverage em pp (default: 1.0)
 #   QA_LOG_DIR             onde guardar logs por etapa (default: target/qa-logs)
+#   QA_FORCE_FULL          1 → força gate completo mesmo em PR sem .rs/Cargo.* (issue #431)
 #
 # Pré-requisitos: cargo, cargo-llvm-cov, jq.
 
@@ -38,9 +39,75 @@ QA_BASE_REF="${QA_BASE_REF:-origin/develop}"
 QA_COV_MARGIN="${QA_COV_MARGIN:-1.0}"
 QA_LOG_DIR="${QA_LOG_DIR:-target/qa-logs}"
 QA_REFRESH_BASELINE="${QA_REFRESH_BASELINE:-0}"
+QA_FORCE_FULL="${QA_FORCE_FULL:-0}"
 
 cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 mkdir -p "$QA_LOG_DIR"
+
+# ─── Fast-path: skip cargo gates when no Rust changed ───────────────────────
+#
+# PR que só toca scripts/docs/YAML/etc não pode regredir clippy/build/test/
+# coverage do código Rust — matemática simples (não há .rs mudando). Hoje o
+# gate roda ~30min mesmo nesse caso por causa do duplo cargo build + llvm-cov.
+#
+# Detecta o escopo via `git diff --name-only $QA_BASE_REF...HEAD` e cai num
+# fast-path que só roda `cargo fmt --check` (validação simbólica, < 5s) e o
+# sintaxe-check dos scripts modificados. Issue #431.
+#
+# Bypass: QA_FORCE_FULL=1 força o gate completo mesmo em PR não-Rust.
+RUST_PATH_RE='\.rs$|^Cargo\.|^crates/.*Cargo\.toml$|build\.rs$|^rust-toolchain'
+
+if [ "$QA_FORCE_FULL" != "1" ]; then
+  git fetch origin --quiet 2>/dev/null || true
+  # Combine 3 sources of "modified files":
+  #   1. commits ahead of base ref (already merged into PR's branch)
+  #   2. staged changes (git add'd but not committed)
+  #   3. working-tree changes (modified but unstaged)
+  # Garantir que pré-commit também pegue o fast-path quando o user roda
+  # qa.sh local antes de commitar.
+  committed_files=$(git diff --name-only "$QA_BASE_REF...HEAD" 2>/dev/null || true)
+  staged_files=$(git diff --cached --name-only 2>/dev/null || true)
+  worktree_files=$(git diff --name-only 2>/dev/null || true)
+  changed_files=$(printf '%s\n%s\n%s\n' "$committed_files" "$staged_files" "$worktree_files" | sort -u | sed '/^$/d')
+  if [ -n "$changed_files" ]; then
+    if ! echo "$changed_files" | grep -qE "$RUST_PATH_RE"; then
+      echo "═══ OpenRig Quality Gate (fast-path) ═══"
+      echo "  branch:    $(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo '<detached>')"
+      echo "  base ref:  $QA_BASE_REF"
+      echo "  scope:     no Rust files touched → skipping cargo gates"
+      echo "  override:  QA_FORCE_FULL=1 to run full gate"
+      echo ""
+      echo "── changed files ──"
+      echo "$changed_files" | sed 's/^/  /'
+      echo ""
+      # Sem `cargo fmt --check` aqui: PR sem `.rs` no diff não pode
+      # introduzir nova violação de fmt (workspace Rust intacto). Se
+      # rodar fmt-check captura DÍVIDA da develop e bloqueia PR de
+      # script/doc por erro alheio — frustração documentada na primeira
+      # tentativa de validar este PR #431.
+      #
+      # Sintaxe shell para qualquer .sh modificado — pega `bash -n`
+      # errors que mataram CI antes (catch barato, segundos).
+      shell_files=$(echo "$changed_files" | grep -E '\.sh$' || true)
+      if [ -n "$shell_files" ]; then
+        echo "── bash syntax check ──"
+        while IFS= read -r f; do
+          [ -z "$f" ] && continue
+          [ ! -f "$f" ] && continue
+          if ! bash -n "$f" 2>&1; then
+            echo "::error::syntax error in $f"
+            exit 1
+          fi
+          echo "  $f: OK"
+        done <<< "$shell_files"
+      fi
+      echo ""
+      echo "✅ fast-path passed (no Rust to measure)"
+      exit 0
+    fi
+  fi
+fi
+# end fast-path
 
 # ─── Baseline provisioning ──────────────────────────────────────────────────
 prepare_baseline() {


### PR DESCRIPTION
Resolve #431.

## Problema

`qa.sh` roda 6 checks × 2 (baseline + PR) sequencial, ~30min. llvm-cov sozinho come ~60% do tempo. PR de script/doc/YAML não pode regredir o código Rust mas roda tudo de qualquer jeito.

## Fix

Bloco novo no topo do `qa.sh`:

1. Coleta arquivos mudados via 3 fontes (commits ahead, staged, working tree, dedupe).
2. Se diff vazio ou regex Rust matcha (`\.rs$|^Cargo\.|^crates/.*Cargo\.toml$|build\.rs$|^rust-toolchain`) → gate completo.
3. Se diff não toca Rust → fast-path: `bash -n` em cada `.sh` modificado e exit 0.

Override: `QA_FORCE_FULL=1` força gate completo.

## Por que sem `cargo fmt --check` no fast-path

Tentei rodar fmt-check inicialmente. Foi rejeitado pela primeira tentativa do próprio PR: a develop tem dívida de fmt (carryover de outro merge) em `crates/engine/src/runtime_state.rs:490`. PR de script bloqueava por erro alheio. Como PR sem `.rs` não pode introduzir nova violação fmt (workspace Rust intacto), fmt-check é redundante no fast-path.

## Resultado

Dogfoodado neste PR: **~1s end-to-end** (vs ~30min do gate completo).

## Test plan

- [x] Sintaxe bash OK.
- [x] Dogfood neste PR: fast-path engatou, mostrou os 4 paths não-Rust, bash -n OK, exit 0.
- [ ] PR seguinte com `.rs` modificado: confirmar que gate completo roda.
- [ ] CI Linux: confirmar que QA_BASELINE_DIR pre-checkout funciona com a nova lógica.