### PR TITLE
fix(packaging): instala presets/ junto com plugins + resolver via detect_data_root

### DIFF
--- a/crates/adapter-gui/src/project.rs
+++ b/crates/adapter-gui/src/project.rs
@@ -184,12 +184,27 @@ pub(crate) fn parse_path_argument(flag: &str) -> Option<PathBuf> {
     None
 }
 
+/// Default location for the bundled preset library.
+///
+/// Resolves to `<data_root>/presets` where `data_root` is:
+/// - `<bundle>/Contents/Resources/` on macOS (.dmg / .app)
+/// - `/usr/share/openrig/` on Linux (.deb / .rpm)
+/// - `<install_dir>/` on Windows (.msi)
+/// - the current working directory in dev (so `./presets` in the repo still works).
+///
+/// Used as the fallback when `config.yaml` has no `presets_path` entry; user
+/// projects can still override this by setting `presets_path` in their own
+/// `config.yaml`.
+fn default_presets_path() -> PathBuf {
+    infra_filesystem::detect_data_root().join("presets")
+}
+
 pub(crate) fn create_new_project_session(default_config_path: &Path) -> ProjectSession {
     let config = if default_config_path.exists() {
         load_app_config(default_config_path).unwrap_or_default()
     } else {
         AppConfigYaml {
-            presets_path: Some(PathBuf::from("./presets")),
+            presets_path: Some(default_presets_path()),
         }
     };
     let project = Project {
@@ -201,9 +216,7 @@ pub(crate) fn create_new_project_session(default_config_path: &Path) -> ProjectS
         project,
         project_path: None,
         config_path: None,
-        presets_path: config
-            .presets_path
-            .unwrap_or_else(|| PathBuf::from("./presets")),
+        presets_path: config.presets_path.unwrap_or_else(default_presets_path),
     }
 }
 
