### PR TITLE
feat(gui): GraphView component — auto-layout, drag-reorder, customizable palette

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2318,6 +2318,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "graphview-demo"
+version = "0.1.0"
+dependencies = [
+ "adapter-gui",
+ "env_logger",
+ "log",
+ "slint",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
   "crates/adapter-gui",
   "crates/adapter-vst3",
   "crates/vst3",
+  "crates/graphview-demo",
 ]
 resolver = "2"
 

--- a/crates/adapter-gui/examples/graph_view_demo.rs
+++ b/crates/adapter-gui/examples/graph_view_demo.rs
@@ -10,17 +10,21 @@
 //! macro — same source the production UI consumes, no duplication.
 
 use adapter_gui::graph_view_model::{
-    self as model, linear_chain_layout, BlockBlueprint, ChainStage, GridMetrics, NodeCategory,
+    self as model, default_palette, linear_chain_layout, reorder_for_drop, topological_layout,
+    BlockBlueprint, ChainStage, GridMetrics, NodeCategory,
 };
 use slint::Model;
+use std::collections::HashMap;
 
 slint::slint! {
+    import { CheckBox } from "std-widgets.slint";
     import { GraphView, GraphNode, GraphEdgeGeometry }
         from "ui/components/graph_view.slint";
 
     export component DemoWindow inherits Window {
         in property <[GraphNode]> nodes;
         in property <[GraphEdgeGeometry]> edges;
+        out property <bool> auto <=> auto_box.checked;
 
         callback node-clicked(string);
         callback node-double-clicked(string);
@@ -38,12 +42,19 @@ slint::slint! {
             Rectangle {
                 height: 36px;
                 background: #161b25;
-                Text {
-                    x: 16px;
-                    text: "GraphView demo — drag a node, scroll to zoom, drag empty area to pan, double-click for editor stub";
-                    color: #c9d3e2;
-                    font-size: 11px;
-                    vertical-alignment: center;
+                HorizontalLayout {
+                    padding-left: 16px;
+                    spacing: 16px;
+                    Text {
+                        text: "GraphView demo — drag a node, scroll zoom, drag empty area pan, double-click editor stub";
+                        color: #c9d3e2;
+                        font-size: 11px;
+                        vertical-alignment: center;
+                    }
+                    auto_box := CheckBox {
+                        text: "auto-layout";
+                        checked: true;
+                    }
                 }
             }
 
@@ -52,6 +63,7 @@ slint::slint! {
                 edges: root.edges;
                 node-width: 110px;
                 node-height: 56px;
+                auto-layout: root.auto;
                 node-clicked(id) => { root.node-clicked(id); }
                 node-double-clicked(id) => { root.node-double-clicked(id); }
                 node-dragged(id, x, y) => { root.node-dragged(id, x, y); }
@@ -59,6 +71,24 @@ slint::slint! {
             }
         }
     }
+}
+
+/// Resolve every category to a Slint colour once, from the single-source
+/// `default_palette()`. Host owns colour; the component is colour-blind.
+fn palette_lookup() -> HashMap<String, (slint::Color, slint::Color)> {
+    default_palette()
+        .into_iter()
+        .map(|s| {
+            let to_c = |rgb: u32| {
+                slint::Color::from_rgb_u8(
+                    ((rgb >> 16) & 0xff) as u8,
+                    ((rgb >> 8) & 0xff) as u8,
+                    (rgb & 0xff) as u8,
+                )
+            };
+            (s.category.to_string(), (to_c(s.fill), to_c(s.border)))
+        })
+        .collect()
 }
 
 fn demo_chain() -> (Vec<model::GraphNode>, Vec<model::GraphEdge>) {
@@ -105,22 +135,30 @@ fn demo_chain() -> (Vec<model::GraphNode>, Vec<model::GraphEdge>) {
 fn into_slint_models(
     nodes: Vec<model::GraphNode>,
     edges: Vec<model::GraphEdge>,
+    palette: &HashMap<String, (slint::Color, slint::Color)>,
 ) -> (Vec<GraphNode>, Vec<GraphEdgeGeometry>) {
-    use std::collections::HashMap;
-
     let coords: HashMap<&str, (f32, f32)> =
         nodes.iter().map(|n| (n.id.as_str(), (n.x, n.y))).collect();
 
+    let neutral = (
+        slint::Color::from_rgb_u8(0x8a, 0x94, 0xa2),
+        slint::Color::from_rgb_u8(0x5c, 0x63, 0x6e),
+    );
     let slint_nodes = nodes
         .iter()
-        .map(|n| GraphNode {
-            id: n.id.clone().into(),
-            label: n.label.clone().into(),
-            category: n.category.as_str().into(),
-            layout_x: n.x,
-            layout_y: n.y,
-            bypass: n.bypass,
-            selected: false,
+        .map(|n| {
+            let (fill, border) = palette.get(n.category.as_str()).copied().unwrap_or(neutral);
+            GraphNode {
+                id: n.id.clone().into(),
+                label: n.label.clone().into(),
+                category: n.category.as_str().into(),
+                fill,
+                border,
+                layout_x: n.x,
+                layout_y: n.y,
+                bypass: n.bypass,
+                selected: false,
+            }
         })
         .collect();
 
@@ -150,7 +188,11 @@ fn main() -> Result<(), slint::PlatformError> {
     let errors = adapter_gui::graph_view_model::validate_graph(&nodes, &edges);
     assert!(errors.is_empty(), "demo graph is invalid: {errors:?}");
 
-    let (slint_nodes, slint_edges) = into_slint_models(nodes, edges);
+    let metrics = GridMetrics::default();
+    let palette = palette_lookup();
+    // Start from the topological auto-layout (auto-layout defaults on).
+    let laid = topological_layout(&nodes, &edges, metrics);
+    let (slint_nodes, slint_edges) = into_slint_models(laid, edges.clone(), &palette);
 
     // Shared models, mutated in place. Issue #435 invariant: drag/zoom
     // must not reallocate per frame — so the host keeps one VecModel and
@@ -210,8 +252,47 @@ fn main() -> Result<(), slint::PlatformError> {
         }
     });
 
-    window.on_node_drag_ended(|id, x, y| {
+    let nodes_dl = node_model.clone();
+    let edges_dl = edge_model.clone();
+    let win_weak = window.as_weak();
+    let base_nodes = nodes.clone();
+    let base_edges = edges.clone();
+    window.on_node_drag_ended(move |id, x, y| {
         log::info!("drag end: {id} -> ({x}, {y})");
+        let Some(w) = win_weak.upgrade() else { return };
+        if !w.get_auto() {
+            return;
+        }
+        let relaid = reorder_for_drop(
+            &base_nodes,
+            &base_edges,
+            id.as_str(),
+            x,
+            y,
+            GridMetrics::default(),
+        );
+        let coords: HashMap<String, (f32, f32)> =
+            relaid.iter().map(|n| (n.id.clone(), (n.x, n.y))).collect();
+        for i in 0..nodes_dl.row_count() {
+            let mut nd = nodes_dl.row_data(i).unwrap();
+            if let Some((nx, ny)) = coords.get(nd.id.as_str()) {
+                nd.layout_x = *nx;
+                nd.layout_y = *ny;
+                nodes_dl.set_row_data(i, nd);
+            }
+        }
+        for i in 0..edges_dl.row_count() {
+            let mut ed = edges_dl.row_data(i).unwrap();
+            if let Some((fx, fy)) = coords.get(ed.from_id.as_str()) {
+                ed.from_x = *fx;
+                ed.from_y = *fy;
+            }
+            if let Some((tx, ty)) = coords.get(ed.to_id.as_str()) {
+                ed.to_x = *tx;
+                ed.to_y = *ty;
+            }
+            edges_dl.set_row_data(i, ed);
+        }
     });
 
     window.run()

--- a/crates/adapter-gui/examples/graph_view_demo.rs
+++ b/crates/adapter-gui/examples/graph_view_demo.rs
@@ -1,0 +1,205 @@
+//! Standalone visual demo for `GraphView`. Hardcodes a signal-chain
+//! topology (compressor → drive → split → 2 amps → time fx → reverb)
+//! so the component can be validated without the rest of OpenRig.
+//!
+//! Run:
+//!     cargo run -p adapter-gui --example graph_view_demo
+//!
+//! The example imports the component from
+//! `crates/adapter-gui/ui/components/graph_view.slint` via the `slint!`
+//! macro — same source the production UI consumes, no duplication.
+
+use adapter_gui::graph_view_model::{
+    self as model, linear_chain_layout, BlockBlueprint, ChainStage, GridMetrics, NodeCategory,
+};
+use slint::Model;
+
+slint::slint! {
+    import { GraphView, GraphNode, GraphEdgeGeometry }
+        from "ui/components/graph_view.slint";
+
+    export component DemoWindow inherits Window {
+        in property <[GraphNode]> nodes;
+        in property <[GraphEdgeGeometry]> edges;
+
+        callback node-clicked(string);
+        callback node-double-clicked(string);
+        callback node-dragged(string, length, length);
+        callback node-drag-ended(string, length, length);
+
+        title: "GraphView demo";
+        preferred-width: 1100px;
+        preferred-height: 600px;
+        background: #0b0d12;
+
+        VerticalLayout {
+            padding: 0px;
+
+            Rectangle {
+                height: 36px;
+                background: #161b25;
+                Text {
+                    x: 16px;
+                    text: "GraphView demo — drag a node, scroll to zoom, drag empty area to pan, double-click for editor stub";
+                    color: #c9d3e2;
+                    font-size: 11px;
+                    vertical-alignment: center;
+                }
+            }
+
+            graph := GraphView {
+                nodes: root.nodes;
+                edges: root.edges;
+                node-width: 110px;
+                node-height: 56px;
+                node-clicked(id) => { root.node-clicked(id); }
+                node-double-clicked(id) => { root.node-double-clicked(id); }
+                node-dragged(id, x, y) => { root.node-dragged(id, x, y); }
+                node-drag-ended(id, x, y) => { root.node-drag-ended(id, x, y); }
+            }
+        }
+    }
+}
+
+fn demo_chain() -> (Vec<model::GraphNode>, Vec<model::GraphEdge>) {
+    let stages = vec![
+        ChainStage::Single(BlockBlueprint::new(
+            "noise",
+            "Noise Gate",
+            NodeCategory::Dynamics,
+        )),
+        ChainStage::Single(BlockBlueprint::new(
+            "comp",
+            "Compressor",
+            NodeCategory::Dynamics,
+        )),
+        ChainStage::Single(BlockBlueprint::new(
+            "drive",
+            "Overdrive",
+            NodeCategory::Drive,
+        )),
+        ChainStage::Parallel(vec![
+            vec![
+                BlockBlueprint::new("amp_l", "Amp L (Vox)", NodeCategory::Amp),
+                BlockBlueprint::new("dly_l", "Delay L 1/8D", NodeCategory::Time),
+            ],
+            vec![
+                BlockBlueprint::new("amp_r", "Amp R (Vox)", NodeCategory::Amp),
+                BlockBlueprint::new("dly_r", "Delay R 1/8", NodeCategory::Time),
+            ],
+        ]),
+        ChainStage::Single(BlockBlueprint::new(
+            "reverb",
+            "Shimmer Reverb",
+            NodeCategory::Reverb,
+        )),
+        ChainStage::Single(BlockBlueprint::new("out", "Output", NodeCategory::Output)),
+    ];
+    linear_chain_layout(&stages, GridMetrics::default())
+}
+
+/// Convert pure-Rust `GraphNode` / `GraphEdge` into the Slint-generated
+/// structs the component consumes. Edge geometry resolves each edge's
+/// node ids to actual coordinates so the Slint side doesn't need to
+/// do the lookup per frame.
+fn into_slint_models(
+    nodes: Vec<model::GraphNode>,
+    edges: Vec<model::GraphEdge>,
+) -> (Vec<GraphNode>, Vec<GraphEdgeGeometry>) {
+    use std::collections::HashMap;
+
+    let coords: HashMap<&str, (f32, f32)> =
+        nodes.iter().map(|n| (n.id.as_str(), (n.x, n.y))).collect();
+
+    let slint_nodes = nodes
+        .iter()
+        .map(|n| GraphNode {
+            id: n.id.clone().into(),
+            label: n.label.clone().into(),
+            category: n.category.as_str().into(),
+            layout_x: n.x,
+            layout_y: n.y,
+            bypass: n.bypass,
+            selected: false,
+        })
+        .collect();
+
+    let slint_edges = edges
+        .iter()
+        .filter_map(|e| {
+            let from = coords.get(e.from_id.as_str())?;
+            let to = coords.get(e.to_id.as_str())?;
+            Some(GraphEdgeGeometry {
+                from_id: e.from_id.clone().into(),
+                to_id: e.to_id.clone().into(),
+                from_x: from.0,
+                from_y: from.1,
+                to_x: to.0,
+                to_y: to.1,
+            })
+        })
+        .collect();
+
+    (slint_nodes, slint_edges)
+}
+
+fn main() -> Result<(), slint::PlatformError> {
+    env_logger::init();
+
+    let (nodes, edges) = demo_chain();
+    let errors = adapter_gui::graph_view_model::validate_graph(&nodes, &edges);
+    assert!(errors.is_empty(), "demo graph is invalid: {errors:?}");
+
+    let (slint_nodes, slint_edges) = into_slint_models(nodes, edges);
+
+    let window = DemoWindow::new()?;
+    window.set_nodes(slint::ModelRc::new(slint::VecModel::from(slint_nodes)));
+    window.set_edges(slint::ModelRc::new(slint::VecModel::from(slint_edges)));
+
+    let weak = window.as_weak();
+    window.on_node_clicked(move |id| {
+        log::info!("clicked: {id}");
+        if let Some(w) = weak.upgrade() {
+            let mut nodes: Vec<_> = w.get_nodes().iter().collect();
+            for n in nodes.iter_mut() {
+                n.selected = n.id == id;
+            }
+            w.set_nodes(slint::ModelRc::new(slint::VecModel::from(nodes)));
+        }
+    });
+
+    window.on_node_double_clicked(|id| {
+        log::info!("double-clicked: {id} (would open block editor)");
+    });
+
+    let weak_drag = window.as_weak();
+    window.on_node_dragged(move |id, x, y| {
+        let Some(w) = weak_drag.upgrade() else { return };
+        let mut nodes: Vec<_> = w.get_nodes().iter().collect();
+        let mut edges: Vec<_> = w.get_edges().iter().collect();
+        for n in nodes.iter_mut() {
+            if n.id == id {
+                n.layout_x = x;
+                n.layout_y = y;
+            }
+        }
+        for e in edges.iter_mut() {
+            if e.from_id == id {
+                e.from_x = x;
+                e.from_y = y;
+            }
+            if e.to_id == id {
+                e.to_x = x;
+                e.to_y = y;
+            }
+        }
+        w.set_nodes(slint::ModelRc::new(slint::VecModel::from(nodes)));
+        w.set_edges(slint::ModelRc::new(slint::VecModel::from(edges)));
+    });
+
+    window.on_node_drag_ended(|id, x, y| {
+        log::info!("drag end: {id} -> ({x}, {y})");
+    });
+
+    window.run()
+}

--- a/crates/adapter-gui/examples/graph_view_demo.rs
+++ b/crates/adapter-gui/examples/graph_view_demo.rs
@@ -152,19 +152,26 @@ fn main() -> Result<(), slint::PlatformError> {
 
     let (slint_nodes, slint_edges) = into_slint_models(nodes, edges);
 
-    let window = DemoWindow::new()?;
-    window.set_nodes(slint::ModelRc::new(slint::VecModel::from(slint_nodes)));
-    window.set_edges(slint::ModelRc::new(slint::VecModel::from(slint_edges)));
+    // Shared models, mutated in place. Issue #435 invariant: drag/zoom
+    // must not reallocate per frame — so the host keeps one VecModel and
+    // edits rows via set_row_data, never rebuilds the Vec each callback.
+    let node_model = std::rc::Rc::new(slint::VecModel::from(slint_nodes));
+    let edge_model = std::rc::Rc::new(slint::VecModel::from(slint_edges));
 
-    let weak = window.as_weak();
+    let window = DemoWindow::new()?;
+    window.set_nodes(node_model.clone().into());
+    window.set_edges(edge_model.clone().into());
+
+    let nodes_for_click = node_model.clone();
     window.on_node_clicked(move |id| {
         log::info!("clicked: {id}");
-        if let Some(w) = weak.upgrade() {
-            let mut nodes: Vec<_> = w.get_nodes().iter().collect();
-            for n in nodes.iter_mut() {
-                n.selected = n.id == id;
+        for i in 0..nodes_for_click.row_count() {
+            let mut n = nodes_for_click.row_data(i).unwrap();
+            let want = n.id == id;
+            if n.selected != want {
+                n.selected = want;
+                nodes_for_click.set_row_data(i, n);
             }
-            w.set_nodes(slint::ModelRc::new(slint::VecModel::from(nodes)));
         }
     });
 
@@ -172,29 +179,35 @@ fn main() -> Result<(), slint::PlatformError> {
         log::info!("double-clicked: {id} (would open block editor)");
     });
 
-    let weak_drag = window.as_weak();
+    let nodes_for_drag = node_model.clone();
+    let edges_for_drag = edge_model.clone();
     window.on_node_dragged(move |id, x, y| {
-        let Some(w) = weak_drag.upgrade() else { return };
-        let mut nodes: Vec<_> = w.get_nodes().iter().collect();
-        let mut edges: Vec<_> = w.get_edges().iter().collect();
-        for n in nodes.iter_mut() {
+        for i in 0..nodes_for_drag.row_count() {
+            let mut n = nodes_for_drag.row_data(i).unwrap();
             if n.id == id {
                 n.layout_x = x;
                 n.layout_y = y;
+                nodes_for_drag.set_row_data(i, n);
+                break;
             }
         }
-        for e in edges.iter_mut() {
+        for i in 0..edges_for_drag.row_count() {
+            let mut e = edges_for_drag.row_data(i).unwrap();
+            let mut touched = false;
             if e.from_id == id {
                 e.from_x = x;
                 e.from_y = y;
+                touched = true;
             }
             if e.to_id == id {
                 e.to_x = x;
                 e.to_y = y;
+                touched = true;
+            }
+            if touched {
+                edges_for_drag.set_row_data(i, e);
             }
         }
-        w.set_nodes(slint::ModelRc::new(slint::VecModel::from(nodes)));
-        w.set_edges(slint::ModelRc::new(slint::VecModel::from(edges)));
     });
 
     window.on_node_drag_ended(|id, x, y| {

--- a/crates/adapter-gui/examples/graph_view_demo.rs
+++ b/crates/adapter-gui/examples/graph_view_demo.rs
@@ -28,8 +28,8 @@ slint::slint! {
         callback node-drag-ended(string, length, length);
 
         title: "GraphView demo";
-        preferred-width: 1100px;
-        preferred-height: 600px;
+        preferred-width: 1500px;
+        preferred-height: 520px;
         background: #0b0d12;
 
         VerticalLayout {

--- a/crates/adapter-gui/src/graph_view_model.rs
+++ b/crates/adapter-gui/src/graph_view_model.rs
@@ -62,6 +62,48 @@ impl NodeCategory {
     }
 }
 
+/// Visual style for a node category. The component is colour-agnostic;
+/// the host supplies a palette (or uses [`default_palette`]). Colours are
+/// `0xRRGGBB`. Single source of truth — the default lives here only.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CategoryStyle {
+    pub category: &'static str,
+    pub fill: u32,
+    pub border: u32,
+}
+
+fn darken(rgb: u32, factor: f32) -> u32 {
+    let r = ((rgb >> 16) & 0xff) as f32 * (1.0 - factor);
+    let g = ((rgb >> 8) & 0xff) as f32 * (1.0 - factor);
+    let b = (rgb & 0xff) as f32 * (1.0 - factor);
+    ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
+}
+
+/// Default palette covering every [`NodeCategory`]. Host may override
+/// fully; this is just sane defaults.
+pub fn default_palette() -> Vec<CategoryStyle> {
+    [
+        (NodeCategory::Input, 0x1e8aff),
+        (NodeCategory::Output, 0xff8a1e),
+        (NodeCategory::Dynamics, 0xc69b3f),
+        (NodeCategory::Drive, 0xd04a3a),
+        (NodeCategory::Amp, 0x4a7fd0),
+        (NodeCategory::Modulation, 0x8d4ad0),
+        (NodeCategory::Time, 0x2d9b9b),
+        (NodeCategory::Reverb, 0x3aa86a),
+        (NodeCategory::Eq, 0xc8b400),
+        (NodeCategory::Util, 0x6a7483),
+        (NodeCategory::Other, 0x8a94a2),
+    ]
+    .into_iter()
+    .map(|(cat, fill)| CategoryStyle {
+        category: cat.as_str(),
+        fill,
+        border: darken(fill, 0.35),
+    })
+    .collect()
+}
+
 /// A node in the graph view. Coordinates are in **layout space**
 /// (logical pixels before zoom/pan). The component applies the
 /// viewport transform when rendering.

--- a/crates/adapter-gui/src/graph_view_model.rs
+++ b/crates/adapter-gui/src/graph_view_model.rs
@@ -358,6 +358,104 @@ pub fn validate_graph(nodes: &[GraphNode], edges: &[GraphEdge]) -> Vec<String> {
     errors
 }
 
+/// Index adjacency built from edges: `(out, indeg)` keyed by node index.
+/// Edges whose endpoints are not both in `node_idx` are ignored.
+fn build_adjacency(
+    node_idx: &HashMap<&str, usize>,
+    n: usize,
+    edges: &[GraphEdge],
+) -> (Vec<Vec<usize>>, Vec<usize>) {
+    let mut outs: Vec<Vec<usize>> = vec![Vec::new(); n];
+    let mut indeg = vec![0usize; n];
+    for ed in edges {
+        if let (Some(&f), Some(&t)) = (
+            node_idx.get(ed.from_id.as_str()),
+            node_idx.get(ed.to_id.as_str()),
+        ) {
+            outs[f].push(t);
+            indeg[t] += 1;
+        }
+    }
+    (outs, indeg)
+}
+
+/// Longest-path rank per node index (column). `None` if the graph has a
+/// cycle — caller falls back to input order.
+fn longest_path_ranks(node_ids: &[&str], edges: &[GraphEdge]) -> Option<Vec<usize>> {
+    let n = node_ids.len();
+    let node_idx: HashMap<&str, usize> =
+        node_ids.iter().enumerate().map(|(i, s)| (*s, i)).collect();
+    let (outs, indeg) = build_adjacency(&node_idx, n, edges);
+    let mut rank = vec![0usize; n];
+    let mut queue: Vec<usize> = (0..n).filter(|i| indeg[*i] == 0).collect();
+    let mut indeg_w = indeg.clone();
+    let mut head = 0;
+    let mut processed = 0usize;
+    while head < queue.len() {
+        let u = queue[head];
+        head += 1;
+        processed += 1;
+        for &v in &outs[u] {
+            if rank[u] + 1 > rank[v] {
+                rank[v] = rank[u] + 1;
+            }
+            indeg_w[v] -= 1;
+            if indeg_w[v] == 0 {
+                queue.push(v);
+            }
+        }
+    }
+    (processed == n).then_some(rank)
+}
+
+/// Lane offset per node index. Nodes sharing a rank are ordered by the
+/// barycenter of their predecessors (already-placed earlier ranks) with
+/// input index as tiebreak, then spread symmetrically around 0.
+fn assign_lanes(nodes: &[GraphNode], edges: &[GraphEdge], rank: &[usize]) -> Vec<f32> {
+    let n = nodes.len();
+    let node_idx: HashMap<&str, usize> = nodes
+        .iter()
+        .enumerate()
+        .map(|(i, x)| (x.id.as_str(), i))
+        .collect();
+    let mut preds: Vec<Vec<usize>> = vec![Vec::new(); n];
+    for ed in edges {
+        if let (Some(&f), Some(&t)) = (
+            node_idx.get(ed.from_id.as_str()),
+            node_idx.get(ed.to_id.as_str()),
+        ) {
+            preds[t].push(f);
+        }
+    }
+    let max_rank = rank.iter().copied().max().unwrap_or(0);
+    let mut by_rank: Vec<Vec<usize>> = vec![Vec::new(); max_rank + 1];
+    for (i, &r) in rank.iter().enumerate() {
+        by_rank[r].push(i);
+    }
+    let mut lane = vec![0f32; n];
+    for group in by_rank.iter() {
+        let mut g = group.clone();
+        let bary = |i: usize, lane: &[f32]| -> f32 {
+            if preds[i].is_empty() {
+                i as f32
+            } else {
+                preds[i].iter().map(|&p| lane[p]).sum::<f32>() / preds[i].len() as f32
+            }
+        };
+        g.sort_by(|&a, &b| {
+            bary(a, &lane)
+                .partial_cmp(&bary(b, &lane))
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then(a.cmp(&b))
+        });
+        let k = g.len() as f32;
+        for (slot, i) in g.into_iter().enumerate() {
+            lane[i] = slot as f32 - (k - 1.0) / 2.0;
+        }
+    }
+    lane
+}
+
 /// Auto-layout from graph topology. Column = longest path from a source
 /// (in-degree 0). Lane assignment spreads nodes that share a column
 /// symmetrically around `origin_y`, ordered by the barycenter of their
@@ -369,38 +467,7 @@ pub fn topological_layout(
     metrics: GridMetrics,
 ) -> Vec<GraphNode> {
     let ids: Vec<&str> = nodes.iter().map(|n| n.id.as_str()).collect();
-    let mut indeg: HashMap<&str, usize> = ids.iter().map(|i| (*i, 0)).collect();
-    let mut outs: HashMap<&str, Vec<&str>> = ids.iter().map(|i| (*i, vec![])).collect();
-    for ed in edges {
-        let (f, t) = (ed.from_id.as_str(), ed.to_id.as_str());
-        if indeg.contains_key(f) && indeg.contains_key(t) {
-            *indeg.get_mut(t).unwrap() += 1;
-            outs.get_mut(f).unwrap().push(t);
-        }
-    }
-    let mut rank: HashMap<&str, usize> = ids.iter().map(|i| (*i, 0)).collect();
-    let mut queue: Vec<&str> = ids.iter().filter(|i| indeg[*i] == 0).copied().collect();
-    let mut processed = 0usize;
-    let mut indeg_w = indeg.clone();
-    let mut head = 0;
-    while head < queue.len() {
-        let u = queue[head];
-        head += 1;
-        processed += 1;
-        for &v in &outs[u] {
-            let nr = rank[u] + 1;
-            if nr > rank[v] {
-                *rank.get_mut(v).unwrap() = nr;
-            }
-            let d = indeg_w.get_mut(v).unwrap();
-            *d -= 1;
-            if *d == 0 {
-                queue.push(v);
-            }
-        }
-    }
-    if processed < ids.len() {
-        // Cycle / malformed: degrade to input order, never panic.
+    let Some(rank) = longest_path_ranks(&ids, edges) else {
         return nodes
             .iter()
             .enumerate()
@@ -410,57 +477,14 @@ pub fn topological_layout(
                 ..src.clone()
             })
             .collect();
-    }
-
-    // Group node indices by rank, then assign lanes left→right using the
-    // barycenter (mean lane of predecessors) with input index as tiebreak.
-    let max_rank = ids.iter().map(|i| rank[*i]).max().unwrap_or(0);
-    let mut by_rank: Vec<Vec<usize>> = vec![Vec::new(); max_rank + 1];
-    for (idx, src) in nodes.iter().enumerate() {
-        by_rank[rank[src.id.as_str()]].push(idx);
-    }
-    let id_of = |idx: usize| nodes[idx].id.as_str();
-    let preds: HashMap<&str, Vec<&str>> = {
-        let mut m: HashMap<&str, Vec<&str>> = ids.iter().map(|i| (*i, vec![])).collect();
-        for ed in edges {
-            let (f, t) = (ed.from_id.as_str(), ed.to_id.as_str());
-            if m.contains_key(t) && m.contains_key(f) {
-                m.get_mut(t).unwrap().push(f);
-            }
-        }
-        m
     };
-    let mut lane: HashMap<&str, f32> = HashMap::new();
-    for group in by_rank.iter() {
-        let mut group = group.clone();
-        let bary = |idx: usize| -> f32 {
-            let id = id_of(idx);
-            let known: Vec<f32> = preds[id]
-                .iter()
-                .filter_map(|p| lane.get(*p).copied())
-                .collect();
-            if known.is_empty() {
-                idx as f32
-            } else {
-                known.iter().sum::<f32>() / known.len() as f32
-            }
-        };
-        group.sort_by(|&a, &b| {
-            bary(a)
-                .partial_cmp(&bary(b))
-                .unwrap_or(std::cmp::Ordering::Equal)
-                .then(a.cmp(&b))
-        });
-        let k = group.len() as f32;
-        for (slot, idx) in group.into_iter().enumerate() {
-            lane.insert(id_of(idx), slot as f32 - (k - 1.0) / 2.0);
-        }
-    }
+    let lane = assign_lanes(nodes, edges, &rank);
     nodes
         .iter()
-        .map(|src| GraphNode {
-            x: metrics.origin_x + rank[src.id.as_str()] as f32 * metrics.column_spacing,
-            y: metrics.origin_y + lane[src.id.as_str()] * metrics.lane_spacing,
+        .enumerate()
+        .map(|(i, src)| GraphNode {
+            x: metrics.origin_x + rank[i] as f32 * metrics.column_spacing,
+            y: metrics.origin_y + lane[i] * metrics.lane_spacing,
             ..src.clone()
         })
         .collect()
@@ -474,7 +498,6 @@ pub fn reorder_for_drop(
     nodes: &[GraphNode],
     edges: &[GraphEdge],
     dragged_id: &str,
-    _drop_x: f32,
     drop_y: f32,
     metrics: GridMetrics,
 ) -> Vec<GraphNode> {

--- a/crates/adapter-gui/src/graph_view_model.rs
+++ b/crates/adapter-gui/src/graph_view_model.rs
@@ -1,0 +1,321 @@
+//! Data model and layout helpers for the `GraphView` Slint component.
+//!
+//! Pure Rust types decoupled from Slint. Wiring code converts these into
+//! Slint-generated structs before pushing to the UI. Kept here so the
+//! layout logic can be unit-tested without spinning a UI.
+//!
+//! The component itself is **fully generic**: it knows nothing about
+//! amps, drives, or signal-chain semantics. It only renders nodes
+//! at given coordinates and edges between them. Domain-specific layout
+//! (signal chain, project topology, etc.) is computed by helpers like
+//! [`linear_chain_layout`] and [`parallel_paths_layout`].
+
+use std::collections::HashMap;
+
+/// Visual category of a node — used by the UI to colour the node panel.
+///
+/// Adding a new category does NOT require touching the component; the
+/// UI layer (visual config) maps category → colour.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum NodeCategory {
+    /// Input source (mono/stereo/dual-mono).
+    Input,
+    /// Output sink.
+    Output,
+    /// Gate/compressor/dynamics.
+    Dynamics,
+    /// Drive/distortion/overdrive.
+    Drive,
+    /// Amplifier / preamp / cabinet.
+    Amp,
+    /// Modulation (chorus, phaser, flanger).
+    Modulation,
+    /// Time-based effects (delay, echo).
+    Time,
+    /// Reverb (room, hall, shimmer, plate).
+    Reverb,
+    /// Equalizer / filter.
+    Eq,
+    /// Utility (volume, splitter, merger, send).
+    Util,
+    /// Anything else.
+    Other,
+}
+
+impl NodeCategory {
+    /// Stable string identifier suitable for serialisation and for the
+    /// Slint side to look up colours. Lower-case, no spaces.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Input => "input",
+            Self::Output => "output",
+            Self::Dynamics => "dynamics",
+            Self::Drive => "drive",
+            Self::Amp => "amp",
+            Self::Modulation => "modulation",
+            Self::Time => "time",
+            Self::Reverb => "reverb",
+            Self::Eq => "eq",
+            Self::Util => "util",
+            Self::Other => "other",
+        }
+    }
+}
+
+/// A node in the graph view. Coordinates are in **layout space**
+/// (logical pixels before zoom/pan). The component applies the
+/// viewport transform when rendering.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GraphNode {
+    /// Stable identifier — must be unique within the graph. Used by edges
+    /// and by callbacks (`node-clicked(id)`).
+    pub id: String,
+    /// Human-readable label shown on the node.
+    pub label: String,
+    /// Visual category — drives node colour.
+    pub category: NodeCategory,
+    /// X position in layout space.
+    pub x: f32,
+    /// Y position in layout space.
+    pub y: f32,
+    /// Whether the node represents a bypassed block. Dim in the UI.
+    pub bypass: bool,
+}
+
+/// An edge between two nodes — represents signal flow.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GraphEdge {
+    /// Source node id.
+    pub from_id: String,
+    /// Target node id.
+    pub to_id: String,
+}
+
+/// Logical stage of a signal chain. The layout helpers below consume a
+/// sequence of stages and produce positioned [`GraphNode`]s and
+/// [`GraphEdge`]s.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ChainStage {
+    /// A single block — sits alone in one column.
+    Single(BlockBlueprint),
+    /// Parallel paths between an implicit split and merge. Each inner
+    /// `Vec` is one path; all paths share the same column range.
+    Parallel(Vec<Vec<BlockBlueprint>>),
+}
+
+/// Logical description of one block, without position. Position is
+/// assigned by [`linear_chain_layout`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct BlockBlueprint {
+    pub id: String,
+    pub label: String,
+    pub category: NodeCategory,
+    pub bypass: bool,
+}
+
+impl BlockBlueprint {
+    pub fn new(id: impl Into<String>, label: impl Into<String>, category: NodeCategory) -> Self {
+        Self {
+            id: id.into(),
+            label: label.into(),
+            category,
+            bypass: false,
+        }
+    }
+}
+
+/// Grid metrics used by [`linear_chain_layout`].
+#[derive(Debug, Clone, Copy)]
+pub struct GridMetrics {
+    /// Horizontal distance between adjacent columns (centre to centre).
+    pub column_spacing: f32,
+    /// Vertical distance between parallel lanes (centre to centre).
+    pub lane_spacing: f32,
+    /// X coordinate of the first column's centre.
+    pub origin_x: f32,
+    /// Y coordinate of the central lane (single-path / merged blocks).
+    pub origin_y: f32,
+}
+
+impl Default for GridMetrics {
+    fn default() -> Self {
+        Self {
+            column_spacing: 160.0,
+            lane_spacing: 120.0,
+            origin_x: 80.0,
+            origin_y: 200.0,
+        }
+    }
+}
+
+/// Build a positioned graph from a sequence of [`ChainStage`]s.
+///
+/// Layout strategy:
+///
+/// - [`ChainStage::Single`] blocks sit on the central lane and advance
+///   the column cursor by one.
+/// - [`ChainStage::Parallel`] places each inner path on its own lane
+///   (above/below the centre, distributed symmetrically) and reserves
+///   columns equal to the longest path. Split/merge utility nodes are
+///   inserted automatically so the result is a connected DAG.
+///
+/// Returns the (nodes, edges) pair ready to push to the Slint side. IDs
+/// must be unique across the whole input — duplicates produce undefined
+/// behaviour at the UI level (the panic-free contract is kept here, but
+/// the UI may render only one of the duplicates).
+pub fn linear_chain_layout(
+    stages: &[ChainStage],
+    metrics: GridMetrics,
+) -> (Vec<GraphNode>, Vec<GraphEdge>) {
+    let mut nodes = Vec::new();
+    let mut edges = Vec::new();
+    let mut col: usize = 0;
+    let mut prev_tail: Option<String> = None;
+    let mut split_counter: usize = 0;
+
+    for stage in stages {
+        match stage {
+            ChainStage::Single(block) => {
+                let node = position_block(block, col, 0, &metrics);
+                if let Some(prev) = prev_tail.take() {
+                    edges.push(GraphEdge {
+                        from_id: prev,
+                        to_id: node.id.clone(),
+                    });
+                }
+                prev_tail = Some(node.id.clone());
+                nodes.push(node);
+                col += 1;
+            }
+            ChainStage::Parallel(paths) if paths.is_empty() => {
+                // No-op — nothing to render, no column consumed.
+            }
+            ChainStage::Parallel(paths) => {
+                split_counter += 1;
+                let split_id = format!("__split_{split_counter}");
+                let merge_id = format!("__merge_{split_counter}");
+
+                let longest = paths.iter().map(Vec::len).max().unwrap_or(0);
+                let split_col = col;
+                let merge_col = col + longest + 1;
+
+                // Split node sits at split_col on the centre lane.
+                nodes.push(GraphNode {
+                    id: split_id.clone(),
+                    label: String::new(),
+                    category: NodeCategory::Util,
+                    x: metrics.origin_x + split_col as f32 * metrics.column_spacing,
+                    y: metrics.origin_y,
+                    bypass: false,
+                });
+                if let Some(prev) = prev_tail.take() {
+                    edges.push(GraphEdge {
+                        from_id: prev,
+                        to_id: split_id.clone(),
+                    });
+                }
+
+                // Each path occupies its own lane. With N paths, lanes
+                // are -N/2..N/2 around the centre; 2 paths → -0.5 / +0.5.
+                let n_paths = paths.len() as f32;
+                for (lane_idx, path) in paths.iter().enumerate() {
+                    let lane_offset = lane_idx as f32 - (n_paths - 1.0) / 2.0;
+                    let mut last_in_lane = split_id.clone();
+                    for (block_idx, block) in path.iter().enumerate() {
+                        let node = position_block_lane(
+                            block,
+                            split_col + 1 + block_idx,
+                            lane_offset,
+                            &metrics,
+                        );
+                        edges.push(GraphEdge {
+                            from_id: last_in_lane,
+                            to_id: node.id.clone(),
+                        });
+                        last_in_lane = node.id.clone();
+                        nodes.push(node);
+                    }
+                    edges.push(GraphEdge {
+                        from_id: last_in_lane,
+                        to_id: merge_id.clone(),
+                    });
+                }
+
+                // Merge node sits at merge_col on the centre lane.
+                nodes.push(GraphNode {
+                    id: merge_id.clone(),
+                    label: String::new(),
+                    category: NodeCategory::Util,
+                    x: metrics.origin_x + merge_col as f32 * metrics.column_spacing,
+                    y: metrics.origin_y,
+                    bypass: false,
+                });
+                prev_tail = Some(merge_id);
+                col = merge_col + 1;
+            }
+        }
+    }
+
+    (nodes, edges)
+}
+
+fn position_block(
+    block: &BlockBlueprint,
+    col: usize,
+    lane: i32,
+    metrics: &GridMetrics,
+) -> GraphNode {
+    position_block_lane(block, col, lane as f32, metrics)
+}
+
+fn position_block_lane(
+    block: &BlockBlueprint,
+    col: usize,
+    lane: f32,
+    metrics: &GridMetrics,
+) -> GraphNode {
+    GraphNode {
+        id: block.id.clone(),
+        label: block.label.clone(),
+        category: block.category,
+        x: metrics.origin_x + col as f32 * metrics.column_spacing,
+        y: metrics.origin_y + lane * metrics.lane_spacing,
+        bypass: block.bypass,
+    }
+}
+
+/// Validate that the (nodes, edges) pair is a well-formed graph:
+///
+/// - every node id is unique,
+/// - every edge references existing node ids,
+/// - no node references itself.
+///
+/// Returns a list of error messages — empty means valid. Useful for
+/// guarding the layout output before it reaches the UI.
+pub fn validate_graph(nodes: &[GraphNode], edges: &[GraphEdge]) -> Vec<String> {
+    let mut errors = Vec::new();
+    let mut ids: HashMap<&str, usize> = HashMap::new();
+    for node in nodes {
+        let count = ids.entry(node.id.as_str()).or_insert(0);
+        *count += 1;
+        if *count == 2 {
+            errors.push(format!("duplicate node id: {}", node.id));
+        }
+    }
+    for edge in edges {
+        if !ids.contains_key(edge.from_id.as_str()) {
+            errors.push(format!("edge references unknown source: {}", edge.from_id));
+        }
+        if !ids.contains_key(edge.to_id.as_str()) {
+            errors.push(format!("edge references unknown target: {}", edge.to_id));
+        }
+        if edge.from_id == edge.to_id {
+            errors.push(format!("self-loop on node: {}", edge.from_id));
+        }
+    }
+    errors
+}
+
+#[cfg(test)]
+#[path = "graph_view_model_tests.rs"]
+mod tests;

--- a/crates/adapter-gui/src/graph_view_model.rs
+++ b/crates/adapter-gui/src/graph_view_model.rs
@@ -358,6 +358,172 @@ pub fn validate_graph(nodes: &[GraphNode], edges: &[GraphEdge]) -> Vec<String> {
     errors
 }
 
+/// Auto-layout from graph topology. Column = longest path from a source
+/// (in-degree 0). Lane assignment spreads nodes that share a column
+/// symmetrically around `origin_y`, ordered by the barycenter of their
+/// predecessors so parallel paths stay readable. Panic-free: a cycle or
+/// malformed graph falls back to input-order ranking on the centre lane.
+pub fn topological_layout(
+    nodes: &[GraphNode],
+    edges: &[GraphEdge],
+    metrics: GridMetrics,
+) -> Vec<GraphNode> {
+    let ids: Vec<&str> = nodes.iter().map(|n| n.id.as_str()).collect();
+    let mut indeg: HashMap<&str, usize> = ids.iter().map(|i| (*i, 0)).collect();
+    let mut outs: HashMap<&str, Vec<&str>> = ids.iter().map(|i| (*i, vec![])).collect();
+    for ed in edges {
+        let (f, t) = (ed.from_id.as_str(), ed.to_id.as_str());
+        if indeg.contains_key(f) && indeg.contains_key(t) {
+            *indeg.get_mut(t).unwrap() += 1;
+            outs.get_mut(f).unwrap().push(t);
+        }
+    }
+    let mut rank: HashMap<&str, usize> = ids.iter().map(|i| (*i, 0)).collect();
+    let mut queue: Vec<&str> = ids.iter().filter(|i| indeg[*i] == 0).copied().collect();
+    let mut processed = 0usize;
+    let mut indeg_w = indeg.clone();
+    let mut head = 0;
+    while head < queue.len() {
+        let u = queue[head];
+        head += 1;
+        processed += 1;
+        for &v in &outs[u] {
+            let nr = rank[u] + 1;
+            if nr > rank[v] {
+                *rank.get_mut(v).unwrap() = nr;
+            }
+            let d = indeg_w.get_mut(v).unwrap();
+            *d -= 1;
+            if *d == 0 {
+                queue.push(v);
+            }
+        }
+    }
+    if processed < ids.len() {
+        // Cycle / malformed: degrade to input order, never panic.
+        return nodes
+            .iter()
+            .enumerate()
+            .map(|(i, src)| GraphNode {
+                x: metrics.origin_x + i as f32 * metrics.column_spacing,
+                y: metrics.origin_y,
+                ..src.clone()
+            })
+            .collect();
+    }
+
+    // Group node indices by rank, then assign lanes left→right using the
+    // barycenter (mean lane of predecessors) with input index as tiebreak.
+    let max_rank = ids.iter().map(|i| rank[*i]).max().unwrap_or(0);
+    let mut by_rank: Vec<Vec<usize>> = vec![Vec::new(); max_rank + 1];
+    for (idx, src) in nodes.iter().enumerate() {
+        by_rank[rank[src.id.as_str()]].push(idx);
+    }
+    let id_of = |idx: usize| nodes[idx].id.as_str();
+    let preds: HashMap<&str, Vec<&str>> = {
+        let mut m: HashMap<&str, Vec<&str>> = ids.iter().map(|i| (*i, vec![])).collect();
+        for ed in edges {
+            let (f, t) = (ed.from_id.as_str(), ed.to_id.as_str());
+            if m.contains_key(t) && m.contains_key(f) {
+                m.get_mut(t).unwrap().push(f);
+            }
+        }
+        m
+    };
+    let mut lane: HashMap<&str, f32> = HashMap::new();
+    for group in by_rank.iter() {
+        let mut group = group.clone();
+        let bary = |idx: usize| -> f32 {
+            let id = id_of(idx);
+            let known: Vec<f32> = preds[id]
+                .iter()
+                .filter_map(|p| lane.get(*p).copied())
+                .collect();
+            if known.is_empty() {
+                idx as f32
+            } else {
+                known.iter().sum::<f32>() / known.len() as f32
+            }
+        };
+        group.sort_by(|&a, &b| {
+            bary(a)
+                .partial_cmp(&bary(b))
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then(a.cmp(&b))
+        });
+        let k = group.len() as f32;
+        for (slot, idx) in group.into_iter().enumerate() {
+            lane.insert(id_of(idx), slot as f32 - (k - 1.0) / 2.0);
+        }
+    }
+    nodes
+        .iter()
+        .map(|src| GraphNode {
+            x: metrics.origin_x + rank[src.id.as_str()] as f32 * metrics.column_spacing,
+            y: metrics.origin_y + lane[src.id.as_str()] * metrics.lane_spacing,
+            ..src.clone()
+        })
+        .collect()
+}
+
+/// Re-tidy after a drag in auto mode. The dragged node keeps its
+/// edge-derived column; `drop_y` only reorders it among its column
+/// siblings. Returns a fresh [`topological_layout`]. Panic-free: an
+/// unknown id yields the clean layout unchanged.
+pub fn reorder_for_drop(
+    nodes: &[GraphNode],
+    edges: &[GraphEdge],
+    dragged_id: &str,
+    _drop_x: f32,
+    drop_y: f32,
+    metrics: GridMetrics,
+) -> Vec<GraphNode> {
+    let laid = topological_layout(nodes, edges, metrics);
+    let Some(dragged) = laid.iter().find(|n| n.id == dragged_id) else {
+        return laid;
+    };
+    let dragged_x = dragged.x;
+    let mut siblings: Vec<&GraphNode> = laid.iter().filter(|n| n.x == dragged_x).collect();
+    if siblings.len() < 2 {
+        return laid;
+    }
+    siblings.sort_by(|a, b| a.y.partial_cmp(&b.y).unwrap_or(std::cmp::Ordering::Equal));
+    let order: Vec<&str> = siblings.iter().map(|n| n.id.as_str()).collect();
+    let cur = order.iter().position(|id| *id == dragged_id).unwrap();
+    let mut target = 0usize;
+    let mut best = f32::MAX;
+    for (i, s) in siblings.iter().enumerate() {
+        let d = (s.y - drop_y).abs();
+        if d < best {
+            best = d;
+            target = i;
+        }
+    }
+    if target == cur {
+        return laid;
+    }
+    let mut new_sib_ids: Vec<&str> = order
+        .iter()
+        .filter(|id| **id != dragged_id)
+        .copied()
+        .collect();
+    new_sib_ids.insert(target.min(new_sib_ids.len()), dragged_id);
+    let sib_set: std::collections::HashSet<&str> = order.iter().copied().collect();
+    let mut sib_iter = new_sib_ids.iter();
+    let feed: Vec<GraphNode> = nodes
+        .iter()
+        .map(|src| {
+            if sib_set.contains(src.id.as_str()) {
+                let next = *sib_iter.next().unwrap();
+                nodes.iter().find(|n| n.id == next).unwrap().clone()
+            } else {
+                src.clone()
+            }
+        })
+        .collect();
+    topological_layout(&feed, edges, metrics)
+}
+
 #[cfg(test)]
 #[path = "graph_view_model_tests.rs"]
 mod tests;

--- a/crates/adapter-gui/src/graph_view_model_tests.rs
+++ b/crates/adapter-gui/src/graph_view_model_tests.rs
@@ -30,7 +30,6 @@ mod node_category {
 }
 
 mod palette {
-    use super::*;
     use crate::graph_view_model::{default_palette, NodeCategory};
 
     #[test]
@@ -68,6 +67,189 @@ mod palette {
                 s.category
             );
         }
+    }
+}
+
+mod topological_rank {
+    use super::*;
+    use crate::graph_view_model::topological_layout;
+
+    fn tn(id: &str) -> GraphNode {
+        GraphNode {
+            id: id.into(),
+            label: id.into(),
+            category: NodeCategory::Other,
+            x: 0.0,
+            y: 0.0,
+            bypass: false,
+        }
+    }
+    fn te(a: &str, b: &str) -> GraphEdge {
+        GraphEdge {
+            from_id: a.into(),
+            to_id: b.into(),
+        }
+    }
+
+    #[test]
+    fn linear_chain_ranks_left_to_right() {
+        let m = GridMetrics {
+            origin_x: 0.0,
+            origin_y: 0.0,
+            column_spacing: 100.0,
+            lane_spacing: 50.0,
+        };
+        let nodes = vec![tn("a"), tn("b"), tn("c")];
+        let edges = vec![te("a", "b"), te("b", "c")];
+        let out = topological_layout(&nodes, &edges, m);
+        let get = |id| out.iter().find(|x| x.id == id).unwrap().x;
+        assert_eq!(get("a"), 0.0);
+        assert_eq!(get("b"), 100.0);
+        assert_eq!(get("c"), 200.0);
+    }
+
+    #[test]
+    fn diamond_longest_path_wins() {
+        let m = GridMetrics {
+            origin_x: 0.0,
+            origin_y: 0.0,
+            column_spacing: 100.0,
+            lane_spacing: 50.0,
+        };
+        let nodes = vec![tn("a"), tn("b"), tn("d")];
+        let edges = vec![te("a", "b"), te("b", "d"), te("a", "d")];
+        let out = topological_layout(&nodes, &edges, m);
+        let get = |id| out.iter().find(|x| x.id == id).unwrap().x;
+        assert_eq!(get("d"), 200.0);
+    }
+
+    #[test]
+    fn cycle_falls_back_to_input_order_no_panic() {
+        let m = GridMetrics::default();
+        let nodes = vec![tn("a"), tn("b")];
+        let edges = vec![te("a", "b"), te("b", "a")];
+        let out = topological_layout(&nodes, &edges, m);
+        assert_eq!(out.len(), 2);
+    }
+}
+
+mod topological_lane {
+    use super::*;
+    use crate::graph_view_model::topological_layout;
+
+    fn tn(id: &str) -> GraphNode {
+        GraphNode {
+            id: id.into(),
+            label: id.into(),
+            category: NodeCategory::Other,
+            x: 0.0,
+            y: 0.0,
+            bypass: false,
+        }
+    }
+    fn te(a: &str, b: &str) -> GraphEdge {
+        GraphEdge {
+            from_id: a.into(),
+            to_id: b.into(),
+        }
+    }
+
+    #[test]
+    fn parallel_siblings_get_symmetric_lanes() {
+        let m = GridMetrics {
+            origin_x: 0.0,
+            origin_y: 100.0,
+            column_spacing: 100.0,
+            lane_spacing: 40.0,
+        };
+        let nodes = vec![tn("s"), tn("p"), tn("q"), tn("m")];
+        let edges = vec![te("s", "p"), te("s", "q"), te("p", "m"), te("q", "m")];
+        let out = topological_layout(&nodes, &edges, m);
+        let y = |id| out.iter().find(|x| x.id == id).unwrap().y;
+        assert_eq!(y("s"), 100.0);
+        assert_eq!(y("m"), 100.0);
+        let mut ys = [y("p"), y("q")];
+        ys.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        assert_eq!(ys, [80.0, 120.0]);
+    }
+
+    #[test]
+    fn single_node_per_rank_stays_on_centre_lane() {
+        let m = GridMetrics {
+            origin_x: 0.0,
+            origin_y: 50.0,
+            column_spacing: 100.0,
+            lane_spacing: 40.0,
+        };
+        let nodes = vec![tn("a"), tn("b")];
+        let edges = vec![te("a", "b")];
+        let out = topological_layout(&nodes, &edges, m);
+        assert_eq!(out.iter().find(|x| x.id == "a").unwrap().y, 50.0);
+        assert_eq!(out.iter().find(|x| x.id == "b").unwrap().y, 50.0);
+    }
+}
+
+mod reorder {
+    use super::*;
+    use crate::graph_view_model::{reorder_for_drop, topological_layout};
+
+    fn tn(id: &str) -> GraphNode {
+        GraphNode {
+            id: id.into(),
+            label: id.into(),
+            category: NodeCategory::Other,
+            x: 0.0,
+            y: 0.0,
+            bypass: false,
+        }
+    }
+    fn te(a: &str, b: &str) -> GraphEdge {
+        GraphEdge {
+            from_id: a.into(),
+            to_id: b.into(),
+        }
+    }
+
+    #[test]
+    fn dropping_swaps_sibling_lane_order() {
+        let m = GridMetrics {
+            origin_x: 0.0,
+            origin_y: 0.0,
+            column_spacing: 100.0,
+            lane_spacing: 40.0,
+        };
+        let nodes = vec![tn("s"), tn("p"), tn("q"), tn("g")];
+        let edges = vec![te("s", "p"), te("s", "q"), te("p", "g"), te("q", "g")];
+        let base = topological_layout(&nodes, &edges, m);
+        let p_y = base.iter().find(|x| x.id == "p").unwrap().y;
+        let q_y = base.iter().find(|x| x.id == "q").unwrap().y;
+        let p_x = base.iter().find(|x| x.id == "p").unwrap().x;
+        let after = reorder_for_drop(&nodes, &edges, "p", p_x, q_y, m);
+        let p_y2 = after.iter().find(|x| x.id == "p").unwrap().y;
+        let q_y2 = after.iter().find(|x| x.id == "q").unwrap().y;
+        assert_ne!((p_y, q_y), (p_y2, q_y2), "lane order must change");
+        assert_eq!(p_y2, q_y, "p takes q's old lane");
+        assert_eq!(q_y2, p_y, "q takes p's old lane");
+    }
+
+    #[test]
+    fn dropping_in_place_is_idempotent() {
+        let m = GridMetrics::default();
+        let nodes = vec![tn("a"), tn("b")];
+        let edges = vec![te("a", "b")];
+        let base = topological_layout(&nodes, &edges, m);
+        let a = base.iter().find(|x| x.id == "a").unwrap();
+        let after = reorder_for_drop(&nodes, &edges, "a", a.x, a.y, m);
+        assert_eq!(after, base);
+    }
+
+    #[test]
+    fn unknown_id_returns_clean_layout_no_panic() {
+        let m = GridMetrics::default();
+        let nodes = vec![tn("a"), tn("b")];
+        let edges = vec![te("a", "b")];
+        let after = reorder_for_drop(&nodes, &edges, "zzz", 0.0, 0.0, m);
+        assert_eq!(after, topological_layout(&nodes, &edges, m));
     }
 }
 

--- a/crates/adapter-gui/src/graph_view_model_tests.rs
+++ b/crates/adapter-gui/src/graph_view_model_tests.rs
@@ -111,6 +111,38 @@ mod linear_layout_parallel_stage {
         );
     }
 
+    // GraphView.slint relies on this convention to render split/merge as
+    // a small routing dot instead of a full block card. If the layout
+    // helper starts emitting labels or a non-Util category for split or
+    // merge, the Slint side will draw empty grey rectangles where the
+    // wires meet — exactly the regression we hit before this test
+    // landed.
+    #[test]
+    fn split_and_merge_use_routing_node_convention() {
+        let stages = [ChainStage::Parallel(vec![
+            vec![block("l", "L", NodeCategory::Amp)],
+            vec![block("r", "R", NodeCategory::Amp)],
+        ])];
+        let (nodes, _) = linear_chain_layout(&stages, GridMetrics::default());
+
+        let split = find_node(&nodes, "__split_1");
+        let merge = find_node(&nodes, "__merge_1");
+
+        for routing in [split, merge] {
+            assert_eq!(
+                routing.label, "",
+                "routing node {} must have empty label",
+                routing.id
+            );
+            assert_eq!(
+                routing.category,
+                NodeCategory::Util,
+                "routing node {} must be Util category",
+                routing.id
+            );
+        }
+    }
+
     #[test]
     fn parallel_paths_sit_on_symmetric_lanes() {
         let metrics = GridMetrics {

--- a/crates/adapter-gui/src/graph_view_model_tests.rs
+++ b/crates/adapter-gui/src/graph_view_model_tests.rs
@@ -29,6 +29,48 @@ mod node_category {
     }
 }
 
+mod palette {
+    use super::*;
+    use crate::graph_view_model::{default_palette, NodeCategory};
+
+    #[test]
+    fn default_palette_covers_every_category() {
+        let pal = default_palette();
+        for cat in [
+            NodeCategory::Input,
+            NodeCategory::Output,
+            NodeCategory::Dynamics,
+            NodeCategory::Drive,
+            NodeCategory::Amp,
+            NodeCategory::Modulation,
+            NodeCategory::Time,
+            NodeCategory::Reverb,
+            NodeCategory::Eq,
+            NodeCategory::Util,
+            NodeCategory::Other,
+        ] {
+            assert!(
+                pal.iter().any(|s| s.category == cat.as_str()),
+                "missing palette entry for {}",
+                cat.as_str()
+            );
+        }
+    }
+
+    #[test]
+    fn default_palette_border_is_darker_than_fill() {
+        for s in default_palette() {
+            assert!(
+                s.border <= s.fill,
+                "border 0x{:06x} not darker than fill 0x{:06x} for {}",
+                s.border,
+                s.fill,
+                s.category
+            );
+        }
+    }
+}
+
 mod linear_layout_single_stage {
     use super::*;
 

--- a/crates/adapter-gui/src/graph_view_model_tests.rs
+++ b/crates/adapter-gui/src/graph_view_model_tests.rs
@@ -1,0 +1,330 @@
+//! Tests for `adapter-gui::graph_view_model`. Lifted out per project
+//! convention — production `.rs` files keep `#[cfg(test)] #[path] mod tests;`
+//! at the bottom; the body lives here.
+
+use super::{
+    linear_chain_layout, validate_graph, BlockBlueprint, ChainStage, GraphEdge, GraphNode,
+    GridMetrics, NodeCategory,
+};
+
+fn block(id: &str, label: &str, category: NodeCategory) -> BlockBlueprint {
+    BlockBlueprint::new(id, label, category)
+}
+
+fn find_node<'a>(nodes: &'a [GraphNode], id: &str) -> &'a GraphNode {
+    nodes
+        .iter()
+        .find(|n| n.id == id)
+        .unwrap_or_else(|| panic!("node {id} missing"))
+}
+
+mod node_category {
+    use super::*;
+
+    #[test]
+    fn as_str_returns_stable_lowercase_slug() {
+        assert_eq!(NodeCategory::Drive.as_str(), "drive");
+        assert_eq!(NodeCategory::Amp.as_str(), "amp");
+        assert_eq!(NodeCategory::Util.as_str(), "util");
+    }
+}
+
+mod linear_layout_single_stage {
+    use super::*;
+
+    #[test]
+    fn empty_input_produces_empty_output() {
+        let (nodes, edges) = linear_chain_layout(&[], GridMetrics::default());
+        assert!(nodes.is_empty());
+        assert!(edges.is_empty());
+    }
+
+    #[test]
+    fn single_block_yields_one_node_no_edges() {
+        let stages = [ChainStage::Single(block("a", "A", NodeCategory::Drive))];
+        let (nodes, edges) = linear_chain_layout(&stages, GridMetrics::default());
+
+        assert_eq!(nodes.len(), 1);
+        assert_eq!(edges.len(), 0);
+        let only = &nodes[0];
+        assert_eq!(only.id, "a");
+        assert_eq!(only.label, "A");
+        assert_eq!(only.category, NodeCategory::Drive);
+    }
+
+    #[test]
+    fn two_singles_are_connected_left_to_right() {
+        let stages = [
+            ChainStage::Single(block("a", "A", NodeCategory::Drive)),
+            ChainStage::Single(block("b", "B", NodeCategory::Amp)),
+        ];
+        let (nodes, edges) = linear_chain_layout(&stages, GridMetrics::default());
+
+        assert_eq!(nodes.len(), 2);
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0].from_id, "a");
+        assert_eq!(edges[0].to_id, "b");
+    }
+
+    #[test]
+    fn singles_increment_column_by_one_each() {
+        let metrics = GridMetrics {
+            origin_x: 0.0,
+            origin_y: 0.0,
+            column_spacing: 100.0,
+            lane_spacing: 50.0,
+        };
+        let stages = [
+            ChainStage::Single(block("a", "A", NodeCategory::Drive)),
+            ChainStage::Single(block("b", "B", NodeCategory::Amp)),
+            ChainStage::Single(block("c", "C", NodeCategory::Reverb)),
+        ];
+        let (nodes, _) = linear_chain_layout(&stages, metrics);
+
+        assert_eq!(nodes[0].x, 0.0);
+        assert_eq!(nodes[1].x, 100.0);
+        assert_eq!(nodes[2].x, 200.0);
+        for n in &nodes {
+            assert_eq!(n.y, 0.0, "singles stay on centre lane");
+        }
+    }
+}
+
+mod linear_layout_parallel_stage {
+    use super::*;
+
+    #[test]
+    fn parallel_split_inserts_split_and_merge_nodes() {
+        let stages = [ChainStage::Parallel(vec![
+            vec![block("l", "L", NodeCategory::Amp)],
+            vec![block("r", "R", NodeCategory::Amp)],
+        ])];
+        let (nodes, _) = linear_chain_layout(&stages, GridMetrics::default());
+
+        assert!(
+            nodes.iter().any(|n| n.id.starts_with("__split_")),
+            "split node present"
+        );
+        assert!(
+            nodes.iter().any(|n| n.id.starts_with("__merge_")),
+            "merge node present"
+        );
+    }
+
+    #[test]
+    fn parallel_paths_sit_on_symmetric_lanes() {
+        let metrics = GridMetrics {
+            origin_x: 0.0,
+            origin_y: 0.0,
+            column_spacing: 100.0,
+            lane_spacing: 80.0,
+        };
+        let stages = [ChainStage::Parallel(vec![
+            vec![block("l", "L", NodeCategory::Amp)],
+            vec![block("r", "R", NodeCategory::Amp)],
+        ])];
+        let (nodes, _) = linear_chain_layout(&stages, metrics);
+
+        let l = find_node(&nodes, "l");
+        let r = find_node(&nodes, "r");
+
+        // Two paths → lane offsets are -0.5 and +0.5 around the centre.
+        assert_eq!(l.y, -40.0);
+        assert_eq!(r.y, 40.0);
+    }
+
+    #[test]
+    fn split_connects_to_each_path_first_block() {
+        let stages = [ChainStage::Parallel(vec![
+            vec![block("l", "L", NodeCategory::Amp)],
+            vec![block("r", "R", NodeCategory::Amp)],
+        ])];
+        let (_, edges) = linear_chain_layout(&stages, GridMetrics::default());
+
+        let split_id = "__split_1";
+        let split_edges: Vec<&GraphEdge> = edges.iter().filter(|e| e.from_id == split_id).collect();
+        assert_eq!(split_edges.len(), 2);
+        let targets: Vec<&str> = split_edges.iter().map(|e| e.to_id.as_str()).collect();
+        assert!(targets.contains(&"l"));
+        assert!(targets.contains(&"r"));
+    }
+
+    #[test]
+    fn each_path_last_block_connects_to_merge() {
+        let stages = [ChainStage::Parallel(vec![
+            vec![block("l", "L", NodeCategory::Amp)],
+            vec![block("r", "R", NodeCategory::Amp)],
+        ])];
+        let (_, edges) = linear_chain_layout(&stages, GridMetrics::default());
+
+        let merge_id = "__merge_1";
+        let merge_edges: Vec<&GraphEdge> = edges.iter().filter(|e| e.to_id == merge_id).collect();
+        assert_eq!(merge_edges.len(), 2);
+        let sources: Vec<&str> = merge_edges.iter().map(|e| e.from_id.as_str()).collect();
+        assert!(sources.contains(&"l"));
+        assert!(sources.contains(&"r"));
+    }
+
+    #[test]
+    fn merge_column_accounts_for_longest_path() {
+        let metrics = GridMetrics {
+            origin_x: 0.0,
+            origin_y: 0.0,
+            column_spacing: 100.0,
+            lane_spacing: 50.0,
+        };
+        let stages = [ChainStage::Parallel(vec![
+            vec![
+                block("l1", "L1", NodeCategory::Amp),
+                block("l2", "L2", NodeCategory::Time),
+            ],
+            vec![block("r", "R", NodeCategory::Amp)],
+        ])];
+        let (nodes, _) = linear_chain_layout(&stages, metrics);
+
+        let merge = find_node(&nodes, "__merge_1");
+        // Split at col 0, longest path = 2 blocks → merge at col 3.
+        assert_eq!(merge.x, 300.0);
+    }
+
+    #[test]
+    fn single_after_parallel_continues_past_merge_column() {
+        let metrics = GridMetrics {
+            origin_x: 0.0,
+            origin_y: 0.0,
+            column_spacing: 100.0,
+            lane_spacing: 50.0,
+        };
+        let stages = [
+            ChainStage::Parallel(vec![
+                vec![block("l", "L", NodeCategory::Amp)],
+                vec![block("r", "R", NodeCategory::Amp)],
+            ]),
+            ChainStage::Single(block("rev", "Rev", NodeCategory::Reverb)),
+        ];
+        let (nodes, _) = linear_chain_layout(&stages, metrics);
+
+        let merge = find_node(&nodes, "__merge_1");
+        let rev = find_node(&nodes, "rev");
+        assert!(
+            rev.x > merge.x,
+            "reverb must sit after merge column (got rev.x={}, merge.x={})",
+            rev.x,
+            merge.x,
+        );
+    }
+
+    #[test]
+    fn empty_parallel_stage_is_skipped() {
+        let stages = [
+            ChainStage::Single(block("a", "A", NodeCategory::Drive)),
+            ChainStage::Parallel(vec![]),
+            ChainStage::Single(block("b", "B", NodeCategory::Amp)),
+        ];
+        let (nodes, edges) = linear_chain_layout(&stages, GridMetrics::default());
+
+        assert_eq!(nodes.len(), 2);
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0].from_id, "a");
+        assert_eq!(edges[0].to_id, "b");
+    }
+}
+
+mod validate_graph_invariants {
+    use super::*;
+
+    #[test]
+    fn empty_graph_is_valid() {
+        let errs = validate_graph(&[], &[]);
+        assert!(errs.is_empty());
+    }
+
+    #[test]
+    fn duplicate_node_id_is_reported() {
+        let nodes = vec![
+            GraphNode {
+                id: "a".into(),
+                label: "A".into(),
+                category: NodeCategory::Drive,
+                x: 0.0,
+                y: 0.0,
+                bypass: false,
+            },
+            GraphNode {
+                id: "a".into(),
+                label: "A duplicate".into(),
+                category: NodeCategory::Drive,
+                x: 0.0,
+                y: 0.0,
+                bypass: false,
+            },
+        ];
+        let errs = validate_graph(&nodes, &[]);
+        assert!(
+            errs.iter().any(|e| e.contains("duplicate")),
+            "got: {errs:?}"
+        );
+    }
+
+    #[test]
+    fn edge_to_missing_node_is_reported() {
+        let nodes = vec![GraphNode {
+            id: "a".into(),
+            label: "A".into(),
+            category: NodeCategory::Drive,
+            x: 0.0,
+            y: 0.0,
+            bypass: false,
+        }];
+        let edges = vec![GraphEdge {
+            from_id: "a".into(),
+            to_id: "ghost".into(),
+        }];
+        let errs = validate_graph(&nodes, &edges);
+        assert!(errs.iter().any(|e| e.contains("ghost")), "got: {errs:?}");
+    }
+
+    #[test]
+    fn self_loop_is_reported() {
+        let nodes = vec![GraphNode {
+            id: "a".into(),
+            label: "A".into(),
+            category: NodeCategory::Drive,
+            x: 0.0,
+            y: 0.0,
+            bypass: false,
+        }];
+        let edges = vec![GraphEdge {
+            from_id: "a".into(),
+            to_id: "a".into(),
+        }];
+        let errs = validate_graph(&nodes, &edges);
+        assert!(
+            errs.iter().any(|e| e.contains("self-loop")),
+            "got: {errs:?}"
+        );
+    }
+
+    #[test]
+    fn layout_output_is_always_valid() {
+        let stages = [
+            ChainStage::Single(block("noise", "Noise", NodeCategory::Dynamics)),
+            ChainStage::Single(block("comp", "Comp", NodeCategory::Dynamics)),
+            ChainStage::Single(block("od", "OD", NodeCategory::Drive)),
+            ChainStage::Parallel(vec![
+                vec![
+                    block("amp_l", "Amp L", NodeCategory::Amp),
+                    block("dly_l", "Delay L", NodeCategory::Time),
+                ],
+                vec![
+                    block("amp_r", "Amp R", NodeCategory::Amp),
+                    block("dly_r", "Delay R", NodeCategory::Time),
+                ],
+            ]),
+            ChainStage::Single(block("rev", "Rev", NodeCategory::Reverb)),
+        ];
+        let (nodes, edges) = linear_chain_layout(&stages, GridMetrics::default());
+        let errs = validate_graph(&nodes, &edges);
+        assert!(errs.is_empty(), "layout produced invalid graph: {errs:?}");
+    }
+}

--- a/crates/adapter-gui/src/graph_view_model_tests.rs
+++ b/crates/adapter-gui/src/graph_view_model_tests.rs
@@ -223,8 +223,7 @@ mod reorder {
         let base = topological_layout(&nodes, &edges, m);
         let p_y = base.iter().find(|x| x.id == "p").unwrap().y;
         let q_y = base.iter().find(|x| x.id == "q").unwrap().y;
-        let p_x = base.iter().find(|x| x.id == "p").unwrap().x;
-        let after = reorder_for_drop(&nodes, &edges, "p", p_x, q_y, m);
+        let after = reorder_for_drop(&nodes, &edges, "p", q_y, m);
         let p_y2 = after.iter().find(|x| x.id == "p").unwrap().y;
         let q_y2 = after.iter().find(|x| x.id == "q").unwrap().y;
         assert_ne!((p_y, q_y), (p_y2, q_y2), "lane order must change");
@@ -239,7 +238,7 @@ mod reorder {
         let edges = vec![te("a", "b")];
         let base = topological_layout(&nodes, &edges, m);
         let a = base.iter().find(|x| x.id == "a").unwrap();
-        let after = reorder_for_drop(&nodes, &edges, "a", a.x, a.y, m);
+        let after = reorder_for_drop(&nodes, &edges, "a", a.y, m);
         assert_eq!(after, base);
     }
 
@@ -248,7 +247,7 @@ mod reorder {
         let m = GridMetrics::default();
         let nodes = vec![tn("a"), tn("b")];
         let edges = vec![te("a", "b")];
-        let after = reorder_for_drop(&nodes, &edges, "zzz", 0.0, 0.0, m);
+        let after = reorder_for_drop(&nodes, &edges, "zzz", 0.0, m);
         assert_eq!(after, topological_layout(&nodes, &edges, m));
     }
 }

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -71,6 +71,7 @@ mod block_editor_setters;
 mod block_editor_values;
 mod chain_editor;
 mod eq;
+pub mod graph_view_model;
 mod helpers;
 mod io_groups;
 mod latency_probe;

--- a/crates/adapter-gui/ui/components/graph_view.slint
+++ b/crates/adapter-gui/ui/components/graph_view.slint
@@ -199,10 +199,18 @@ export component GraphView inherits Rectangle {
     // ── Internal state ──────────────────────────────────────────────
     private property <string> hover_id: "";
     private property <string> drag_id: "";
-    private property <length> drag_offset_x: 0px;
-    private property <length> drag_offset_y: 0px;
+    // Local mouse position (TouchArea space) captured at press. The drag
+    // math is delta-based: new_layout = node.layout + (mouse - press)/zoom.
+    // The node's own layout cancels out of that expression, so it tracks
+    // the real cursor without feedback even though the TouchArea moves
+    // with the node it drags.
     private property <length> press_x: 0px;
     private property <length> press_y: 0px;
+    // Set once movement exceeds the threshold so mouse-up can tell a
+    // click from a drag. Local delta collapses to ~0 once the node
+    // catches the cursor, so the decision must latch on the first
+    // significant move, not be re-derived at release.
+    private property <bool> did_drag: false;
     // Click vs drag — threshold of 5px in viewport space (matches issue
     // #435 acceptance criteria).
     private property <length> click_threshold: 5px;
@@ -370,15 +378,13 @@ export component GraphView inherits Rectangle {
                     root.drag_id = node.id;
                     root.press_x = self.mouse-x;
                     root.press_y = self.mouse-y;
-                    root.drag_offset_x = self.mouse-x / root.zoom - root.node_width / 2;
-                    root.drag_offset_y = self.mouse-y / root.zoom - root.node_height / 2;
+                    root.did_drag = false;
                 } else if (event.kind == PointerEventKind.up) {
                     if (root.drag_id == node.id) {
-                        if (abs(self.mouse-x - root.press_x) < root.click_threshold
-                         && abs(self.mouse-y - root.press_y) < root.click_threshold) {
-                            root.node_clicked(node.id);
-                        } else {
+                        if (root.did_drag) {
                             root.node_drag_ended(node.id, node.layout_x, node.layout_y);
+                        } else {
+                            root.node_clicked(node.id);
                         }
                     }
                     root.drag_id = "";
@@ -386,9 +392,18 @@ export component GraphView inherits Rectangle {
             }
             moved => {
                 if (self.pressed && root.drag_id == node.id) {
-                    let new_x = (self.mouse-x - root.pan_x) / root.zoom;
-                    let new_y = (self.mouse-y - root.pan_y) / root.zoom;
-                    root.node_dragged(node.id, new_x, new_y);
+                    if (abs(self.mouse-x - root.press_x) > root.click_threshold
+                     || abs(self.mouse-y - root.press_y) > root.click_threshold) {
+                        root.did_drag = true;
+                    }
+                    // Delta-based: the node's current layout cancels out
+                    // (see press_x note), so this tracks the cursor
+                    // without drift even though the TouchArea moves with
+                    // the node.
+                    root.node_dragged(
+                        node.id,
+                        node.layout_x + (self.mouse-x - root.press_x) / root.zoom,
+                        node.layout_y + (self.mouse-y - root.press_y) / root.zoom);
                 }
             }
             changed has-hover => {

--- a/crates/adapter-gui/ui/components/graph_view.slint
+++ b/crates/adapter-gui/ui/components/graph_view.slint
@@ -114,14 +114,31 @@ component GraphNodeCard inherits Rectangle {
     accessible-label: root.node.label;
 }
 
-// Bezier wire between two layout-space points. Drawn behind the nodes.
+// Bezier wire between two viewport-space points. Drawn behind the nodes.
+//
+// The Path fills the whole canvas and declares its viewbox in canvas
+// pixels so MoveTo/CubicTo can use absolute coordinates. Without a
+// viewbox, Slint normalises the path commands to the Path's own bbox,
+// which collapses every wire to the same screen-space rectangle — the
+// reason the earlier version drew all edges converging in one point.
 component GraphWire inherits Path {
     in property <length> from_x;
     in property <length> from_y;
     in property <length> to_x;
     in property <length> to_y;
+    in property <length> canvas_width;
+    in property <length> canvas_height;
     in property <color> stroke_color: #8aaac8;
     in property <length> stroke_thickness: 2px;
+
+    x: 0px;
+    y: 0px;
+    width: root.canvas_width;
+    height: root.canvas_height;
+    viewbox-x: 0;
+    viewbox-y: 0;
+    viewbox-width: root.canvas_width / 1px;
+    viewbox-height: root.canvas_height / 1px;
 
     stroke: root.stroke_color;
     stroke-width: root.stroke_thickness;
@@ -282,7 +299,13 @@ export component GraphView inherits Rectangle {
     }
 
     // ── Edges (drawn under nodes) ──────────────────────────────────
+    //
+    // Each GraphWire fills the canvas with viewbox in pixel coords so
+    // the absolute MoveTo/CubicTo lands at the right place. See the
+    // note on GraphWire for why this matters.
     for edge in root.edges : GraphWire {
+        canvas_width: root.width;
+        canvas_height: root.height;
         from_x: root.pan_x + edge.from_x * root.zoom;
         from_y: root.pan_y + edge.from_y * root.zoom;
         to_x: root.pan_x + edge.to_x * root.zoom;
@@ -290,34 +313,67 @@ export component GraphView inherits Rectangle {
         stroke_thickness: 2px * root.zoom;
     }
 
-    // ── Nodes ──────────────────────────────────────────────────────
+    // ── Routing dots for util nodes with no label ─────────────────
+    //
+    // Split/merge are real graph nodes (wires connect through them),
+    // but visually they are just routing points — a small dot, not a
+    // full card. Drawn here so they sit between wires and full cards.
     for node[idx] in root.nodes : Rectangle {
-        x: root.pan_x + node.layout_x * root.zoom - card.width / 2;
-        y: root.pan_y + node.layout_y * root.zoom - card.height / 2;
-        width: card.width;
-        height: card.height;
+        x: root.pan_x + node.layout_x * root.zoom - self.width / 2;
+        y: root.pan_y + node.layout_y * root.zoom - self.height / 2;
+        width: node.label == "" && node.category == "util"
+            ? 8px * root.zoom
+            : 0px;
+        height: self.width;
+        border-radius: self.width / 2;
+        background: node.label == "" && node.category == "util"
+            ? #8aaac8
+            : transparent;
+    }
 
-        card := GraphNodeCard {
+    // ── Nodes (full cards for labeled blocks) ─────────────────────
+    //
+    // Position is the card centre at (layout * zoom + pan), shifted
+    // by half the card size so it lands geometrically centred. The
+    // routing dots above skip rendering for util-with-empty-label;
+    // here we skip those entirely so the card doesn't draw on top of
+    // a routing dot.
+    for node[idx] in root.nodes : Rectangle {
+        property <bool> is-routing: node.label == "" && node.category == "util";
+        property <length> w: root.node_width * root.zoom;
+        property <length> h: root.node_height * root.zoom;
+
+        x: root.pan_x + node.layout_x * root.zoom - self.w / 2;
+        y: root.pan_y + node.layout_y * root.zoom - self.h / 2;
+        width: self.is-routing ? 0px : self.w;
+        height: self.is-routing ? 0px : self.h;
+        visible: !self.is-routing;
+
+        GraphNodeCard {
+            x: 0px;
+            y: 0px;
             node: node;
-            card_width: root.node_width * root.zoom;
-            card_height: root.node_height * root.zoom;
+            card_width: parent.width;
+            card_height: parent.height;
             hovered: root.hover_id == node.id && root.drag_id == "";
             dragging: root.drag_id == node.id;
         }
 
         TouchArea {
+            x: 0px;
+            y: 0px;
+            width: parent.width;
+            height: parent.height;
             mouse-cursor: pointer;
             pointer-event(event) => {
                 if (event.kind == PointerEventKind.down) {
                     root.drag_id = node.id;
                     root.press_x = self.mouse-x;
                     root.press_y = self.mouse-y;
-                    // Offset between cursor and node centre, in layout space.
                     root.drag_offset_x = self.mouse-x / root.zoom - root.node_width / 2;
                     root.drag_offset_y = self.mouse-y / root.zoom - root.node_height / 2;
                 } else if (event.kind == PointerEventKind.up) {
                     if (root.drag_id == node.id) {
-                        // Distinguish click from drag by total displacement.
                         if (abs(self.mouse-x - root.press_x) < root.click_threshold
                          && abs(self.mouse-y - root.press_y) < root.click_threshold) {
                             root.node_clicked(node.id);
@@ -330,8 +386,6 @@ export component GraphView inherits Rectangle {
             }
             moved => {
                 if (self.pressed && root.drag_id == node.id) {
-                    // Translate cursor (in viewport) back to layout
-                    // space. The host receives the new centre.
                     let new_x = (self.mouse-x - root.pan_x) / root.zoom;
                     let new_y = (self.mouse-y - root.pan_y) / root.zoom;
                     root.node_dragged(node.id, new_x, new_y);

--- a/crates/adapter-gui/ui/components/graph_view.slint
+++ b/crates/adapter-gui/ui/components/graph_view.slint
@@ -1,0 +1,353 @@
+// GraphView — generic node-and-edge canvas with pan, zoom and per-node
+// drag. Knows nothing about signal-chain semantics; the host computes
+// positions and visual categories, this component just renders them.
+//
+// Coordinate system:
+//
+//   layout space   — coords on the input GraphNode (set by host)
+//   viewport space — layout * zoom + pan (rendered position)
+//
+// All callbacks emit ids and coords in *layout* space.
+
+export struct GraphNode {
+    // Stable identifier — unique within the graph. Must match what the
+    // host gave when computing the layout.
+    id: string,
+    label: string,
+    // Stable category slug ("drive", "amp", "reverb", "util", …).
+    // The component looks up the colour from a fixed palette below.
+    // Adding a new category is an enum string only — no Rust change.
+    category: string,
+    // Layout-space position (centre of the node).
+    layout_x: length,
+    layout_y: length,
+    // Visual state.
+    bypass: bool,
+    selected: bool,
+}
+
+export struct GraphEdge {
+    from_id: string,
+    to_id: string,
+}
+
+// Internal: GraphEdge resolved to actual coordinates, ready to render
+// as a Bézier curve. Host computes this from the node list; we keep the
+// shape simple so the resolved set can be derived in Slint via a
+// helper component or pre-computed in Rust.
+export struct GraphEdgeGeometry {
+    from_id: string,
+    to_id: string,
+    from_x: length,
+    from_y: length,
+    to_x: length,
+    to_y: length,
+}
+
+// Stable palette per category. Centralised here so adding a new
+// category is one line, not a tree of conditionals in every consumer.
+// This is presentation, not domain data — fits the "separation of
+// concerns" rule (business code never names a colour).
+component CategoryPalette {
+    in property <string> category;
+    out property <color> fill: root.category == "input"      ? #1e8aff
+                            : root.category == "output"     ? #ff8a1e
+                            : root.category == "dynamics"   ? #c69b3f
+                            : root.category == "drive"      ? #d04a3a
+                            : root.category == "amp"        ? #4a7fd0
+                            : root.category == "modulation" ? #8d4ad0
+                            : root.category == "time"       ? #2d9b9b
+                            : root.category == "reverb"     ? #3aa86a
+                            : root.category == "eq"         ? #c8b400
+                            : root.category == "util"       ? #6a7483
+                            : /* other */                     #8a94a2;
+    out property <color> border: self.fill.darker(0.35);
+}
+
+// Single node card. Pure visual; drag/click are owned by the parent
+// GraphView TouchArea so we keep one input source per gesture.
+component GraphNodeCard inherits Rectangle {
+    in property <GraphNode> node;
+    in property <bool> hovered;
+    in property <bool> dragging;
+    in property <length> card_width;
+    in property <length> card_height;
+
+    width: root.card_width;
+    height: root.card_height;
+    border-radius: 8px;
+    border-width: root.node.selected ? 2px : 1px;
+    border-color: root.node.selected
+        ? #f5f7fb
+        : palette.border;
+    background: root.node.bypass
+        ? palette.fill.with-alpha(0.35)
+        : root.dragging
+        ? palette.fill.brighter(0.20)
+        : root.hovered
+        ? palette.fill.brighter(0.10)
+        : palette.fill;
+    opacity: root.node.bypass ? 0.7 : 1.0;
+    drop-shadow-blur: root.dragging ? 12px : (root.hovered ? 6px : 2px);
+    drop-shadow-color: #00000080;
+    drop-shadow-offset-y: 2px;
+
+    palette := CategoryPalette {
+        category: root.node.category;
+    }
+
+    Text {
+        x: 8px;
+        y: 0px;
+        width: parent.width - 16px;
+        height: parent.height;
+        text: root.node.label;
+        color: #f5f7fb;
+        font-size: 12px;
+        font-weight: 700;
+        horizontal-alignment: center;
+        vertical-alignment: center;
+        overflow: elide;
+    }
+
+    accessible-role: button;
+    accessible-label: root.node.label;
+}
+
+// Bezier wire between two layout-space points. Drawn behind the nodes.
+component GraphWire inherits Path {
+    in property <length> from_x;
+    in property <length> from_y;
+    in property <length> to_x;
+    in property <length> to_y;
+    in property <color> stroke_color: #8aaac8;
+    in property <length> stroke_thickness: 2px;
+
+    stroke: root.stroke_color;
+    stroke-width: root.stroke_thickness;
+    fill: transparent;
+
+    // Horizontal-S bezier — control points offset by half the
+    // horizontal distance keeps wires readable even with vertical
+    // separation between parallel paths.
+    MoveTo {
+        x: root.from_x / 1px;
+        y: root.from_y / 1px;
+    }
+
+    CubicTo {
+        control-1-x: (root.from_x + (root.to_x - root.from_x) / 2) / 1px;
+        control-1-y: root.from_y / 1px;
+        control-2-x: (root.from_x + (root.to_x - root.from_x) / 2) / 1px;
+        control-2-y: root.to_y / 1px;
+        x: root.to_x / 1px;
+        y: root.to_y / 1px;
+    }
+}
+
+// The actual GraphView. Hosts nodes + edges. Pan/zoom owned here.
+export component GraphView inherits Rectangle {
+    // ── Inputs ──────────────────────────────────────────────────────
+    in property <[GraphNode]> nodes;
+    in property <[GraphEdgeGeometry]> edges;
+
+    // Viewport state. Two-way so the host can persist or programmatically
+    // reset the view (e.g. "fit to content").
+    in-out property <float> zoom: 1.0;
+    in-out property <length> pan_x: 0px;
+    in-out property <length> pan_y: 0px;
+
+    // Visual constants — overridable by the host.
+    in property <length> node_width: 96px;
+    in property <length> node_height: 56px;
+    in property <color> background_color: #11141a;
+    in property <color> grid_color: #1a1f2a;
+    in property <bool> show_grid: true;
+
+    // Zoom limits (matches issue #435 acceptance criteria 0.3..3.0).
+    in property <float> min_zoom: 0.3;
+    in property <float> max_zoom: 3.0;
+
+    // ── Outputs ─────────────────────────────────────────────────────
+    callback node_clicked(string);
+    callback node_double_clicked(string);
+    // Emitted continuously while a node is being dragged. Coords are in
+    // layout space — the host applies them back to its model so the
+    // node sticks under the cursor on the next frame.
+    callback node_dragged(string, length, length);
+    // Fired once when the drag gesture ends (mouse up).
+    callback node_drag_ended(string, length, length);
+    callback viewport_changed(float, length, length);
+
+    // ── Internal state ──────────────────────────────────────────────
+    private property <string> hover_id: "";
+    private property <string> drag_id: "";
+    private property <length> drag_offset_x: 0px;
+    private property <length> drag_offset_y: 0px;
+    private property <length> press_x: 0px;
+    private property <length> press_y: 0px;
+    // Click vs drag — threshold of 5px in viewport space (matches issue
+    // #435 acceptance criteria).
+    private property <length> click_threshold: 5px;
+    // Background pan: anchor + initial pan captured on press.
+    private property <length> pan_anchor_x: 0px;
+    private property <length> pan_anchor_y: 0px;
+    private property <length> pan_initial_x: 0px;
+    private property <length> pan_initial_y: 0px;
+    private property <bool> panning: false;
+
+    background: root.background_color;
+    clip: true;
+
+    accessible-role: list;
+    accessible-label: "Signal chain graph";
+
+    // ── Pan / zoom on empty area ───────────────────────────────────
+    // Declared FIRST so that node TouchAreas (later siblings) sit on
+    // top of it for both rendering and event routing. The pan area is
+    // the fallback — nodes intercept events that fall on them.
+    pan_area := TouchArea {
+        x: 0px;
+        y: 0px;
+        width: parent.width;
+        height: parent.height;
+        mouse-cursor: grab;
+        pointer-event(event) => {
+            if (event.kind == PointerEventKind.down) {
+                root.panning = true;
+                root.pan_anchor_x = self.mouse-x;
+                root.pan_anchor_y = self.mouse-y;
+                root.pan_initial_x = root.pan_x;
+                root.pan_initial_y = root.pan_y;
+            } else if (event.kind == PointerEventKind.up) {
+                if (root.panning) {
+                    root.panning = false;
+                    root.viewport_changed(root.zoom, root.pan_x, root.pan_y);
+                }
+            }
+        }
+        moved => {
+            if (root.panning) {
+                root.pan_x = root.pan_initial_x + (self.mouse-x - root.pan_anchor_x);
+                root.pan_y = root.pan_initial_y + (self.mouse-y - root.pan_anchor_y);
+            }
+        }
+        scroll-event(event) => {
+            // Zoom around cursor.
+            let old_zoom = root.zoom;
+            let dz = event.delta-y > 0 ? 0.1 : -0.1;
+            let target = old_zoom + dz;
+            let clamped = target < root.min_zoom
+                ? root.min_zoom
+                : target > root.max_zoom ? root.max_zoom : target;
+            if (clamped != old_zoom) {
+                // Keep the layout-space point under the cursor stationary.
+                let layout_x = (self.mouse-x - root.pan_x) / old_zoom;
+                let layout_y = (self.mouse-y - root.pan_y) / old_zoom;
+                root.zoom = clamped;
+                root.pan_x = self.mouse-x - layout_x * clamped;
+                root.pan_y = self.mouse-y - layout_y * clamped;
+                root.viewport_changed(root.zoom, root.pan_x, root.pan_y);
+            }
+            accept
+        }
+    }
+
+    // ── Optional grid backdrop ──────────────────────────────────────
+    if root.show_grid : Rectangle {
+        x: 0px;
+        y: 0px;
+        width: parent.width;
+        height: parent.height;
+        background: transparent;
+
+        // Two crossing strips that hint at the grid origin. A real grid
+        // (every N px) would need a custom Path with many MoveTo/LineTo
+        // which costs more than its visual value at this stage — keep
+        // the hint cheap until we know we need more.
+        Rectangle {
+            x: root.pan_x;
+            y: 0px;
+            width: 1px;
+            height: parent.height;
+            background: root.grid_color;
+        }
+        Rectangle {
+            x: 0px;
+            y: root.pan_y;
+            width: parent.width;
+            height: 1px;
+            background: root.grid_color;
+        }
+    }
+
+    // ── Edges (drawn under nodes) ──────────────────────────────────
+    for edge in root.edges : GraphWire {
+        from_x: root.pan_x + edge.from_x * root.zoom;
+        from_y: root.pan_y + edge.from_y * root.zoom;
+        to_x: root.pan_x + edge.to_x * root.zoom;
+        to_y: root.pan_y + edge.to_y * root.zoom;
+        stroke_thickness: 2px * root.zoom;
+    }
+
+    // ── Nodes ──────────────────────────────────────────────────────
+    for node[idx] in root.nodes : Rectangle {
+        x: root.pan_x + node.layout_x * root.zoom - card.width / 2;
+        y: root.pan_y + node.layout_y * root.zoom - card.height / 2;
+        width: card.width;
+        height: card.height;
+
+        card := GraphNodeCard {
+            node: node;
+            card_width: root.node_width * root.zoom;
+            card_height: root.node_height * root.zoom;
+            hovered: root.hover_id == node.id && root.drag_id == "";
+            dragging: root.drag_id == node.id;
+        }
+
+        TouchArea {
+            mouse-cursor: pointer;
+            pointer-event(event) => {
+                if (event.kind == PointerEventKind.down) {
+                    root.drag_id = node.id;
+                    root.press_x = self.mouse-x;
+                    root.press_y = self.mouse-y;
+                    // Offset between cursor and node centre, in layout space.
+                    root.drag_offset_x = self.mouse-x / root.zoom - root.node_width / 2;
+                    root.drag_offset_y = self.mouse-y / root.zoom - root.node_height / 2;
+                } else if (event.kind == PointerEventKind.up) {
+                    if (root.drag_id == node.id) {
+                        // Distinguish click from drag by total displacement.
+                        if (abs(self.mouse-x - root.press_x) < root.click_threshold
+                         && abs(self.mouse-y - root.press_y) < root.click_threshold) {
+                            root.node_clicked(node.id);
+                        } else {
+                            root.node_drag_ended(node.id, node.layout_x, node.layout_y);
+                        }
+                    }
+                    root.drag_id = "";
+                }
+            }
+            moved => {
+                if (self.pressed && root.drag_id == node.id) {
+                    // Translate cursor (in viewport) back to layout
+                    // space. The host receives the new centre.
+                    let new_x = (self.mouse-x - root.pan_x) / root.zoom;
+                    let new_y = (self.mouse-y - root.pan_y) / root.zoom;
+                    root.node_dragged(node.id, new_x, new_y);
+                }
+            }
+            changed has-hover => {
+                if (self.has-hover) {
+                    root.hover_id = node.id;
+                } else if (root.hover_id == node.id) {
+                    root.hover_id = "";
+                }
+            }
+            double-clicked => {
+                root.node_double_clicked(node.id);
+            }
+        }
+    }
+
+}

--- a/crates/adapter-gui/ui/components/graph_view.slint
+++ b/crates/adapter-gui/ui/components/graph_view.slint
@@ -14,10 +14,15 @@ export struct GraphNode {
     // host gave when computing the layout.
     id: string,
     label: string,
-    // Stable category slug ("drive", "amp", "reverb", "util", …).
-    // The component looks up the colour from a fixed palette below.
-    // Adding a new category is an enum string only — no Rust change.
+    // Stable category slug ("drive", "amp", "reverb", "util", …). Kept
+    // for accessibility / debugging; the component does NOT derive
+    // colour from it (Slint can't search an array). The host resolves
+    // colour from its palette and passes fill/border below — the single
+    // source of truth is default_palette() in graph_view_model.rs.
     category: string,
+    // Resolved colours, host-supplied. Component is fully colour-agnostic.
+    fill: color,
+    border: color,
     // Layout-space position (centre of the node).
     layout_x: length,
     layout_y: length,
@@ -44,24 +49,14 @@ export struct GraphEdgeGeometry {
     to_y: length,
 }
 
-// Stable palette per category. Centralised here so adding a new
-// category is one line, not a tree of conditionals in every consumer.
-// This is presentation, not domain data — fits the "separation of
-// concerns" rule (business code never names a colour).
-component CategoryPalette {
-    in property <string> category;
-    out property <color> fill: root.category == "input"      ? #1e8aff
-                            : root.category == "output"     ? #ff8a1e
-                            : root.category == "dynamics"   ? #c69b3f
-                            : root.category == "drive"      ? #d04a3a
-                            : root.category == "amp"        ? #4a7fd0
-                            : root.category == "modulation" ? #8d4ad0
-                            : root.category == "time"       ? #2d9b9b
-                            : root.category == "reverb"     ? #3aa86a
-                            : root.category == "eq"         ? #c8b400
-                            : root.category == "util"       ? #6a7483
-                            : /* other */                     #8a94a2;
-    out property <color> border: self.fill.darker(0.35);
+// Host-supplied category → colour map. The component owns NO colours;
+// the single source of truth is default_palette() in graph_view_model.rs.
+// The host resolves each node's fill/border from this and writes them
+// onto the GraphNode (Slint cannot search an array in a binding).
+export struct CategoryColor {
+    category: string,
+    fill: color,
+    border: color,
 }
 
 // Single node card. Pure visual; drag/click are owned by the parent
@@ -79,22 +74,18 @@ component GraphNodeCard inherits Rectangle {
     border-width: root.node.selected ? 2px : 1px;
     border-color: root.node.selected
         ? #f5f7fb
-        : palette.border;
+        : root.node.border;
     background: root.node.bypass
-        ? palette.fill.with-alpha(0.35)
+        ? root.node.fill.with-alpha(0.35)
         : root.dragging
-        ? palette.fill.brighter(0.20)
+        ? root.node.fill.brighter(0.20)
         : root.hovered
-        ? palette.fill.brighter(0.10)
-        : palette.fill;
+        ? root.node.fill.brighter(0.10)
+        : root.node.fill;
     opacity: root.node.bypass ? 0.7 : 1.0;
     drop-shadow-blur: root.dragging ? 12px : (root.hovered ? 6px : 2px);
     drop-shadow-color: #00000080;
     drop-shadow-offset-y: 2px;
-
-    palette := CategoryPalette {
-        category: root.node.category;
-    }
 
     Text {
         x: 8px;
@@ -180,6 +171,12 @@ export component GraphView inherits Rectangle {
     in property <color> background_color: #11141a;
     in property <color> grid_color: #1a1f2a;
     in property <bool> show_grid: true;
+
+    // When true the host computes positions via topological_layout and
+    // re-tidies on drag end via reorder_for_drop. Documentational on the
+    // Slint side — the algorithm is host-owned (project rule: no logic
+    // in the UI layer).
+    in property <bool> auto_layout: true;
 
     // Zoom limits (matches issue #435 acceptance criteria 0.3..3.0).
     in property <float> min_zoom: 0.3;

--- a/crates/graphview-demo/Cargo.toml
+++ b/crates/graphview-demo/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "graphview-demo"
+version.workspace = true
+edition.workspace = true
+
+# Standalone visual demo for the GraphView component. Deliberately a
+# separate crate so adapter-gui never builds demo code (CI / release).
+
+[dependencies]
+adapter-gui = { path = "../adapter-gui" }
+slint = { workspace = true, features = ["backend-default", "renderer-femtovg"] }
+log.workspace = true
+env_logger.workspace = true
+
+[target.'cfg(target_os = "linux")'.dependencies]
+slint = { workspace = true, features = ["backend-linuxkms", "gettext"] }

--- a/crates/graphview-demo/src/main.rs
+++ b/crates/graphview-demo/src/main.rs
@@ -2,10 +2,14 @@
 //! topology (compressor → drive → split → 2 amps → time fx → reverb)
 //! so the component can be validated without the rest of OpenRig.
 //!
-//! Run:
-//!     cargo run -p adapter-gui --example graph_view_demo
+//! Kept as its own crate (not an `adapter-gui` example) so the gui crate
+//! carries no demo build weight while the demo stays preserved and
+//! runnable.
 //!
-//! The example imports the component from
+//! Run:
+//!     cargo run -p graphview-demo
+//!
+//! The demo imports the component from
 //! `crates/adapter-gui/ui/components/graph_view.slint` via the `slint!`
 //! macro — same source the production UI consumes, no duplication.
 
@@ -19,7 +23,7 @@ use std::collections::HashMap;
 slint::slint! {
     import { CheckBox } from "std-widgets.slint";
     import { GraphView, GraphNode, GraphEdgeGeometry }
-        from "ui/components/graph_view.slint";
+        from "../../adapter-gui/ui/components/graph_view.slint";
 
     export component DemoWindow inherits Window {
         in property <[GraphNode]> nodes;

--- a/crates/graphview-demo/src/main.rs
+++ b/crates/graphview-demo/src/main.rs
@@ -185,38 +185,50 @@ fn into_slint_models(
     (slint_nodes, slint_edges)
 }
 
-fn main() -> Result<(), slint::PlatformError> {
-    env_logger::init();
+type NodeModel = std::rc::Rc<slint::VecModel<GraphNode>>;
+type EdgeModel = std::rc::Rc<slint::VecModel<GraphEdgeGeometry>>;
 
-    let (nodes, edges) = demo_chain();
-    let errors = adapter_gui::graph_view_model::validate_graph(&nodes, &edges);
-    assert!(errors.is_empty(), "demo graph is invalid: {errors:?}");
+/// Apply resolved coords back to the shared models in place (no Vec
+/// rebuild — issue #435 invariant: zero per-frame reallocation).
+fn apply_coords(nm: &NodeModel, em: &EdgeModel, coords: &HashMap<String, (f32, f32)>) {
+    for i in 0..nm.row_count() {
+        let mut nd = nm.row_data(i).unwrap();
+        if let Some((x, y)) = coords.get(nd.id.as_str()) {
+            nd.layout_x = *x;
+            nd.layout_y = *y;
+            nm.set_row_data(i, nd);
+        }
+    }
+    for i in 0..em.row_count() {
+        let mut ed = em.row_data(i).unwrap();
+        if let Some((x, y)) = coords.get(ed.from_id.as_str()) {
+            ed.from_x = *x;
+            ed.from_y = *y;
+        }
+        if let Some((x, y)) = coords.get(ed.to_id.as_str()) {
+            ed.to_x = *x;
+            ed.to_y = *y;
+        }
+        em.set_row_data(i, ed);
+    }
+}
 
-    let metrics = GridMetrics::default();
-    let palette = palette_lookup();
-    // Start from the topological auto-layout (auto-layout defaults on).
-    let laid = topological_layout(&nodes, &edges, metrics);
-    let (slint_nodes, slint_edges) = into_slint_models(laid, edges.clone(), &palette);
-
-    // Shared models, mutated in place. Issue #435 invariant: drag/zoom
-    // must not reallocate per frame — so the host keeps one VecModel and
-    // edits rows via set_row_data, never rebuilds the Vec each callback.
-    let node_model = std::rc::Rc::new(slint::VecModel::from(slint_nodes));
-    let edge_model = std::rc::Rc::new(slint::VecModel::from(slint_edges));
-
-    let window = DemoWindow::new()?;
-    window.set_nodes(node_model.clone().into());
-    window.set_edges(edge_model.clone().into());
-
-    let nodes_for_click = node_model.clone();
+fn wire_callbacks(
+    window: &DemoWindow,
+    node_model: &NodeModel,
+    edge_model: &EdgeModel,
+    nodes: Vec<model::GraphNode>,
+    edges: Vec<model::GraphEdge>,
+) {
+    let nm = node_model.clone();
     window.on_node_clicked(move |id| {
         log::info!("clicked: {id}");
-        for i in 0..nodes_for_click.row_count() {
-            let mut n = nodes_for_click.row_data(i).unwrap();
+        for i in 0..nm.row_count() {
+            let mut n = nm.row_data(i).unwrap();
             let want = n.id == id;
             if n.selected != want {
                 n.selected = want;
-                nodes_for_click.set_row_data(i, n);
+                nm.set_row_data(i, n);
             }
         }
     });
@@ -225,79 +237,47 @@ fn main() -> Result<(), slint::PlatformError> {
         log::info!("double-clicked: {id} (would open block editor)");
     });
 
-    let nodes_for_drag = node_model.clone();
-    let edges_for_drag = edge_model.clone();
+    let (nm, em) = (node_model.clone(), edge_model.clone());
     window.on_node_dragged(move |id, x, y| {
-        for i in 0..nodes_for_drag.row_count() {
-            let mut n = nodes_for_drag.row_data(i).unwrap();
-            if n.id == id {
-                n.layout_x = x;
-                n.layout_y = y;
-                nodes_for_drag.set_row_data(i, n);
-                break;
-            }
-        }
-        for i in 0..edges_for_drag.row_count() {
-            let mut e = edges_for_drag.row_data(i).unwrap();
-            let mut touched = false;
-            if e.from_id == id {
-                e.from_x = x;
-                e.from_y = y;
-                touched = true;
-            }
-            if e.to_id == id {
-                e.to_x = x;
-                e.to_y = y;
-                touched = true;
-            }
-            if touched {
-                edges_for_drag.set_row_data(i, e);
-            }
-        }
+        let mut c = HashMap::new();
+        c.insert(id.to_string(), (x, y));
+        apply_coords(&nm, &em, &c);
     });
 
-    let nodes_dl = node_model.clone();
-    let edges_dl = edge_model.clone();
-    let win_weak = window.as_weak();
-    let base_nodes = nodes.clone();
-    let base_edges = edges.clone();
+    let (nm, em, weak) = (node_model.clone(), edge_model.clone(), window.as_weak());
     window.on_node_drag_ended(move |id, x, y| {
         log::info!("drag end: {id} -> ({x}, {y})");
-        let Some(w) = win_weak.upgrade() else { return };
+        let Some(w) = weak.upgrade() else { return };
         if !w.get_auto() {
             return;
         }
-        let relaid = reorder_for_drop(
-            &base_nodes,
-            &base_edges,
-            id.as_str(),
-            x,
-            y,
-            GridMetrics::default(),
-        );
+        let relaid = reorder_for_drop(&nodes, &edges, id.as_str(), y, GridMetrics::default());
         let coords: HashMap<String, (f32, f32)> =
             relaid.iter().map(|n| (n.id.clone(), (n.x, n.y))).collect();
-        for i in 0..nodes_dl.row_count() {
-            let mut nd = nodes_dl.row_data(i).unwrap();
-            if let Some((nx, ny)) = coords.get(nd.id.as_str()) {
-                nd.layout_x = *nx;
-                nd.layout_y = *ny;
-                nodes_dl.set_row_data(i, nd);
-            }
-        }
-        for i in 0..edges_dl.row_count() {
-            let mut ed = edges_dl.row_data(i).unwrap();
-            if let Some((fx, fy)) = coords.get(ed.from_id.as_str()) {
-                ed.from_x = *fx;
-                ed.from_y = *fy;
-            }
-            if let Some((tx, ty)) = coords.get(ed.to_id.as_str()) {
-                ed.to_x = *tx;
-                ed.to_y = *ty;
-            }
-            edges_dl.set_row_data(i, ed);
-        }
+        apply_coords(&nm, &em, &coords);
     });
+}
+
+fn main() -> Result<(), slint::PlatformError> {
+    env_logger::init();
+
+    let (nodes, edges) = demo_chain();
+    let errors = adapter_gui::graph_view_model::validate_graph(&nodes, &edges);
+    assert!(errors.is_empty(), "demo graph is invalid: {errors:?}");
+
+    let palette = palette_lookup();
+    // Start from the topological auto-layout (auto-layout defaults on).
+    let laid = topological_layout(&nodes, &edges, GridMetrics::default());
+    let (slint_nodes, slint_edges) = into_slint_models(laid, edges.clone(), &palette);
+
+    // Shared models, mutated in place (see apply_coords).
+    let node_model: NodeModel = std::rc::Rc::new(slint::VecModel::from(slint_nodes));
+    let edge_model: EdgeModel = std::rc::Rc::new(slint::VecModel::from(slint_edges));
+
+    let window = DemoWindow::new()?;
+    window.set_nodes(node_model.clone().into());
+    window.set_edges(edge_model.clone().into());
+    wire_callbacks(&window, &node_model, &edge_model, nodes, edges);
 
     window.run()
 }

--- a/docs/gui/graph-view.md
+++ b/docs/gui/graph-view.md
@@ -2,7 +2,7 @@
 
 **Status:** introduced in #435.
 **Source:** `crates/adapter-gui/ui/components/graph_view.slint` + `crates/adapter-gui/src/graph_view_model.rs`.
-**Demo:** `cargo run -p adapter-gui --example graph_view_demo`.
+**Demo:** `cargo run -p graphview-demo` (own crate — keeps adapter-gui free of demo build weight).
 
 A reusable Slint component for rendering a directed graph with full interactivity. Built first as a standalone primitive — integration with the existing chain UI (`secondary_windows_chain.slint`, `chain_chips.slint`) is a separate effort and not part of this component.
 
@@ -175,7 +175,7 @@ Visual behaviour (drag, zoom, click thresholds) is validated by running the demo
 ## Demo
 
 ```bash
-cargo run -p adapter-gui --example graph_view_demo
+cargo run -p graphview-demo
 ```
 
 Opens a window with a hardcoded chain (Noise Gate → Compressor → Overdrive → split → 2× Vox AC30 → 2× delays → merge → Shimmer Reverb → Output). Click a node to select, double-click to log "would open editor", drag to reposition, scroll to zoom, drag empty space to pan.

--- a/docs/gui/graph-view.md
+++ b/docs/gui/graph-view.md
@@ -1,0 +1,192 @@
+# GraphView — node-and-edge canvas with pan/zoom/drag
+
+**Status:** introduced in #435.
+**Source:** `crates/adapter-gui/ui/components/graph_view.slint` + `crates/adapter-gui/src/graph_view_model.rs`.
+**Demo:** `cargo run -p adapter-gui --example graph_view_demo`.
+
+A reusable Slint component for rendering a directed graph with full interactivity. Built first as a standalone primitive — integration with the existing chain UI (`secondary_windows_chain.slint`, `chain_chips.slint`) is a separate effort and not part of this component.
+
+The visual language follows pedalboards in the **Helix / Quad Cortex / Mooer GE1000** family: grid-aligned nodes, explicit Bézier wires, parallel paths drawn on dedicated lanes. Not force-directed — signal chains are too structured for spring physics to give a stable result across reopens.
+
+## When to use it
+
+| You want… | Component? |
+|---|---|
+| Single signal chain with up to ~30 blocks, branched paths | **Yes** |
+| Project topology (inputs → chains → outputs) | **Yes** (once #436 lands and you can feed it the project graph) |
+| Arbitrary graph with hundreds of nodes, force-directed | Out of scope. Different layout algo, different perf budget. |
+| Static diagram for docs | Overkill. Render to SVG offline. |
+
+## Architecture
+
+```
+                ┌─ Rust ───────────────────────────────────────┐
+                │                                              │
+  domain  ───►  │  graph_view_model.rs                         │
+   data         │   ChainStage[]  → linear_chain_layout()      │
+                │   → (Vec<GraphNode>, Vec<GraphEdge>)         │
+                │   → validate_graph()                         │
+                │                                              │
+                │  wiring code (per use site)                  │
+                │   converts pure Rust → Slint structs         │
+                │   resolves GraphEdge → GraphEdgeGeometry     │
+                └──────────────────────────────────────────────┘
+                                       │
+                                       ▼ ModelRc<...>
+                ┌─ Slint ──────────────────────────────────────┐
+                │  GraphView component                         │
+                │   renders nodes + Bezier wires               │
+                │   handles pan/zoom/drag/click                │
+                │   emits callbacks with layout-space coords   │
+                └──────────────────────────────────────────────┘
+```
+
+**Two coordinate systems:**
+
+| Space | Where | Computed how |
+|---|---|---|
+| Layout space | `GraphNode.layout_x/y`, `GraphEdgeGeometry.from/to_x/y`, all callback args | `linear_chain_layout()` (or by the host) |
+| Viewport space | `x: pan_x + layout_x * zoom` inside Slint | applied per frame by the component |
+
+The host **never** computes viewport coords — only emits layout coords. The component applies the transform.
+
+## Slint API
+
+### Structs
+
+```slint
+struct GraphNode {
+    id: string;
+    label: string;
+    category: string;     // "drive", "amp", "reverb", "util", ...
+    layout_x: length;
+    layout_y: length;
+    bypass: bool;
+    selected: bool;
+}
+
+struct GraphEdgeGeometry {
+    from_id: string;
+    to_id: string;
+    from_x: length;
+    from_y: length;
+    to_x: length;
+    to_y: length;
+}
+```
+
+`GraphEdgeGeometry` is the resolved form of an edge — coordinates are already looked up from the node list so Slint doesn't search per frame.
+
+### Properties
+
+| Property | Direction | Type | Default | Purpose |
+|---|---|---|---|---|
+| `nodes` | `in` | `[GraphNode]` | — | nodes to render |
+| `edges` | `in` | `[GraphEdgeGeometry]` | — | resolved edges to render |
+| `zoom` | `in-out` | `float` | `1.0` | viewport scale, clamped to `[min_zoom, max_zoom]` |
+| `pan_x`, `pan_y` | `in-out` | `length` | `0px` | viewport offset |
+| `node_width`, `node_height` | `in` | `length` | `96px` × `56px` | per-node card size in layout space |
+| `background_color` | `in` | `color` | `#11141a` | canvas background |
+| `grid_color` | `in` | `color` | `#1a1f2a` | grid hint colour |
+| `show_grid` | `in` | `bool` | `true` | render origin-cross grid hint |
+| `min_zoom`, `max_zoom` | `in` | `float` | `0.3`, `3.0` | zoom limits |
+
+### Callbacks
+
+| Callback | Args | When |
+|---|---|---|
+| `node_clicked(string)` | node id | press + release within 5 px (no drag) |
+| `node_double_clicked(string)` | node id | double click on a node |
+| `node_dragged(string, length, length)` | id, new layout-space x, y | continuously while drag in progress |
+| `node_drag_ended(string, length, length)` | id, layout x, y | on mouse up after drag |
+| `viewport_changed(float, length, length)` | zoom, pan_x, pan_y | after pan release or wheel zoom step |
+
+The host receives layout-space coords. To persist a moved node, write them back into `nodes` — the Slint side reads positions reactively.
+
+## Rust helpers (`graph_view_model`)
+
+| Item | What it does |
+|---|---|
+| `GraphNode` | pure Rust mirror of the Slint struct |
+| `GraphEdge` | source/target id pair (no geometry) |
+| `NodeCategory` | enum of visual categories — `as_str()` produces the slug the Slint side expects |
+| `BlockBlueprint` | one block in a logical chain — id, label, category, bypass |
+| `ChainStage` | `Single(...)` or `Parallel(Vec<Vec<...>>)` |
+| `GridMetrics` | column/lane spacing + origin |
+| `linear_chain_layout(stages, metrics)` | builds positioned nodes + edges, inserts split/merge utility nodes for parallel stages |
+| `validate_graph(nodes, edges)` | returns error strings (empty = valid). Catches duplicate ids, dangling edges, self-loops. |
+
+`linear_chain_layout` is pure — same input, same output. Used in tests + at runtime to compute positions from a logical chain description. Splits and merges are auto-generated with id prefix `__split_N` / `__merge_N`.
+
+## Category → colour mapping
+
+Centralised in the Slint `CategoryPalette` component (single source of truth). Adding a new category:
+
+1. Add a variant to `NodeCategory` and its `as_str()` slug.
+2. Add one ternary arm in `CategoryPalette` in `graph_view.slint`.
+
+No other file touches. This is the **only authorised** brand-of-conditional in this component (an exception explicit in `slint-best-practices`: Slint cannot select assets/colours via runtime strings without a ternary chain).
+
+## Interactivity contract
+
+- **Pan:** drag on empty canvas. Cursor turns `grab`. Released → fires `viewport_changed`.
+- **Zoom:** scroll wheel anywhere over the canvas. Zooms around the cursor (the point under the cursor stays fixed in layout space). Clamped to `[min_zoom, max_zoom]`. Fires `viewport_changed`.
+- **Drag a node:** press on a node card, move beyond 5 px. Fires `node_dragged` continuously, `node_drag_ended` on release.
+- **Click vs drag:** total displacement < 5 px in viewport space → `node_clicked`. Threshold is a `private property` so it can be retuned without changing the API.
+- **Double-click:** fires `node_double_clicked` — host opens the block editor.
+
+## What this component is NOT responsible for
+
+| Concern | Where it lives instead |
+|---|---|
+| Persisting moved nodes | host (write back into `nodes` on `node_drag_ended`) |
+| Block editor | existing `BlockEditorPanel` — host wires `node_double_clicked` to it |
+| Real-time audio meters on nodes | future `GraphNodeMeter` overlay component |
+| Edge routing avoidance (no crossings) | future — current Bézier is naive |
+| Touch gestures (pinch-to-zoom) | future — scroll-wheel only for now |
+
+## Invariants
+
+- **Audio thread:** untouched. This is pure UI. ✅ invariant #4/#8 of `CLAUDE.md`.
+- **Allocations per frame:** none — `for` loops bind to the model, no `set_*` in render path.
+- **Cross-platform:** no `cfg`-gated logic, no hardcoded paths. ✅
+- **No mock audio:** this component doesn't process audio. N/A.
+
+## Tests
+
+Layout helper has 17 tests in `crates/adapter-gui/src/graph_view_model_tests.rs` covering:
+
+- Empty input → empty output
+- Single block → 1 node, 0 edges
+- Sequential blocks connected left-to-right
+- Column spacing math (origin + N × column_spacing)
+- Parallel stage inserts split + merge nodes
+- Symmetric lane offsets (N paths → offsets `-N/2..N/2`)
+- Split connects to each path's first block
+- Each path's last block connects to merge
+- Merge column accounts for longest path
+- Singles after parallel continue past merge
+- Empty parallel stage is a no-op
+- `validate_graph` reports duplicate ids, dangling edges, self-loops
+- The output of `linear_chain_layout` is always valid
+
+Visual behaviour (drag, zoom, click thresholds) is validated by running the demo example. There is no automated UI test harness for Slint at this time — that's a project-wide gap, not specific to this component.
+
+## Demo
+
+```bash
+cargo run -p adapter-gui --example graph_view_demo
+```
+
+Opens a window with a hardcoded chain (Noise Gate → Compressor → Overdrive → split → 2× Vox AC30 → 2× delays → merge → Shimmer Reverb → Output). Click a node to select, double-click to log "would open editor", drag to reposition, scroll to zoom, drag empty space to pan.
+
+## Future work
+
+Captured here so the next contributor doesn't reinvent it:
+
+- **Routing avoidance:** Bézier wires currently cross when paths zig-zag. Use a layered routing algorithm (Manhattan or orthogonal-with-bends).
+- **Keyboard navigation:** Tab/arrow to move focus between nodes, Enter for click, Shift+Enter for double-click. `petgraph` can supply BFS/DFS over the graph if we add it as a dep.
+- **Persist viewport** between sessions per chain.
+- **Meter overlays** on amp/dynamics nodes for live signal level.
+- **Multi-select** with drag-rectangle for bulk operations.
+- **Snap-to-grid** during drag.

--- a/docs/superpowers/plans/2026-05-15-graphview-auto-layout.md
+++ b/docs/superpowers/plans/2026-05-15-graphview-auto-layout.md
@@ -1,0 +1,895 @@
+# GraphView Auto-Layout & Customizable Palette Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a topology-driven auto-layout, drag-to-reorder, and a host-customizable color palette to the GraphView component, all in the testable Rust model layer.
+
+**Architecture:** `graph_view_model.rs` gains pure functions (`topological_layout`, `reorder_for_drop`, `default_palette`). `graph_view.slint` swaps its hardcoded category ternary for a host-supplied `[CategoryColor]` and adds an `auto_layout` flag. The demo wires the toggle. No system core, no chain model, no engine.
+
+**Tech Stack:** Rust (std only), Slint, cargo test.
+
+---
+
+## File Structure
+
+- Modify: `crates/adapter-gui/src/graph_view_model.rs` (~321 → ~480 lines, < 600 cap) — add `CategoryStyle`, `default_palette`, `topological_layout`, `reorder_for_drop`.
+- Modify: `crates/adapter-gui/src/graph_view_model_tests.rs` — new test modules.
+- Modify: `crates/adapter-gui/ui/components/graph_view.slint` — `CategoryColor` struct, `palette` + `auto_layout` props, palette lookup.
+- Modify: `crates/adapter-gui/examples/graph_view_demo.rs` — supply default palette, auto toggle, call new fns.
+
+All commands run from `.solvers/issue-435/`.
+
+---
+
+## Task 1: CategoryStyle + default_palette
+
+**Files:**
+- Modify: `crates/adapter-gui/src/graph_view_model.rs`
+- Test: `crates/adapter-gui/src/graph_view_model_tests.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `graph_view_model_tests.rs` after the `node_category` module:
+
+```rust
+mod palette {
+    use super::*;
+    use crate::graph_view_model::{default_palette, NodeCategory};
+
+    #[test]
+    fn default_palette_covers_every_category() {
+        let pal = default_palette();
+        for cat in [
+            NodeCategory::Input, NodeCategory::Output, NodeCategory::Dynamics,
+            NodeCategory::Drive, NodeCategory::Amp, NodeCategory::Modulation,
+            NodeCategory::Time, NodeCategory::Reverb, NodeCategory::Eq,
+            NodeCategory::Util, NodeCategory::Other,
+        ] {
+            assert!(
+                pal.iter().any(|s| s.category == cat.as_str()),
+                "missing palette entry for {}",
+                cat.as_str()
+            );
+        }
+    }
+
+    #[test]
+    fn default_palette_border_is_darker_than_fill() {
+        for s in default_palette() {
+            assert!(
+                s.border <= s.fill,
+                "border 0x{:06x} not darker than fill 0x{:06x} for {}",
+                s.border, s.fill, s.category
+            );
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p adapter-gui --lib palette:: 2>&1 | tail -5`
+Expected: FAIL — `default_palette` not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `graph_view_model.rs` (after `NodeCategory` impl):
+
+```rust
+/// Visual style for a node category. The component is colour-agnostic;
+/// the host supplies a palette (or uses [`default_palette`]). Colours are
+/// `0xRRGGBB`. Single source of truth — the default lives here only.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CategoryStyle {
+    pub category: &'static str,
+    pub fill: u32,
+    pub border: u32,
+}
+
+fn darken(rgb: u32, factor: f32) -> u32 {
+    let r = ((rgb >> 16) & 0xff) as f32 * (1.0 - factor);
+    let g = ((rgb >> 8) & 0xff) as f32 * (1.0 - factor);
+    let b = (rgb & 0xff) as f32 * (1.0 - factor);
+    ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
+}
+
+/// Default palette covering every [`NodeCategory`]. Host may override
+/// fully; this is just sane defaults.
+pub fn default_palette() -> Vec<CategoryStyle> {
+    [
+        (NodeCategory::Input, 0x1e8aff),
+        (NodeCategory::Output, 0xff8a1e),
+        (NodeCategory::Dynamics, 0xc69b3f),
+        (NodeCategory::Drive, 0xd04a3a),
+        (NodeCategory::Amp, 0x4a7fd0),
+        (NodeCategory::Modulation, 0x8d4ad0),
+        (NodeCategory::Time, 0x2d9b9b),
+        (NodeCategory::Reverb, 0x3aa86a),
+        (NodeCategory::Eq, 0xc8b400),
+        (NodeCategory::Util, 0x6a7483),
+        (NodeCategory::Other, 0x8a94a2),
+    ]
+    .into_iter()
+    .map(|(cat, fill)| CategoryStyle {
+        category: cat.as_str(),
+        fill,
+        border: darken(fill, 0.35),
+    })
+    .collect()
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p adapter-gui --lib palette:: 2>&1 | tail -5`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/adapter-gui/src/graph_view_model.rs crates/adapter-gui/src/graph_view_model_tests.rs
+git commit -m "feat(435): CategoryStyle + default_palette (single-source colours)"
+```
+
+---
+
+## Task 2: topological_layout — rank (column) assignment
+
+**Files:**
+- Modify: `crates/adapter-gui/src/graph_view_model.rs`
+- Test: `crates/adapter-gui/src/graph_view_model_tests.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+mod topological_rank {
+    use super::*;
+    use crate::graph_view_model::{topological_layout, GraphEdge};
+
+    fn n(id: &str) -> GraphNode {
+        GraphNode { id: id.into(), label: id.into(),
+            category: NodeCategory::Other, x: 0.0, y: 0.0, bypass: false }
+    }
+    fn e(a: &str, b: &str) -> GraphEdge {
+        GraphEdge { from_id: a.into(), to_id: b.into() }
+    }
+
+    #[test]
+    fn linear_chain_ranks_left_to_right() {
+        let m = GridMetrics { origin_x: 0.0, origin_y: 0.0,
+            column_spacing: 100.0, lane_spacing: 50.0 };
+        let nodes = vec![n("a"), n("b"), n("c")];
+        let edges = vec![e("a", "b"), e("b", "c")];
+        let out = topological_layout(&nodes, &edges, m);
+        let get = |id| out.iter().find(|x| x.id == id).unwrap().x;
+        assert_eq!(get("a"), 0.0);
+        assert_eq!(get("b"), 100.0);
+        assert_eq!(get("c"), 200.0);
+    }
+
+    #[test]
+    fn diamond_longest_path_wins() {
+        // a -> b -> d ; a -> d  : d must be at rank 2 (via b), not 1.
+        let m = GridMetrics { origin_x: 0.0, origin_y: 0.0,
+            column_spacing: 100.0, lane_spacing: 50.0 };
+        let nodes = vec![n("a"), n("b"), n("d")];
+        let edges = vec![e("a", "b"), e("b", "d"), e("a", "d")];
+        let out = topological_layout(&nodes, &edges, m);
+        let get = |id| out.iter().find(|x| x.id == id).unwrap().x;
+        assert_eq!(get("d"), 200.0);
+    }
+
+    #[test]
+    fn cycle_falls_back_to_input_order_no_panic() {
+        let m = GridMetrics::default();
+        let nodes = vec![n("a"), n("b")];
+        let edges = vec![e("a", "b"), e("b", "a")];
+        let out = topological_layout(&nodes, &edges, m); // must not panic
+        assert_eq!(out.len(), 2);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p adapter-gui --lib topological_rank:: 2>&1 | tail -5`
+Expected: FAIL — `topological_layout` not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `graph_view_model.rs`:
+
+```rust
+/// Auto-layout from graph topology. Column = longest path from a source
+/// (in-degree 0). Lane assignment is added in a later step; for now all
+/// nodes sit on the centre lane. Panic-free: a cycle or malformed graph
+/// falls back to input-order ranking.
+pub fn topological_layout(
+    nodes: &[GraphNode],
+    edges: &[GraphEdge],
+    metrics: GridMetrics,
+) -> Vec<GraphNode> {
+    let ids: Vec<&str> = nodes.iter().map(|n| n.id.as_str()).collect();
+    let mut indeg: HashMap<&str, usize> = ids.iter().map(|i| (*i, 0)).collect();
+    let mut outs: HashMap<&str, Vec<&str>> = ids.iter().map(|i| (*i, vec![])).collect();
+    for ed in edges {
+        let (f, t) = (ed.from_id.as_str(), ed.to_id.as_str());
+        if indeg.contains_key(f) && indeg.contains_key(t) {
+            *indeg.get_mut(t).unwrap() += 1;
+            outs.get_mut(f).unwrap().push(t);
+        }
+    }
+    let mut rank: HashMap<&str, usize> = ids.iter().map(|i| (*i, 0)).collect();
+    let mut queue: Vec<&str> =
+        ids.iter().filter(|i| indeg[*i] == 0).copied().collect();
+    let mut processed = 0usize;
+    let mut indeg_w = indeg.clone();
+    let mut head = 0;
+    while head < queue.len() {
+        let u = queue[head];
+        head += 1;
+        processed += 1;
+        for &v in &outs[u] {
+            let nr = rank[u] + 1;
+            if nr > rank[v] {
+                *rank.get_mut(v).unwrap() = nr;
+            }
+            let d = indeg_w.get_mut(v).unwrap();
+            *d -= 1;
+            if *d == 0 {
+                queue.push(v);
+            }
+        }
+    }
+    if processed < ids.len() {
+        // Cycle / malformed: degrade to input order, never panic.
+        return nodes
+            .iter()
+            .enumerate()
+            .map(|(i, src)| GraphNode {
+                x: metrics.origin_x + i as f32 * metrics.column_spacing,
+                y: metrics.origin_y,
+                ..src.clone()
+            })
+            .collect();
+    }
+    nodes
+        .iter()
+        .map(|src| GraphNode {
+            x: metrics.origin_x + rank[src.id.as_str()] as f32 * metrics.column_spacing,
+            y: metrics.origin_y,
+            ..src.clone()
+        })
+        .collect()
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p adapter-gui --lib topological_rank:: 2>&1 | tail -5`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/adapter-gui/src/graph_view_model.rs crates/adapter-gui/src/graph_view_model_tests.rs
+git commit -m "feat(435): topological_layout rank (longest-path columns, cycle-safe)"
+```
+
+---
+
+## Task 3: topological_layout — lane (barycenter) assignment
+
+**Files:**
+- Modify: `crates/adapter-gui/src/graph_view_model.rs`
+- Test: `crates/adapter-gui/src/graph_view_model_tests.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+mod topological_lane {
+    use super::*;
+    use crate::graph_view_model::{topological_layout, GraphEdge};
+
+    fn n(id: &str) -> GraphNode {
+        GraphNode { id: id.into(), label: id.into(),
+            category: NodeCategory::Other, x: 0.0, y: 0.0, bypass: false }
+    }
+    fn e(a: &str, b: &str) -> GraphEdge {
+        GraphEdge { from_id: a.into(), to_id: b.into() }
+    }
+
+    #[test]
+    fn parallel_siblings_get_symmetric_lanes() {
+        // s -> p ; s -> q ; p -> m ; q -> m  : p and q share rank 1,
+        // symmetric around origin_y.
+        let m = GridMetrics { origin_x: 0.0, origin_y: 100.0,
+            column_spacing: 100.0, lane_spacing: 40.0 };
+        let nodes = vec![n("s"), n("p"), n("q"), n("m")];
+        let edges = vec![e("s","p"), e("s","q"), e("p","m"), e("q","m")];
+        let out = topological_layout(&nodes, &edges, m);
+        let y = |id| out.iter().find(|x| x.id == id).unwrap().y;
+        assert_eq!(y("s"), 100.0);
+        assert_eq!(y("m"), 100.0);
+        // Two siblings → offsets -0.5 / +0.5 → y = 80 / 120.
+        let mut ys = [y("p"), y("q")];
+        ys.sort_by(|a,b| a.partial_cmp(b).unwrap());
+        assert_eq!(ys, [80.0, 120.0]);
+    }
+
+    #[test]
+    fn single_node_per_rank_stays_on_centre_lane() {
+        let m = GridMetrics { origin_x: 0.0, origin_y: 50.0,
+            column_spacing: 100.0, lane_spacing: 40.0 };
+        let nodes = vec![n("a"), n("b")];
+        let edges = vec![e("a","b")];
+        let out = topological_layout(&nodes, &edges, m);
+        assert_eq!(out.iter().find(|x| x.id=="a").unwrap().y, 50.0);
+        assert_eq!(out.iter().find(|x| x.id=="b").unwrap().y, 50.0);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p adapter-gui --lib topological_lane:: 2>&1 | tail -5`
+Expected: FAIL — both `p`/`q` currently at `origin_y` (no lane logic yet).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Replace the final `nodes.iter().map(...)` block (the success path) in `topological_layout` with lane assignment:
+
+```rust
+    // Group node indices by rank.
+    let max_rank = ids.iter().map(|i| rank[*i]).max().unwrap_or(0);
+    let mut by_rank: Vec<Vec<usize>> = vec![Vec::new(); max_rank + 1];
+    for (idx, src) in nodes.iter().enumerate() {
+        by_rank[rank[src.id.as_str()]].push(idx);
+    }
+    // lane_offset per node id, computed rank by rank left→right.
+    let mut lane: HashMap<&str, f32> = HashMap::new();
+    let id_of = |idx: usize| nodes[idx].id.as_str();
+    let preds: HashMap<&str, Vec<&str>> = {
+        let mut m: HashMap<&str, Vec<&str>> =
+            ids.iter().map(|i| (*i, vec![])).collect();
+        for ed in edges {
+            let (f, t) = (ed.from_id.as_str(), ed.to_id.as_str());
+            if m.contains_key(t) && m.contains_key(f) {
+                m.get_mut(t).unwrap().push(f);
+            }
+        }
+        m
+    };
+    for r in 0..by_rank.len() {
+        let mut group = by_rank[r].clone();
+        // Barycenter = mean predecessor lane; rank 0 uses input index.
+        let bary = |idx: usize| -> f32 {
+            let id = id_of(idx);
+            let ps = &preds[id];
+            let known: Vec<f32> =
+                ps.iter().filter_map(|p| lane.get(*p).copied()).collect();
+            if known.is_empty() {
+                idx as f32
+            } else {
+                known.iter().sum::<f32>() / known.len() as f32
+            }
+        };
+        group.sort_by(|&a, &b| {
+            bary(a)
+                .partial_cmp(&bary(b))
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then(a.cmp(&b))
+        });
+        let k = group.len() as f32;
+        for (slot, idx) in group.into_iter().enumerate() {
+            let offset = slot as f32 - (k - 1.0) / 2.0;
+            lane.insert(id_of(idx), offset);
+        }
+    }
+    nodes
+        .iter()
+        .map(|src| GraphNode {
+            x: metrics.origin_x
+                + rank[src.id.as_str()] as f32 * metrics.column_spacing,
+            y: metrics.origin_y
+                + lane[src.id.as_str()] * metrics.lane_spacing,
+            ..src.clone()
+        })
+        .collect()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p adapter-gui --lib topological_lane:: topological_rank:: 2>&1 | tail -5`
+Expected: PASS (5 tests, no regression in rank tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/adapter-gui/src/graph_view_model.rs crates/adapter-gui/src/graph_view_model_tests.rs
+git commit -m "feat(435): topological_layout lane assignment (barycenter, symmetric)"
+```
+
+---
+
+## Task 4: reorder_for_drop
+
+**Files:**
+- Modify: `crates/adapter-gui/src/graph_view_model.rs`
+- Test: `crates/adapter-gui/src/graph_view_model_tests.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+mod reorder {
+    use super::*;
+    use crate::graph_view_model::{reorder_for_drop, topological_layout, GraphEdge};
+
+    fn n(id: &str) -> GraphNode {
+        GraphNode { id: id.into(), label: id.into(),
+            category: NodeCategory::Other, x: 0.0, y: 0.0, bypass: false }
+    }
+    fn e(a: &str, b: &str) -> GraphEdge {
+        GraphEdge { from_id: a.into(), to_id: b.into() }
+    }
+
+    #[test]
+    fn dropping_swaps_sibling_lane_order() {
+        let m = GridMetrics { origin_x: 0.0, origin_y: 0.0,
+            column_spacing: 100.0, lane_spacing: 40.0 };
+        let nodes = vec![n("s"), n("p"), n("q"), n("g")];
+        let edges = vec![e("s","p"), e("s","q"), e("p","g"), e("q","g")];
+        let base = topological_layout(&nodes, &edges, m);
+        let p_y = base.iter().find(|x| x.id=="p").unwrap().y;
+        let q_y = base.iter().find(|x| x.id=="q").unwrap().y;
+        // Drag p to q's lane: drop at q's y.
+        let after = reorder_for_drop(&nodes, &edges, "p",
+            base.iter().find(|x| x.id=="p").unwrap().x, q_y, m);
+        let p_y2 = after.iter().find(|x| x.id=="p").unwrap().y;
+        let q_y2 = after.iter().find(|x| x.id=="q").unwrap().y;
+        assert_ne!((p_y, q_y), (p_y2, q_y2), "lane order must change");
+        assert_eq!(p_y2, q_y, "p takes q's old lane");
+        assert_eq!(q_y2, p_y, "q takes p's old lane");
+    }
+
+    #[test]
+    fn dropping_in_place_is_idempotent() {
+        let m = GridMetrics::default();
+        let nodes = vec![n("a"), n("b")];
+        let edges = vec![e("a","b")];
+        let base = topological_layout(&nodes, &edges, m);
+        let a = base.iter().find(|x| x.id=="a").unwrap();
+        let after = reorder_for_drop(&nodes, &edges, "a", a.x, a.y, m);
+        assert_eq!(after, base);
+    }
+
+    #[test]
+    fn unknown_id_returns_clean_layout_no_panic() {
+        let m = GridMetrics::default();
+        let nodes = vec![n("a"), n("b")];
+        let edges = vec![e("a","b")];
+        let after = reorder_for_drop(&nodes, &edges, "zzz", 0.0, 0.0, m);
+        assert_eq!(after, topological_layout(&nodes, &edges, m));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p adapter-gui --lib reorder:: 2>&1 | tail -5`
+Expected: FAIL — `reorder_for_drop` not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `graph_view_model.rs`:
+
+```rust
+/// Re-tidy after a drag in auto mode. The dragged node keeps its
+/// edge-derived column; `drop_y` only reorders it among its column
+/// siblings. Returns a fresh [`topological_layout`]. Panic-free: an
+/// unknown id yields the clean layout unchanged.
+pub fn reorder_for_drop(
+    nodes: &[GraphNode],
+    edges: &[GraphEdge],
+    dragged_id: &str,
+    _drop_x: f32,
+    drop_y: f32,
+    metrics: GridMetrics,
+) -> Vec<GraphNode> {
+    let laid = topological_layout(nodes, edges, metrics);
+    let Some(dragged) = laid.iter().find(|n| n.id == dragged_id) else {
+        return laid;
+    };
+    // Column siblings = same x as the dragged node.
+    let mut siblings: Vec<&GraphNode> =
+        laid.iter().filter(|n| n.x == dragged.x).collect();
+    if siblings.len() < 2 {
+        return laid;
+    }
+    siblings.sort_by(|a, b| a.y.partial_cmp(&b.y).unwrap());
+    let order: Vec<&str> = siblings.iter().map(|n| n.id.as_str()).collect();
+    let cur = order.iter().position(|id| *id == dragged_id).unwrap();
+    // Target slot = sibling whose lane is closest to drop_y.
+    let mut target = 0usize;
+    let mut best = f32::MAX;
+    for (i, s) in siblings.iter().enumerate() {
+        let d = (s.y - drop_y).abs();
+        if d < best {
+            best = d;
+            target = i;
+        }
+    }
+    if target == cur {
+        return laid;
+    }
+    // Rebuild the input order with the dragged node moved to `target`
+    // among its siblings; topological_layout's tiebreak (input index)
+    // then yields the new lane order.
+    let mut new_sib_ids: Vec<&str> =
+        order.iter().filter(|id| **id != dragged_id).copied().collect();
+    new_sib_ids.insert(target.min(new_sib_ids.len()), dragged_id);
+    let sib_set: std::collections::HashSet<&str> =
+        order.iter().copied().collect();
+    let mut feed: Vec<GraphNode> = Vec::with_capacity(nodes.len());
+    let mut sib_iter = new_sib_ids.iter();
+    for src in nodes {
+        if sib_set.contains(src.id.as_str()) {
+            let next = sib_iter.next().unwrap();
+            feed.push(nodes.iter().find(|n| n.id == *next).unwrap().clone());
+        } else {
+            feed.push(src.clone());
+        }
+    }
+    topological_layout(&feed, edges, metrics)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p adapter-gui --lib reorder:: 2>&1 | tail -5`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Run full model suite (no regression)**
+
+Run: `cargo test -p adapter-gui --lib graph_view_model 2>&1 | tail -3`
+Expected: all PASS, 0 failed, 0 ignored.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/adapter-gui/src/graph_view_model.rs crates/adapter-gui/src/graph_view_model_tests.rs
+git commit -m "feat(435): reorder_for_drop — drag re-tidies sibling lane order"
+```
+
+---
+
+## Task 5: Slint — CategoryColor struct, palette property, lookup
+
+**Files:**
+- Modify: `crates/adapter-gui/ui/components/graph_view.slint`
+
+- [ ] **Step 1: Add the struct and property**
+
+After the existing `export struct GraphEdgeGeometry { ... }` block, add:
+
+```slint
+export struct CategoryColor {
+    category: string,
+    fill: color,
+    border: color,
+}
+```
+
+- [ ] **Step 2: Replace the hardcoded CategoryPalette body**
+
+Replace the whole `component CategoryPalette { ... }` with:
+
+```slint
+// Looks the node's category up in the host-supplied palette. The
+// component owns NO colours — only a single neutral fallback so an
+// unmapped category still renders. Single source of truth lives in the
+// Rust host (default_palette()).
+component CategoryPalette {
+    in property <string> category;
+    in property <[CategoryColor]> palette;
+    out property <color> fill: root.resolve().fill;
+    out property <color> border: root.resolve().border;
+
+    pure function resolve() -> CategoryColor {
+        for c in root.palette {
+            if c.category == root.category {
+                return c;
+            }
+        }
+        return { category: root.category, fill: #8a94a2, border: #5c636e };
+    }
+}
+```
+
+- [ ] **Step 3: Thread the palette to the card**
+
+In `GraphView`, add the input property near the other `in property`s
+(after `in property <bool> show_grid: true;`):
+
+```slint
+    // Host-supplied category → colour map. Empty = every node uses the
+    // neutral fallback. See default_palette() in graph_view_model.rs.
+    in property <[CategoryColor]> palette;
+```
+
+In `GraphNodeCard`, add a forwarding property at the top of its
+`in property` list:
+
+```slint
+    in property <[CategoryColor]> palette;
+```
+
+Change the `palette := CategoryPalette { category: root.node.category; }`
+line inside `GraphNodeCard` to:
+
+```slint
+    palette := CategoryPalette {
+        category: root.node.category;
+        palette: root.palette;
+    }
+```
+
+In the node `for` loop where `GraphNodeCard` is instantiated, pass it:
+
+```slint
+        GraphNodeCard {
+            x: 0px;
+            y: 0px;
+            node: node;
+            palette: root.palette;
+            card_width: parent.width;
+            card_height: parent.height;
+            hovered: root.hover_id == node.id && root.drag_id == "";
+            dragging: root.drag_id == node.id;
+        }
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `cargo build -p adapter-gui --example graph_view_demo 2>&1 | tail -3`
+Expected: `Finished` (the demo doesn't set `palette` yet → all nodes
+fall back to neutral grey; fixed in Task 7).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/adapter-gui/ui/components/graph_view.slint
+git commit -m "feat(435): host-customizable palette (CategoryColor, no hardcoded colours)"
+```
+
+---
+
+## Task 6: Slint — auto_layout flag
+
+**Files:**
+- Modify: `crates/adapter-gui/ui/components/graph_view.slint`
+
+- [ ] **Step 1: Add the property**
+
+In `GraphView`, right after the `palette` property from Task 5, add:
+
+```slint
+    // When true the host computes positions via topological_layout and
+    // re-tidies on drag end via reorder_for_drop. Documentational on the
+    // Slint side — the algorithm is host-owned (project rule: no logic
+    // in the UI layer).
+    in property <bool> auto_layout: true;
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cargo build -p adapter-gui --example graph_view_demo 2>&1 | tail -3`
+Expected: `Finished`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/adapter-gui/ui/components/graph_view.slint
+git commit -m "feat(435): auto_layout flag on GraphView"
+```
+
+---
+
+## Task 7: Demo — wire palette, auto toggle, topological layout
+
+**Files:**
+- Modify: `crates/adapter-gui/examples/graph_view_demo.rs`
+
+- [ ] **Step 1: Import the new helper and convert palette**
+
+In the `use adapter_gui::graph_view_model::{...}` line, add
+`default_palette` and `topological_layout`, `reorder_for_drop`.
+
+In the `slint::slint!` `DemoWindow`, add to the exported component a
+checkbox + the palette/auto props. Replace the `VerticalLayout { ... }`
+header `Rectangle` with one that also holds a toggle:
+
+```slint
+            Rectangle {
+                height: 36px;
+                background: #161b25;
+                HorizontalLayout {
+                    padding-left: 16px;
+                    spacing: 16px;
+                    Text {
+                        text: "GraphView demo — drag a node, scroll zoom, drag empty area pan";
+                        color: #c9d3e2;
+                        font-size: 11px;
+                        vertical-alignment: center;
+                    }
+                    auto_box := CheckBox {
+                        text: "auto-layout";
+                        checked: true;
+                    }
+                }
+            }
+```
+
+Add `import { CheckBox } from "std-widgets.slint";` at the top of the
+`slint::slint!` block (first line inside the macro), and expose:
+
+```slint
+        in property <[CategoryColor]> palette <=> graph.palette;
+        out property <bool> auto <=> auto_box.checked;
+```
+
+Also add `palette: root.palette;` and `auto-layout: root.auto;` to the
+`graph := GraphView { ... }` instantiation, and
+`import { ... CategoryColor }` to the existing import line from
+`graph_view.slint`.
+
+- [ ] **Step 2: Build the palette and apply auto layout at startup**
+
+Replace the `let (slint_nodes, slint_edges) = into_slint_models(...)`
+section's downstream up to `window.set_edges(...)` with:
+
+```rust
+    let (nodes, edges) = demo_chain();
+    let errors = adapter_gui::graph_view_model::validate_graph(&nodes, &edges);
+    assert!(errors.is_empty(), "demo graph is invalid: {errors:?}");
+
+    let metrics = GridMetrics::default();
+    let laid = topological_layout(&nodes, &edges, metrics);
+    let (slint_nodes, slint_edges) = into_slint_models(laid, edges.clone());
+
+    let palette: Vec<CategoryColor> = default_palette()
+        .into_iter()
+        .map(|s| CategoryColor {
+            category: s.category.into(),
+            fill: slint::Color::from_rgb_u8(
+                ((s.fill >> 16) & 0xff) as u8,
+                ((s.fill >> 8) & 0xff) as u8,
+                (s.fill & 0xff) as u8,
+            ),
+            border: slint::Color::from_rgb_u8(
+                ((s.border >> 16) & 0xff) as u8,
+                ((s.border >> 8) & 0xff) as u8,
+                (s.border & 0xff) as u8,
+            ),
+        })
+        .collect();
+
+    let node_model = std::rc::Rc::new(slint::VecModel::from(slint_nodes));
+    let edge_model = std::rc::Rc::new(slint::VecModel::from(slint_edges));
+
+    let window = DemoWindow::new()?;
+    window.set_palette(slint::ModelRc::new(slint::VecModel::from(palette)));
+    window.set_nodes(node_model.clone().into());
+    window.set_edges(edge_model.clone().into());
+```
+
+Add `CategoryColor` to the `slint::slint!` re-exported imports and to
+the Rust `use` of generated types if needed (the `slint!` macro
+generates `CategoryColor`; reference it as in the demo's existing
+`GraphNode`/`GraphEdgeGeometry` pattern).
+
+- [ ] **Step 3: Re-tidy on drag end when auto is on**
+
+Replace the `window.on_node_drag_ended(...)` closure with one that
+re-runs the layout:
+
+```rust
+    let nodes_dl = node_model.clone();
+    let edges_dl = edge_model.clone();
+    let win_weak = window.as_weak();
+    let base_nodes = nodes.clone();
+    let base_edges = edges.clone();
+    window.on_node_drag_ended(move |id, x, y| {
+        log::info!("drag end: {id} -> ({x}, {y})");
+        let Some(w) = win_weak.upgrade() else { return };
+        if !w.get_auto() {
+            return;
+        }
+        let relaid = reorder_for_drop(
+            &base_nodes, &base_edges, id.as_str(), x, y, GridMetrics::default(),
+        );
+        let coords: std::collections::HashMap<String, (f32, f32)> =
+            relaid.iter().map(|n| (n.id.clone(), (n.x, n.y))).collect();
+        for i in 0..nodes_dl.row_count() {
+            let mut nd = nodes_dl.row_data(i).unwrap();
+            if let Some((nx, ny)) = coords.get(nd.id.as_str()) {
+                nd.layout_x = *nx;
+                nd.layout_y = *ny;
+                nodes_dl.set_row_data(i, nd);
+            }
+        }
+        for i in 0..edges_dl.row_count() {
+            let mut ed = edges_dl.row_data(i).unwrap();
+            if let Some((fx, fy)) = coords.get(ed.from_id.as_str()) {
+                ed.from_x = *fx; ed.from_y = *fy;
+            }
+            if let Some((tx, ty)) = coords.get(ed.to_id.as_str()) {
+                ed.to_x = *tx; ed.to_y = *ty;
+            }
+            edges_dl.set_row_data(i, ed);
+        }
+    });
+```
+
+Ensure `use slint::Model;` is present (it is) for `row_count`/`row_data`.
+
+- [ ] **Step 4: Build**
+
+Run: `cargo build -p adapter-gui --example graph_view_demo 2>&1 | tail -3`
+Expected: `Finished`.
+
+- [ ] **Step 5: Run model + fmt + clippy gate**
+
+Run:
+```bash
+cargo test -p adapter-gui --lib graph_view_model 2>&1 | tail -3
+cargo fmt --all -- --check && echo "fmt ok"
+cargo clippy -p adapter-gui --example graph_view_demo 2>&1 | tail -3
+```
+Expected: tests PASS, fmt ok, no new clippy errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/adapter-gui/examples/graph_view_demo.rs
+git commit -m "feat(435): demo wires palette + auto-layout toggle + reorder on drop"
+```
+
+---
+
+## Task 8: Visual validation + push + issue comment
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push 2>&1 | tail -2
+```
+
+- [ ] **Step 2: Comment on the issue with the checkout block**
+
+```bash
+gh issue comment 435 --body "Auto-layout + palette customizável implementados. Branch atualizada.
+
+\`\`\`bash
+git checkout feature/issue-435 && git pull
+cargo run -p adapter-gui --example graph_view_demo
+\`\`\`
+
+Testa: nasce organizado (topológico). Arrasta um nó com 'auto-layout' ligado → solta → re-organiza tidy. Desliga o checkbox → drag livre como antes. Cores vêm de default_palette() (host pode trocar 100%). Screenshot se algo estiver torto."
+```
+
+- [ ] **Step 3: Wait for user visual confirmation**
+
+The component render cannot be unit-tested (project rule). Do not mark
+the feature done until the user confirms the demo looks right.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** topological_layout (Tasks 2-3), reorder_for_drop (Task 4), auto_layout flag (Task 6), customizable palette (Tasks 1,5,7), default_palette single-source (Task 1), panic-free/cycle (Tasks 2,4), tests pure-Rust (Tasks 1-4), demo toggle (Task 7), visual validation (Task 8). All spec sections covered.
+- **Placeholder scan:** none — every code step is complete.
+- **Type consistency:** `CategoryStyle` (Rust, `&'static str` + `u32`) vs `CategoryColor` (Slint, `string` + `color`); demo Task 7 converts between them explicitly. `topological_layout`/`reorder_for_drop` signatures match across Tasks 2-4 and 7. `GridMetrics`, `GraphNode`, `GraphEdge` reuse existing fields.
+- **Note:** `reorder_for_drop` takes `_drop_x` unused (column is edge-fixed per spec) — intentional, documented.

--- a/docs/superpowers/specs/2026-05-15-graphview-auto-layout-design.md
+++ b/docs/superpowers/specs/2026-05-15-graphview-auto-layout-design.md
@@ -1,0 +1,119 @@
+# GraphView — Auto-Layout & Customizable Palette
+
+**Date:** 2026-05-15
+**Issue:** #435 (component-level increment)
+**Scope:** GraphView component only — its Rust half (`graph_view_model.rs`) and Slint half (`graph_view.slint`). **No system core, no chain model, no engine, no other issues.**
+
+## Goal
+
+The GraphView component must be *malleable but always tidy*. Today nodes sit
+wherever the host puts them and free-drag leaves the graph messy. Add:
+
+1. A topology-driven auto-layout the component computes itself from the edges.
+2. Drag in auto mode that **reorders** a node and recomputes the tidy grid.
+3. Fully host-customizable node colors (no hardcoded palette in the component).
+
+All logic lives in the testable Rust model layer. Slint stays a pure renderer
+(project rule: "tela não tem regra de negócio").
+
+## Non-Goals
+
+- Changing the chain data model, routing engine, or any non-component code.
+- Editing graph topology by drag (creating/removing edges/splits). Edges are
+  owned by the host and immutable from the component's perspective.
+- Persisting user-edited positions (auto mode recomputes; free mode unchanged).
+- Sugiyama-grade crossing minimization (single barycenter pass only).
+
+## Architecture
+
+### 1. Topological auto-layout — `graph_view_model.rs`
+
+`pub fn topological_layout(nodes: &[GraphNode], edges: &[GraphEdge], metrics: GridMetrics) -> Vec<GraphNode>`
+
+- Build incoming/outgoing adjacency from `edges`.
+- **Column (rank)** = longest path from any source (in-degree 0), via Kahn
+  topological order: `rank[v] = max(rank[pred] + 1)`, sources at rank 0.
+- **Cycle / malformed safety:** if a cycle is detected (should never happen for
+  a signal chain) or the graph is invalid per `validate_graph`, fall back to
+  input-order ranking. Never panic — preserves the existing panic-free contract.
+- **Lane (y)** per rank: order the nodes sharing a rank by the *barycenter* =
+  mean lane of their predecessors (single left→right pass). Tiebreak by original
+  input index for determinism. Center each rank's lane band symmetrically around
+  `metrics.origin_y` (same convention as today's ±0.5 offsets).
+- Returns positioned `GraphNode`s: `x = origin_x + rank*column_spacing`,
+  `y = origin_y + lane_offset*lane_spacing`.
+
+### 2. Drag-reorder on drop — `graph_view_model.rs`
+
+`pub fn reorder_for_drop(nodes: &[GraphNode], edges: &[GraphEdge], dragged_id: &str, drop_x: f32, drop_y: f32, metrics: GridMetrics) -> Vec<GraphNode>`
+
+- Map `drop_x` → nearest rank, `drop_y` → target slot among that rank's nodes.
+- Re-key the dragged node's ordering tiebreak so a re-run of
+  `topological_layout` places it at the dropped slot. Edges unchanged.
+- Because rank is edge-derived and edges are immutable, dropping a node onto a
+  different column does **not** move it to that column — it snaps back to its
+  topological column at the dropped *lane order*. This is intentional: the graph
+  stays a faithful, tidy picture of the actual topology; the malleable part is
+  the vertical ordering of siblings, not the wiring.
+- Returns the freshly laid-out node list. Idempotent: re-dropping in place is a
+  no-op.
+
+### 3. Config flag — `graph_view.slint`
+
+- `in property <bool> auto_layout: true;` on `GraphView` (documentational on the
+  Slint side; the host owns the algorithm).
+- Demo exposes a checkbox toggling it. When on: host runs `topological_layout`
+  initially and `reorder_for_drop` on `node_drag_ended`; `node_dragged` keeps
+  the free-follow visual feedback, snap happens on drop. When off: free drag as
+  it works today.
+
+### 4. Customizable palette — `graph_view.slint` + `graph_view_model.rs`
+
+- New Slint struct `CategoryColor { category: string, fill: color, border: color }`.
+- `in property <[CategoryColor]> palette;` on `GraphView`.
+- `CategoryPalette` looks the category up in `root.palette`; on miss, falls back
+  to ONE neutral default constant (no per-category ternary tree — single source
+  of truth).
+- Rust helper `pub fn default_palette() -> Vec<(/*category*/&str,/*fill*/u32,/*border*/u32)>`
+  (or equivalent typed struct) in the model layer: the default lives **once** in
+  Rust, host gets sane defaults and can fully override.
+
+## Data Flow
+
+```
+host nodes+edges ──> topological_layout() ──> positioned nodes ──> Slint render
+        ▲                                                              │
+        │                                                       node_drag_ended
+        └──────────── reorder_for_drop() ◀─────────────────────────────┘
+host palette (or default_palette()) ──> GraphView.palette ──> CategoryPalette lookup
+```
+
+## Testing
+
+Pure Rust unit tests in `graph_view_model_tests.rs` (no Slint UI tests):
+
+- **Rank:** linear chain → ranks `0..n`; diamond split/merge → correct ranks;
+  longest path wins when paths differ in length.
+- **Lane:** parallel siblings get distinct symmetric lanes; barycenter reduces
+  an obvious crossing; deterministic under tiebreak.
+- **reorder_for_drop:** dropping changes lane order; idempotent; never panics on
+  empty / duplicate / cyclic input (reuse `validate_graph`).
+- **palette:** `default_palette()` covers every `NodeCategory` variant; lookup
+  fallback returns the neutral default.
+
+Visual validation via the demo + user screenshot (component render can't be
+unit-tested; project convention).
+
+## Constraints / Invariants
+
+- Pure UI. No audio thread, no DSP, no per-frame allocation (layout computed on
+  drop, not per frame; demo model already mutated in place).
+- File caps: `graph_view_model.rs` ~321 → ~470 lines (< 600 Rust cap OK);
+  `graph_view.slint` near the 500 cap — split if it crosses during impl.
+- Zero coupling: component still knows nothing about amps/drives/chains. Palette
+  and topology are generic graph concepts.
+
+## Risk
+
+- Barycenter lane heuristic is the only non-trivial algorithm; bounded to a
+  single pass, fully unit-tested, deterministic. Acceptable.


### PR DESCRIPTION
## Resumo

Componente Slint reusável de visualização de grafo de signal chain + camada Rust testável. Escopo: **só o componente** (`adapter-gui` Rust half + `.slint`), zero core/engine/chain-model.

Closes #435.

## O que entrega

- **Render correto**: wires Bézier com viewbox em canvas-space (não colapsam num ponto), split/merge como routing dots, sizing/posição corretos, click vs drag por flag `did_drag`, drag delta-based estável.
- **Auto-layout topológico** (`topological_layout`): coluna = longest-path dos edges, lane = barycenter dos predecessores (simétrico, determinístico, input-index como tiebreak). Panic-free em ciclo/grafo malformado (fallback ordem de input).
- **Drag-reorder** (`reorder_for_drop`): solta um nó → re-tidy da ordem dos irmãos da coluna; coluna fixada pela topologia (picture fiel). Idempotente.
- **Cores 100% customizáveis**: componente é colour-agnostic; host resolve fill/border por nó a partir de `default_palette()` (fonte única em Rust). Trocar paleta = só mudar o host.
- **Flag `auto_layout`** no GraphView; demo com checkbox (ligado: nasce tidy + reorder no drop; desligado: drag livre).
- **Demo isolado**: crate próprio `crates/graphview-demo` (`cargo run -p graphview-demo`) — adapter-gui não carrega peso de demo em CI/release.

## Decisões

- Layout topológico (longest-path + barycenter 1-passada), não Sugiyama completo — signal chain é majoritariamente linear, crossing-minimization completo seria overkill.
- Cor resolvida no host e escrita no `GraphNode` (Slint não busca array em binding). Resultado: componente ainda mais decoupled — zero conhecimento de cor.
- Demo como crate separado em vez de `--example` do adapter-gui (pedido do autor): gui sem build de demo.

## Testes

28 testes Rust puros em `graph_view_model_tests.rs` (rank, lane, reorder, palette, validate, routing-node convention). Sem teste de UI Slint (regra do projeto: tela não tem regra de negócio — validação visual via demo).

## Invariantes

- UI pura. Zero audio thread, zero DSP, zero realocação por frame (layout no drop, model mutado in-place via set_row_data).
- Zero coupling: componente não conhece amps/drives/chains. Topologia e paleta são conceitos genéricos de grafo.
- Volume invariants: N/A (sem código de áudio).

## Spec & plano

`docs/superpowers/specs/2026-05-15-graphview-auto-layout-design.md` + `docs/superpowers/plans/2026-05-15-graphview-auto-layout.md`.

## Test plan

- [x] `cargo test -p adapter-gui --lib graph_view_model` → 28 passed, 0 ignored
- [x] `cargo build -p graphview-demo` limpo, fmt/clippy limpos nos arquivos tocados
- [x] Validação visual pelo autor (auto-layout, drag-reorder, paleta, toggle)
- [ ] `./scripts/qa.sh` (rodando local; CI roda o mesmo gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)