### PR TITLE
feat(435): GraphView Slint component + Rust layout helpers

### DIFF
--- a/crates/adapter-gui/examples/graph_view_demo.rs
+++ b/crates/adapter-gui/examples/graph_view_demo.rs
@@ -1,0 +1,205 @@
+//! Standalone visual demo for `GraphView`. Hardcodes a signal-chain
+//! topology (compressor → drive → split → 2 amps → time fx → reverb)
+//! so the component can be validated without the rest of OpenRig.
+//!
+//! Run:
+//!     cargo run -p adapter-gui --example graph_view_demo
+//!
+//! The example imports the component from
+//! `crates/adapter-gui/ui/components/graph_view.slint` via the `slint!`
+//! macro — same source the production UI consumes, no duplication.
+
+use adapter_gui::graph_view_model::{
+    self as model, linear_chain_layout, BlockBlueprint, ChainStage, GridMetrics, NodeCategory,
+};
+use slint::Model;
+
+slint::slint! {
+    import { GraphView, GraphNode, GraphEdgeGeometry }
+        from "ui/components/graph_view.slint";
+
+    export component DemoWindow inherits Window {
+        in property <[GraphNode]> nodes;
+        in property <[GraphEdgeGeometry]> edges;
+
+        callback node-clicked(string);
+        callback node-double-clicked(string);
+        callback node-dragged(string, length, length);
+        callback node-drag-ended(string, length, length);
+
+        title: "GraphView demo";
+        preferred-width: 1100px;
+        preferred-height: 600px;
+        background: #0b0d12;
+
+        VerticalLayout {
+            padding: 0px;
+
+            Rectangle {
+                height: 36px;
+                background: #161b25;
+                Text {
+                    x: 16px;
+                    text: "GraphView demo — drag a node, scroll to zoom, drag empty area to pan, double-click for editor stub";
+                    color: #c9d3e2;
+                    font-size: 11px;
+                    vertical-alignment: center;
+                }
+            }
+
+            graph := GraphView {
+                nodes: root.nodes;
+                edges: root.edges;
+                node-width: 110px;
+                node-height: 56px;
+                node-clicked(id) => { root.node-clicked(id); }
+                node-double-clicked(id) => { root.node-double-clicked(id); }
+                node-dragged(id, x, y) => { root.node-dragged(id, x, y); }
+                node-drag-ended(id, x, y) => { root.node-drag-ended(id, x, y); }
+            }
+        }
+    }
+}
+
+fn demo_chain() -> (Vec<model::GraphNode>, Vec<model::GraphEdge>) {
+    let stages = vec![
+        ChainStage::Single(BlockBlueprint::new(
+            "noise",
+            "Noise Gate",
+            NodeCategory::Dynamics,
+        )),
+        ChainStage::Single(BlockBlueprint::new(
+            "comp",
+            "Compressor",
+            NodeCategory::Dynamics,
+        )),
+        ChainStage::Single(BlockBlueprint::new(
+            "drive",
+            "Overdrive",
+            NodeCategory::Drive,
+        )),
+        ChainStage::Parallel(vec![
+            vec![
+                BlockBlueprint::new("amp_l", "Amp L (Vox)", NodeCategory::Amp),
+                BlockBlueprint::new("dly_l", "Delay L 1/8D", NodeCategory::Time),
+            ],
+            vec![
+                BlockBlueprint::new("amp_r", "Amp R (Vox)", NodeCategory::Amp),
+                BlockBlueprint::new("dly_r", "Delay R 1/8", NodeCategory::Time),
+            ],
+        ]),
+        ChainStage::Single(BlockBlueprint::new(
+            "reverb",
+            "Shimmer Reverb",
+            NodeCategory::Reverb,
+        )),
+        ChainStage::Single(BlockBlueprint::new("out", "Output", NodeCategory::Output)),
+    ];
+    linear_chain_layout(&stages, GridMetrics::default())
+}
+
+/// Convert pure-Rust `GraphNode` / `GraphEdge` into the Slint-generated
+/// structs the component consumes. Edge geometry resolves each edge's
+/// node ids to actual coordinates so the Slint side doesn't need to
+/// do the lookup per frame.
+fn into_slint_models(
+    nodes: Vec<model::GraphNode>,
+    edges: Vec<model::GraphEdge>,
+) -> (Vec<GraphNode>, Vec<GraphEdgeGeometry>) {
+    use std::collections::HashMap;
+
+    let coords: HashMap<&str, (f32, f32)> =
+        nodes.iter().map(|n| (n.id.as_str(), (n.x, n.y))).collect();
+
+    let slint_nodes = nodes
+        .iter()
+        .map(|n| GraphNode {
+            id: n.id.clone().into(),
+            label: n.label.clone().into(),
+            category: n.category.as_str().into(),
+            layout_x: n.x,
+            layout_y: n.y,
+            bypass: n.bypass,
+            selected: false,
+        })
+        .collect();
+
+    let slint_edges = edges
+        .iter()
+        .filter_map(|e| {
+            let from = coords.get(e.from_id.as_str())?;
+            let to = coords.get(e.to_id.as_str())?;
+            Some(GraphEdgeGeometry {
+                from_id: e.from_id.clone().into(),
+                to_id: e.to_id.clone().into(),
+                from_x: from.0,
+                from_y: from.1,
+                to_x: to.0,
+                to_y: to.1,
+            })
+        })
+        .collect();
+
+    (slint_nodes, slint_edges)
+}
+
+fn main() -> Result<(), slint::PlatformError> {
+    env_logger::init();
+
+    let (nodes, edges) = demo_chain();
+    let errors = adapter_gui::graph_view_model::validate_graph(&nodes, &edges);
+    assert!(errors.is_empty(), "demo graph is invalid: {errors:?}");
+
+    let (slint_nodes, slint_edges) = into_slint_models(nodes, edges);
+
+    let window = DemoWindow::new()?;
+    window.set_nodes(slint::ModelRc::new(slint::VecModel::from(slint_nodes)));
+    window.set_edges(slint::ModelRc::new(slint::VecModel::from(slint_edges)));
+
+    let weak = window.as_weak();
+    window.on_node_clicked(move |id| {
+        log::info!("clicked: {id}");
+        if let Some(w) = weak.upgrade() {
+            let mut nodes: Vec<_> = w.get_nodes().iter().collect();
+            for n in nodes.iter_mut() {
+                n.selected = n.id == id;
+            }
+            w.set_nodes(slint::ModelRc::new(slint::VecModel::from(nodes)));
+        }
+    });
+
+    window.on_node_double_clicked(|id| {
+        log::info!("double-clicked: {id} (would open block editor)");
+    });
+
+    let weak_drag = window.as_weak();
+    window.on_node_dragged(move |id, x, y| {
+        let Some(w) = weak_drag.upgrade() else { return };
+        let mut nodes: Vec<_> = w.get_nodes().iter().collect();
+        let mut edges: Vec<_> = w.get_edges().iter().collect();
+        for n in nodes.iter_mut() {
+            if n.id == id {
+                n.layout_x = x;
+                n.layout_y = y;
+            }
+        }
+        for e in edges.iter_mut() {
+            if e.from_id == id {
+                e.from_x = x;
+                e.from_y = y;
+            }
+            if e.to_id == id {
+                e.to_x = x;
+                e.to_y = y;
+            }
+        }
+        w.set_nodes(slint::ModelRc::new(slint::VecModel::from(nodes)));
+        w.set_edges(slint::ModelRc::new(slint::VecModel::from(edges)));
+    });
+
+    window.on_node_drag_ended(|id, x, y| {
+        log::info!("drag end: {id} -> ({x}, {y})");
+    });
+
+    window.run()
+}

