### PR TITLE
fix(jack): block edit no longer triggers destructive jackd restart (#479)

### DIFF
--- a/crates/infra-cpal/src/jack_supervisor/supervisor.rs
+++ b/crates/infra-cpal/src/jack_supervisor/supervisor.rs
@@ -485,10 +485,25 @@ impl<B: JackBackend> JackSupervisor<B> {
     /// `Ready` with a matching config. The latter two cases are handled
     /// in-place by `ensure_server` without needing a pre-kill teardown.
     pub fn would_restart(&self, name: &ServerName, desired: &JackConfig) -> bool {
+        // Restart ONLY for params jackd cannot change on a live server:
+        // ALSA device (`card_num`), sample rate (no live SR API), and
+        // buffer size (the live-resize fast-path runs *before* this is
+        // consulted; a residual delta here means soft-resize failed and
+        // a restart is the fallback). Channel counts / nperiods /
+        // rt_priority / realtime are EXCLUDED — they differ run-to-run
+        // from device re-detection (a 4-capture-channel Scarlett,
+        // default vs stored values) with NO port-shape change. Comparing
+        // the whole struct made every chain edit (even a pure block
+        // swap) spuriously report "restart", driving the destructive
+        // stop()+kill+libjack-recreate that wedges into the #294/#308
+        // "Cannot open shm segment" limbo and freezes the app. Mirrors
+        // `ensure_server`'s adopt criteria so the predicates agree (#479).
         matches!(
             self.servers.get(name).map(|s| &s.state),
             Some(JackServerState::Ready { launched_config, .. })
-                if launched_config != desired
+                if launched_config.sample_rate != desired.sample_rate
+                    || launched_config.buffer_size != desired.buffer_size
+                    || launched_config.card_num != desired.card_num
         )
     }
 

--- a/crates/infra-cpal/src/jack_supervisor/supervisor_tests.rs
+++ b/crates/infra-cpal/src/jack_supervisor/supervisor_tests.rs
@@ -667,3 +667,53 @@ fn probe_meta_returned_by_ensure_server_is_the_backends_meta() {
         .unwrap();
     assert_eq!(meta, custom_meta());
 }
+
+// Regression #479: a chain edit (swapping a block) re-detects the USB
+// card and rebuilds the JackConfig. Incidental fields (channel counts,
+// nperiods, rt_priority, realtime) can differ run-to-run (a
+// 4-capture-channel Scarlett, default vs stored values) WITHOUT any
+// port-shape change. would_restart must NOT report a restart for those
+// — the old full-struct compare did, driving the destructive
+// stop()+kill+libjack-recreate that froze the app on every block swap.
+// Only sample_rate / buffer_size / card_num may restart.
+#[test]
+fn would_restart_ignores_incidental_config_fields() {
+    let mut sup = make_supervisor();
+    let base = JackConfig::test_default();
+    sup.ensure_server(&name(), &base, &mut noop_hook()).unwrap();
+
+    let incidental_only = JackConfig {
+        capture_channels: base.capture_channels + 2,
+        playback_channels: base.playback_channels + 1,
+        nperiods: base.nperiods + 1,
+        rt_priority: base.rt_priority.wrapping_add(5),
+        realtime: !base.realtime,
+        ..base
+    };
+    assert!(
+        !sup.would_restart(&name(), &incidental_only),
+        "incidental field delta must NOT trigger a jackd restart (#479)"
+    );
+
+    assert!(sup.would_restart(
+        &name(),
+        &JackConfig {
+            sample_rate: base.sample_rate + 1000,
+            ..base
+        }
+    ));
+    assert!(sup.would_restart(
+        &name(),
+        &JackConfig {
+            buffer_size: base.buffer_size * 2,
+            ..base
+        }
+    ));
+    assert!(sup.would_restart(
+        &name(),
+        &JackConfig {
+            card_num: base.card_num + 1,
+            ..base
+        }
+    ));
+}


### PR DESCRIPTION
Ref #479 — the deterministic "JACK trava ao editar/religar chain → app congela".

**Root cause:** `would_restart` compared the WHOLE `JackConfig` while `ensure_server`'s adopt path only checks `sample_rate` + `buffer_size`. Every chain edit re-runs `ensure_jack_servers`, rebuilding `JackConfig` from a re-detected USB card; incidental fields (capture/playback channel counts — 4 on a Scarlett 2i2 4th Gen —, nperiods, rt_priority, realtime) differ run-to-run with no port-shape change → `would_restart` spuriously true → `self.stop()` + jackd kill + libjack recreate → #294/#308 "Cannot open shm segment" limbo → freeze. The two predicates disagreed.

**Fix:** `would_restart` now mirrors `ensure_server`'s adopt criteria — restart only when `sample_rate`, `buffer_size`, or `card_num` genuinely differ. A pure block/DSP edit touches none → no jackd churn; engine graph updates in place.

**Validation:** macOS build/check clean, 61 infra-cpal tests green. New regression test added; jack_supervisor tests are cfg(linux+jack)-gated → validated by Linux CI (qa.sh). Existing `would_restart_distinguishes…` uses a buffer_size mismatch (still restart-significant) → stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)