### PR TITLE
fix(491): NAM loudness calibration — read output_gain_db (dB), not output_gain_pct

### DIFF
--- a/crates/block-core/src/lib.rs
+++ b/crates/block-core/src/lib.rs
@@ -37,7 +37,7 @@ pub use dsp::{
     EnvelopeFollower, OnePoleHighPass, OnePoleLowPass, BIQUAD_COEFF_RAMP_FRAMES,
 };
 pub use traits::{
-    wrap_with_output_gain_pct, BlockProcessor, MonoProcessor, NamedModel, PluginEditorHandle,
+    wrap_with_output_gain_db, BlockProcessor, MonoProcessor, NamedModel, PluginEditorHandle,
     StereoProcessor,
 };
 pub use visual::{KnobLayoutEntry, ModelVisualData};

--- a/crates/block-core/src/traits.rs
+++ b/crates/block-core/src/traits.rs
@@ -46,8 +46,8 @@ pub enum BlockProcessor {
 }
 
 /// Wraps a [`MonoProcessor`] with a static linear gain applied post-process.
-/// Usado pelos `from_package` (LV2 / IR) pra aplicar `manifest.output_gain_pct`
-/// como baseline objetivo do plugin (issue #440).
+/// Usado pelos `from_package` (LV2 / IR) pra aplicar `manifest.output_gain_db`
+/// como baseline objetivo do plugin (issue #491).
 struct GainScaledMono {
     inner: Box<dyn MonoProcessor>,
     gain: f32,
@@ -95,18 +95,19 @@ impl StereoProcessor for GainScaledStereo {
     }
 }
 
-/// Aplica `manifest.output_gain_pct` (percentual multiplicativo, 100 = unity)
-/// como linha de gain estática pós-process. No-op se `pct` é `None` ou `100.0`.
+/// Aplica `manifest.output_gain_db` (offset aditivo em dB, 0 = unity) como
+/// linha de gain estática pós-process. No-op se `db` é `None` ou `0.0`.
+/// Conversão dB→linear: `10^(db/20)`.
 ///
 /// Usado pelos `from_package` dos backends LV2 / IR. NAM aplica via
 /// `plugin_params.output_level_db` (NAM C++ host nativo já tem level shift
 /// embutido), então não passa por aqui.