--- a/crates/adapter-gui/src/graph_view_model.rs
+++ b/crates/adapter-gui/src/graph_view_model.rs
@@ -1,0 +1,321 @@
+//! Data model and layout helpers for the `GraphView` Slint component.
+//!
+//! Pure Rust types decoupled from Slint. Wiring code converts these into
+//! Slint-generated structs before pushing to the UI. Kept here so the
+//! layout logic can be unit-tested without spinning a UI.
+//!
+//! The component itself is **fully generic**: it knows nothing about
+//! amps, drives, or signal-chain semantics. It only renders nodes
+//! at given coordinates and edges between them. Domain-specific layout
+//! (signal chain, project topology, etc.) is computed by helpers like
+//! [`linear_chain_layout`] and [`parallel_paths_layout`].
+
+use std::collections::HashMap;
+
+/// Visual category of a node — used by the UI to colour the node panel.
+///
+/// Adding a new category does NOT require touching the component; the
+/// UI layer (visual config) maps category → colour.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum NodeCategory {
+    /// Input source (mono/stereo/dual-mono).
+    Input,
+    /// Output sink.
+    Output,
+    /// Gate/compressor/dynamics.
+    Dynamics,
+    /// Drive/distortion/overdrive.
+    Drive,
+    /// Amplifier / preamp / cabinet.
+    Amp,
+    /// Modulation (chorus, phaser, flanger).
+    Modulation,
+    /// Time-based effects (delay, echo).
+    Time,
+    /// Reverb (room, hall, shimmer, plate).
+    Reverb,
+    /// Equalizer / filter.
+    Eq,
+    /// Utility (volume, splitter, merger, send).
+    Util,
+    /// Anything else.
+    Other,
+}
+
+impl NodeCategory {
+    /// Stable string identifier suitable for serialisation and for the
+    /// Slint side to look up colours. Lower-case, no spaces.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Input => "input",
+            Self::Output => "output",
+            Self::Dynamics => "dynamics",
+            Self::Drive => "drive",
+            Self::Amp => "amp",
+            Self::Modulation => "modulation",
+            Self::Time => "time",
+            Self::Reverb => "reverb",
+            Self::Eq => "eq",
+            Self::Util => "util",
+            Self::Other => "other",
+        }
+    }
+}
+
+/// A node in the graph view. Coordinates are in **layout space**
+/// (logical pixels before zoom/pan). The component applies the
+/// viewport transform when rendering.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GraphNode {
+    /// Stable identifier — must be unique within the graph. Used by edges
+    /// and by callbacks (`node-clicked(id)`).
+    pub id: String,
+    /// Human-readable label shown on the node.
+    pub label: String,
+    /// Visual category — drives node colour.
+    pub category: NodeCategory,
+    /// X position in layout space.
+    pub x: f32,
+    /// Y position in layout space.
+    pub y: f32,
+    /// Whether the node represents a bypassed block. Dim in the UI.
+    pub bypass: bool,
+}
+
+/// An edge between two nodes — represents signal flow.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GraphEdge {
+    /// Source node id.
+    pub from_id: String,
+    /// Target node id.
+    pub to_id: String,
+}
+
+/// Logical stage of a signal chain. The layout helpers below consume a
+/// sequence of stages and produce positioned [`GraphNode`]s and
+/// [`GraphEdge`]s.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ChainStage {
+    /// A single block — sits alone in one column.
+    Single(BlockBlueprint),
+    /// Parallel paths between an implicit split and merge. Each inner
+    /// `Vec` is one path; all paths share the same column range.
+    Parallel(Vec<Vec<BlockBlueprint>>),
+}
+
+/// Logical description of one block, without position. Position is
+/// assigned by [`linear_chain_layout`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct BlockBlueprint {
+    pub id: String,
+    pub label: String,
+    pub category: NodeCategory,
+    pub bypass: bool,
+}
+
+impl BlockBlueprint {
+    pub fn new(id: impl Into<String>, label: impl Into<String>, category: NodeCategory) -> Self {
+        Self {
+            id: id.into(),
+            label: label.into(),
+            category,
+            bypass: false,
+        }
+    }
+}
+
+/// Grid metrics used by [`linear_chain_layout`].
+#[derive(Debug, Clone, Copy)]
+pub struct GridMetrics {
+    /// Horizontal distance between adjacent columns (centre to centre).
+    pub column_spacing: f32,
+    /// Vertical distance between parallel lanes (centre to centre).
+    pub lane_spacing: f32,
+    /// X coordinate of the first column's centre.
+    pub origin_x: f32,
+    /// Y coordinate of the central lane (single-path / merged blocks).
+    pub origin_y: f32,
+}
+
+impl Default for GridMetrics {
+    fn default() -> Self {
+        Self {
+            column_spacing: 160.0,
+            lane_spacing: 120.0,
+            origin_x: 80.0,
+            origin_y: 200.0,
+        }
+    }
+}
+
+/// Build a positioned graph from a sequence of [`ChainStage`]s.
+///
+/// Layout strategy:
+///
+/// - [`ChainStage::Single`] blocks sit on the central lane and advance
+///   the column cursor by one.
+/// - [`ChainStage::Parallel`] places each inner path on its own lane
+///   (above/below the centre, distributed symmetrically) and reserves
+///   columns equal to the longest path. Split/merge utility nodes are
+///   inserted automatically so the result is a connected DAG.
+///
+/// Returns the (nodes, edges) pair ready to push to the Slint side. IDs
+/// must be unique across the whole input — duplicates produce undefined
+/// behaviour at the UI level (the panic-free contract is kept here, but
+/// the UI may render only one of the duplicates).
+pub fn linear_chain_layout(
+    stages: &[ChainStage],
+    metrics: GridMetrics,
+) -> (Vec<GraphNode>, Vec<GraphEdge>) {
+    let mut nodes = Vec::new();
+    let mut edges = Vec::new();
+    let mut col: usize = 0;
+    let mut prev_tail: Option<String> = None;
+    let mut split_counter: usize = 0;
+
+    for stage in stages {
+        match stage {
+            ChainStage::Single(block) => {
+                let node = position_block(block, col, 0, &metrics);
+                if let Some(prev) = prev_tail.take() {
+                    edges.push(GraphEdge {
+                        from_id: prev,
+                        to_id: node.id.clone(),
+                    });
+                }
+                prev_tail = Some(node.id.clone());
+                nodes.push(node);
+                col += 1;
+            }
+            ChainStage::Parallel(paths) if paths.is_empty() => {
+                // No-op — nothing to render, no column consumed.
+            }
+            ChainStage::Parallel(paths) => {
+                split_counter += 1;
+                let split_id = format!("__split_{split_counter}");
+                let merge_id = format!("__merge_{split_counter}");
+
+                let longest = paths.iter().map(Vec::len).max().unwrap_or(0);
+                let split_col = col;
+                let merge_col = col + longest + 1;
+
+                // Split node sits at split_col on the centre lane.
+                nodes.push(GraphNode {
+                    id: split_id.clone(),
+                    label: String::new(),
+                    category: NodeCategory::Util,
+                    x: metrics.origin_x + split_col as f32 * metrics.column_spacing,
+                    y: metrics.origin_y,
+                    bypass: false,
+                });
+                if let Some(prev) = prev_tail.take() {
+                    edges.push(GraphEdge {
+                        from_id: prev,
+                        to_id: split_id.clone(),
+                    });
+                }
+
+                // Each path occupies its own lane. With N paths, lanes
+                // are -N/2..N/2 around the centre; 2 paths → -0.5 / +0.5.
+                let n_paths = paths.len() as f32;
+                for (lane_idx, path) in paths.iter().enumerate() {
+                    let lane_offset = lane_idx as f32 - (n_paths - 1.0) / 2.0;
+                    let mut last_in_lane = split_id.clone();
+                    for (block_idx, block) in path.iter().enumerate() {
+                        let node = position_block_lane(
+                            block,
+                            split_col + 1 + block_idx,
+                            lane_offset,
+                            &metrics,
+                        );
+                        edges.push(GraphEdge {
+                            from_id: last_in_lane,
+                            to_id: node.id.clone(),
+                        });
+                        last_in_lane = node.id.clone();
+                        nodes.push(node);
+                    }
+                    edges.push(GraphEdge {
+                        from_id: last_in_lane,
+                        to_id: merge_id.clone(),
+                    });
+                }
+
+                // Merge node sits at merge_col on the centre lane.
+                nodes.push(GraphNode {
+                    id: merge_id.clone(),
+                    label: String::new(),
+                    category: NodeCategory::Util,
+                    x: metrics.origin_x + merge_col as f32 * metrics.column_spacing,
+                    y: metrics.origin_y,
+                    bypass: false,
+                });
+                prev_tail = Some(merge_id);
+                col = merge_col + 1;
+            }
+        }
+    }
+
+    (nodes, edges)
+}
+
+fn position_block(
+    block: &BlockBlueprint,
+    col: usize,
+    lane: i32,
+    metrics: &GridMetrics,
+) -> GraphNode {
+    position_block_lane(block, col, lane as f32, metrics)
+}
+
+fn position_block_lane(
+    block: &BlockBlueprint,
+    col: usize,
+    lane: f32,
+    metrics: &GridMetrics,
+) -> GraphNode {
+    GraphNode {
+        id: block.id.clone(),
+        label: block.label.clone(),
+        category: block.category,
+        x: metrics.origin_x + col as f32 * metrics.column_spacing,
+        y: metrics.origin_y + lane * metrics.lane_spacing,
+        bypass: block.bypass,
+    }
+}
+
+/// Validate that the (nodes, edges) pair is a well-formed graph:
+///
+/// - every node id is unique,
+/// - every edge references existing node ids,
+/// - no node references itself.
+///
+/// Returns a list of error messages — empty means valid. Useful for
+/// guarding the layout output before it reaches the UI.
+pub fn validate_graph(nodes: &[GraphNode], edges: &[GraphEdge]) -> Vec<String> {
+    let mut errors = Vec::new();
+    let mut ids: HashMap<&str, usize> = HashMap::new();
+    for node in nodes {
+        let count = ids.entry(node.id.as_str()).or_insert(0);
+        *count += 1;
+        if *count == 2 {
+            errors.push(format!("duplicate node id: {}", node.id));
+        }
+    }
+    for edge in edges {
+        if !ids.contains_key(edge.from_id.as_str()) {
+            errors.push(format!("edge references unknown source: {}", edge.from_id));
+        }
+        if !ids.contains_key(edge.to_id.as_str()) {
+            errors.push(format!("edge references unknown target: {}", edge.to_id));
+        }
+        if edge.from_id == edge.to_id {
+            errors.push(format!("self-loop on node: {}", edge.from_id));
+        }
+    }
+    errors
+}
+
+#[cfg(test)]
+#[path = "graph_view_model_tests.rs"]
+mod tests;

