### PR TITLE
docs(gitflow): document symmetric workspace isolation rule

### DIFF
--- a/docs/development/gitflow.md
+++ b/docs/development/gitflow.md
@@ -46,6 +46,15 @@ NUNCA atribuir ao milestone de release final puro durante ciclo dev.
 
 NUNCA editar código no workspace principal. Cada agent trabalha numa cópia.
 
+**Duas pastas, isolamento simétrico:**
+
+| Pasta | Quem usa | Quem NÃO usa |
+|---|---|---|
+| principal (`/Users/<user>/.../OpenRig`) | usuário — edição, validação visual, testes em hardware real | agent — NUNCA `git checkout`, `pull`, `commit`, `push`, edit, revert |
+| `.solvers/issue-N/` (rsync) | agent — implementação, commits, push, `cargo test` | usuário — NUNCA entra, não testa daqui |
+
+Pra o usuário testar uma branch do agent, ele faz `git fetch && git checkout feature/issue-N && git pull` **na pasta principal dele**. O agent NUNCA propõe `cd .solvers/...` pro usuário — `.solvers/` é exclusivo do agent.
+
 Diretórios sempre excluídos da cópia: `target`, `.logs`, `coverage`, `deps`, `plugins`, `.solvers`.
 
 ```bash


### PR DESCRIPTION
## Resumo

Adiciona tabela explícita na seção \"Workspace isolado (.solvers/)\" do `docs/development/gitflow.md` documentando que principal é exclusiva do usuário e `.solvers/issue-N/` é exclusiva do agent — e que o usuário testa branches do agent na pasta principal dele via `git checkout`, nunca dentro de `.solvers/`.

Closes #444.

## Por que

A regra existia na memória do usuário e na memória do agent, mas não estava escrita na doc. Sessão real (2026-05-14): agent propôs `cd .solvers/...` pro usuário testar a branch da #435. Doc agora fecha esse furo.

## Mudança

Doc-only. Zero código tocado.

## Test plan

- [x] Lê limpo
- [x] Tabela renderiza no GitHub