### PR TITLE
fix(gui): wrap LV2 panel parameters into rows so dense plugins fit (#500)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,6 +1834,7 @@ dependencies = [
  "log",
  "lv2",
  "nam",
+ "plugin-loader",
  "project",
  "vst3-host",
 ]

--- a/crates/adapter-gui/ui/pages/block_panel_editor.slint
+++ b/crates/adapter-gui/ui/pages/block_panel_editor.slint
@@ -228,30 +228,43 @@ export component BlockPanelEditor inherits Rectangle {
             }
         }
 
-        // ── All parameters (distributed like table columns, when no knob overlays) ──
-        // When stream data is active (tuner etc.), push params to right side
+        // ── All parameters (grid, wraps into rows when many params, when no knob overlays) ──
+        // LV2 plugins ship arbitrary control-port counts (ZaMultiComp = 27,
+        // ZamGEQ31 = 30) — the original single-row HorizontalLayout forced
+        // the host window past 1800px wide and squashed each knob to ~64px,
+        // so the user perceived "no parameters" (issue #500). We now wrap
+        // into a fixed-column grid: `max-cols` per row, vertically stacked.
+        // When stream data is active (tuner etc.), push the grid to the
+        // right side and keep the single-row look (stream blocks are
+        // never the dense LV2 case).
         property <bool> has-stream: root.block-stream-data.stream-kind != ""
             && root.block-stream-data.stream-kind != "spectrum";
-        HorizontalLayout {
-            visible: root.block-knob-overlays.length == 0
-                && root.curve-editor-points.length == 0
-                && root.multi-slider-points.length == 0;
-            alignment: stretch;
-            padding-left: parent.has-stream ? parent.width - 220px : 60px;
-            padding-right: 8px;
-            x: 0;
-            y: parent.height * 0.54;
-            width: parent.width;
-            height: 90px;
+        property <bool> params-visible:
+            root.block-knob-overlays.length == 0
+            && root.curve-editor-points.length == 0
+            && root.multi-slider-points.length == 0;
+        property <int> param-count: root.block-parameter-items.length;
+        // Must match `secondary_windows_block.slint`'s `max-cols` — they
+        // jointly drive the window width and the grid columns.
+        property <int> max-cols: 12;
+        property <int> grid-cols: param-count > 0 ? Math.min(param-count, max-cols) : 0;
+        property <length> grid-area-x: has-stream ? parent.width - 220px : 60px;
+        property <length> grid-area-w: has-stream ? 212px : parent.width - 68px;
+        property <length> grid-cell-w: grid-cols > 0 ? grid-area-w / grid-cols : 64px;
+        property <length> grid-base-y: parent.height * 0.54;
 
-            for param[pi] in root.block-parameter-items : BlockPanelParameterItem {
-                param: param;
-                panel-text: root.panel-text;
-                update-number(p, v) => { root.update-block-parameter-number(p, v); }
-                select-option(p, i) => { root.select-block-parameter-option(p, i); }
-                pick-file(p) => { root.pick-block-parameter-file(p); }
-                update-bool(p, v) => { root.update-block-parameter-bool(p, v); }
-            }
+        for param[pi] in root.block-parameter-items : BlockPanelParameterItem {
+            visible: parent.params-visible;
+            x: parent.grid-area-x + mod(pi, parent.grid-cols) * parent.grid-cell-w;
+            y: parent.grid-base-y + Math.floor(pi / parent.grid-cols) * 90px;
+            width: parent.grid-cell-w;
+            height: 90px;
+            param: param;
+            panel-text: root.panel-text;
+            update-number(p, v) => { root.update-block-parameter-number(p, v); }
+            select-option(p, i) => { root.select-block-parameter-option(p, i); }
+            pick-file(p) => { root.pick-block-parameter-file(p); }
+            update-bool(p, v) => { root.update-block-parameter-bool(p, v); }
         }
     }
 