--- a/crates/adapter-gui/src/graph_view_model_tests.rs
+++ b/crates/adapter-gui/src/graph_view_model_tests.rs
@@ -1,0 +1,330 @@
+//! Tests for `adapter-gui::graph_view_model`. Lifted out per project
+//! convention — production `.rs` files keep `#[cfg(test)] #[path] mod tests;`
+//! at the bottom; the body lives here.
+
+use super::{
+    linear_chain_layout, validate_graph, BlockBlueprint, ChainStage, GraphEdge, GraphNode,
+    GridMetrics, NodeCategory,
+};
+
+fn block(id: &str, label: &str, category: NodeCategory) -> BlockBlueprint {
+    BlockBlueprint::new(id, label, category)
+}
+
+fn find_node<'a>(nodes: &'a [GraphNode], id: &str) -> &'a GraphNode {
+    nodes
+        .iter()
+        .find(|n| n.id == id)
+        .unwrap_or_else(|| panic!("node {id} missing"))
+}
+
+mod node_category {
+    use super::*;
+
+    #[test]
+    fn as_str_returns_stable_lowercase_slug() {
+        assert_eq!(NodeCategory::Drive.as_str(), "drive");
+        assert_eq!(NodeCategory::Amp.as_str(), "amp");
+        assert_eq!(NodeCategory::Util.as_str(), "util");
+    }
+}
+
+mod linear_layout_single_stage {
+    use super::*;
+
+    #[test]
+    fn empty_input_produces_empty_output() {
+        let (nodes, edges) = linear_chain_layout(&[], GridMetrics::default());
+        assert!(nodes.is_empty());
+        assert!(edges.is_empty());
+    }
+
+    #[test]
+    fn single_block_yields_one_node_no_edges() {
+        let stages = [ChainStage::Single(block("a", "A", NodeCategory::Drive))];
+        let (nodes, edges) = linear_chain_layout(&stages, GridMetrics::default());
+
+        assert_eq!(nodes.len(), 1);
+        assert_eq!(edges.len(), 0);
+        let only = &nodes[0];
+        assert_eq!(only.id, "a");
+        assert_eq!(only.label, "A");
+        assert_eq!(only.category, NodeCategory::Drive);
+    }
+
+    #[test]
+    fn two_singles_are_connected_left_to_right() {
+        let stages = [
+            ChainStage::Single(block("a", "A", NodeCategory::Drive)),
+            ChainStage::Single(block("b", "B", NodeCategory::Amp)),
+        ];
+        let (nodes, edges) = linear_chain_layout(&stages, GridMetrics::default());
+
+        assert_eq!(nodes.len(), 2);
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0].from_id, "a");
+        assert_eq!(edges[0].to_id, "b");
+    }
+
+    #[test]
+    fn singles_increment_column_by_one_each() {
+        let metrics = GridMetrics {
+            origin_x: 0.0,
+            origin_y: 0.0,
+            column_spacing: 100.0,
+            lane_spacing: 50.0,
+        };
+        let stages = [
+            ChainStage::Single(block("a", "A", NodeCategory::Drive)),
+            ChainStage::Single(block("b", "B", NodeCategory::Amp)),
+            ChainStage::Single(block("c", "C", NodeCategory::Reverb)),
+        ];
+        let (nodes, _) = linear_chain_layout(&stages, metrics);
+
+        assert_eq!(nodes[0].x, 0.0);
+        assert_eq!(nodes[1].x, 100.0);
+        assert_eq!(nodes[2].x, 200.0);
+        for n in &nodes {
+            assert_eq!(n.y, 0.0, "singles stay on centre lane");
+        }
+    }
+}
+
+mod linear_layout_parallel_stage {
+    use super::*;
+
+    #[test]
+    fn parallel_split_inserts_split_and_merge_nodes() {
+        let stages = [ChainStage::Parallel(vec![
+            vec![block("l", "L", NodeCategory::Amp)],
+            vec![block("r", "R", NodeCategory::Amp)],
+        ])];
+        let (nodes, _) = linear_chain_layout(&stages, GridMetrics::default());
+
+        assert!(
+            nodes.iter().any(|n| n.id.starts_with("__split_")),
+            "split node present"
+        );
+        assert!(
+            nodes.iter().any(|n| n.id.starts_with("__merge_")),
+            "merge node present"
+        );
+    }
+
+    #[test]
+    fn parallel_paths_sit_on_symmetric_lanes() {
+        let metrics = GridMetrics {
+            origin_x: 0.0,
+            origin_y: 0.0,
+            column_spacing: 100.0,
+            lane_spacing: 80.0,
+        };
+        let stages = [ChainStage::Parallel(vec![
+            vec![block("l", "L", NodeCategory::Amp)],
+            vec![block("r", "R", NodeCategory::Amp)],
+        ])];
+        let (nodes, _) = linear_chain_layout(&stages, metrics);
+
+        let l = find_node(&nodes, "l");
+        let r = find_node(&nodes, "r");
+
+        // Two paths → lane offsets are -0.5 and +0.5 around the centre.
+        assert_eq!(l.y, -40.0);
+        assert_eq!(r.y, 40.0);
+    }
+
+    #[test]
+    fn split_connects_to_each_path_first_block() {
+        let stages = [ChainStage::Parallel(vec![
+            vec![block("l", "L", NodeCategory::Amp)],
+            vec![block("r", "R", NodeCategory::Amp)],
+        ])];
+        let (_, edges) = linear_chain_layout(&stages, GridMetrics::default());
+
+        let split_id = "__split_1";
+        let split_edges: Vec<&GraphEdge> = edges.iter().filter(|e| e.from_id == split_id).collect();
+        assert_eq!(split_edges.len(), 2);
+        let targets: Vec<&str> = split_edges.iter().map(|e| e.to_id.as_str()).collect();
+        assert!(targets.contains(&"l"));
+        assert!(targets.contains(&"r"));
+    }
+
+    #[test]
+    fn each_path_last_block_connects_to_merge() {
+        let stages = [ChainStage::Parallel(vec![
+            vec![block("l", "L", NodeCategory::Amp)],
+            vec![block("r", "R", NodeCategory::Amp)],
+        ])];
+        let (_, edges) = linear_chain_layout(&stages, GridMetrics::default());
+
+        let merge_id = "__merge_1";
+        let merge_edges: Vec<&GraphEdge> = edges.iter().filter(|e| e.to_id == merge_id).collect();
+        assert_eq!(merge_edges.len(), 2);
+        let sources: Vec<&str> = merge_edges.iter().map(|e| e.from_id.as_str()).collect();
+        assert!(sources.contains(&"l"));
+        assert!(sources.contains(&"r"));
+    }
+
+    #[test]
+    fn merge_column_accounts_for_longest_path() {
+        let metrics = GridMetrics {
+            origin_x: 0.0,
+            origin_y: 0.0,
+            column_spacing: 100.0,
+            lane_spacing: 50.0,
+        };
+        let stages = [ChainStage::Parallel(vec![
+            vec![
+                block("l1", "L1", NodeCategory::Amp),
+                block("l2", "L2", NodeCategory::Time),
+            ],
+            vec![block("r", "R", NodeCategory::Amp)],
+        ])];
+        let (nodes, _) = linear_chain_layout(&stages, metrics);
+
+        let merge = find_node(&nodes, "__merge_1");
+        // Split at col 0, longest path = 2 blocks → merge at col 3.
+        assert_eq!(merge.x, 300.0);
+    }
+
+    #[test]
+    fn single_after_parallel_continues_past_merge_column() {
+        let metrics = GridMetrics {
+            origin_x: 0.0,
+            origin_y: 0.0,
+            column_spacing: 100.0,
+            lane_spacing: 50.0,
+        };
+        let stages = [
+            ChainStage::Parallel(vec![
+                vec![block("l", "L", NodeCategory::Amp)],
+                vec![block("r", "R", NodeCategory::Amp)],
+            ]),
+            ChainStage::Single(block("rev", "Rev", NodeCategory::Reverb)),
+        ];
+        let (nodes, _) = linear_chain_layout(&stages, metrics);
+
+        let merge = find_node(&nodes, "__merge_1");
+        let rev = find_node(&nodes, "rev");
+        assert!(
+            rev.x > merge.x,
+            "reverb must sit after merge column (got rev.x={}, merge.x={})",
+            rev.x,
+            merge.x,
+        );
+    }
+
+    #[test]
+    fn empty_parallel_stage_is_skipped() {
+        let stages = [
+            ChainStage::Single(block("a", "A", NodeCategory::Drive)),
+            ChainStage::Parallel(vec![]),
+            ChainStage::Single(block("b", "B", NodeCategory::Amp)),
+        ];
+        let (nodes, edges) = linear_chain_layout(&stages, GridMetrics::default());
+
+        assert_eq!(nodes.len(), 2);
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0].from_id, "a");
+        assert_eq!(edges[0].to_id, "b");
+    }
+}
+
+mod validate_graph_invariants {
+    use super::*;
+
+    #[test]
+    fn empty_graph_is_valid() {
+        let errs = validate_graph(&[], &[]);
+        assert!(errs.is_empty());
+    }
+
+    #[test]
+    fn duplicate_node_id_is_reported() {
+        let nodes = vec![
+            GraphNode {
+                id: "a".into(),
+                label: "A".into(),
+                category: NodeCategory::Drive,
+                x: 0.0,
+                y: 0.0,
+                bypass: false,
+            },
+            GraphNode {
+                id: "a".into(),
+                label: "A duplicate".into(),
+                category: NodeCategory::Drive,
+                x: 0.0,
+                y: 0.0,
+                bypass: false,
+            },
+        ];
+        let errs = validate_graph(&nodes, &[]);
+        assert!(
+            errs.iter().any(|e| e.contains("duplicate")),
+            "got: {errs:?}"
+        );
+    }
+
+    #[test]
+    fn edge_to_missing_node_is_reported() {
+        let nodes = vec![GraphNode {
+            id: "a".into(),
+            label: "A".into(),
+            category: NodeCategory::Drive,
+            x: 0.0,
+            y: 0.0,
+            bypass: false,
+        }];
+        let edges = vec![GraphEdge {
+            from_id: "a".into(),
+            to_id: "ghost".into(),
+        }];
+        let errs = validate_graph(&nodes, &edges);
+        assert!(errs.iter().any(|e| e.contains("ghost")), "got: {errs:?}");
+    }
+
+    #[test]
+    fn self_loop_is_reported() {
+        let nodes = vec![GraphNode {
+            id: "a".into(),
+            label: "A".into(),
+            category: NodeCategory::Drive,
+            x: 0.0,
+            y: 0.0,
+            bypass: false,
+        }];
+        let edges = vec![GraphEdge {
+            from_id: "a".into(),
+            to_id: "a".into(),
+        }];
+        let errs = validate_graph(&nodes, &edges);
+        assert!(
+            errs.iter().any(|e| e.contains("self-loop")),
+            "got: {errs:?}"
+        );
+    }
+
+    #[test]
+    fn layout_output_is_always_valid() {
+        let stages = [
+            ChainStage::Single(block("noise", "Noise", NodeCategory::Dynamics)),
+            ChainStage::Single(block("comp", "Comp", NodeCategory::Dynamics)),
+            ChainStage::Single(block("od", "OD", NodeCategory::Drive)),
+            ChainStage::Parallel(vec![
+                vec![
+                    block("amp_l", "Amp L", NodeCategory::Amp),
+                    block("dly_l", "Delay L", NodeCategory::Time),
+                ],
+                vec![
+                    block("amp_r", "Amp R", NodeCategory::Amp),
+                    block("dly_r", "Delay R", NodeCategory::Time),
+                ],
+            ]),
+            ChainStage::Single(block("rev", "Rev", NodeCategory::Reverb)),
+        ];
+        let (nodes, edges) = linear_chain_layout(&stages, GridMetrics::default());
+        let errs = validate_graph(&nodes, &edges);
+        assert!(errs.is_empty(), "layout produced invalid graph: {errs:?}");
+    }
+}

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -71,6 +71,7 @@ mod block_editor_setters;
 mod block_editor_values;
 mod chain_editor;
 mod eq;
