### PR TITLE
fix(packaging/macos): robust Mach-O discovery (fix #459 broken-pipe regression)

### DIFF
--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -149,10 +149,20 @@ PLIST
 # No `xattr -cr` here: the user's download re-applies com.apple.quarantine,
 # so stripping it at build time is a no-op (issue #459).
 echo "==> Signing app (ad-hoc, inside-out)..."
-while IFS= read -r macho; do
-    codesign --force --sign - --timestamp=none "$macho"
-done < <(find "$APP/Contents" -type f \( -name '*.dylib' -o -name '*.so' -o -perm +111 \) \
-    -exec sh -c 'file -b "$1" | grep -q "Mach-O" && printf "%s\n" "$1"' _ {} \;)
+# NUL-delimited find + `case` on full `file` output. No `grep -q` (it
+# closes the pipe early → SIGPIPE on `file`, which under `set -o
+# pipefail` aborts the loop while `find` keeps writing → a flood of
+# "printf: Broken pipe" and exit 1 once the .app's full plugin tree is
+# present). No per-file `-exec sh -c` subshell either (issue #463,
+# regression of #459 which only tested a tiny bundle).
+while IFS= read -r -d '' f; do
+    case "$(file -b "$f" 2>/dev/null)" in
+        *Mach-O*)
+            codesign --force --sign - --timestamp=none "$f" \
+                || { echo "FATAL: codesign failed for $f" >&2; exit 1; }
+            ;;
+    esac
+done < <(find "$APP/Contents" -type f -print0)
 codesign --force --sign - --timestamp=none "$APP/Contents/MacOS/openrig"
 codesign --force --sign - --timestamp=none "$APP"
 


### PR DESCRIPTION
Ref #463

Regressão do #459/PR #460: o build macOS da `v0.1.0-dev.20` falhou com flood de `printf: write error: Broken pipe` → release não criada (Linux/Windows/plugins passaram).

**Causa:** `find -exec sh -c 'file | grep -q Mach-O && printf'` alimentando `while read` sob `set -euo pipefail`. Na árvore real do .app (centenas de Mach-O em plugins), `grep -q` fecha o pipe cedo → SIGPIPE no `file`; pipefail+set -e derrubam o loop, `find` continua escrevendo em pipe morto → flood + exit 1. O teste do #459 usou bundle pequeno, não pegou a escala.

**Fix:** `find -print0` + `while read -d ''`, detecção via `case` no output do `file` (sem `grep -q` → sem SIGPIPE), sem subshell por arquivo, erro de codesign explícito. Gate `codesign --verify` mantido.

**Validado em escala** (703 arquivos / 402 Mach-O) sob `set -euo pipefail`: assina tudo + verify OK, zero broken pipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)