### PR TITLE
fix(packaging/macos): valid ad-hoc signature + curl installer

### DIFF
--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -7,7 +7,8 @@
 | `scripts/build-orange-pi-image.sh` | Imagem SD para Orange Pi |
 | `scripts/flash-sd.sh` | Flasha SD card |
 | `scripts/coverage.sh` | Relatório HTML de cobertura |
-| `scripts/package-macos.sh` | Empacota macOS |
+| `scripts/package-macos.sh` | Empacota macOS (assina ad-hoc inside-out + gate de verificação) |
+| `scripts/install-macos.sh` | Instalador one-liner via `curl` (baixa .dmg, copia pro /Applications, tira quarentena) |
 | `scripts/build-lib.sh` | Libs externas |
 
 ## Fluxo branch → .deb → Orange Pi

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -28,6 +28,31 @@ Prebuilt binaries are available for all supported platforms. Download the approp
 
 After downloading, extract the archive and run the `adapter-gui` binary for your platform.
 
+### macOS — one-line install (recommended)
+
+The macOS build is ad-hoc signed but **not** Apple-notarized (no paid
+Developer certificate). A browser/Finder download tags it with
+`com.apple.quarantine`, so double-clicking the `.dmg` can show
+*"OpenRig is damaged and can't be opened"*. That message is misleading —
+the app is fine, Gatekeeper just blocks un-notarized downloads.
+
+Install with one command (fetched via `curl`, which does not quarantine,
+so it runs without the block):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/jpfaria/OpenRig/develop/scripts/install-macos.sh | bash
+```
+
+It downloads the latest release `.dmg`, copies `OpenRig.app` to
+`/Applications`, and strips the quarantine attribute. Pin a version with
+`| bash -s -- v0.1.0-dev.19`.
+
+If you installed the `.dmg` manually instead, clear the flag yourself:
+
+```bash
+xattr -dr com.apple.quarantine /Applications/OpenRig.app
+```
+
 ## Build from Source
 
 ### Prerequisites
@@ -95,6 +120,13 @@ docker build -f docker/Dockerfile.build-libs -t openrig-build .
 This is primarily intended for CI and release workflows, but can also be used for local cross-compilation.
 
 ## Troubleshooting
+
+### "OpenRig is damaged and can't be opened" (macOS)
+
+The app is not damaged. macOS shows this for downloads that are not
+Apple-notarized. Use the one-line installer, or strip the quarantine
+flag manually — see [macOS — one-line install](#macos--one-line-install-recommended)
+above. Right-click → *Open* also works once the app is a valid bundle.
 
 ### ALSA not found (Linux)
 

--- a/scripts/install-macos.sh
+++ b/scripts/install-macos.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# OpenRig macOS installer — no Apple Developer certificate involved.
+#
+# Why this exists: the released .app is only ad-hoc signed (no paid Apple
+# notarization). A browser/Finder download tags it com.apple.quarantine
+# and Gatekeeper refuses to open it. Nothing the app ships can run before
+# that block (Gatekeeper evaluates before our code; quarantine is applied
+# post-download) — so the only "automatic" path is this script, fetched
+# with curl (curl does NOT set quarantine, so the script itself runs
+# freely) and run by the user:
+#
+#   curl -fsSL https://raw.githubusercontent.com/jpfaria/OpenRig/develop/scripts/install-macos.sh | bash
+#
+# Optional: pass a version to pin it, otherwise the latest release is used:
+#   ... | bash -s -- v0.1.0-dev.19
+#
+# Issue: #459
+set -euo pipefail
+
+REPO="jpfaria/OpenRig"
+VERSION="${1:-latest}"
+APP_DEST="/Applications/OpenRig.app"
+
+if [ "$(uname -s)" != "Darwin" ]; then
+    echo "install-macos.sh is for macOS only (got $(uname -s))." >&2
+    exit 1
+fi
+
+api="https://api.github.com/repos/${REPO}/releases/$(
+    [ "$VERSION" = "latest" ] && echo "latest" || echo "tags/${VERSION}"
+)"
+
+echo "==> Resolving macOS .dmg from ${REPO} (${VERSION})..."
+dmg_url="$(curl -fsSL "$api" \
+    | grep -o 'https://[^"]*-macos-universal\.dmg' \
+    | head -1)"
+if [ -z "$dmg_url" ]; then
+    echo "Could not find a macOS .dmg asset for '${VERSION}'." >&2
+    exit 1
+fi
+
+work="$(mktemp -d)"
+mount_point=""
+cleanup() {
+    [ -n "$mount_point" ] && hdiutil detach "$mount_point" -quiet 2>/dev/null || true
+    rm -rf "$work"
+}
+trap cleanup EXIT
+
+dmg="${work}/OpenRig.dmg"
+echo "==> Downloading $(basename "$dmg_url")..."
+curl -fL# "$dmg_url" -o "$dmg"
+
+echo "==> Mounting..."
+mount_point="$(hdiutil attach "$dmg" -nobrowse -readonly \
+    | grep -o '/Volumes/.*' | head -1)"
+src_app="$(find "$mount_point" -maxdepth 1 -name '*.app' -type d | head -1)"
+if [ -z "$src_app" ]; then
+    echo "No .app found inside the .dmg." >&2
+    exit 1
+fi
+
+echo "==> Installing to ${APP_DEST}..."
+rm -rf "$APP_DEST"
+cp -R "$src_app" "$APP_DEST"
+
+# The whole point: strip the quarantine the download applied so
+# Gatekeeper lets the (ad-hoc signed) app run.
+echo "==> Removing quarantine..."
+xattr -dr com.apple.quarantine "$APP_DEST" 2>/dev/null || true
+
+echo ""
+echo "==> Done. Launch with:  open -a OpenRig"

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -137,10 +137,30 @@ cat > "$APP/Contents/Info.plist" <<PLIST
 </plist>
 PLIST
 
-# ── 5. Ad-hoc signing (bypasses Gatekeeper without Apple certificate) ─────────
-echo "==> Signing app (ad-hoc)..."
-codesign --force --deep --sign - "$APP"
-xattr -cr "$APP"
+# ── 5. Ad-hoc signing — inside-out so the bundle signature is VALID ──────────
+# Ad-hoc signing does NOT bypass Gatekeeper. Its only purpose: a *valid*
+# signature downgrades the Gatekeeper block from "OpenRig is damaged"
+# (hard, unbypassable) to "unidentified developer" (right-click → Open
+# works, no Terminal). `codesign --deep` is unreliable on bundles with
+# Mach-O outside Contents/MacOS (we ship dylibs in Frameworks/ and nested
+# plugin .dylibs in Resources/plugins/.../macos-universal/) — it leaves
+# some unsigned, the seal fails verification, and macOS reports "damaged".
+# Fix: sign every Mach-O explicitly, innermost first, bundle last.
+# No `xattr -cr` here: the user's download re-applies com.apple.quarantine,
+# so stripping it at build time is a no-op (issue #459).
+echo "==> Signing app (ad-hoc, inside-out)..."
+while IFS= read -r macho; do
+    codesign --force --sign - --timestamp=none "$macho"
+done < <(find "$APP/Contents" -type f \( -name '*.dylib' -o -name '*.so' -o -perm +111 \) \
+    -exec sh -c 'file -b "$1" | grep -q "Mach-O" && printf "%s\n" "$1"' _ {} \;)
+codesign --force --sign - --timestamp=none "$APP/Contents/MacOS/openrig"
+codesign --force --sign - --timestamp=none "$APP"
+
+# Gate: an invalid signature IS the "damaged" bug. Fail the build loudly
+# here rather than ship a .dmg that no one can open.
+echo "==> Verifying signature..."
+codesign --verify --deep --strict --verbose=2 "$APP"
+echo "    signature valid"
 
 # ── 6. Verify binary ──────────────────────────────────────────────────────────
 echo "==> Verifying binary..."


### PR DESCRIPTION
Ref #459

`OpenRig.app` da release `v0.1.0-dev.19` abria como "danificado".

**Causa raiz:** `package-macos.sh` assinava com `codesign --deep --sign -`. `--deep` é não-confiável em bundles com Mach-O fora de `Contents/MacOS` (enviamos `libNeuralAudioCAPI.dylib` em `Frameworks/` e `.dylib` de plugin em `Resources/plugins/.../macos-universal/`). Bundle mal-selado + quarentena do download = Gatekeeper "danificado" (bloqueio duro). `xattr -cr` em build time era no-op. Sem cert Apple e o dono não vai notarizar.

**Fix (grátis):**
- Assinatura **inside-out** (Mach-O aninhadas primeiro, bundle por último) + **gate** `codesign --verify --deep --strict` → assinatura inválida **falha o CI** em vez de publicar .dmg inabrível. Rebaixa "danificado" (irreversível) → "desenvolvedor não identificado" (botão-direito → Abrir).
- `scripts/install-macos.sh`: one-liner `curl … | bash` (baixa .dmg, instala em /Applications, tira quarentena). curl não aplica quarentena → roda sem bloqueio. É o único "automático" possível (Gatekeeper avalia antes do nosso código).
- Docs em `installation.md` (linkado pelos 3 READMEs) + `scripts.md`.

Validado: sintaxe OK, installer resolve a release real, inside-out gera assinatura válida (`codesign --verify` exit 0). Prova e2e = próxima release (o gate garante que não publica quebrado de novo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)