+pub mod graph_view_model;
 mod helpers;
 mod io_groups;
 mod latency_probe;

--- a/crates/adapter-gui/ui/components/graph_view.slint
+++ b/crates/adapter-gui/ui/components/graph_view.slint
@@ -1,0 +1,353 @@
+// GraphView — generic node-and-edge canvas with pan, zoom and per-node
+// drag. Knows nothing about signal-chain semantics; the host computes
+// positions and visual categories, this component just renders them.
+//
+// Coordinate system:
+//
+//   layout space   — coords on the input GraphNode (set by host)
+//   viewport space — layout * zoom + pan (rendered position)
+//
+// All callbacks emit ids and coords in *layout* space.
+
+export struct GraphNode {
+    // Stable identifier — unique within the graph. Must match what the
+    // host gave when computing the layout.
+    id: string,
+    label: string,
+    // Stable category slug ("drive", "amp", "reverb", "util", …).
+    // The component looks up the colour from a fixed palette below.
+    // Adding a new category is an enum string only — no Rust change.
+    category: string,
+    // Layout-space position (centre of the node).
+    layout_x: length,
+    layout_y: length,
+    // Visual state.
+    bypass: bool,
+    selected: bool,
+}
+
+export struct GraphEdge {
+    from_id: string,
+    to_id: string,
+}
+
+// Internal: GraphEdge resolved to actual coordinates, ready to render
+// as a Bézier curve. Host computes this from the node list; we keep the
+// shape simple so the resolved set can be derived in Slint via a
+// helper component or pre-computed in Rust.
+export struct GraphEdgeGeometry {
+    from_id: string,
+    to_id: string,
+    from_x: length,
+    from_y: length,
+    to_x: length,
+    to_y: length,
+}
+
+// Stable palette per category. Centralised here so adding a new
+// category is one line, not a tree of conditionals in every consumer.
+// This is presentation, not domain data — fits the "separation of
+// concerns" rule (business code never names a colour).
+component CategoryPalette {
+    in property <string> category;
+    out property <color> fill: root.category == "input"      ? #1e8aff
+                            : root.category == "output"     ? #ff8a1e
+                            : root.category == "dynamics"   ? #c69b3f
+                            : root.category == "drive"      ? #d04a3a
+                            : root.category == "amp"        ? #4a7fd0
+                            : root.category == "modulation" ? #8d4ad0
+                            : root.category == "time"       ? #2d9b9b
+                            : root.category == "reverb"     ? #3aa86a
+                            : root.category == "eq"         ? #c8b400
+                            : root.category == "util"       ? #6a7483
+                            : /* other */                     #8a94a2;
+    out property <color> border: self.fill.darker(0.35);
+}
+
+// Single node card. Pure visual; drag/click are owned by the parent
+// GraphView TouchArea so we keep one input source per gesture.
+component GraphNodeCard inherits Rectangle {
+    in property <GraphNode> node;
+    in property <bool> hovered;
+    in property <bool> dragging;
+    in property <length> card_width;
+    in property <length> card_height;
+
+    width: root.card_width;
+    height: root.card_height;
+    border-radius: 8px;
+    border-width: root.node.selected ? 2px : 1px;
+    border-color: root.node.selected
+        ? #f5f7fb
+        : palette.border;
+    background: root.node.bypass
+        ? palette.fill.with-alpha(0.35)
+        : root.dragging
+        ? palette.fill.brighter(0.20)
+        : root.hovered
+        ? palette.fill.brighter(0.10)
+        : palette.fill;
+    opacity: root.node.bypass ? 0.7 : 1.0;
+    drop-shadow-blur: root.dragging ? 12px : (root.hovered ? 6px : 2px);
+    drop-shadow-color: #00000080;
+    drop-shadow-offset-y: 2px;
+
+    palette := CategoryPalette {
+        category: root.node.category;
+    }
+
+    Text {
+        x: 8px;
+        y: 0px;
+        width: parent.width - 16px;
+        height: parent.height;
+        text: root.node.label;
+        color: #f5f7fb;
+        font-size: 12px;
+        font-weight: 700;
+        horizontal-alignment: center;
+        vertical-alignment: center;
+        overflow: elide;
+    }
+
+    accessible-role: button;
+    accessible-label: root.node.label;
+}
+
+// Bezier wire between two layout-space points. Drawn behind the nodes.
+component GraphWire inherits Path {
+    in property <length> from_x;
+    in property <length> from_y;
+    in property <length> to_x;
+    in property <length> to_y;
+    in property <color> stroke_color: #8aaac8;
+    in property <length> stroke_thickness: 2px;
+
+    stroke: root.stroke_color;
+    stroke-width: root.stroke_thickness;
+    fill: transparent;
+
+    // Horizontal-S bezier — control points offset by half the
+    // horizontal distance keeps wires readable even with vertical
+    // separation between parallel paths.
+    MoveTo {
+        x: root.from_x / 1px;
+        y: root.from_y / 1px;
+    }
+
+    CubicTo {
+        control-1-x: (root.from_x + (root.to_x - root.from_x) / 2) / 1px;
+        control-1-y: root.from_y / 1px;
+        control-2-x: (root.from_x + (root.to_x - root.from_x) / 2) / 1px;
+        control-2-y: root.to_y / 1px;
+        x: root.to_x / 1px;
+        y: root.to_y / 1px;
+    }
+}
+
+// The actual GraphView. Hosts nodes + edges. Pan/zoom owned here.
+export component GraphView inherits Rectangle {
+    // ── Inputs ──────────────────────────────────────────────────────
+    in property <[GraphNode]> nodes;
+    in property <[GraphEdgeGeometry]> edges;
+
+    // Viewport state. Two-way so the host can persist or programmatically
+    // reset the view (e.g. "fit to content").
+    in-out property <float> zoom: 1.0;
+    in-out property <length> pan_x: 0px;
+    in-out property <length> pan_y: 0px;
+
+    // Visual constants — overridable by the host.
+    in property <length> node_width: 96px;
+    in property <length> node_height: 56px;
+    in property <color> background_color: #11141a;
+    in property <color> grid_color: #1a1f2a;
+    in property <bool> show_grid: true;
+
+    // Zoom limits (matches issue #435 acceptance criteria 0.3..3.0).
+    in property <float> min_zoom: 0.3;
+    in property <float> max_zoom: 3.0;
+
+    // ── Outputs ─────────────────────────────────────────────────────
+    callback node_clicked(string);
+    callback node_double_clicked(string);
+    // Emitted continuously while a node is being dragged. Coords are in
+    // layout space — the host applies them back to its model so the
+    // node sticks under the cursor on the next frame.
+    callback node_dragged(string, length, length);
+    // Fired once when the drag gesture ends (mouse up).
+    callback node_drag_ended(string, length, length);
+    callback viewport_changed(float, length, length);
+
+    // ── Internal state ──────────────────────────────────────────────
+    private property <string> hover_id: "";
+    private property <string> drag_id: "";
+    private property <length> drag_offset_x: 0px;
+    private property <length> drag_offset_y: 0px;
+    private property <length> press_x: 0px;
+    private property <length> press_y: 0px;
+    // Click vs drag — threshold of 5px in viewport space (matches issue
+    // #435 acceptance criteria).
+    private property <length> click_threshold: 5px;
+    // Background pan: anchor + initial pan captured on press.
+    private property <length> pan_anchor_x: 0px;
+    private property <length> pan_anchor_y: 0px;
+    private property <length> pan_initial_x: 0px;
+    private property <length> pan_initial_y: 0px;
+    private property <bool> panning: false;
+
+    background: root.background_color;
+    clip: true;
+
+    accessible-role: list;
+    accessible-label: "Signal chain graph";
+
+    // ── Pan / zoom on empty area ───────────────────────────────────
+    // Declared FIRST so that node TouchAreas (later siblings) sit on
+    // top of it for both rendering and event routing. The pan area is
+    // the fallback — nodes intercept events that fall on them.
+    pan_area := TouchArea {
+        x: 0px;
+        y: 0px;
+        width: parent.width;
+        height: parent.height;
+        mouse-cursor: grab;
+        pointer-event(event) => {
+            if (event.kind == PointerEventKind.down) {
+                root.panning = true;
+                root.pan_anchor_x = self.mouse-x;
+                root.pan_anchor_y = self.mouse-y;
+                root.pan_initial_x = root.pan_x;
+                root.pan_initial_y = root.pan_y;
+            } else if (event.kind == PointerEventKind.up) {
+                if (root.panning) {
+                    root.panning = false;
+                    root.viewport_changed(root.zoom, root.pan_x, root.pan_y);
+                }
+            }
+        }
+        moved => {
+            if (root.panning) {
+                root.pan_x = root.pan_initial_x + (self.mouse-x - root.pan_anchor_x);
+                root.pan_y = root.pan_initial_y + (self.mouse-y - root.pan_anchor_y);
+            }
+        }
+        scroll-event(event) => {
+            // Zoom around cursor.
+            let old_zoom = root.zoom;
+            let dz = event.delta-y > 0 ? 0.1 : -0.1;
+            let target = old_zoom + dz;
+            let clamped = target < root.min_zoom
+                ? root.min_zoom
+                : target > root.max_zoom ? root.max_zoom : target;
+            if (clamped != old_zoom) {
+                // Keep the layout-space point under the cursor stationary.
+                let layout_x = (self.mouse-x - root.pan_x) / old_zoom;
+                let layout_y = (self.mouse-y - root.pan_y) / old_zoom;
+                root.zoom = clamped;
+                root.pan_x = self.mouse-x - layout_x * clamped;
+                root.pan_y = self.mouse-y - layout_y * clamped;
+                root.viewport_changed(root.zoom, root.pan_x, root.pan_y);
+            }
+            accept
+        }
+    }
+
+    // ── Optional grid backdrop ──────────────────────────────────────
+    if root.show_grid : Rectangle {
+        x: 0px;
+        y: 0px;
+        width: parent.width;
+        height: parent.height;
+        background: transparent;
+
+        // Two crossing strips that hint at the grid origin. A real grid
+        // (every N px) would need a custom Path with many MoveTo/LineTo
+        // which costs more than its visual value at this stage — keep
+        // the hint cheap until we know we need more.
+        Rectangle {
+            x: root.pan_x;
+            y: 0px;
+            width: 1px;
+            height: parent.height;
+            background: root.grid_color;
+        }
+        Rectangle {
+            x: 0px;
+            y: root.pan_y;
+            width: parent.width;
+            height: 1px;
+            background: root.grid_color;
+        }
+    }
+
+    // ── Edges (drawn under nodes) ──────────────────────────────────
+    for edge in root.edges : GraphWire {
+        from_x: root.pan_x + edge.from_x * root.zoom;
+        from_y: root.pan_y + edge.from_y * root.zoom;
+        to_x: root.pan_x + edge.to_x * root.zoom;
+        to_y: root.pan_y + edge.to_y * root.zoom;
+        stroke_thickness: 2px * root.zoom;
+    }
+
+    // ── Nodes ──────────────────────────────────────────────────────
+    for node[idx] in root.nodes : Rectangle {
+        x: root.pan_x + node.layout_x * root.zoom - card.width / 2;
+        y: root.pan_y + node.layout_y * root.zoom - card.height / 2;
+        width: card.width;
+        height: card.height;
+
+        card := GraphNodeCard {
+            node: node;
+            card_width: root.node_width * root.zoom;
+            card_height: root.node_height * root.zoom;
+            hovered: root.hover_id == node.id && root.drag_id == "";
+            dragging: root.drag_id == node.id;
+        }
+
+        TouchArea {
+            mouse-cursor: pointer;
+            pointer-event(event) => {
+                if (event.kind == PointerEventKind.down) {
+                    root.drag_id = node.id;
+                    root.press_x = self.mouse-x;
+                    root.press_y = self.mouse-y;
+                    // Offset between cursor and node centre, in layout space.
+                    root.drag_offset_x = self.mouse-x / root.zoom - root.node_width / 2;
+                    root.drag_offset_y = self.mouse-y / root.zoom - root.node_height / 2;
+                } else if (event.kind == PointerEventKind.up) {
+                    if (root.drag_id == node.id) {
+                        // Distinguish click from drag by total displacement.
+                        if (abs(self.mouse-x - root.press_x) < root.click_threshold
+                         && abs(self.mouse-y - root.press_y) < root.click_threshold) {
+                            root.node_clicked(node.id);
+                        } else {
+                            root.node_drag_ended(node.id, node.layout_x, node.layout_y);
+                        }
+                    }
+                    root.drag_id = "";
+                }
+            }
+            moved => {
+                if (self.pressed && root.drag_id == node.id) {
+                    // Translate cursor (in viewport) back to layout
+                    // space. The host receives the new centre.
+                    let new_x = (self.mouse-x - root.pan_x) / root.zoom;
+                    let new_y = (self.mouse-y - root.pan_y) / root.zoom;
+                    root.node_dragged(node.id, new_x, new_y);
+                }
+            }
+            changed has-hover => {
+                if (self.has-hover) {
+                    root.hover_id = node.id;
+                } else if (root.hover_id == node.id) {
+                    root.hover_id = "";
+                }
+            }
+            double-clicked => {
+                root.node_double_clicked(node.id);
+            }
+        }
+    }
+
+}