@@ -258,7 +271,7 @@ pub(crate) fn load_project_session(
     let presets_path = config
         .presets_path
         .clone()
-        .unwrap_or_else(|| PathBuf::from("./presets"));
+        .unwrap_or_else(default_presets_path);
     let mut project = YamlProjectRepository {
         path: project_path.to_path_buf(),
     }

--- a/crates/adapter-gui/src/project_ops.rs
+++ b/crates/adapter-gui/src/project_ops.rs
@@ -183,12 +183,27 @@ pub(crate) fn parse_path_argument(flag: &str) -> Option<PathBuf> {
     None
 }
 
+/// Default location for the bundled preset library.
+///
+/// Resolves to `<data_root>/presets` where `data_root` is:
+/// - `<bundle>/Contents/Resources/` on macOS (.dmg / .app)
+/// - `/usr/share/openrig/` on Linux (.deb / .rpm)
+/// - `<install_dir>/` on Windows (.msi)
+/// - the current working directory in dev (so `./presets` in the repo still works).
+///
+/// Used as the fallback when `config.yaml` has no `presets_path` entry; user
+/// projects can still override this by setting `presets_path` in their own
+/// `config.yaml`.
+fn default_presets_path() -> PathBuf {
+    infra_filesystem::detect_data_root().join("presets")
+}
+
 pub(crate) fn create_new_project_session(default_config_path: &Path) -> ProjectSession {
     let config = if default_config_path.exists() {
         load_app_config(default_config_path).unwrap_or_default()
     } else {
         AppConfigYaml {
-            presets_path: Some(PathBuf::from("./presets")),
+            presets_path: Some(default_presets_path()),
         }
     };
     let project = Project {
@@ -200,9 +215,7 @@ pub(crate) fn create_new_project_session(default_config_path: &Path) -> ProjectS
         project,
         project_path: None,
         config_path: None,
-        presets_path: config
-            .presets_path
-            .unwrap_or_else(|| PathBuf::from("./presets")),
+        presets_path: config.presets_path.unwrap_or_else(default_presets_path),
     }
 }
 
@@ -257,7 +270,7 @@ pub(crate) fn load_project_session(
     let presets_path = config
         .presets_path
         .clone()
-        .unwrap_or_else(|| PathBuf::from("./presets"));
+        .unwrap_or_else(default_presets_path);
     let mut project = YamlProjectRepository {
         path: project_path.to_path_buf(),
     }

--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -92,6 +92,14 @@ cp target/release/adapter-gui              "$S/usr/bin/openrig"
 cp -r "libs/nam/linux-${ARCH}"             "$S/usr/lib/openrig/libs/nam/linux-${ARCH}"
 cp -r assets                               "$S/usr/share/openrig/assets"
 
+# Bundled preset library: the 21 default presets under presets/*.yaml ship
+# next to plugins/ and assets/ so the app finds them via
+# infra_filesystem::detect_data_root().join("presets"). Without this copy,
+# a fresh install shows an empty preset list.
+if [ -d presets ]; then
+    cp -r presets                          "$S/usr/share/openrig/presets"
+fi
+
 # Bundled plugins ship as a pre-extracted directory under
 # /usr/share/openrig/plugins, which is what
 # infra_filesystem::detect_data_root() returns for Linux installs.
@@ -151,6 +159,8 @@ if $BUILD_TARBALL; then
     cp -r "$S/usr/share/openrig/translations"   "$OUTPUT_DIR/${D}/translations"
     [ -d "$S/usr/share/openrig/plugins" ] && \
         cp -r "$S/usr/share/openrig/plugins"   "$OUTPUT_DIR/${D}/plugins"
+    [ -d "$S/usr/share/openrig/presets" ] && \
+        cp -r "$S/usr/share/openrig/presets"   "$OUTPUT_DIR/${D}/presets"
     tar -czf "$OUTPUT_DIR/${D}.tar.gz" -C "$OUTPUT_DIR" "${D}"
     echo "  → $OUTPUT_DIR/${D}.tar.gz"
 fi

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -68,6 +68,14 @@ install_name_tool \
 cp assets/brands/openrig/icon.icns "$APP/Contents/Resources/openrig.icns"
 cp -r libs/nam/macos-universal "$APP/Contents/Resources/libs/nam/macos-universal"
 cp -r assets                   "$APP/Contents/Resources/assets"
+
+# Bundled preset library: the 21 default presets under presets/*.yaml ship
+# next to plugins/ and assets/ so the app finds them via
+# infra_filesystem::detect_data_root().join("presets"). Without this copy,
+# a fresh install shows an empty preset list.
+if [ -d presets ]; then
+    cp -r presets              "$APP/Contents/Resources/presets"
+fi
 # data/lv2, libs/lv2, captures were removed in 2011110d — LV2 plugins now
 # ship via openrig-plugins.zip (extracted on first launch).
 

--- a/scripts/package-windows.ps1
+++ b/scripts/package-windows.ps1
@@ -91,6 +91,14 @@ try {
     New-Item -ItemType Directory -Force "$stageDir\libs\nam" | Out-Null
     Copy-Item -Recurse "libs\nam\windows-x64" "$stageDir\libs\nam\windows-x64"
     Copy-Item -Recurse "assets"               "$stageDir\assets"
+
+    # Bundled preset library: the 21 default presets under presets\*.yaml ship
+    # next to plugins\ and assets\ so the app finds them via
+    # infra_filesystem::detect_data_root().join("presets"). Without this copy,
+    # a fresh install shows an empty preset list.
+    if (Test-Path "presets") {
+        Copy-Item -Recurse "presets"          "$stageDir\presets"
+    }
     # libs/lv2, data, captures were removed in 2011110d — LV2 plugins now
     # ship via openrig-plugins.zip (extracted on first launch).
 


### PR DESCRIPTION
## Summary

Closes #433.

Bug: os 21 presets default em \`presets/*.yaml\` **não chegavam ao usuário final** em nenhum dos 6 artefatos de release (.deb, .rpm, .tar.gz, .AppImage, .dmg, .msi, .zip). Tela de presets vazia logo após instalar.

Duas camadas de fix:

1. **Scripts de package** copiam \`presets/\` pro \`data_root\` em paralelo a \`plugins/\`, \`assets/\` e \`translations/\`:

   | Artefato | Como recebe \`presets/\` |
   |---|---|
   | Linux \`.deb\` / \`.rpm\` | \`fpm -C $stage usr\` arrasta \`usr/share/openrig/presets/\` (incluído no stage) |
   | Linux \`.tar.gz\` portátil | cp explícito de \`\$S/usr/share/openrig/presets\` |
   | Linux \`.AppImage\` | \`cp -r stage AppDir\` leva tudo |
   | macOS \`.app\` / \`.dmg\` | cp direto pra \`\$APP/Contents/Resources/presets\` |
   | Windows \`.msi\` | \`heat.exe dir \$stageDir\` empacota \`presets/\` automaticamente |
   | Windows \`.zip\` portátil | \`Copy-Item -Recurse \$stageDir \$zipDir\` leva tudo |

2. **Resolver**: \`crates/adapter-gui/src/project_ops.rs\` hardcodava \`PathBuf::from(\"./presets\")\` (relativo ao CWD) em 3 sítios de fallback. Em produção o CWD é \`\$HOME\` ou \`/\`, não o data_root — o app procurava no lugar errado. Substituído por um helper \`default_presets_path()\` que delega ao já-existente \`infra_filesystem::detect_data_root()\`, mesma estratégia que plugins/translations usam:

   - macOS \`.app\`: \`<bundle>/Contents/Resources/presets\`
   - Linux deb: \`/usr/share/openrig/presets\`
   - Windows MSI: \`<install_dir>/presets\`
   - dev (\`cargo run\`): \`<repo>/presets\` (CWD = repo root)

   Override via \`config.yaml\` (campo \`presets_path\`) continua funcionando — user que apontar pra pasta própria não é afetado.

\`project.rs\` recebe o mesmo helper como espelho defensivo; hoje o módulo não está incluído no \`lib.rs\` (\`project_ops\` é o real), mas mantê-los em sincronia evita armadilha futura caso o módulo seja reativado.

## Test plan

- [x] \`./scripts/qa.sh\` verde — fmt improved 1→0, demais métricas \`same\`.
- [x] \`cargo check -p adapter-gui\` limpo.
- [ ] Reviewer instala o .deb (ou .dmg / .msi) numa máquina virgem e verifica que a lista de presets na Launcher não está mais vazia.
- [ ] Reviewer com \`config.yaml\` existente apontando pra pasta própria continua usando ela (não foi sobrescrito).

🤖 Generated with [Claude Code](https://claude.com/claude-code)