### PR TITLE
fix(linux): capture clipping (unity capture) + block editor too short

### DIFF
--- a/crates/adapter-gui/ui/secondary_windows_block.slint
+++ b/crates/adapter-gui/ui/secondary_windows_block.slint
@@ -72,8 +72,12 @@ export component BlockEditorWindow inherits Window {
         root.use-panel-editor ?
             (has-eq-widget ? eq-panel-width : Math.max(900px, needed-width)) :
             520px;
+    // Non-panel editor (form/knob blocks): 640px clipped the lower
+    // controls once the size was applied explicitly (#479) — the Linux
+    // WM used to over-size the window and hid the shortfall. 820px
+    // fits the model picker + parameter grid + drawer with margin.
     out property <length> panel-height:
-        root.use-panel-editor ? eq-extra-height : 640px;
+        root.use-panel-editor ? eq-extra-height : 820px;
     // EQ widget heights: CurveEditor = 280px, MultiSlider = 240px.
     // Total = header(48) + panel-height(width/4) + gap(8) + widget-height + margin(8).
     // 200px / 180px were too tight for the full -24..+24 dB range — the cap of

--- a/crates/infra-cpal/src/controller.rs
+++ b/crates/infra-cpal/src/controller.rs
@@ -93,7 +93,15 @@ impl ProjectRuntimeController {
             .iter()
             .find(|s| s.device_id.0 == card.device_id);
         let sample_rate = matched.map(|s| s.sample_rate).unwrap_or(48_000);
-        let buffer_size = matched.map(|s| s.buffer_size_frames).unwrap_or(64);
+        // Unconfigured-device fallback. 64 frames continuously xruns on a
+        // generic (non-RT) desktop kernel with USB audio — the stream
+        // smears into a dull "muffled / in a bag" sound (NOT clicks),
+        // which is exactly what users reported (#479). 256 is the safe
+        // USB minimum. Configured setups carry an explicit value so this
+        // is never hit (Orange Pi unaffected). THIS is the path that
+        // builds the live JackConfig — device_settings.rs has a twin
+        // fallback (kept in sync; both 256).
+        let buffer_size = matched.map(|s| s.buffer_size_frames).unwrap_or(256);
         let nperiods = matched.map(|s| s.nperiods).unwrap_or(3);
         let realtime = matched.map(|s| s.realtime).unwrap_or(true);
         let rt_priority = matched.map(|s| s.rt_priority).unwrap_or(70);

--- a/crates/infra-cpal/src/jack_supervisor/alsa_mixer.rs
+++ b/crates/infra-cpal/src/jack_supervisor/alsa_mixer.rs
@@ -10,7 +10,6 @@
 use std::process::{Command, Stdio};
 
 /// Playback control names seen across the USB interfaces we target.
-/// A card only has a few of these; the rest are skipped silently.
 const PLAYBACK_CONTROLS: &[&str] = &[
     "PCM",
     "Master",
@@ -21,30 +20,38 @@ const PLAYBACK_CONTROLS: &[&str] = &[
     "Speaker+LO",
 ];
 
-/// Drive the card's playback mixer to unity (100% / 0 dB, unmuted).
+/// Capture control names. These ship maxed on many USB interfaces
+/// (e.g. Teyun Q26: Mic at +27 dB) — a guitar into a +27 dB input
+/// clips the ADC, so the signal is loud but distorted/muffled. Unity
+/// (0 dB = no boost) is the safe default; the player raises it if they
+/// actually need gain (#479).
+const CAPTURE_CONTROLS: &[&str] = &["Mic", "Capture", "Line In", "Line", "Mic Boost"];
+
+/// Drive the card to unity: playback AND capture to 0 dB, unmuted.
 ///
-/// Best-effort and never fatal: an absent control is expected and
-/// skipped; a missing `amixer` (alsa-utils not installed) is logged
-/// and ignored — jackd still starts, only the level is left as-is.
-/// Capture gain is intentionally untouched (instrument level is the
-/// player's call / the interface's hardware knob).
-pub(super) fn set_playback_mixer_unity(card_num: u32) {
-    for ctrl in PLAYBACK_CONTROLS {
+/// `0dB` (not `100%`): on many interfaces 100% is well above unity and
+/// either over-drives the output or, on capture, clips the input.
+/// Best-effort and never fatal: an absent control is skipped; a missing
+/// `amixer` (alsa-utils not installed) is logged once and ignored —
+/// jackd still starts, only the level is left as-is.
+pub(super) fn set_mixer_unity(card_num: u32) {
+    let card = card_num.to_string();
+    for ctrl in PLAYBACK_CONTROLS.iter().chain(CAPTURE_CONTROLS) {
         let status = Command::new("amixer")
-            .args(["-c", &card_num.to_string(), "sset", ctrl, "100%", "unmute"])
+            .args(["-c", &card, "sset", ctrl, "0dB", "unmute"])
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .status();
         match status {
             Ok(s) if s.success() => {
-                log::info!("mixer: {ctrl} -> 100% unmute on card {card_num}");
+                log::info!("mixer: {ctrl} -> 0dB unmute on card {card_num}");
             }
             Ok(_) => {} // control absent on this card — expected
             Err(e) => {
                 log::warn!(
                     "mixer: `amixer` unavailable ({e}); card {card_num} \
-                     playback left as-is (install alsa-utils)"
+                     levels left as-is (install alsa-utils)"
                 );
                 return;
             }

--- a/crates/infra-cpal/src/jack_supervisor/live_backend.rs
+++ b/crates/infra-cpal/src/jack_supervisor/live_backend.rs
@@ -291,7 +291,7 @@ impl JackBackend for LiveJackBackend {
             Self::nuke_process_wide_jack_shm();
         }
 
-        super::alsa_mixer::set_playback_mixer_unity(config.card_num);
+        super::alsa_mixer::set_mixer_unity(config.card_num);
 
         let stderr_log = Self::stderr_log_path(name);
         let stderr_file = std::fs::File::create(&stderr_log)

--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -109,6 +109,11 @@ Icon=openrig
 Type=Application
 Categories=AudioVideo;Audio;Music;
 Terminal=false
+# GNOME/Wayland matches the running window to this .desktop by app_id
+# (Wayland) / WM_CLASS (X11). Slint's winit backend uses the binary
+# name ("openrig"); without this key the shell shows it as an unknown
+# app — no dock icon, can't pin (#479).
+StartupWMClass=openrig
 DESKTOP
 cp crates/adapter-gui/ui/assets/openrig-logomark.svg \
    "$S/usr/share/icons/hicolor/scalable/apps/openrig.svg"


### PR DESCRIPTION
Ref #479. Two follow-ups from dev.22 testing: (1) auto-mixer now sets capture to 0 dB too — Teyun Mic shipped at +27 dB, clipping the guitar (loud but muffled/distorted); (2) block editor window opened too short (640px clipped controls) → 820px. infra-cpal 61/61, adapter-gui slint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)