--- a/docs/gui/graph-view.md
+++ b/docs/gui/graph-view.md
@@ -1,0 +1,192 @@
+# GraphView — node-and-edge canvas with pan/zoom/drag
+
+**Status:** introduced in #435.
+**Source:** `crates/adapter-gui/ui/components/graph_view.slint` + `crates/adapter-gui/src/graph_view_model.rs`.
+**Demo:** `cargo run -p adapter-gui --example graph_view_demo`.
+
+A reusable Slint component for rendering a directed graph with full interactivity. Built first as a standalone primitive — integration with the existing chain UI (`secondary_windows_chain.slint`, `chain_chips.slint`) is a separate effort and not part of this component.
+
+The visual language follows pedalboards in the **Helix / Quad Cortex / Mooer GE1000** family: grid-aligned nodes, explicit Bézier wires, parallel paths drawn on dedicated lanes. Not force-directed — signal chains are too structured for spring physics to give a stable result across reopens.
+
+## When to use it
+
+| You want… | Component? |
+|---|---|
+| Single signal chain with up to ~30 blocks, branched paths | **Yes** |
+| Project topology (inputs → chains → outputs) | **Yes** (once #436 lands and you can feed it the project graph) |
+| Arbitrary graph with hundreds of nodes, force-directed | Out of scope. Different layout algo, different perf budget. |
+| Static diagram for docs | Overkill. Render to SVG offline. |
+
+## Architecture
+
+```
+                ┌─ Rust ───────────────────────────────────────┐
+                │                                              │
+  domain  ───►  │  graph_view_model.rs                         │
+   data         │   ChainStage[]  → linear_chain_layout()      │
+                │   → (Vec<GraphNode>, Vec<GraphEdge>)         │
+                │   → validate_graph()                         │
+                │                                              │
+                │  wiring code (per use site)                  │
+                │   converts pure Rust → Slint structs         │
+                │   resolves GraphEdge → GraphEdgeGeometry     │
+                └──────────────────────────────────────────────┘
+                                       │
+                                       ▼ ModelRc<...>
+                ┌─ Slint ──────────────────────────────────────┐
+                │  GraphView component                         │
+                │   renders nodes + Bezier wires               │
+                │   handles pan/zoom/drag/click                │
+                │   emits callbacks with layout-space coords   │
+                └──────────────────────────────────────────────┘
+```
+
+**Two coordinate systems:**
+
+| Space | Where | Computed how |
+|---|---|---|
+| Layout space | `GraphNode.layout_x/y`, `GraphEdgeGeometry.from/to_x/y`, all callback args | `linear_chain_layout()` (or by the host) |
+| Viewport space | `x: pan_x + layout_x * zoom` inside Slint | applied per frame by the component |
+
+The host **never** computes viewport coords — only emits layout coords. The component applies the transform.
+
+## Slint API
+
+### Structs
+
+```slint
+struct GraphNode {
+    id: string;
+    label: string;
+    category: string;     // "drive", "amp", "reverb", "util", ...
+    layout_x: length;
+    layout_y: length;
+    bypass: bool;
+    selected: bool;
+}
+
+struct GraphEdgeGeometry {
+    from_id: string;
+    to_id: string;
+    from_x: length;
+    from_y: length;
+    to_x: length;
+    to_y: length;
+}
+```
+
+`GraphEdgeGeometry` is the resolved form of an edge — coordinates are already looked up from the node list so Slint doesn't search per frame.
+
+### Properties
+
+| Property | Direction | Type | Default | Purpose |
+|---|---|---|---|---|
+| `nodes` | `in` | `[GraphNode]` | — | nodes to render |
+| `edges` | `in` | `[GraphEdgeGeometry]` | — | resolved edges to render |
+| `zoom` | `in-out` | `float` | `1.0` | viewport scale, clamped to `[min_zoom, max_zoom]` |
+| `pan_x`, `pan_y` | `in-out` | `length` | `0px` | viewport offset |
+| `node_width`, `node_height` | `in` | `length` | `96px` × `56px` | per-node card size in layout space |
+| `background_color` | `in` | `color` | `#11141a` | canvas background |
+| `grid_color` | `in` | `color` | `#1a1f2a` | grid hint colour |
+| `show_grid` | `in` | `bool` | `true` | render origin-cross grid hint |
+| `min_zoom`, `max_zoom` | `in` | `float` | `0.3`, `3.0` | zoom limits |
+
+### Callbacks
+
+| Callback | Args | When |
+|---|---|---|
+| `node_clicked(string)` | node id | press + release within 5 px (no drag) |
+| `node_double_clicked(string)` | node id | double click on a node |
+| `node_dragged(string, length, length)` | id, new layout-space x, y | continuously while drag in progress |
+| `node_drag_ended(string, length, length)` | id, layout x, y | on mouse up after drag |
+| `viewport_changed(float, length, length)` | zoom, pan_x, pan_y | after pan release or wheel zoom step |
+
+The host receives layout-space coords. To persist a moved node, write them back into `nodes` — the Slint side reads positions reactively.
+
+## Rust helpers (`graph_view_model`)
+
+| Item | What it does |
+|---|---|
+| `GraphNode` | pure Rust mirror of the Slint struct |
+| `GraphEdge` | source/target id pair (no geometry) |
+| `NodeCategory` | enum of visual categories — `as_str()` produces the slug the Slint side expects |
+| `BlockBlueprint` | one block in a logical chain — id, label, category, bypass |
+| `ChainStage` | `Single(...)` or `Parallel(Vec<Vec<...>>)` |
+| `GridMetrics` | column/lane spacing + origin |
+| `linear_chain_layout(stages, metrics)` | builds positioned nodes + edges, inserts split/merge utility nodes for parallel stages |
+| `validate_graph(nodes, edges)` | returns error strings (empty = valid). Catches duplicate ids, dangling edges, self-loops. |
+
+`linear_chain_layout` is pure — same input, same output. Used in tests + at runtime to compute positions from a logical chain description. Splits and merges are auto-generated with id prefix `__split_N` / `__merge_N`.
+
+## Category → colour mapping
+
+Centralised in the Slint `CategoryPalette` component (single source of truth). Adding a new category:
+
+1. Add a variant to `NodeCategory` and its `as_str()` slug.
+2. Add one ternary arm in `CategoryPalette` in `graph_view.slint`.
+
+No other file touches. This is the **only authorised** brand-of-conditional in this component (an exception explicit in `slint-best-practices`: Slint cannot select assets/colours via runtime strings without a ternary chain).
+
+## Interactivity contract
+
+- **Pan:** drag on empty canvas. Cursor turns `grab`. Released → fires `viewport_changed`.
+- **Zoom:** scroll wheel anywhere over the canvas. Zooms around the cursor (the point under the cursor stays fixed in layout space). Clamped to `[min_zoom, max_zoom]`. Fires `viewport_changed`.
+- **Drag a node:** press on a node card, move beyond 5 px. Fires `node_dragged` continuously, `node_drag_ended` on release.
+- **Click vs drag:** total displacement < 5 px in viewport space → `node_clicked`. Threshold is a `private property` so it can be retuned without changing the API.
+- **Double-click:** fires `node_double_clicked` — host opens the block editor.
+
+## What this component is NOT responsible for
+
+| Concern | Where it lives instead |
+|---|---|
+| Persisting moved nodes | host (write back into `nodes` on `node_drag_ended`) |
+| Block editor | existing `BlockEditorPanel` — host wires `node_double_clicked` to it |
+| Real-time audio meters on nodes | future `GraphNodeMeter` overlay component |
+| Edge routing avoidance (no crossings) | future — current Bézier is naive |
+| Touch gestures (pinch-to-zoom) | future — scroll-wheel only for now |
+
+## Invariants
+
+- **Audio thread:** untouched. This is pure UI. ✅ invariant #4/#8 of `CLAUDE.md`.
+- **Allocations per frame:** none — `for` loops bind to the model, no `set_*` in render path.
+- **Cross-platform:** no `cfg`-gated logic, no hardcoded paths. ✅
+- **No mock audio:** this component doesn't process audio. N/A.
+
+## Tests
+
+Layout helper has 17 tests in `crates/adapter-gui/src/graph_view_model_tests.rs` covering:
+
+- Empty input → empty output
+- Single block → 1 node, 0 edges
+- Sequential blocks connected left-to-right
+- Column spacing math (origin + N × column_spacing)
+- Parallel stage inserts split + merge nodes
+- Symmetric lane offsets (N paths → offsets `-N/2..N/2`)
+- Split connects to each path's first block
+- Each path's last block connects to merge
+- Merge column accounts for longest path
+- Singles after parallel continue past merge
+- Empty parallel stage is a no-op
+- `validate_graph` reports duplicate ids, dangling edges, self-loops
+- The output of `linear_chain_layout` is always valid
+
+Visual behaviour (drag, zoom, click thresholds) is validated by running the demo example. There is no automated UI test harness for Slint at this time — that's a project-wide gap, not specific to this component.
+
+## Demo
+
+```bash
+cargo run -p adapter-gui --example graph_view_demo
+```
+
+Opens a window with a hardcoded chain (Noise Gate → Compressor → Overdrive → split → 2× Vox AC30 → 2× delays → merge → Shimmer Reverb → Output). Click a node to select, double-click to log "would open editor", drag to reposition, scroll to zoom, drag empty space to pan.
+
+## Future work
+
+Captured here so the next contributor doesn't reinvent it:
+
+- **Routing avoidance:** Bézier wires currently cross when paths zig-zag. Use a layered routing algorithm (Manhattan or orthogonal-with-bends).
+- **Keyboard navigation:** Tab/arrow to move focus between nodes, Enter for click, Shift+Enter for double-click. `petgraph` can supply BFS/DFS over the graph if we add it as a dep.
+- **Persist viewport** between sessions per chain.
+- **Meter overlays** on amp/dynamics nodes for live signal level.
+- **Multi-select** with drag-rectangle for bulk operations.
+- **Snap-to-grid** during drag.


### PR DESCRIPTION
## Resumo

Componente Slint reusável de visualização de grafo + Rust layout helpers, escopo intencionalmente apertado: **só o componente isolado**, sem integração com a chain UI existente. Base pra #436 (refactor de project I/O) sem couplar nada ainda.

Closes #435.

## Decisões

- **Sem `petgraph` como dep**: Vec<Node>+Vec<Edge> + grid manual resolvem signal chain. petgraph entra no #436 se needed.
- **Layout grid-based, não force-directed**: signal chain é estruturado (Helix/Quad-Cortex/Mooer style). Force-directed seria instável visualmente entre reabertes.
- **Callback `node-dragged` emite layout-space**: o host precisa de coords pra atualizar o modelo. Viewport-space não tem uso prático aqui.
- **Pinch-to-zoom adiado**: scroll wheel funciona; pinch precisa gesture handling Slint adicional. Issue separada se precisar.

## Acceptance criteria (#435)

- [x] `GraphView` renderiza grid com 6+ blocos + split L/R + merge (demo tem 7 blocos)
- [x] Pan funciona em desktop (mouse drag em área vazia)
- [x] Zoom funciona com scroll wheel entre 0.3x e 3.0x (`min_zoom`/`max_zoom` configuráveis)
- [x] Drag de nó dispara callback com coords (em **layout-space** — ver decisão #3 acima)
- [x] Click vs drag separados por threshold de 5px (`click_threshold` configurável)
- [x] Example `graph_view_demo` builda e roda (`cargo run --example graph_view_demo`)
- [x] Zero warnings em adapter-gui, `./scripts/qa.sh` verde
- [x] Doc: `docs/gui/graph-view.md` com props/callbacks/decisões/exemplo

## Invariantes

- Audio thread: untouched (pure UI)
- Allocations per frame: zero (model bindings, sem `set_*` no render path)
- Cross-platform: sem `cfg`-gates, sem paths hardcoded
- Volume invariants: N/A (sem código de áudio)
- Isolation entre streams: preservada (não toca em runtime)

## Quality gate

```
metric        base       pr     verdict
─────────────────────────────────────────
fmt              1       0    ✅ improved
clippy          18      18    ✅ same
build            0       0    ✅ same
test fails       0       0    ✅ same
complexity     137     137    ✅ same
coverage      0,00%   0,00%   ✅ improved
```

## Test plan

- [x] `cargo test -p adapter-gui --lib graph_view_model` → 17 passed
- [x] `cargo build -p adapter-gui --example graph_view_demo` → clean
- [x] `cargo run -p adapter-gui --example graph_view_demo` (rodar local, validar visual)
- [x] `./scripts/qa.sh` → no regressions

## Follow-ups

Trackeados na própria #435 e em #436:
- Edge routing avoidance (Bézier crossings)
- Keyboard navigation
- Persistência de viewport
- Meter overlays nos nodes
- Multi-select com drag-rectangle
- Snap-to-grid
- Integração com chain UI atual (`chain_chips.slint` / `secondary_windows_chain.slint`)
- Pinch-to-zoom

🤖 Generated with [Claude Code](https://claude.com/claude-code)