### PR TITLE
fix(packaging/linux): resolve libNeuralAudioCAPI.so + libseat at runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
             libjack-jackd2-dev \
             fakeroot rpm ruby-dev build-essential \
             librsvg2-bin imagemagick \
-            gettext
+            gettext patchelf
 
       - name: Install fpm
         run: sudo gem install fpm --no-document
@@ -207,7 +207,7 @@ jobs:
             libjack-jackd2-dev \
             fakeroot rpm ruby-dev build-essential \
             librsvg2-bin imagemagick \
-            gettext
+            gettext patchelf
 
       - name: Install fpm
         run: sudo gem install fpm --no-document

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -7,6 +7,7 @@
 | `scripts/build-orange-pi-image.sh` | Imagem SD para Orange Pi |
 | `scripts/flash-sd.sh` | Flasha SD card |
 | `scripts/coverage.sh` | Relatório HTML de cobertura |
+| `scripts/package-linux.sh` | Empacota Linux .tar.gz/.deb/.rpm/.AppImage (patchelf RUNPATH p/ libNeuralAudioCAPI + libseat) |
 | `scripts/package-macos.sh` | Empacota macOS (assina ad-hoc inside-out + gate de verificação) |
 | `scripts/install-macos.sh` | Instalador one-liner via `curl` (baixa .dmg, copia pro /Applications, tira quarentena) |
 | `scripts/build-lib.sh` | Libs externas |

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -154,6 +154,18 @@ Apple-notarized. Use the one-line installer, or strip the quarantine
 flag manually — see [macOS — one-line install](#macos--one-line-install-recommended)
 above. Right-click → *Open* also works once the app is a valid bundle.
 
+### "cannot open shared object file" on Linux
+
+Builds from `v0.1.0-dev.20` onward bundle `libNeuralAudioCAPI.so` (via
+RUNPATH) and the `.deb` declares `libseat1` as a dependency, so this is
+handled automatically. On older builds the app fails to start with
+`error while loading shared libraries: libNeuralAudioCAPI.so` or
+`libseat.so.1`. Fix by upgrading, or for `libseat`:
+
+```bash
+sudo apt install libseat1   # Debian / Ubuntu
+```
+
 ### ALSA not found (Linux)
 
 If you encounter errors related to ALSA during compilation on Linux, install the ALSA development headers:

--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -92,6 +92,26 @@ cp target/release/adapter-gui              "$S/usr/bin/openrig"
 cp -r "libs/nam/linux-${ARCH}"             "$S/usr/lib/openrig/libs/nam/linux-${ARCH}"
 cp -r assets                               "$S/usr/share/openrig/assets"
 
+# The binary links libNeuralAudioCAPI.so with RUNPATH=$ORIGIN, but the lib
+# is staged under usr/lib/openrig/libs/nam/, NOT next to the binary — so
+# ld.so can't find it and the app dies at startup with "cannot open
+# shared object file" (issue #461; macOS solves the equivalent via
+# install_name_tool). Point RUNPATH at the staged lib, relative to the
+# binary. The path resolves identically once installed to /usr (.deb/
+# .rpm), unpacked (.tar.gz), or inside the AppImage's AppDir.
+patchelf --set-rpath "\$ORIGIN/../lib/openrig/libs/nam/linux-${ARCH}" \
+    "$S/usr/bin/openrig"
+
+# Gate: a package no one can open is worse than a failed build. Verify
+# the NAM lib actually resolves through the new RUNPATH before we wrap
+# it in a .deb/.AppImage (lesson from #459).
+if ldd "$S/usr/bin/openrig" 2>/dev/null \
+    | grep -q 'libNeuralAudioCAPI\.so .*not found'; then
+    echo "FATAL: libNeuralAudioCAPI.so still unresolved after RUNPATH patch" >&2
+    exit 1
+fi
+echo "    RUNPATH patched; libNeuralAudioCAPI.so resolves"
+
 # Bundled preset library: the 21 default presets under presets/*.yaml ship
 # next to plugins/ and assets/ so the app finds them via
 # infra_filesystem::detect_data_root().join("presets"). Without this copy,
@@ -174,6 +194,7 @@ if $BUILD_DEB; then
         --maintainer "Joao Paulo Faria" \
         --category sound \
         --depends libasound2 \
+        --depends libseat1 \
         --deb-no-default-config-files \
         -C "$OUTPUT_DIR/stage" \
         --package "$OUTPUT_DIR/openrig_${VERSION}_${DEB_ARCH}.deb" \
@@ -189,6 +210,7 @@ if $BUILD_RPM; then
         --url "https://github.com/jpfaria/OpenRig" \
         --maintainer "Joao Paulo Faria" \
         --category "Applications/Multimedia" \
+        --depends libseat \
         -C "$OUTPUT_DIR/stage" \
         --package "$OUTPUT_DIR/openrig-${VERSION}-1.${RPM_ARCH}.rpm" \
         usr
@@ -204,11 +226,28 @@ if $BUILD_APPIMAGE; then
     APPDIR="$OUTPUT_DIR/AppDir"
     cp -r "$OUTPUT_DIR/stage" "$APPDIR"
 
+    # An AppImage must be self-contained. libseat.so.1 is NEEDED by the
+    # binary (Slint/winit backend) but is absent on minimal desktops
+    # (no compositor/seatd) — bundle it (issue #461). The build runner
+    # links against it, so it is present here to copy.
+    mkdir -p "$APPDIR/usr/lib/openrig/syslibs"
+    seat_lib="$(ldconfig -p | awk '/libseat\.so\.1/ {print $NF; exit}')"
+    if [ -z "$seat_lib" ] || [ ! -e "$seat_lib" ]; then
+        echo "FATAL: libseat.so.1 not found on build host — cannot bundle" >&2
+        exit 1
+    fi
+    cp -L "$seat_lib" "$APPDIR/usr/lib/openrig/syslibs/libseat.so.1"
+
     printf '%s\n' \
         '#!/bin/bash' \
         'HERE="$(dirname "$(readlink -f "${0}")")"' \
         'export OPENRIG_LIBS_DIR="$HERE/usr/lib/openrig/libs"' \
         'export OPENRIG_ASSETS_DIR="$HERE/usr/share/openrig/assets"' \
+        'LD_LIBRARY_PATH="$HERE/usr/lib/openrig/syslibs${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"' \
+        'for d in "$HERE"/usr/lib/openrig/libs/nam/linux-*; do' \
+        '    [ -d "$d" ] && LD_LIBRARY_PATH="$d:$LD_LIBRARY_PATH"' \
+        'done' \
+        'export LD_LIBRARY_PATH' \
         'exec "$HERE/usr/bin/openrig" "$@"' \
         > "$APPDIR/AppRun"
     chmod +x "$APPDIR/AppRun"


### PR DESCRIPTION
Ref #461

Release `v0.1.0-dev.19` não abria no Linux: `error while loading shared libraries: libNeuralAudioCAPI.so`.

**Causa raiz:** binário com `RUNPATH=$ORIGIN` mas `package-linux.sh` stage a lib em `usr/lib/openrig/libs/nam/` (não ao lado do binário) e nunca corrige o RUNPATH. 2º problema: `libseat.so.1` NEEDED mas `.deb` só dependia de libasound2 e AppImage não bundlava.

**Fix:** patchelf RUNPATH + gate de verificação (build falha se não resolver, lição do #459); `.deb --depends libseat1` / `.rpm --depends libseat`; AppImage bundla libseat + LD_LIBRARY_PATH no AppRun; release.yml +patchelf.

**Provado e2e** na máquina do usuário (Ubuntu 24.04): `ldd` resolve as 2 libs, binário inicializa (só falha depois por SSH headless sem display — esperado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)