### PR TITLE
docs(macos): surface the mandatory quarantine step in all 3 READMEs

### DIFF
--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -124,6 +124,20 @@ Cada `model:` ID está registrado en el [Blocks Reference Quick Reference](docs/
 
 Releases para todas las plataformas soportadas (macOS aarch64/x86_64, Linux x86_64/aarch64, Windows x86_64) se publican en la [página de Releases](https://github.com/jpfaria/OpenRig/releases/latest).
 
+#### macOS: "OpenRig está dañado y no se puede abrir"
+
+**La app no está dañada.** OpenRig está firmada ad-hoc pero no notarizada por Apple (sin certificado de Desarrollador de pago), así que macOS pone la descarga en cuarentena y muestra ese mensaje engañoso — en Apple Silicon es un bloqueo duro. Tras mover OpenRig a Aplicaciones, quita el atributo de cuarentena:
+
+```bash
+xattr -dr com.apple.quarantine /Applications/OpenRig.app
+```
+
+O instala con un comando (las descargas vía `curl` nunca quedan en cuarentena — baja el `.dmg`, instala en Aplicaciones y quita el atributo por ti):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/jpfaria/OpenRig/develop/scripts/install-macos.sh | bash
+```
+
 ### Compilar desde el código
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -124,6 +124,20 @@ Every `model:` ID is registered in the [Blocks Reference Quick Reference](docs/u
 
 Releases for every supported platform (macOS aarch64/x86_64, Linux x86_64/aarch64, Windows x86_64) are published on the [Releases page](https://github.com/jpfaria/OpenRig/releases/latest).
 
+#### macOS: "OpenRig is damaged and can't be opened"
+
+**The app is not damaged.** OpenRig is ad-hoc signed but not Apple-notarized (no paid Developer certificate), so macOS quarantines the download and shows that misleading message — on Apple Silicon it is a hard block. After moving OpenRig to Applications, clear the quarantine flag:
+
+```bash
+xattr -dr com.apple.quarantine /Applications/OpenRig.app
+```
+
+Or install with one command (`curl` downloads are never quarantined — this fetches the `.dmg`, installs to Applications, and clears the flag for you):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/jpfaria/OpenRig/develop/scripts/install-macos.sh | bash
+```
+
 ### Build from Source
 
 ```bash

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -124,6 +124,20 @@ Todo `model:` ID está registrado no [Blocks Reference Quick Reference](docs/use
 
 Releases para todas as plataformas suportadas (macOS aarch64/x86_64, Linux x86_64/aarch64, Windows x86_64) são publicados na [página de Releases](https://github.com/jpfaria/OpenRig/releases/latest).
 
+#### macOS: "OpenRig está danificado e não pode ser aberto"
+
+**O app não está danificado.** O OpenRig é assinado ad-hoc mas não notarizado pela Apple (sem certificado de Desenvolvedor pago), então o macOS põe o download em quarentena e mostra essa mensagem enganosa — no Apple Silicon é bloqueio duro. Depois de mover o OpenRig pra Aplicativos, remova o atributo de quarentena:
+
+```bash
+xattr -dr com.apple.quarantine /Applications/OpenRig.app
+```
+
+Ou instale com um comando (downloads via `curl` nunca entram em quarentena — ele baixa o `.dmg`, instala em Aplicativos e remove o atributo pra você):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/jpfaria/OpenRig/develop/scripts/install-macos.sh | bash
+```
+
 ### Compilar do código
 
 ```bash

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -50,6 +50,12 @@ A portable `openrig-<ver>-linux-<arch>.tar.gz` is also published: extract it and
 
 Download `OpenRig-<ver>-macos-universal.dmg`, open it, and drag OpenRig to Applications. The build is universal (Apple Silicon + Intel).
 
+> ⚠️ **Required step — otherwise macOS says "OpenRig is damaged".** The build is not Apple-notarized, so the download is quarantined (a hard block on Apple Silicon). After moving the app to Applications, run:
+> ```bash
+> xattr -dr com.apple.quarantine /Applications/OpenRig.app
+> ```
+> Or use the one-line `curl` installer below, which does this for you.
+
 ### Windows
 
 Run the `OpenRig-<ver>-windows-x64.msi` installer, or download `OpenRig-<ver>-windows-x64.zip` for a portable copy and run the `adapter-gui` executable.


### PR DESCRIPTION
Ref #471

macOS: usuário trava em "OpenRig está danificado" e não tem como achar a solução — o passo de quarentena / instalador curl só existia enterrado em `installation.md`, que ainda por cima mandava "arrastar pro Applications" sem aviso. Os 3 READMEs (o que as pessoas leem) não tinham nada.

- README.md/pt-BR/es-ES: subseção macOS visível em Instalação com `xattr -dr com.apple.quarantine` + one-liner curl, explicando que "danificado" = não-notarizado (sem cert Apple paga), não app corrompido.
- installation.md: callout ⚠️ inline na seção de download macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)