### PR TITLE
fix(build): install patchelf in Dockerfile.linux-builder

### DIFF
--- a/docker/Dockerfile.linux-builder
+++ b/docker/Dockerfile.linux-builder
@@ -37,6 +37,7 @@ RUN apt-get update && apt-get install -y \
     fakeroot rpm ruby-dev build-essential \
     librsvg2-bin imagemagick \
     gettext \
+    patchelf \
     && rm -rf /var/lib/apt/lists/*
 
 RUN gem install fpm --no-document


### PR DESCRIPTION
Ref #468

`build-linux-local.sh` quebrava com `patchelf: command not found` — o #461 pôs `patchelf` no `release.yml` (CI nativo) mas não no `docker/Dockerfile.linux-builder` (usado pelo build local). Miss de escopo do #461. Fix: 1 linha, `patchelf` no apt-get install. Sem `--clean`/`--nuke` — re-rodar refaz a layer apt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)