### PR TITLE
test(485): pin stereo-image invariant #5 — mono→stereo never collapses

### DIFF
--- a/crates/engine/src/runtime.rs
+++ b/crates/engine/src/runtime.rs
@@ -730,5 +730,9 @@ mod audio_deadline;
 mod audio_signal_integrity;
 
 #[cfg(test)]
+#[path = "stereo_image_tests.rs"]
+mod stereo_image;
+
+#[cfg(test)]
 #[path = "runtime_lock_recovery_tests.rs"]
 mod runtime_lock_recovery;

--- a/crates/engine/src/stereo_image_tests.rs
+++ b/crates/engine/src/stereo_image_tests.rs
@@ -1,0 +1,220 @@
+//! Stereo-image invariant guard (#485 / CLAUDE.md invariant #5).
+//!
+//! "Stream é SEMPRE estéreo internamente. Mono input → broadcast
+//! Stereo([s,s])." A mono guitar through a *stereo* effect (MonoToStereo
+//! reverb/chorus) MUST reach the output with L != R; a chain with no
+//! stereo block is correctly dual-mono (L == R, both channels non-silent).
+//! These tests pin that end-to-end so the dual-mono regression can never
+//! come back silently.
+
+use super::{
+    build_chain_runtime_state, process_input_f32, process_output_f32, DEFAULT_ELASTIC_TARGET,
+};
+use domain::ids::{BlockId, ChainId, DeviceId};
+use domain::value_objects::ParameterValue;
+use project::block::{
+    schema_for_block_model, AudioBlock, AudioBlockKind, CoreBlock, InputBlock, InputEntry,
+    OutputBlock, OutputEntry,
+};
+use project::chain::{Chain, ChainInputMode, ChainOutputMode};
+use project::param::ParameterSet;
+use std::sync::Arc;
+
+const SR: f32 = 48_000.0;
+const BUFFER_FRAMES: usize = 64;
+
+fn input_mono(channels: Vec<usize>) -> AudioBlock {
+    AudioBlock {
+        id: BlockId("input:0".into()),
+        enabled: true,
+        kind: AudioBlockKind::Input(InputBlock {
+            model: "standard".into(),
+            entries: vec![InputEntry {
+                device_id: DeviceId("dev".into()),
+                mode: ChainInputMode::Mono,
+                channels,
+            }],
+        }),
+    }
+}
+
+fn output(mode: ChainOutputMode, channels: Vec<usize>) -> AudioBlock {
+    AudioBlock {
+        id: BlockId("output:0".into()),
+        enabled: true,
+        kind: AudioBlockKind::Output(OutputBlock {
+            model: "standard".into(),
+            entries: vec![OutputEntry {
+                device_id: DeviceId("dev".into()),
+                mode,
+                channels,
+            }],
+        }),
+    }
+}
+
+fn chain_with_blocks(id: &str, blocks: Vec<AudioBlock>) -> Chain {
+    Chain {
+        id: ChainId(id.into()),
+        description: Some("stereo image test".into()),
+        instrument: "electric_guitar".into(),
+        enabled: true,
+        volume: 100.0,
+        blocks,
+    }
+}
+
+fn params_with(effect_type: &str, model: &str, overrides: &[(&str, f32)]) -> ParameterSet {
+    let schema =
+        schema_for_block_model(effect_type, model).expect("schema must exist for test model");
+    let mut p = ParameterSet::default()
+        .normalized_against(&schema)
+        .expect("defaults must normalize");
+    for (k, v) in overrides {
+        p.insert(*k, ParameterValue::Float(*v));
+    }
+    p
+}
+
+fn core_block(id: &str, effect_type: &str, model: &str, params: ParameterSet) -> AudioBlock {
+    AudioBlock {
+        id: BlockId(id.into()),
+        enabled: true,
+        kind: AudioBlockKind::Core(CoreBlock {
+            effect_type: effect_type.to_string(),
+            model: model.to_string(),
+            params,
+        }),
+    }
+}
+
+fn build(chain: &Chain) -> Arc<super::ChainRuntimeState> {
+    Arc::new(
+        build_chain_runtime_state(chain, SR, &[DEFAULT_ELASTIC_TARGET])
+            .expect("runtime state should build"),
+    )
+}
+
+/// Drive a 1 kHz-ish mono ramp/sine through `n` callbacks, return the
+/// concatenated interleaved stereo output of the steady-state callbacks.
+fn drive_stereo(runtime: &Arc<super::ChainRuntimeState>, n: usize, warmup: usize) -> Vec<f32> {
+    let mut input_buf = vec![0.0_f32; BUFFER_FRAMES];
+    let mut output_buf = vec![0.0_f32; BUFFER_FRAMES * 2];
+    let mut captured = Vec::with_capacity((n - warmup) * BUFFER_FRAMES * 2);
+    let mut phase = 0.0_f32;
+    let step = 2.0 * std::f32::consts::PI * 440.0 / SR;
+    for cb in 0..n {
+        for s in input_buf.iter_mut() {
+            *s = 0.5 * phase.sin();
+            phase += step;
+        }
+        process_input_f32(runtime, 0, &input_buf, 1);
+        process_output_f32(runtime, 0, &mut output_buf, 2);
+        if cb >= warmup {
+            captured.extend_from_slice(&output_buf);
+        }
+    }
+    captured
+}
+
+fn max_lr_divergence(interleaved_stereo: &[f32]) -> f32 {
+    interleaved_stereo
+        .chunks_exact(2)
+        .map(|f| (f[0] - f[1]).abs())
+        .fold(0.0_f32, f32::max)
+}
+
+fn peak_abs(interleaved_stereo: &[f32]) -> f32 {
+    interleaved_stereo
+        .iter()
+        .fold(0.0_f32, |m, s| m.max(s.abs()))
+}
+
+#[test]
+fn mono_in_stereo_block_stereo_out_is_true_stereo() {
+    // Mono guitar → MonoToStereo reverb (wet) → stereo output.
+    // Invariant #5: the stereo effect MUST reach the output decorrelated
+    // (L != R). If this fails, the pipeline is collapsing stereo to mono.
+    let chain = chain_with_blocks(
+        "mono-reverb-stereo",
+        vec![
+            input_mono(vec![0]),
+            core_block(
+                "rv",
+                "reverb",
+                "room",
+                params_with("reverb", "room", &[("mix", 60.0), ("room_size", 70.0)]),
+            ),
+            output(ChainOutputMode::Stereo, vec![0, 1]),
+        ],
+    );
+    let runtime = build(&chain);
+    // Reverb needs tail build-up; warm up generously.
+    let out = drive_stereo(&runtime, 96, 32);
+
+    assert!(
+        peak_abs(&out) > 1e-3,
+        "output is silent — chain not producing"
+    );
+    let div = max_lr_divergence(&out);
+    assert!(
+        div > 1e-3,
+        "STEREO COLLAPSE: mono input through a MonoToStereo reverb \
+         produced L == R (max |L-R| = {div:e}); invariant #5 violated"
+    );
+}
+
+#[test]
+fn mono_in_stereo_block_via_modulation_is_true_stereo() {
+    let chain = chain_with_blocks(
+        "mono-chorus-stereo",
+        vec![
+            input_mono(vec![0]),
+            core_block(
+                "ch",
+                "modulation",
+                "stereo_chorus",
+                params_with("modulation", "stereo_chorus", &[("mix", 60.0)]),
+            ),
+            output(ChainOutputMode::Stereo, vec![0, 1]),
+        ],
+    );
+    let runtime = build(&chain);
+    let out = drive_stereo(&runtime, 96, 32);
+
+    assert!(peak_abs(&out) > 1e-3, "output is silent");
+    let div = max_lr_divergence(&out);
+    assert!(
+        div > 1e-4,
+        "STEREO COLLAPSE: stereo_chorus produced L == R (max |L-R| = {div:e})"
+    );
+}
+
+#[test]
+fn mono_in_no_stereo_block_is_dual_mono_not_silent() {
+    // No stereo block: dual-mono (L == R) is the CORRECT behaviour for a
+    // mono source (invariant #5 broadcast). Pins that the broadcast keeps
+    // both channels non-silent and identical (not "one channel only").
+    let chain = chain_with_blocks(
+        "mono-pipe-stereo-out",
+        vec![
+            input_mono(vec![0]),
+            core_block(
+                "vol",
+                "gain",
+                "volume",
+                params_with("gain", "volume", &[("volume", 80.0)]),
+            ),
+            output(ChainOutputMode::Stereo, vec![0, 1]),
+        ],
+    );
+    let runtime = build(&chain);
+    let out = drive_stereo(&runtime, 48, 16);
+
+    assert!(peak_abs(&out) > 1e-3, "broadcast produced silence");
+    let div = max_lr_divergence(&out);
+    assert!(
+        div < 1e-6,
+        "expected dual-mono (L == R) with no stereo block, got max |L-R| = {div:e}"
+    );
+}