--- a/crates/adapter-gui/ui/secondary_windows_block.slint
+++ b/crates/adapter-gui/ui/secondary_windows_block.slint
@@ -51,9 +51,19 @@ export component BlockEditorWindow inherits Window {
         && root.block-drawer-selected-type-index < root.block-type-options.length
         && root.block-type-options[root.block-drawer-selected-type-index].use_panel_editor;
 
-    // Dynamic width: each knob=56px, gap=8px, margins=80px (power btn + right padding)
+    // Parameter grid: knobs wrap into multiple rows when more than
+    // `max-cols` arrive (LV2 plugins like ZaMultiComp ship 27 control
+    // ports — without wrapping the window opened ~1800px wide and the
+    // knobs squashed to invisibility, issue #500).
+    // - cell width 64px (matches BlockPanelParameterItem layout)
+    // - margins: 60px (power button) + 8px (right padding) = 68px
+    // - max-cols 12 caps the row at 12*64 + 68 = 836px, well under the
+    //   900px minimum panel width below.
     property <int> param-count: root.block-parameter-items.length;
-    property <length> needed-width: param-count > 0 ? param-count * 64px + 80px : 520px;
+    property <int> max-cols: 12;
+    property <int> param-cols: param-count > 0 ? Math.min(param-count, max-cols) : 0;
+    property <int> param-rows: param-cols > 0 ? Math.ceil(param-count / param-cols) : 0;
+    property <length> needed-width: param-cols > 0 ? param-cols * 64px + 68px : 520px;
     private property <bool> has-eq-widget:
         root.curve-editor-points.length > 0 || root.multi-slider-points.length > 0;
     // EQ width: ~35px per band for MultiSlider, ~200px per band for CurveEditor (few bands).
@@ -76,8 +86,13 @@ export component BlockEditorWindow inherits Window {
     // controls once the size was applied explicitly (#479) — the Linux
     // WM used to over-size the window and hid the shortfall. 820px
     // fits the model picker + parameter grid + drawer with margin.
+    // Extra rows of parameters (beyond the first) each add 90px — the
+    // BlockPanelParameterItem row height. Without this, wrapped rows
+    // would render below the window's bottom edge and be invisible.
+    private property <length> param-rows-extra-height:
+        param-rows > 1 ? (param-rows - 1) * 90px : 0px;
     out property <length> panel-height:
-        root.use-panel-editor ? eq-extra-height : 820px;
+        root.use-panel-editor ? (eq-extra-height + param-rows-extra-height) : 820px;
     // EQ widget heights: CurveEditor = 280px, MultiSlider = 240px.
     // Total = header(48) + panel-height(width/4) + gap(8) + widget-height + margin(8).
     // 200px / 180px were too tight for the full -24..+24 dB range — the cap of


### PR DESCRIPTION
## Summary

LV2 plugins with many control ports (ZaMultiComp = 27, ZamGEQ31 = 30, fat1_autotune = 64) opened the block-editor window at ~1800px+ wide and squashed every knob into ~64px slots — labels elided to nothing and the user perceived "no parameters." Verified through the schema chain: all 103 LV2 disk packages already synthesize the correct parameter list; the failure was purely visual.

Switch `BlockPanelEditor` to a fixed 12-column grid that wraps into additional rows; window grows in height (90px per extra row) instead of width.

## Changes

- `crates/adapter-gui/ui/secondary_windows_block.slint` — cap `needed-width` via `max-cols = 12`; grow `panel-height` by 90px per extra row of params.
- `crates/adapter-gui/ui/pages/block_panel_editor.slint` — replace the single-row `HorizontalLayout` with an absolutely-positioned grid (`x = mod(pi, cols) * cell-w`, `y = floor(pi / cols) * 90px`). `max-cols` constant is duplicated and a comment pings the other file — they must stay in sync.

## Window sizes before / after

| Plugin | Params | Before | After |
|---|---|---|---|
| `bolliedelay` | 15 | 1040 × 275 | 900 × 365 (2 rows) |
| `tap_equalizer` | 16 | 1104 × 275 | 900 × 365 (2 rows) |
| `dragonfly_room` | 17 | 1168 × 275 | 900 × 365 (2 rows) |
| `dragonfly_hall` | 18 | 1232 × 275 | 900 × 365 (2 rows) |
| `tap_equalizer_bw` | 24 | 1616 × 275 | 900 × 365 (2 rows) |
| `zamulticomp` | 27 | 1808 × 275 | 900 × 455 (3 rows) |
| `zamgeq31` | 30 | 2000 × 275 | 900 × 455 (3 rows) |

Plugins with ≤12 params: layout unchanged (still 1 row, ≥900px wide).

## Test plan

- [x] `cargo build -p adapter-gui` → exit 0
- [x] `cargo test -p plugin-loader --test lv2_bundles_have_ports -- --ignored` → every bundle still surfaces ≥1 control port (1 passed)
- [x] All 103 LV2 disk packages return non-zero parameter counts from `project::block::schema_for_block_model` (probe across `plugin_loader::registry::packages()`)
- [ ] Smoke test in app: open `zamulticomp`, `zamgeq31`, `fat1_autotune`, `dragonfly_hall` in block editor → confirm knobs visible and arranged in rows
- [ ] Smoke test plugins with ≤12 params (`gx_sd1`, `tap_echo`, `mverb`) → confirm layout unchanged

Fixes #500