### PR TITLE
fix(lv2): connect output control ports + pre-flight port guard

### DIFF
--- a/crates/lv2/src/from_package.rs
+++ b/crates/lv2/src/from_package.rs
@@ -16,14 +16,68 @@ use block_core::param::ParameterSet;
 use block_core::{
     wrap_with_output_gain_pct, AudioChannelLayout, BlockProcessor, MonoProcessor, StereoProcessor,
 };
-use plugin_loader::dispatch::{lv2_control_value, scan_lv2_ports, Lv2PortRole};
+use plugin_loader::dispatch::{lv2_control_value, scan_lv2_ports, Lv2Port, Lv2PortRole};
 use plugin_loader::manifest::{Backend, Lv2Slot};
 use plugin_loader::LoadedPackage;
 
-use crate::{
-    build_lv2_processor, build_lv2_processor_with_atoms, build_stereo_lv2_processor,
-    build_stereo_lv2_processor_with_atoms,
-};
+use crate::{build_lv2_processor_full, build_stereo_lv2_processor_full};
+
+/// Result of partitioning a plugin's scanned ports by role.
+///
+/// `extra_out` holds output **control** ports (gain-reduction meters,
+/// latency indicators, etc.). LV2 requires every port to be connected
+/// before `run()`; an unconnected output control port makes the plugin
+/// write to null/garbage memory → SIGSEGV (issue #457). They are routed
+/// to a scratch buffer just like surplus audio outputs.
+#[derive(Debug, Default, PartialEq)]
+struct PortPlan {
+    audio_in: Vec<usize>,
+    audio_out: Vec<usize>,
+    /// `(port_index, initial_value)` for input control ports.
+    control: Vec<(usize, f32)>,
+    /// Atom/MIDI ports (in and out, deduplicated and sorted).
+    atom: Vec<usize>,
+    /// Output control ports — connected to a dummy buffer, never read.
+    extra_out: Vec<usize>,
+}
+
+/// Partition scanned LV2 ports into the buckets the processor builders
+/// expect. Pure (no FFI/IO) so the role→bucket mapping is unit-tested.
+fn plan_ports(ports: &[Lv2Port], params: &ParameterSet) -> PortPlan {
+    let indices = |role: Lv2PortRole| -> Vec<usize> {
+        ports
+            .iter()
+            .filter(|p| p.role == role)
+            .map(|p| p.index)
+            .collect()
+    };
+
+    let control = ports
+        .iter()
+        .filter(|p| p.role == Lv2PortRole::ControlIn)
+        .map(|p| {
+            (
+                p.index,
+                lv2_control_value(&p.symbol, p.default_value, params),
+            )
+        })
+        .collect();
+
+    let mut atom: Vec<usize> = indices(Lv2PortRole::AtomIn)
+        .into_iter()
+        .chain(indices(Lv2PortRole::AtomOut))
+        .collect();
+    atom.sort_unstable();
+    atom.dedup();
+
+    PortPlan {
+        audio_in: indices(Lv2PortRole::AudioIn),
+        audio_out: indices(Lv2PortRole::AudioOut),
+        control,
+        atom,
+        extra_out: indices(Lv2PortRole::ControlOut),
+    }
+}
 
 /// Build a [`BlockProcessor`] from a disk-backed LV2 package.
 pub fn build_from_package(
@@ -66,55 +120,19 @@ pub fn build_from_package(
     };
 
     let ports = scan_lv2_ports(&bundle_path, &plugin_uri)?;
-
-    let audio_in: Vec<usize> = ports
-        .iter()
-        .filter(|p| p.role == Lv2PortRole::AudioIn)
-        .map(|p| p.index)
-        .collect();
-    let audio_out: Vec<usize> = ports
-        .iter()
-        .filter(|p| p.role == Lv2PortRole::AudioOut)
-        .map(|p| p.index)
-        .collect();
-    let atom_in: Vec<usize> = ports
-        .iter()
-        .filter(|p| p.role == Lv2PortRole::AtomIn)
-        .map(|p| p.index)
-        .collect();
-    let atom_out: Vec<usize> = ports
-        .iter()
-        .filter(|p| p.role == Lv2PortRole::AtomOut)
-        .map(|p| p.index)
-        .collect();
-    let control_ports: Vec<(usize, f32)> = ports
-        .iter()
-        .filter(|p| p.role == Lv2PortRole::ControlIn)
-        .map(|p| {
-            (
-                p.index,
-                lv2_control_value(&p.symbol, p.default_value, params),
-            )
-        })
-        .collect();
-    let mut atom_ports: Vec<usize> = atom_in.iter().chain(atom_out.iter()).copied().collect();
-    atom_ports.sort_unstable();
-    atom_ports.dedup();
+    let plan = plan_ports(&ports, params);
 
     let lib_str = path_str(&lib_path)?;
     let bundle_str = path_str(&bundle_path)?;
     let sr = sample_rate as f64;
 
-    let processor = match (audio_in.len(), audio_out.len()) {
+    let processor = match (plan.audio_in.len(), plan.audio_out.len()) {
         (1, 1) | (1, 2) => build_mono_input(
             &lib_str,
             &plugin_uri,
             sr,
             &bundle_str,
-            &audio_in,
-            &audio_out,
-            &control_ports,
-            &atom_ports,
+            &plan,
             layout,
             &package.manifest.id,
         )?,
@@ -123,10 +141,7 @@ pub fn build_from_package(
             &plugin_uri,
             sr,
             &bundle_str,
-            &audio_in,
-            &audio_out,
-            &control_ports,
-            &atom_ports,
+            &plan,
             layout,
             &package.manifest.id,
         )?,
@@ -145,46 +160,37 @@ pub fn build_from_package(
     ))
 }
 
+// FFI builder: threads plugin location (lib/uri/sr/bundle) + the full
+// port plan + chain layout into the processor. Bundling these into a
+// struct would not reduce real coupling — kept flat like the rest of
+// this file's builders.
 #[allow(clippy::too_many_arguments)]
 fn build_mono_input(
     lib_path: &str,
     uri: &str,
     sample_rate: f64,
     bundle_path: &str,
-    audio_in: &[usize],
-    audio_out: &[usize],
-    control_ports: &[(usize, f32)],
-    atom_ports: &[usize],
+    plan: &PortPlan,
     layout: AudioChannelLayout,
     plugin_id: &str,
 ) -> Result<BlockProcessor> {
     // Lv2Processor implements MonoProcessor (single sample in, single
     // sample out). Wrap into the requested layout — for stereo we
     // duplicate the processor across L/R (DualMono) so a 1-out plugin
-    // also satisfies stereo chains.
+    // also satisfies stereo chains. `build_lv2_processor_full` connects
+    // atom + output-control ports; empty slices reduce to the plain case.
     let make = || -> Result<crate::Lv2Processor> {
-        if atom_ports.is_empty() {
-            build_lv2_processor(
-                lib_path,
-                uri,
-                sample_rate,
-                bundle_path,
-                audio_in,
-                audio_out,
-                control_ports,
-            )
-        } else {
-            build_lv2_processor_with_atoms(
-                lib_path,
-                uri,
-                sample_rate,
-                bundle_path,
-                audio_in,
-                audio_out,
-                control_ports,
-                atom_ports,
-            )
-        }
+        build_lv2_processor_full(
+            lib_path,
+            uri,
+            sample_rate,
+            bundle_path,
+            &plan.audio_in,
+            &plan.audio_out,
+            &plan.control,
+            &plan.atom,
+            &plan.extra_out,
+        )
     };
     let _ = plugin_id;
     match layout {
@@ -200,42 +206,28 @@ fn build_mono_input(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)] // see build_mono_input
 fn build_stereo_input(
     lib_path: &str,
     uri: &str,
     sample_rate: f64,
     bundle_path: &str,
-    audio_in: &[usize],
-    audio_out: &[usize],
-    control_ports: &[(usize, f32)],
-    atom_ports: &[usize],
+    plan: &PortPlan,
     layout: AudioChannelLayout,
     plugin_id: &str,
 ) -> Result<BlockProcessor> {
     let make = || -> Result<crate::StereoLv2Processor> {
-        if atom_ports.is_empty() {
-            build_stereo_lv2_processor(
-                lib_path,
-                uri,
-                sample_rate,
-                bundle_path,
-                audio_in,
-                audio_out,
-                control_ports,
-            )
-        } else {
-            build_stereo_lv2_processor_with_atoms(
-                lib_path,
-                uri,
-                sample_rate,
-                bundle_path,
-                audio_in,
-                audio_out,
-                control_ports,
-                atom_ports,
-            )
-        }
+        build_stereo_lv2_processor_full(
+            lib_path,
+            uri,
+            sample_rate,
+            bundle_path,
+            &plan.audio_in,
+            &plan.audio_out,
+            &plan.control,
+            &plan.atom,
+            &plan.extra_out,
+        )
     };
     let _ = plugin_id;
     match layout {
@@ -324,3 +316,7 @@ pub fn register_builder() {
         build_from_package,
     );
 }
+
+#[cfg(test)]
+#[path = "from_package_tests.rs"]
+mod tests;

--- a/crates/lv2/src/from_package.rs
+++ b/crates/lv2/src/from_package.rs
@@ -9,6 +9,7 @@
 //!
 //! Issue: #287
 
+use std::collections::BTreeSet;
 use std::path::PathBuf;
 
 use anyhow::{anyhow, bail, Result};
@@ -79,6 +80,46 @@ fn plan_ports(ports: &[Lv2Port], params: &ParameterSet) -> PortPlan {
     }
 }
 
+/// Pre-flight safety net: every port the TTL scanner found MUST be in a
+/// connected bucket before the plugin runs. LV2 requires all ports
+/// connected before `run()`; an unconnected one makes the plugin write
+/// to null/garbage memory → SIGSEGV, which no `catch_unwind` can catch
+/// because it is a hardware fault inside foreign C code (issue #457).
+///
+/// Returning `Err` here converts that unrecoverable process crash into a
+/// graceful "block failed to load" — the app stays alive. This guards
+/// the #457 fix against future regressions (e.g. a new port role added
+/// to the scanner but not bucketed in [`plan_ports`]).
+///
+/// It does NOT see ports the TTL scanner skipped or could not classify
+/// (`scan_lv2_ports` drops `Other`): catching those needs the plugin's
+/// real port count from the host, which the bare-ABI loader doesn't
+/// expose — that is the out-of-process-sandbox boundary, out of scope.
+fn assert_all_ports_connected(ports: &[Lv2Port], plan: &PortPlan, plugin_id: &str) -> Result<()> {
+    let mut connected: BTreeSet<usize> = BTreeSet::new();
+    connected.extend(&plan.audio_in);
+    connected.extend(&plan.audio_out);
+    connected.extend(plan.control.iter().map(|(idx, _)| *idx));
+    connected.extend(&plan.atom);
+    connected.extend(&plan.extra_out);
+
+    let orphans: Vec<String> = ports
+        .iter()
+        .filter(|p| !connected.contains(&p.index))
+        .map(|p| format!("port {} `{}` ({:?})", p.index, p.symbol, p.role))
+        .collect();
+
+    if !orphans.is_empty() {
+        bail!(
+            "LV2 plugin `{plugin_id}` has {} unconnectable port(s) — refusing \
+             to load to avoid a SIGSEGV on run(): {}",
+            orphans.len(),
+            orphans.join(", ")
+        );
+    }
+    Ok(())
+}
+
 /// Build a [`BlockProcessor`] from a disk-backed LV2 package.
 pub fn build_from_package(
     package: &LoadedPackage,
@@ -121,6 +162,7 @@ pub fn build_from_package(
 
     let ports = scan_lv2_ports(&bundle_path, &plugin_uri)?;
     let plan = plan_ports(&ports, params);
+    assert_all_ports_connected(&ports, &plan, &package.manifest.id)?;
 
     let lib_str = path_str(&lib_path)?;
     let bundle_str = path_str(&bundle_path)?;

--- a/crates/lv2/src/from_package_tests.rs
+++ b/crates/lv2/src/from_package_tests.rs
@@ -74,6 +74,50 @@ fn tap_deesser_layout_connects_the_attenuation_meter() {
 }
 
 #[test]
+fn fully_connected_plan_passes_preflight() {
+    let ports = vec![
+        port(0, "audio_in", Lv2PortRole::AudioIn),
+        port(1, "audio_out", Lv2PortRole::AudioOut),
+        port(2, "threshold", Lv2PortRole::ControlIn),
+        port(4, "attenuation", Lv2PortRole::ControlOut),
+    ];
+    let plan = plan_ports(&ports, &ParameterSet::default());
+
+    assert!(assert_all_ports_connected(&ports, &plan, "tap_deesser").is_ok());
+}
+
+#[test]
+fn dropped_control_out_is_refused_instead_of_crashing() {
+    // Simulate the original #457 regression: the partitioner forgot to
+    // route ControlOut → extra_out. The pre-flight must turn the
+    // would-be SIGSEGV into a graceful load error.
+    let ports = vec![
+        port(0, "audio_in", Lv2PortRole::AudioIn),
+        port(1, "audio_out", Lv2PortRole::AudioOut),
+        port(4, "attenuation", Lv2PortRole::ControlOut),
+    ];
+    let buggy_plan = PortPlan {
+        audio_in: vec![0],
+        audio_out: vec![1],
+        control: vec![],
+        atom: vec![],
+        extra_out: vec![], // regression: port 4 dropped
+    };
+
+    let err = assert_all_ports_connected(&ports, &buggy_plan, "tap_deesser")
+        .expect_err("an unconnected ControlOut port must be refused");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("port 4"),
+        "error must name the orphan port: {msg}"
+    );
+    assert!(
+        msg.contains("attenuation"),
+        "error must name the symbol: {msg}"
+    );
+}
+
+#[test]
 fn every_role_lands_in_exactly_one_bucket() {
     // Registry-style guard: a mixed port set must partition cleanly so
     // no future role change leaks a port into the wrong bucket.

--- a/crates/lv2/src/from_package_tests.rs
+++ b/crates/lv2/src/from_package_tests.rs
@@ -1,0 +1,103 @@
+//! Tests for `plan_ports` (issue #457 — LV2 plugins with output
+//! control ports crashed on chain start because the port partitioner
+//! discarded `ControlOut` ports, leaving them unconnected → SIGSEGV).
+
+use super::*;
+use plugin_loader::dispatch::Lv2Port;
+
+fn port(index: usize, symbol: &str, role: Lv2PortRole) -> Lv2Port {
+    Lv2Port {
+        index,
+        symbol: symbol.to_string(),
+        role,
+        default_value: None,
+        minimum: None,
+        maximum: None,
+        name: None,
+        is_toggle: false,
+        is_integer: false,
+        is_enumeration: false,
+        scale_points: Vec::new(),
+        range_steps: None,
+    }
+}
+
+#[test]
+fn control_out_port_is_routed_to_extra_out() {
+    // The regression: a ControlOut port must NOT be silently dropped —
+    // it has to be connected (via extra_out) or the plugin SIGSEGVs.
+    let ports = vec![port(4, "attenuation", Lv2PortRole::ControlOut)];
+
+    let plan = plan_ports(&ports, &ParameterSet::default());
+
+    assert_eq!(
+        plan.extra_out,
+        vec![4],
+        "ControlOut port must land in extra_out so it gets connected"
+    );
+}
+
+#[test]
+fn control_out_is_never_treated_as_input_control() {
+    let ports = vec![port(4, "gr_meter", Lv2PortRole::ControlOut)];
+
+    let plan = plan_ports(&ports, &ParameterSet::default());
+
+    assert!(
+        plan.control.is_empty(),
+        "output control ports must not be fed as input control values"
+    );
+}
+
+#[test]
+fn tap_deesser_layout_connects_the_attenuation_meter() {
+    // Exact shape of the reported plugin (TAP DeEsser, issue #457):
+    // audio in=0, audio out=1, threshold/freq control in (2,3),
+    // attenuation meter ControlOut=4.
+    let ports = vec![
+        port(0, "audio_in", Lv2PortRole::AudioIn),
+        port(1, "audio_out", Lv2PortRole::AudioOut),
+        port(2, "threshold", Lv2PortRole::ControlIn),
+        port(3, "frequency", Lv2PortRole::ControlIn),
+        port(4, "attenuation", Lv2PortRole::ControlOut),
+    ];
+
+    let plan = plan_ports(&ports, &ParameterSet::default());
+
+    assert_eq!(plan.audio_in, vec![0]);
+    assert_eq!(plan.audio_out, vec![1]);
+    assert_eq!(
+        plan.control.iter().map(|(i, _)| *i).collect::<Vec<_>>(),
+        vec![2, 3]
+    );
+    assert_eq!(plan.extra_out, vec![4]);
+}
+
+#[test]
+fn every_role_lands_in_exactly_one_bucket() {
+    // Registry-style guard: a mixed port set must partition cleanly so
+    // no future role change leaks a port into the wrong bucket.
+    let ports = vec![
+        port(0, "in_l", Lv2PortRole::AudioIn),
+        port(1, "in_r", Lv2PortRole::AudioIn),
+        port(2, "out_l", Lv2PortRole::AudioOut),
+        port(3, "out_r", Lv2PortRole::AudioOut),
+        port(4, "gain", Lv2PortRole::ControlIn),
+        port(5, "midi_in", Lv2PortRole::AtomIn),
+        port(6, "midi_out", Lv2PortRole::AtomOut),
+        port(7, "latency", Lv2PortRole::ControlOut),
+        port(8, "gr_meter", Lv2PortRole::ControlOut),
+        port(9, "unknown", Lv2PortRole::Other),
+    ];
+
+    let plan = plan_ports(&ports, &ParameterSet::default());
+
+    assert_eq!(plan.audio_in, vec![0, 1]);
+    assert_eq!(plan.audio_out, vec![2, 3]);
+    assert_eq!(
+        plan.control.iter().map(|(i, _)| *i).collect::<Vec<_>>(),
+        vec![4]
+    );
+    assert_eq!(plan.atom, vec![5, 6]);
+    assert_eq!(plan.extra_out, vec![7, 8]);
+}

--- a/crates/lv2/src/lib.rs
+++ b/crates/lv2/src/lib.rs
@@ -10,61 +10,21 @@ pub use stereo_processor::StereoLv2Processor;
 
 use anyhow::Result;
 
-/// Build a ready-to-use mono LV2 processor.
+/// Build a mono LV2 processor connecting audio, control, atom AND
+/// output-control ports.
 ///
 /// - `lib_path`: full path to the plugin shared library (`.dylib`/`.so`/`.dll`)
 /// - `uri`: LV2 plugin URI
 /// - `sample_rate`: audio sample rate
 /// - `bundle_path`: path to the `.lv2` bundle directory containing TTL metadata
-/// - `audio_in_ports`: port indices for audio inputs
-/// - `audio_out_ports`: port indices for audio outputs
-/// - `control_ports`: `(port_index, initial_value)` pairs for control ports
-pub fn build_lv2_processor(
-    lib_path: &str,
-    uri: &str,
-    sample_rate: f64,
-    bundle_path: &str,
-    audio_in_ports: &[usize],
-    audio_out_ports: &[usize],
-    control_ports: &[(usize, f32)],
-) -> Result<Lv2Processor> {
-    let plugin = Lv2Plugin::load(lib_path, uri, sample_rate, bundle_path)?;
-    Ok(Lv2Processor::new(
-        plugin,
-        audio_in_ports,
-        audio_out_ports,
-        control_ports,
-    ))
-}
-
-/// Build a mono LV2 processor with extra (dummy) output ports connected.
-///
-/// Use for plugins with more outputs than you read (e.g., mono-in/stereo-out
-/// used as mono). The extra ports are connected to a scratch buffer.
-pub fn build_lv2_processor_with_extras(
-    lib_path: &str,
-    uri: &str,
-    sample_rate: f64,
-    bundle_path: &str,
-    audio_in_ports: &[usize],
-    audio_out_ports: &[usize],
-    control_ports: &[(usize, f32)],
-    extra_out_ports: &[usize],
-) -> Result<Lv2Processor> {
-    build_lv2_processor_full(
-        lib_path,
-        uri,
-        sample_rate,
-        bundle_path,
-        audio_in_ports,
-        audio_out_ports,
-        control_ports,
-        &[],
-        extra_out_ports,
-    )
-}
-
-/// Build a mono LV2 processor with atom ports AND extra output ports.
+/// - `audio_in_ports` / `audio_out_ports`: audio port indices
+/// - `control_ports`: `(port_index, initial_value)` for input control ports
+/// - `atom_ports`: atom/MIDI sidechain ports (connected to an empty buffer)
+/// - `extra_out_ports`: output control ports (meters, latency) connected to
+///   a scratch buffer so the plugin never writes to unconnected memory on
+///   `run()` (issue #457). Empty atom/extra slices reduce this to the
+///   plain audio+control case — this is the single entry point so no
+///   caller can accidentally skip a port and reintroduce the crash.
 pub fn build_lv2_processor_full(
     lib_path: &str,
     uri: &str,
@@ -87,11 +47,13 @@ pub fn build_lv2_processor_full(
     ))
 }
 
-/// Build a mono LV2 processor with atom/MIDI sidechain ports connected.
+/// Build a stereo LV2 processor with atom ports AND extra output ports.
 ///
-/// Use this for plugins that have MIDI atom input ports (like pitch correction
-/// plugins) that need a valid buffer even when unused.
-pub fn build_lv2_processor_with_atoms(
+/// `extra_out_ports` (output control ports — meters, latency) are
+/// connected to a scratch buffer so the plugin never writes to
+/// unconnected memory on `run()` (issue #457). Empty atom/extra slices
+/// reduce this to the plain stereo case.
+pub fn build_stereo_lv2_processor_full(
     lib_path: &str,
     uri: &str,
     sample_rate: f64,
@@ -100,54 +62,16 @@ pub fn build_lv2_processor_with_atoms(
     audio_out_ports: &[usize],
     control_ports: &[(usize, f32)],
     atom_ports: &[usize],
-) -> Result<Lv2Processor> {
+    extra_out_ports: &[usize],
+) -> Result<StereoLv2Processor> {
     let plugin = Lv2Plugin::load(lib_path, uri, sample_rate, bundle_path)?;
-    Ok(Lv2Processor::with_atom_ports(
+    Ok(StereoLv2Processor::with_extra_ports(
         plugin,
         audio_in_ports,
         audio_out_ports,
         control_ports,
         atom_ports,
-    ))
-}
-
-/// Build a ready-to-use stereo LV2 processor (2-in / 2-out).
-pub fn build_stereo_lv2_processor(
-    lib_path: &str,
-    uri: &str,
-    sample_rate: f64,
-    bundle_path: &str,
-    audio_in_ports: &[usize],
-    audio_out_ports: &[usize],
-    control_ports: &[(usize, f32)],
-) -> Result<StereoLv2Processor> {
-    let plugin = Lv2Plugin::load(lib_path, uri, sample_rate, bundle_path)?;
-    Ok(StereoLv2Processor::new(
-        plugin,
-        audio_in_ports,
-        audio_out_ports,
-        control_ports,
-    ))
-}
-
-/// Build a stereo LV2 processor with atom/MIDI ports connected.
-pub fn build_stereo_lv2_processor_with_atoms(
-    lib_path: &str,
-    uri: &str,
-    sample_rate: f64,
-    bundle_path: &str,
-    audio_in_ports: &[usize],
-    audio_out_ports: &[usize],
-    control_ports: &[(usize, f32)],
-    atom_ports: &[usize],
-) -> Result<StereoLv2Processor> {
-    let plugin = Lv2Plugin::load(lib_path, uri, sample_rate, bundle_path)?;
-    Ok(StereoLv2Processor::with_atom_ports(
-        plugin,
-        audio_in_ports,
-        audio_out_ports,
-        control_ports,
-        atom_ports,
+        extra_out_ports,
     ))
 }
 

--- a/crates/lv2/src/stereo_processor.rs
+++ b/crates/lv2/src/stereo_processor.rs
@@ -19,6 +19,9 @@ pub struct StereoLv2Processor {
     in_buf_r: Box<[f32; MAX_BLOCK_SIZE]>,
     out_buf_l: Box<[f32; MAX_BLOCK_SIZE]>,
     out_buf_r: Box<[f32; MAX_BLOCK_SIZE]>,
+    /// Scratch buffer for output control ports (meters, latency) that
+    /// must be connected but are never read (issue #457).
+    _dummy_out_buf: Box<[f32; MAX_BLOCK_SIZE]>,
     control_values: Vec<f32>,
     _atom_buf: Box<[u8; ATOM_BUF_SIZE]>,
 }
@@ -45,6 +48,32 @@ impl StereoLv2Processor {
         control_ports: &[(usize, f32)],
         atom_ports: &[usize],
     ) -> Self {
+        Self::with_extra_ports(
+            plugin,
+            audio_in_ports,
+            audio_out_ports,
+            control_ports,
+            atom_ports,
+            &[],
+        )
+    }
+
+    /// Create a stereo processor with atom ports and extra (dummy)
+    /// output ports.
+    ///
+    /// `extra_out_ports` are output control ports (gain-reduction
+    /// meters, latency indicators). LV2 requires every port to be
+    /// connected before `run()`; leaving an output control port
+    /// unconnected makes the plugin write to null/garbage memory →
+    /// SIGSEGV (issue #457). They are connected to a scratch buffer.
+    pub fn with_extra_ports(
+        plugin: Lv2Plugin,
+        audio_in_ports: &[usize],
+        audio_out_ports: &[usize],
+        control_ports: &[(usize, f32)],
+        atom_ports: &[usize],
+        extra_out_ports: &[usize],
+    ) -> Self {
         assert!(audio_in_ports.len() == 2, "stereo requires 2 audio inputs");
         assert!(
             audio_out_ports.len() == 2,
@@ -55,6 +84,7 @@ impl StereoLv2Processor {
         let mut in_buf_r = Box::new([0.0f32; MAX_BLOCK_SIZE]);
         let mut out_buf_l = Box::new([0.0f32; MAX_BLOCK_SIZE]);
         let mut out_buf_r = Box::new([0.0f32; MAX_BLOCK_SIZE]);
+        let mut dummy_out_buf = Box::new([0.0f32; MAX_BLOCK_SIZE]);
         let mut control_values: Vec<f32> = control_ports.iter().map(|(_, v)| *v).collect();
 
         let mut atom_buf = Box::new([0u8; ATOM_BUF_SIZE]);
@@ -63,6 +93,14 @@ impl StereoLv2Processor {
         for &port_idx in atom_ports {
             unsafe {
                 plugin.connect_port(port_idx as u32, atom_buf.as_mut_ptr() as *mut c_void);
+            }
+        }
+
+        // Connect output control ports to the scratch buffer so the
+        // plugin never writes to unconnected memory (issue #457).
+        for &port_idx in extra_out_ports {
+            unsafe {
+                plugin.connect_port(port_idx as u32, dummy_out_buf.as_mut_ptr() as *mut c_void);
             }
         }
 
@@ -100,6 +138,7 @@ impl StereoLv2Processor {
             in_buf_r,
             out_buf_l,
             out_buf_r,
+            _dummy_out_buf: dummy_out_buf,
             control_values,
             _atom_buf: atom_buf,
         }


### PR DESCRIPTION
Ref #457

## Problema

Adicionar qualquer LV2 com output control port (medidor/latência) e iniciar a chain → **SIGSEGV** no `run()`. **14 de 103 plugins** do catálogo afetados (tap_deesser, tap_dynamics, tap_limiter, zamcomp, zamgate, zamulticomp, bolliedelay, ewham_harmonizer, fat1_autotune, gx_clubdrive, invada_tube, satma, wolf_shaper).

## Causa-raiz

Regressão do #287: o loader disk-backed (`from_package.rs`) coletava AudioIn/Out, ControlIn e Atom mas **descartava ControlOut**. LV2 exige toda porta conectada antes do `run()`; porta de saída solta → plugin escreve em memória não conectada → SIGSEGV. O wiring por-plugin (`extras`, commit a9b336f8) se perdeu na migração pro OpenRig-plugins e o loader genérico nunca o reimplementou.

## Mudanças

1. **Fix** — `plan_ports()` puro e testável; `ControlOut` → `extra_out` (conectado a scratch buffer). `StereoLv2Processor::with_extra_ports()` + dummy buffer espelhando o mono. Builders por-plugin colapsados num único `build_*_processor_full` (single source of truth — ninguém consegue pular porta de novo); removidos 5 builders mortos.
2. **Defesa** — `assert_all_ports_connected()`: pré-flight antes de instanciar. Porta escaneada sem bucket conectado → `Result::Err` gracioso (bloco falha ao carregar, app vivo) em vez de SIGSEGV. `catch_unwind` (panic recovery existente) **não pega** SIGSEGV — é falha de hardware em código C; este guard é a defesa in-process viável e pin de regressão da #457.

**Limite:** porta que o scanner do TTL pula/classifica `Other` continua invisível — exige port count real via host (sandbox out-of-process), decisão arquitetural separada.

## Testes

- `cargo test -p lv2` 6/6, 0 ignored (RED→GREEN confirmado: partitioner e pré-flight)
- `cargo test --workspace --lib` 35 suites ok, 0 falhas
- `cargo build --workspace` limpo; clippy lv2 sem regressão (too-many-args 7→4 vs base)
- Validado pelo usuário na máquina dele: TAP DeEsser + start chain não crasha mais

🤖 Generated with [Claude Code](https://claude.com/claude-code)