-pub fn wrap_with_output_gain_pct(processor: BlockProcessor, pct: Option<f32>) -> BlockProcessor {
-    let pct = match pct {
-        Some(p) if (p - 100.0).abs() > f32::EPSILON => p,
+pub fn wrap_with_output_gain_db(processor: BlockProcessor, db: Option<f32>) -> BlockProcessor {
+    let db = match db {
+        Some(d) if d.abs() > f32::EPSILON => d,
         _ => return processor,
     };
-    let gain = pct / 100.0;
+    let gain = 10.0_f32.powf(db / 20.0);
     match processor {
         BlockProcessor::Mono(inner) => {
             BlockProcessor::Mono(Box::new(GainScaledMono { inner, gain }))
@@ -127,3 +128,7 @@ pub trait NamedModel {
 /// Dropping the handle closes the window and releases all resources.
 /// The concrete type is an implementation detail of the plugin host crate.
 pub trait PluginEditorHandle: Send {}
+
+#[cfg(test)]
+#[path = "traits_tests.rs"]
+mod tests;

--- a/crates/block-core/src/traits_tests.rs
+++ b/crates/block-core/src/traits_tests.rs
@@ -1,0 +1,44 @@
+//! Tests for the post-process output-gain wrapper. Issue #491 — the
+//! manifest calibration is in dB, so the wrapper applies a dB offset
+//! (linear `10^(db/20)`), not a percentage ratio.
+
+use super::*;
+
+struct UnitMono;
+impl MonoProcessor for UnitMono {
+    fn process_sample(&mut self, input: f32) -> f32 {
+        input
+    }
+}
+
+fn run_mono(p: &mut BlockProcessor, x: f32) -> f32 {
+    match p {
+        BlockProcessor::Mono(m) => m.process_sample(x),
+        BlockProcessor::Stereo(_) => panic!("expected mono"),
+    }
+}
+
+#[test]
+fn none_is_passthrough() {
+    let mut p = wrap_with_output_gain_db(BlockProcessor::Mono(Box::new(UnitMono)), None);
+    assert_eq!(run_mono(&mut p, 0.5), 0.5);
+}
+
+#[test]
+fn zero_db_is_passthrough() {
+    let mut p = wrap_with_output_gain_db(BlockProcessor::Mono(Box::new(UnitMono)), Some(0.0));
+    assert_eq!(run_mono(&mut p, 0.5), 0.5);
+}
+
+#[test]
+fn plus_six_db_doubles_amplitude() {
+    // +6.0206 dB == linear ×2.0 (10^(6.0206/20)).
+    let mut p = wrap_with_output_gain_db(BlockProcessor::Mono(Box::new(UnitMono)), Some(6.0206));
+    assert!((run_mono(&mut p, 0.5) - 1.0).abs() < 1e-4);
+}
+
+#[test]
+fn minus_six_db_halves_amplitude() {
+    let mut p = wrap_with_output_gain_db(BlockProcessor::Mono(Box::new(UnitMono)), Some(-6.0206));
+    assert!((run_mono(&mut p, 1.0) - 0.5).abs() < 1e-4);
+}

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -31,3 +31,10 @@ block-util = { path = "../block-util" }
 project = { path = "../project" }
 vst3-host = { path = "../vst3" }
 
+[dev-dependencies]
+plugin-loader = { path = "../plugin-loader" }
+domain = { path = "../domain" }
+nam = { path = "../nam" }
+ir = { path = "../ir" }
+block-core = { path = "../block-core" }
+

--- a/crates/engine/tests/fixtures/plugins/ir/taylor_714ce/ir/taylor_714ce_48000.wav
+++ b/crates/engine/tests/fixtures/plugins/ir/taylor_714ce/ir/taylor_714ce_48000.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f3b5417e84789633b99339e9aa6a4907f30d56ae082d5e95de0ec92ef589c8e
+size 6188

--- a/crates/engine/tests/fixtures/plugins/ir/taylor_714ce/manifest.yaml
+++ b/crates/engine/tests/fixtures/plugins/ir/taylor_714ce/manifest.yaml
@@ -1,0 +1,15 @@
+manifest_version: 1
+id: ir_taylor_714ce
+display_name: 714ce
+brand: taylor
+type: body
+backend: ir
+parameters:
+- name: flavor
+  display_name: Flavor
+  values:
+  - standard
+captures:
+- values:
+    flavor: standard
+  file: ir/taylor_714ce_48000.wav

--- a/crates/engine/tests/fixtures/plugins/nam/marshall_plexi/captures/angus_nano.nam
+++ b/crates/engine/tests/fixtures/plugins/nam/marshall_plexi/captures/angus_nano.nam
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4003dbdce22f3cf7fb979032dd12524754eaa4a39627eabfdcd4677dd0a06f6d
+size 18615

--- a/crates/engine/tests/fixtures/plugins/nam/marshall_plexi/manifest.yaml
+++ b/crates/engine/tests/fixtures/plugins/nam/marshall_plexi/manifest.yaml
@@ -1,0 +1,19 @@
+manifest_version: 1
+id: nam_marshall_plexi
+display_name: Plexi
+brand: marshall
+brand_logo: assets/brand_logo.svg
+sources:
+- https://www.tone3000.com/tones/2717
+output_gain_db: 8.9318924
+type: amp
+backend: nam
+parameters:
+- name: preset
+  display_name: Preset
+  values:
+  - angus
+captures:
+- values:
+    preset: angus
+  file: captures/angus_nano.nam

--- a/crates/engine/tests/nam_ir_chain_loudness.rs
+++ b/crates/engine/tests/nam_ir_chain_loudness.rs
@@ -1,0 +1,151 @@
+//! End-to-end loudness guard for the NAM/IR signal chain. Issue #491.
+//!
+//! THE PROPERTY UNDER TEST: a NAM plugin shipped with a measured
+//! `output_gain_db` calibration in its manifest must actually be louder
+//! by that dB amount when loaded into a real block chain. Before #491
+//! the engine read the wrong field name (`output_gain_pct`), the
+//! calibration deserialized to `None`, and every NAM played at raw model
+//! output — dramatically quieter than the calibrated reference. This
+//! test fails (no level difference) if that regression ever returns.
+//!
+//! It builds a real two-block chain from bundled minimal fixtures
+//! (real `marshall_plexi` NAM amp + real `taylor_714ce` IR body) and
+//! measures the signal level AFTER EACH BLOCK:
+//!
+//!   DI sine → [NAM amp] → measure → [IR body] → measure
+//!
+//! The regression guard is differential: the same NAM package is built
+//! twice — once with its real `output_gain_db: 8.9318924`, once with
+//! the field cleared (the pre-#491 behaviour). `output_level_db` is the
+//! NAM host's post-model output trim, so the calibrated build must be
+//! exactly that many dB louder. A near-zero delta means the calibration
+//! is dead again.
+//!
+//! No `#[ignore]`: the fixtures are bundled in-repo
+//! (`tests/fixtures/plugins/`, ~36 KB), so this always runs.
+
+use std::path::PathBuf;
+
+use block_core::param::ParameterSet;
+use block_core::{AudioChannelLayout, BlockProcessor};
+use domain::value_objects::ParameterValue;
+use plugin_loader::discover;
+use plugin_loader::discover::LoadedPackage;
+
+const SR: f32 = 48_000.0;
+/// `output_gain_db` in the bundled `marshall_plexi/manifest.yaml`.
+const PLEXI_CAL_DB: f32 = 8.931_892_4;
+
+fn fixtures_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/plugins")
+}
+
+fn load(rel_dir: &str) -> LoadedPackage {
+    let root = fixtures_root();
+    let target = root.join(rel_dir);
+    let found = discover::discover(&root).expect("discover fixture root");
+    found
+        .into_iter()
+        .filter_map(Result::ok)
+        .find(|p| p.root == target)
+        .unwrap_or_else(|| panic!("fixture package not found: {rel_dir}"))
+}
+
+/// A quiet sine — small enough that the amp stays well-behaved, so the
+/// only thing that moves the level between the calibrated and the
+/// uncalibrated build is the post-model `output_gain_db` trim.
+fn di_sine(frames: usize) -> Vec<f32> {
+    (0..frames)
+        .map(|n| 0.05 * (2.0 * std::f32::consts::PI * 110.0 * n as f32 / SR).sin())
+        .collect()
+}
+
+fn run_mono(proc: &mut BlockProcessor, input: &[f32]) -> Vec<f32> {
+    let mut buf = input.to_vec();
+    match proc {
+        BlockProcessor::Mono(m) => m.process_block(&mut buf),
+        BlockProcessor::Stereo(_) => panic!("expected a mono processor for this fixture"),
+    }
+    buf
+}
+
+/// Peak level of the steady-state tail in dBFS (skip warmup transient).
+fn steady_peak_dbfs(samples: &[f32]) -> f32 {
+    let tail = &samples[samples.len() / 2..];
+    let peak = tail.iter().fold(0.0_f32, |a, &b| a.max(b.abs()));
+    20.0 * peak.max(1e-9).log10()
+}
+
+fn assert_clean(samples: &[f32], stage: &str) {
+    assert!(
+        samples.iter().all(|s| s.is_finite()),
+        "{stage}: produced NaN/Inf"
+    );
+    assert!(
+        steady_peak_dbfs(samples) > -60.0,
+        "{stage}: signal collapsed to silence (volume lost)"
+    );
+}
+
+#[test]
+fn nam_ir_chain_keeps_calibrated_loudness_after_each_block() {
+    nam::register_builder();
+    ir::register_builder();
+
+    // ── Block 1: real NAM amp, WITH its shipped output_gain_db ──────────
+    let plexi = load("nam/marshall_plexi");
+    assert_eq!(
+        plexi.manifest.output_gain_db,
+        Some(PLEXI_CAL_DB),
+        "fixture manifest must carry the dB calibration the engine reads"
+    );
+    let mut amp_params = ParameterSet::default();
+    amp_params.insert("preset", ParameterValue::String("angus".into()));
+    let mut amp = plexi
+        .build_processor(&amp_params, SR, AudioChannelLayout::Mono)
+        .expect("NAM amp should build from the bundled fixture");
+
+    // ── Block 1 (control): same package, calibration field cleared ─────
+    // This is exactly the pre-#491 state (field deserialized to None).
+    let mut plexi_dead = plexi.clone();
+    plexi_dead.manifest.output_gain_db = None;
+    let mut amp_dead = plexi_dead
+        .build_processor(&amp_params, SR, AudioChannelLayout::Mono)
+        .expect("control NAM amp should build");
+
+    let di = di_sine(8_192);
+    let after_amp = run_mono(&mut amp, &di);
+    let after_amp_dead = run_mono(&mut amp_dead, &di);
+    assert_clean(&after_amp, "after NAM (calibrated)");
+    assert_clean(&after_amp_dead, "after NAM (uncalibrated control)");
+
+    // The calibration is a post-model linear trim, so the delta must be
+    // the manifest's dB value — not zero. Pre-#491 both builds were
+    // identical (delta ≈ 0): that is the regression this guards.
+    let delta_db = steady_peak_dbfs(&after_amp) - steady_peak_dbfs(&after_amp_dead);
+    assert!(
+        (delta_db - PLEXI_CAL_DB).abs() < 0.5,
+        "NAM calibration not applied correctly: expected ≈{PLEXI_CAL_DB:.2} dB \
+         louder than the uncalibrated control, got {delta_db:.3} dB \
+         (≈0 dB means the loudness calibration is dead again — issue #491)"
+    );
+
+    // ── Block 2: real IR body, fed the calibrated amp output ───────────
+    let cab = load("ir/taylor_714ce");
+    let mut ir_params = ParameterSet::default();
+    ir_params.insert("flavor", ParameterValue::String("standard".into()));
+    let mut body = cab
+        .build_processor(&ir_params, SR, AudioChannelLayout::Mono)
+        .expect("IR body should build from the bundled fixture");
+
+    let after_ir = run_mono(&mut body, &after_amp);
+    assert_clean(&after_ir, "after IR");
+
+    // Convolving with a real body IR reshapes the spectrum but must not
+    // silently swallow the chain — the calibrated loudness has to
+    // survive to the end of the chain.
+    assert!(
+        steady_peak_dbfs(&after_ir) > -60.0,
+        "calibrated loudness lost after the IR block (issue #491)"
+    );
+}

--- a/crates/ir/src/from_package.rs
+++ b/crates/ir/src/from_package.rs
@@ -10,7 +10,7 @@
 use anyhow::{anyhow, bail, Result};
 use block_core::param::ParameterSet;
 use block_core::{
-    wrap_with_output_gain_pct, AudioChannelLayout, BlockProcessor, MonoProcessor, StereoProcessor,
+    wrap_with_output_gain_db, AudioChannelLayout, BlockProcessor, MonoProcessor, StereoProcessor,
 };
 use plugin_loader::manifest::Backend;
 use plugin_loader::LoadedPackage;
@@ -69,13 +69,13 @@ pub fn build_from_package(
             package.manifest.id
         ),
     };
-    // Issue #440: aplica `manifest.output_gain_pct` (baseline objetivo do
-    // audit) como wrapper linear pós-convolução. IR pura é gain-passive,
-    // mas o ganho efetivo perceptual varia bastante (cab/body shapers
-    // atenuam graves diferente) — manifest pct nivela.
-    Ok(wrap_with_output_gain_pct(
+    // Issue #491: aplica `manifest.output_gain_db` (baseline objetivo do
+    // audit, em dB) como wrapper estático pós-convolução. IR pura é
+    // gain-passive, mas o ganho efetivo perceptual varia bastante
+    // (cab/body shapers atenuam graves diferente) — o offset nivela.
+    Ok(wrap_with_output_gain_db(
         processor,
-        package.manifest.output_gain_pct,
+        package.manifest.output_gain_db,
     ))
 }
 

--- a/crates/lv2/src/from_package.rs
+++ b/crates/lv2/src/from_package.rs
@@ -15,7 +15,7 @@ use std::path::PathBuf;
 use anyhow::{anyhow, bail, Result};
 use block_core::param::ParameterSet;
 use block_core::{
-    wrap_with_output_gain_pct, AudioChannelLayout, BlockProcessor, MonoProcessor, StereoProcessor,
+    wrap_with_output_gain_db, AudioChannelLayout, BlockProcessor, MonoProcessor, StereoProcessor,
 };
 use plugin_loader::dispatch::{lv2_control_value, scan_lv2_ports, Lv2Port, Lv2PortRole};
 use plugin_loader::manifest::{Backend, Lv2Slot};
@@ -192,13 +192,15 @@ pub fn build_from_package(
             package.manifest.id
         ),
     };
-    // Issue #440: aplica `manifest.output_gain_pct` (baseline objetivo do
-    // audit) como wrapper linear pós-process. NAM faz isso via
+    // Issue #491: aplica `manifest.output_gain_db` (baseline objetivo do
+    // audit, em dB) como wrapper estático pós-process. NAM faz isso via
     // `plugin_params.output_level_db`; LV2 não tem level shift embutido,
-    // então um wrapper estático é o caminho mais simples.
-    Ok(wrap_with_output_gain_pct(
+    // então um wrapper estático é o caminho mais simples. Na prática os
+    // manifests LV2 não carregam o campo (calibração é só NAM), então é
+    // no-op — mantido por consistência de contrato.
+    Ok(wrap_with_output_gain_db(
         processor,
-        package.manifest.output_gain_pct,
+        package.manifest.output_gain_db,
     ))
 }
 

--- a/crates/nam/src/from_package.rs
+++ b/crates/nam/src/from_package.rs
@@ -66,18 +66,19 @@ pub fn build_from_package(
         .to_str()
         .ok_or_else(|| anyhow!("non-utf8 capture path: {model_path:?}"))?;
     let mut plugin_params = plugin_params_from_set_with_defaults(params, DEFAULT_PLUGIN_PARAMS)?;
-    // Issue #440 (híbrido): plugin baseline via `manifest.output_gain_pct`
+    // Issue #491 (híbrido): plugin baseline via `manifest.output_gain_db`
     // + controle do usuário via `preset.volume` (aplicado no master output
-    // do engine). Em série: signal × manifest_pct × preset_volume / 100^2.
+    // do engine).
     //
-    // O manifest pct é o **baseline objetivo** calibrado pelo
-    // `nam_loudness_audit` (em OpenRig-plugins) — sem ele, plugins com
-    // recommended_output_db baked muito baixo (preamps quietos) ficam
-    // inviavelmente atenuados. O preset volume é **ajuste subjetivo** do
-    // usuário em cima desse baseline.
-    if let Some(pct) = package.manifest.output_gain_pct {
-        let ratio = (pct / 100.0).max(1e-6);
-        plugin_params.output_level_db += 20.0 * ratio.log10();
+    // O `output_gain_db` é o **baseline objetivo** calibrado pelo
+    // `nam_loudness_audit` (em OpenRig-plugins), já em dB — sem ele,
+    // plugins com recommended_output_db baked muito baixo (preamps
+    // quietos) ficam inviavelmente atenuados. Como `output_level_db`
+    // também é dB, o offset entra por **soma direta** (sem conversão
+    // percentual). O preset volume é **ajuste subjetivo** do usuário
+    // em cima desse baseline.
+    if let Some(db) = package.manifest.output_gain_db {
+        plugin_params.output_level_db += db;
     }
     plugin_params.audit_overrides_baked_output = true;
     build_processor_with_assets_for_layout(model_path_str, None, plugin_params, sample_rate, layout)

--- a/crates/nam/src/lib.rs
+++ b/crates/nam/src/lib.rs
@@ -51,7 +51,7 @@ pub fn build_processor_with_assets_for_layout(
     _sample_rate: f32,
     layout: AudioChannelLayout,
 ) -> Result<BlockProcessor> {
-    // Loudness alignment is now metadata — `output_gain_pct` baked into
+    // Loudness alignment is now metadata — `output_gain_db` baked into
     // the plugin's `manifest.yaml` by `tools/nam_loudness_audit` and
     // summed into `plugin_params.output_level_db` in
     // `from_package::build_from_package`. So this entry point is a

--- a/crates/nam/src/processor.rs
+++ b/crates/nam/src/processor.rs
@@ -130,7 +130,7 @@ pub struct NamPluginParams {
     pub bass: f32,
     pub middle: f32,
     pub treble: f32,
-    /// True quando o `output_gain_pct` do manifest (audit-populated)
+    /// True quando o `output_gain_db` do manifest (audit-populated)
     /// já está empilhado no `input_level_db`. Sinal pro NamProcessor
     /// SKIPPAR o `recommended_output_db` baked pelo trainer — senão
     /// a atenuação típica do trainer (-7 a -8 dB) come o boost do
@@ -184,7 +184,7 @@ pub fn plugin_params_from_set_with_defaults(
         middle: float_or_default(params, "eq.middle", defaults.middle)?,
         treble: float_or_default(params, "eq.treble", defaults.treble)?,
         // Não vem de `params` — é setado pelo `from_package` quando
-        // o manifest tem `output_gain_pct`. Defaults inherit do caller.
+        // o manifest tem `output_gain_db`. Defaults inherit do caller.
         audit_overrides_baked_output: defaults.audit_overrides_baked_output,
     })
 }
@@ -262,7 +262,7 @@ pub unsafe fn recommended_adjustments(model: *mut NeuralModel) -> (f32, f32) {
     )
 }
 
-// Loudness alignment lives in `manifest.output_gain_pct`, populated
+// Loudness alignment lives in `manifest.output_gain_db`, populated
 // offline by `tools/nam_loudness_audit` (issue #413). The per-NAM
 // `loudness_probe` module is kept around as the measurement engine
 // the tool uses; it does not drive gain at runtime.
@@ -335,7 +335,7 @@ impl NamProcessor {
 
         // Loudness alignment do catalog vai por dentro do
         // `params.input_level_db` (somado pelo `from_package` a
-        // partir de `manifest.output_gain_pct`). Aplicar mais signal
+        // partir de `manifest.output_gain_db`). Aplicar mais signal
         // pelo MODELO do NAM faz o amp responder com sua própria
         // curva — sem clip digital, sem virar gain linear pós-amp.
         //

--- a/crates/plugin-loader/src/manifest.rs
+++ b/crates/plugin-loader/src/manifest.rs
@@ -86,28 +86,29 @@ pub struct PluginManifest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sources: Option<Vec<String>>,
 
-    /// Output gain do plugin como PERCENTUAL multiplicativo (issue #440).
-    /// **NÃO é dB.**
+    /// Output gain do plugin como offset ADITIVO em **dB** (issue #491).
     ///
-    /// - `100.0` = unity (sem mudança no output do plugin)
-    /// - `125.0` = output × 1.25 (amplifica 25%)
-    /// - `80.0`  = output × 0.80 (atenua 20%)
+    /// - `0.0`   = unity (sem mudança no output do plugin)
+    /// - `+6.0`  = output +6 dB (≈ ×2.0 em amplitude linear)
+    /// - `-6.0`  = output −6 dB (≈ ×0.5)
     ///
     /// **Baseline de calibração**: o `nam_loudness_audit` mede cada
-    /// plugin com sinal de teste fixo e escreve `output_gain_pct` pra
-    /// que o output do plugin fique num nível razoável isolado.
-    /// Plugins NAM têm range natural de output muito variável (algumas
-    /// capturas saem em -25 LUFS, outras em 0 LUFS); o manifest pct
-    /// nivela esse baseline.
+    /// plugin com sinal de teste fixo e escreve `output_gain_db` pra
+    /// que o output do plugin fique num nível de referência calibrado
+    /// isolado. Plugins NAM têm range natural de output muito variável
+    /// (algumas capturas saem em -25 LUFS, outras em 0 LUFS); o offset
+    /// em dB do manifest nivela esse baseline.
     ///
-    /// **Combinação com `preset.volume`**: em runtime, o NAM aplica
-    /// `output_gain_pct` (baseline) e o engine multiplica por
-    /// `preset.volume / 100` (controle do usuário). Os dois entram
-    /// em série: signal × (manifest_pct/100) × (preset_volume/100).
+    /// **Combinação com `preset.volume`**: em runtime, o backend soma
+    /// `output_gain_db` (baseline) ao nível do plugin e o engine aplica
+    /// `preset.volume` (controle do usuário) por cima. Os dois entram
+    /// em série.
     ///
-    /// Ausente = `100.0` (default unity).
+    /// Ausente = `0.0 dB` (default unity). É o **mesmo nome e unidade**
+    /// que o `nam_loudness_audit` escreve — contrato cross-repo single
+    /// source of truth, sem serde alias.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub output_gain_pct: Option<f32>,
+    pub output_gain_db: Option<f32>,
 
     /// Which block category this plugin belongs to.
     #[serde(rename = "type")]

--- a/crates/plugin-loader/src/manifest_tests.rs
+++ b/crates/plugin-loader/src/manifest_tests.rs
@@ -181,7 +181,7 @@ fn round_trip_nam_preserves_data() {
         license: None,
         homepage: None,
         sources: None,
-        output_gain_pct: None,
+        output_gain_db: None,
         block_type: BlockType::Preamp,
         backend: Backend::Nam {
             parameters: vec![GridParameter {
@@ -199,6 +199,37 @@ fn round_trip_nam_preserves_data() {
     let yaml = serde_yaml::to_string(&original).expect("serialize");
     let decoded: PluginManifest = serde_yaml::from_str(&yaml).expect("deserialize");
     assert_eq!(original, decoded);
+}
+
+#[test]
+fn nam_manifest_surfaces_output_gain_db_calibration_to_engine() {
+    // Issue #491: every shipped NAM manifest carries the measured loudness
+    // offset under `output_gain_db` (dB, written by `nam_loudness_audit`).
+    // The engine must read that exact key+unit, or the calibration is
+    // silently dead (field deserializes to None, plugin plays at raw level).
+    // This is a production-shaped manifest copied from `plugins/source/`.
+    let yaml = r#"
+manifest_version: 1
+id: calibrated_amp
+display_name: Calibrated Amp
+type: amp
+backend: nam
+output_gain_db: 13.0556831
+parameters:
+  - name: gain
+    values: [5]
+captures:
+  - values: { gain: 5 }
+    file: captures/g5.nam
+"#;
+
+    let m = parse(yaml);
+
+    assert_eq!(
+        m.output_gain_db,
+        Some(13.0556831),
+        "manifest output_gain_db calibration must reach the engine in dB, unchanged"
+    );
 }
 
 #[test]

--- a/crates/plugin-loader/src/package_tests.rs
+++ b/crates/plugin-loader/src/package_tests.rs
@@ -63,7 +63,7 @@ fn nam_manifest(captures: Vec<GridCapture>) -> PluginManifest {
         license: None,
         homepage: None,
         sources: None,
-        output_gain_pct: None,
+        output_gain_db: None,
         block_type: BlockType::Preamp,
         backend: Backend::Nam {
             parameters: vec![GridParameter {
@@ -121,7 +121,7 @@ fn accepts_ir_package_with_existing_wav() {
         license: None,
         homepage: None,
         sources: None,
-        output_gain_pct: None,
+        output_gain_db: None,
         block_type: BlockType::Cab,
         backend: Backend::Ir {
             parameters: vec![],
@@ -147,7 +147,7 @@ fn lv2_manifest(binaries: BTreeMap<Lv2Slot, PathBuf>) -> PluginManifest {
         license: None,
         homepage: None,
         sources: None,
-        output_gain_pct: None,
+        output_gain_db: None,
         block_type: BlockType::GainPedal,
         backend: Backend::Lv2 {
             plugin_uri: "urn:test:plugin".to_string(),

--- a/crates/plugin-loader/src/registry.rs
+++ b/crates/plugin-loader/src/registry.rs
@@ -76,7 +76,7 @@ pub fn register_native_simple(
         brand: brand.map(str::to_string),
         thumbnail: None,
         photo: None,
-        output_gain_pct: None,
+        output_gain_db: None,
         screenshot: None,
         brand_logo: None,
         license: Some("internal".to_string()),

--- a/crates/plugin-loader/src/validate_tests.rs
+++ b/crates/plugin-loader/src/validate_tests.rs
@@ -19,7 +19,7 @@ fn nam_manifest(parameters: Vec<GridParameter>, captures: Vec<GridCapture>) -> P
         license: None,
         homepage: None,
         sources: None,
-        output_gain_pct: None,
+        output_gain_db: None,
         block_type: BlockType::Preamp,
         backend: Backend::Nam {
             parameters,
@@ -44,7 +44,7 @@ fn lv2_manifest() -> PluginManifest {
         license: None,
         homepage: None,
         sources: None,
-        output_gain_pct: None,
+        output_gain_db: None,
         block_type: BlockType::GainPedal,
         backend: Backend::Lv2 {
             plugin_uri: "urn:test:plugin".to_string(),
@@ -368,7 +368,7 @@ fn accepts_ir_with_no_parameters_and_one_capture() {
         license: None,
         homepage: None,
         sources: None,
-        output_gain_pct: None,
+        output_gain_db: None,
         block_type: BlockType::Cab,
         backend: Backend::Ir {
             parameters: vec![],

--- a/crates/project/src/block/dispatch.rs
+++ b/crates/project/src/block/dispatch.rs
@@ -124,7 +124,7 @@ pub(crate) fn synthesize_parameters_from_manifest(
                 parameters.iter().map(grid_parameter_to_spec).collect();
             // Keep input_db / noise_gate.* / eq.* but drop output_db —
             // issue #402 moved per-NAM loudness compensation into the
-            // manifest's `output_gain_pct` field (applied automatically
+            // manifest's `output_gain_db` field (applied automatically
             // by the loader) so users no longer see / fight a level
             // knob.
             specs.extend(
@@ -517,7 +517,7 @@ mod tests {
                 license: None,
                 homepage: None,
                 sources: None,
-                output_gain_pct: None,
+                output_gain_db: None,
                 block_type: BlockType::Amp,
                 backend: Backend::Nam {
                     parameters: vec![GridParameter {
@@ -537,7 +537,7 @@ mod tests {
     #[test]
     fn nam_synthesized_schema_does_not_expose_output_db_knob() {
         // Issue #402: loudness compensation is per-package, baked into
-        // the manifest's `output_gain_pct` by the audit tool. The user
+        // the manifest's `output_gain_db` by the audit tool. The user
         // does NOT see a knob — every NAM is meant to ride at the same
         // perceived level out of the box.
         let pkg = nam_package_with_axes();
@@ -571,7 +571,7 @@ mod tests {
                 license: None,
                 homepage: None,
                 sources: None,
-                output_gain_pct: None,
+                output_gain_db: None,
                 block_type: BlockType::Amp,
                 backend: Backend::Nam {
                     parameters: vec![GridParameter {

--- a/crates/project/tests/disk_package_schema.rs
+++ b/crates/project/tests/disk_package_schema.rs
@@ -148,7 +148,7 @@ binaries:
     // (input_db/noise_gate.{enabled,threshold_db}/eq.{enabled,bass,middle,treble})
     // restored by the disk-package synthesizer post-#287 migration. The
     // 8th NAM-standard knob (output_db) is intentionally dropped — issue
-    // #402 moved per-NAM loudness compensation into manifest.output_gain_pct.
+    // #402 moved per-NAM loudness compensation into manifest.output_gain_db.
     assert_eq!(amp_schema.parameters.len(), 9);
 
     // ── IR: one text axis → one enum parameter ──


### PR DESCRIPTION
## Problem (issue #491)

Every shipped NAM manifest carries the audit-measured loudness offset under `output_gain_db` (dB), but the engine deserialized `output_gain_pct`. The unknown key dropped silently to `None`, so every NAM plugin played at raw model output — dramatically quieter than the calibrated reference. Field name **and** unit had drifted across the OpenRig ↔ OpenRig-plugins boundary with no error, no gate.

## Fix — Option A (engine changes; manifests and `nam_loudness_audit` untouched)

- `plugin-loader/src/manifest.rs`: field `output_gain_pct` → **`output_gain_db`** (dB, additive). Doc rewritten; **no `serde(alias)`** — single source of truth.
- `nam/src/from_package.rs`: **direct sum** `output_level_db += db` (removed the `20*log10(pct/100)` conversion).
- `block-core/src/traits.rs`: `wrap_with_output_gain_pct` → `wrap_with_output_gain_db` (`10^(db/20)`); re-export updated.
- `ir/` + `lv2/from_package.rs`: dB wrapper. Each manifest carries its own `output_gain_db`; applied by whichever backend has it (NAM via `output_level_db`, IR/LV2 via wrapper). Absent field = 0 dB = unity.
- Stale doc comments fixed in the same change (`nam/processor.rs`, `nam/lib.rs`, `project/block/dispatch.rs`, `manifest.rs`). **Zero `output_gain_pct` left** in the codebase. Nothing hardcoded — production reads each manifest verbatim.

## Tests (TDD red-first, both seen failing before the fix)

- `manifest_tests.rs::nam_manifest_surfaces_output_gain_db_calibration_to_engine` — the cross-repo contract (E0609 before).
- `block-core traits::tests` — 4 dB-math tests for `wrap_with_output_gain_db`.
- **`engine/tests/nam_ir_chain_loudness.rs`** — end-to-end guard: real two-block chain (bundled minimal real fixtures, marshall_plexi NAM amp → taylor_714ce IR body), measures level after each block. Differential guard: same NAM built with the real `output_gain_db: 8.93` vs field cleared → calibrated build must be exactly that many dB louder. **Proven real**: reverting only the production application collapses the delta to `0.000 dB` and the test FAILs; restoring returns to green. No `#[ignore]`.

## Audio invariants

Per-stream volume path (`runtime.rs`, `volume_invariants_tests.rs`) **untouched** (zero diff vs base); pinned invariant #10 → **33 passed, 0 failed**. Plugins with no gain field: identical behaviour (None→None, 0 dB). The only volume change is the NAM calibration coming alive — the explicit goal of #491.

## Quality gate (`qg --base origin/feature/issue-436`)

| metric | base | pr | verdict |
|---|---|---|---|
| fmt | 0 | 7 | ❌ regressed — **false positive, see below** |
| lint | 18 | 18 | ✅ same |
| build | 0 | 0 | ✅ same |
| test fails | 0 | 0 | ✅ same |
| complexity | 63 | 63 | ✅ same |
| coverage | — | — | ✅ improved |

The 7 fmt errors are entirely in `adapter-console/src/main.rs` and `adapter-mcp/src/{server,tools}.rs` — files **not touched by this PR** and **byte-identical to `origin/feature/issue-436`** (`git diff origin/feature/issue-436 -- <those files>` is empty). Pre-existing base/#165 debt, the documented sibling-base false-fmt artifact. **Zero** files changed by #491 fail `cargo fmt --check`. No bypass set, no sibling files reformatted (would inflate the PR and violate single-concern).

Base is `feature/issue-436` (this branch's fork point), so the diff is the #491 change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)