### PR DESCRIPTION
Fixes #485. PR alvo: `feature/issue-436` (não develop), conforme pedido.

## Investigação (honesta)
Reportado: saída dual-mono no Mac. Rastreado a fundo o caminho de áudio.

**Conclusão: NÃO há bug no pipeline do engine.** O caminho `stream_builder`/`chain_resolve`/`runtime_io`/`write_output_frame` é **byte-idêntico ao develop** (não introduzido pelo #436), e o pipeline **preserva estéreo corretamente**.

Provado por 3 testes de caracterização end-to-end (não TDD red→green — caracterização; **vi o controle negativo falhar explicitamente** pra garantir que não são viciados):

| caso | divergência L≠R medida | limiar | veredito |
|---|---|---|---|
| mono → reverb `room` (MonoToStereo) → stereo out | **0.52** | >1e-3 | estéreo real |
| mono → `stereo_chorus` → stereo out | **0.60** | >1e-4 | estéreo real |
| mono → só blocos mono → stereo out | **0.0 exato** | <1e-6 | dual-mono correto (#5, sem auto-pan) |

Margem ~500x sobre o limiar — não é raspão. Controle negativo (mono-only = 0.0) provado falhando a barra estéreo → métrica tem dente.

## Causa real do que o usuário ouviu
Comportamento DSP esperado, não regressão: guitarra **mono** + blocos estéreo dos presets com **mix 4–15%** ou `enabled:false` → sinal seco mono domina, L≈R. Invariante #5 + "NUNCA auto-pan": fonte mono fica centrada até um bloco estéreo com mix relevante.

## Entrega
Guard permanente (o "MUITOS testes pra nunca mais" pedido): qualquer colapso real de estéreo no pipeline passa a quebrar build. Sem mudança de produção (não há bug a corrigir no pipeline).

Gate: volume_invariants 33 · stream_isolation 11 · audio_signal_integrity 14 · rig_spillover 2 · **stereo_image 3** · qa.sh sem regressão.

🤖 Generated with [Claude Code](https://claude.com/claude-code)