### PR TITLE
fix(gui): pure-Rust knob-wrap policy gated by unit tests (#500 follow-up)

### DIFF
--- a/crates/adapter-gui/src/block_editor_window_lifecycle.rs
+++ b/crates/adapter-gui/src/block_editor_window_lifecycle.rs
@@ -52,6 +52,63 @@ use crate::{
     MultiSliderPoint, PluginInfoWindow, ProjectChainItem,
 };
 
+/// Compute the knob-grid window dimensions in Rust and push them into
+/// the Slint `BlockEditorWindow` via its `in` properties. Must be
+/// called whenever the knob source changes (initial editor setup OR
+/// model switch inside the editor). The pure policy lives in
+/// `block_panel_dimensions` and is gated by unit tests — Slint never
+/// re-derives the wrap math. Issue #500.
+pub(crate) fn apply_panel_dimensions(win: &BlockEditorWindow) {
+    use slint::Model;
+    let overlay_count = win.get_block_knob_overlays().row_count();
+    let param_count = win.get_block_parameter_items().row_count();
+    // Slint hides the param grid when overlays are present
+    // (`block-knob-overlays.length == 0` gates `params-visible`), so
+    // the count that drives layout is whichever source actually renders.
+    let knob_count = if overlay_count > 0 {
+        overlay_count
+    } else {
+        param_count
+    };
+    let has_eq_widget = win.get_multi_slider_points().row_count() > 0
+        || win.get_curve_editor_points().row_count() > 0;
+    let type_idx = win.get_block_drawer_selected_type_index();
+    let types = win.get_block_type_options();
+    let use_panel_editor = if type_idx >= 0 {
+        types
+            .row_data(type_idx as usize)
+            .map(|t| t.use_panel_editor)
+            .unwrap_or(false)
+    } else {
+        // No selection yet — default to the panel editor so the window
+        // sizes for the upcoming knob grid instead of the form-editor
+        // fallback (which would briefly flash a 520x820 window).
+        true
+    };
+
+    let dims = crate::block_panel_dimensions::compute(
+        crate::block_panel_dimensions::PanelInputs {
+            knob_count,
+            use_panel_editor,
+            has_eq_widget,
+        },
+    );
+    win.set_panel_knob_window_width(dims.window_width_px);
+    win.set_panel_knob_window_height(dims.window_height_px);
+    win.set_panel_knob_inner_height(dims.inner_panel_height_px);
+    win.set_panel_grid_cols(dims.grid_cols as i32);
+    win.set_panel_grid_rows(dims.grid_rows as i32);
+
+    // Resize the OS window so the new dimensions take effect immediately
+    // — Linux WMs ignore Slint min/max/preferred-* without this (#479).
+    let pw = win.get_panel_width();
+    let ph = win.get_panel_height();
+    if pw.is_finite() && ph.is_finite() && pw > 0.0 && ph > 0.0 {
+        win.window()
+            .set_size(slint::WindowSize::Logical(slint::LogicalSize::new(pw, ph)));
+    }
+}
+
 pub(crate) struct BlockEditorWindowLifecycleCtx {
     pub win_draft: Rc<RefCell<Option<BlockEditorDraft>>>,
     pub win_param_items: Rc<VecModel<BlockParameterItem>>,
@@ -167,6 +224,9 @@ pub(crate) fn wire(
                     .collect::<Vec<_>>(),
             );
             win.set_eq_total_curve(eq_total.into());
+            // Re-size the window for the new knob count / EQ state
+            // (issue #500: model switch inside the editor must resize).
+            apply_panel_dimensions(&win);
             drop(draft_borrow);
             if win_draft
                 .borrow()

--- a/crates/adapter-gui/src/block_editor_window_setup.rs
+++ b/crates/adapter-gui/src/block_editor_window_setup.rs
@@ -304,10 +304,12 @@ pub(crate) fn create_and_wire(
     );
 
     // All size-driving data (params, EQ points, use_panel_editor) is set
-    // above, so the Slint-computed panel size is now final. Apply it as
-    // an explicit window size: some Linux WMs ignore Slint's
-    // min/max/preferred-* and otherwise open this window huge (#479).
-    // Harmless on macOS/Windows — it matches the existing constraints.
+    // above. Push the knob-grid dimensions through the pure Rust
+    // policy (issue #500) so Slint never re-derives the wrap math —
+    // and apply them as an explicit window size: some Linux WMs ignore
+    // Slint's min/max/preferred-* and otherwise open this window huge
+    // (#479). Harmless on macOS/Windows.
+    crate::block_editor_window_lifecycle::apply_panel_dimensions(&win);
     let pw = win.get_panel_width();
     let ph = win.get_panel_height();
     if pw.is_finite() && ph.is_finite() && pw > 0.0 && ph > 0.0 {

--- a/crates/adapter-gui/src/block_panel_dimensions.rs
+++ b/crates/adapter-gui/src/block_panel_dimensions.rs
@@ -1,0 +1,157 @@
+//! Pure dimensional layout for the block editor's `BlockPanelEditor`.
+//!
+//! Wrap policy is universal: every block kind (NAM, native, LV2, IR,
+//! VST3) that uses the panel editor must wrap its knobs into multiple
+//! rows when the count exceeds `MAX_COLS`. The exact source of the
+//! knobs (synthesized LV2 ports vs. curated `knob_layout` overlays)
+//! makes no difference — the caller hands us `knob_count` and we lay
+//! it out the same way.
+//!
+//! Living outside Slint so the policy is testable in plain Rust and
+//! shared across every code path. Slint reads the result as `in`
+//! properties and never re-derives it. Issue #500.
+
+/// Knob cell width — must match `BlockPanelParameterItem`'s natural
+/// horizontal footprint.
+pub const CELL_WIDTH_PX: f32 = 64.0;
+
+/// Horizontal padding consumed by the inner panel's chrome: 60px on
+/// the left (power button) + 8px on the right.
+pub const HORIZONTAL_MARGIN_PX: f32 = 68.0;
+
+/// Maximum columns per wrapped row. Lower values force more rows (a
+/// 10-knob plugin must wrap into two rows, not stretch into one wide
+/// strip).
+pub const MAX_COLS: usize = 6;
+
+/// Vertical spacing between rows. Strictly greater than item height so
+/// wrapped rows have breathing room.
+pub const ROW_STRIDE_PX: f32 = 100.0;
+
+/// Item height (matches `BlockPanelParameterItem` `height: 90px`).
+/// Only consumed by the test suite (clip-safety assertion) — production
+/// code uses `ROW_STRIDE_PX` instead.
+#[allow(dead_code)]
+pub const ITEM_HEIGHT_PX: f32 = 90.0;
+
+/// Minimum window width — keeps the header chrome legible even on
+/// plugins with one or two knobs.
+pub const MIN_PANEL_WIDTH_PX: f32 = 900.0;
+
+/// Baseline outer-window height for a single-row panel.
+pub const BASE_PANEL_HEIGHT_PX: f32 = 275.0;
+
+/// Window dimensions when no panel editor is shown (form-based editor).
+pub const FORM_EDITOR_WIDTH_PX: f32 = 520.0;
+pub const FORM_EDITOR_HEIGHT_PX: f32 = 820.0;
+
+/// Inputs to the dimension solver. Every flag that can shift the
+/// resulting window size sits here so the test matrix can enumerate
+/// combinations explicitly.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PanelInputs {
+    /// Number of knobs to render in the grid. Caller picks the
+    /// authoritative source: when curated `knob_layout` overlays are
+    /// present, use their count; otherwise use `block_parameter_items`
+    /// length. EQ blocks (see `has_eq_widget`) pass 0.
+    pub knob_count: usize,
+    /// `true` when the selected effect type renders a panel-style
+    /// editor (Amp, Cab, Dyn, Mod, Filter, …). Native form blocks
+    /// fall back to the form editor regardless of knob count.
+    pub use_panel_editor: bool,
+    /// `true` when an EQ widget (`MultiSliderControl` or
+    /// `CurveEditorControl`) is rendered instead of the knob grid.
+    pub has_eq_widget: bool,
+}
+
+impl PanelInputs {
+    #[allow(dead_code)] // used by the unit tests
+    pub const fn plain(knob_count: usize) -> Self {
+        Self {
+            knob_count,
+            use_panel_editor: true,
+            has_eq_widget: false,
+        }
+    }
+}
+
+/// Computed layout consumed by Slint.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PanelDimensions {
+    pub window_width_px: f32,
+    pub window_height_px: f32,
+    /// Columns occupied by the grid (0 when no grid renders).
+    pub grid_cols: usize,
+    /// Rows occupied by the grid (0 when no grid renders).
+    pub grid_rows: usize,
+    /// Inner Rectangle height inside `BlockPanelEditor`. Grows past
+    /// `window_width / 4` so wrapped rows stay inside the clipped
+    /// panel rectangle.
+    pub inner_panel_height_px: f32,
+}
+
+const FORM_FALLBACK: PanelDimensions = PanelDimensions {
+    window_width_px: FORM_EDITOR_WIDTH_PX,
+    window_height_px: FORM_EDITOR_HEIGHT_PX,
+    grid_cols: 0,
+    grid_rows: 0,
+    inner_panel_height_px: 0.0,
+};
+
+/// Number of columns the wrapped grid will occupy for `knob_count`.
+pub fn grid_cols(knob_count: usize) -> usize {
+    knob_count.min(MAX_COLS)
+}
+
+/// Number of rows the wrapped grid will occupy — int-safe ceil so the
+/// formula matches Slint's truncating integer division.
+pub fn grid_rows(knob_count: usize) -> usize {
+    let cols = grid_cols(knob_count);
+    if cols == 0 {
+        0
+    } else {
+        ((knob_count - 1) / cols) + 1
+    }
+}
+
+/// Solve dimensions for a given input. Pure function — every Slint
+/// branch maps to a path here, every path is unit-tested below.
+pub fn compute(inputs: PanelInputs) -> PanelDimensions {
+    if !inputs.use_panel_editor {
+        return FORM_FALLBACK;
+    }
+    if inputs.has_eq_widget {
+        return PanelDimensions {
+            window_width_px: MIN_PANEL_WIDTH_PX,
+            window_height_px: BASE_PANEL_HEIGHT_PX,
+            grid_cols: 0,
+            grid_rows: 0,
+            inner_panel_height_px: MIN_PANEL_WIDTH_PX / 4.0,
+        };
+    }
+
+    let cols = grid_cols(inputs.knob_count);
+    let rows = grid_rows(inputs.knob_count);
+    let needed_width = if cols == 0 {
+        MIN_PANEL_WIDTH_PX
+    } else {
+        cols as f32 * CELL_WIDTH_PX + HORIZONTAL_MARGIN_PX
+    };
+    let window_width = needed_width.max(MIN_PANEL_WIDTH_PX);
+    let extra_rows = rows.saturating_sub(1) as f32;
+    let window_height = BASE_PANEL_HEIGHT_PX + extra_rows * ROW_STRIDE_PX;
+    let base_inner = window_width / 4.0;
+    let inner_panel_height = base_inner + extra_rows * ROW_STRIDE_PX;
+
+    PanelDimensions {
+        window_width_px: window_width,
+        window_height_px: window_height,
+        grid_cols: cols,
+        grid_rows: rows,
+        inner_panel_height_px: inner_panel_height,
+    }
+}
+
+#[cfg(test)]
+#[path = "block_panel_dimensions_tests.rs"]
+mod tests;

--- a/crates/adapter-gui/src/block_panel_dimensions_tests.rs
+++ b/crates/adapter-gui/src/block_panel_dimensions_tests.rs
@@ -1,0 +1,348 @@
+//! Property-based coverage for `block_panel_dimensions::compute`.
+//!
+//! Every assertion below encodes a requirement stated by the user or
+//! recovered from the bug history of issue #500, NOT an echo of the
+//! current constant values. If `MAX_COLS` changes from 6 to 5 or
+//! `ROW_STRIDE_PX` from 100 to 110, these tests must still pass —
+//! the policy is what they protect, not the chosen numbers.
+//!
+//! Bug catalogue (each got a numbered property below):
+//! 1. ZaMultiComp (27 params) opened the window at ~1808px wide.
+//! 2. Dragonfly Hall (18 params) rendered every knob in one row.
+//! 3. Slint integer division returned `ceil(13/6) == 2` instead of 3,
+//!    sizing the window 1 row short and clipping the remainder.
+//! 4. The inner panel Rectangle clipped wrapped rows behind the
+//!    footer/drawer because its height was hardcoded to `width/4`.
+
+use super::*;
+
+fn dims(knob_count: usize) -> PanelDimensions {
+    compute(PanelInputs::plain(knob_count))
+}
+
+// ── Requirement 1: knobs above MAX_COLS must wrap ────────────
+// User: "a porra tem que pular de linha. nao pode ser somente horizontal".
+
+#[test]
+fn req_anything_above_max_cols_wraps() {
+    for n in (MAX_COLS + 1)..=300 {
+        assert!(
+            grid_rows(n) >= 2,
+            "n={n} produced {} rows, must wrap to ≥2",
+            grid_rows(n)
+        );
+    }
+}
+
+#[test]
+fn req_ten_knobs_wrap_into_at_least_two_rows() {
+    // User example: "se eu tiver 10 parametros por ex.. tinha que
+    // cresver vertical e ter duas linhas". This is a hard requirement
+    // independent of MAX_COLS — it constrains MAX_COLS ≤ 9.
+    assert!(
+        grid_rows(10) >= 2,
+        "ten knobs collapsed into {} row(s)",
+        grid_rows(10)
+    );
+    assert!(
+        grid_cols(10) < 10,
+        "ten knobs spread across {} cols, leaving no rows to grow into",
+        grid_cols(10)
+    );
+}
+
+#[test]
+fn req_eighteen_knobs_dragonfly_hall_wraps() {
+    // Screenshot bug: 18 knobs in one row.
+    assert!(
+        grid_rows(18) >= 3,
+        "dragonfly_hall (18 knobs) only produced {} row(s)",
+        grid_rows(18)
+    );
+}
+
+#[test]
+fn req_zamulticomp_twentyseven_knobs_wraps_into_many_rows() {
+    // 27 knobs is well past any reasonable single-row count.
+    assert!(
+        grid_rows(27) >= 4,
+        "zamulticomp (27 knobs) only produced {} row(s)",
+        grid_rows(27)
+    );
+}
+
+// ── Requirement 2: window width must stay bounded ────────────
+// Bug 1: window opened at 1808px for 27 params.
+
+#[test]
+fn req_window_width_bounded_regardless_of_count() {
+    // The window must never grow past a sane upper bound. We pick the
+    // theoretical max from the formula constants — anything wider
+    // means the wrap policy regressed.
+    let single_row_max =
+        (MAX_COLS as f32) * CELL_WIDTH_PX + HORIZONTAL_MARGIN_PX;
+    let cap = MIN_PANEL_WIDTH_PX.max(single_row_max);
+    for n in 0..=1_000 {
+        let w = dims(n).window_width_px;
+        assert!(
+            w <= cap,
+            "n={n} produced width {w}px (cap {cap}px) — wrap policy regressed"
+        );
+    }
+}
+
+#[test]
+fn req_window_never_exceeds_typical_screen_for_real_plugins() {
+    // No real LV2/NAM/IR bundle ships more than ~150 knobs; ensure the
+    // policy holds under realistic conditions and never produces a
+    // window wider than 1280px (1366p laptops still need to host it).
+    for n in 0..=200 {
+        assert!(
+            dims(n).window_width_px <= 1280.0,
+            "n={n} would not fit a 1366×768 screen"
+        );
+    }
+}
+
+// ── Requirement 3: window grows VERTICALLY, not horizontally ─
+// User: "tinha que crescer vertical e ter duas linhas".
+
+#[test]
+fn req_width_is_invariant_across_panel_counts() {
+    // Adding more knobs must not widen the window — vertical growth only.
+    let any_width = dims(1).window_width_px;
+    for n in 2..=300 {
+        assert_eq!(
+            dims(n).window_width_px, any_width,
+            "n={n} changed width to {} (expected constant)",
+            dims(n).window_width_px
+        );
+    }
+}
+
+#[test]
+fn req_height_grows_strictly_at_each_wrap_boundary() {
+    // Every additional *wrapped* row must produce a strictly taller
+    // window. The 0→1 transition is excluded (empty grid and single-
+    // row grid both use the baseline height by design — the single
+    // row fits inside the amp-head base aspect).
+    let mut last_rows = 1;
+    let mut last_height = dims(1).window_height_px;
+    for n in 2..=200 {
+        let d = dims(n);
+        if d.grid_rows > last_rows {
+            assert!(
+                d.window_height_px > last_height,
+                "n={n}: rows went {last_rows}→{} but height stayed {last_height}",
+                d.grid_rows
+            );
+            last_rows = d.grid_rows;
+            last_height = d.window_height_px;
+        }
+    }
+}
+
+#[test]
+fn req_height_monotonic_non_decreasing() {
+    let mut prev = dims(0).window_height_px;
+    for n in 1..=200 {
+        let h = dims(n).window_height_px;
+        assert!(h >= prev, "n={n}: height {h} < previous {prev}");
+        prev = h;
+    }
+}
+
+// ── Requirement 4: wrap math is correct (no off-by-one) ──────
+// Bug 3: Slint int division produced 1 row short for partial last rows.
+
+#[test]
+fn req_grid_has_capacity_for_every_knob() {
+    for n in 1..=300 {
+        let d = dims(n);
+        assert!(
+            d.grid_cols * d.grid_rows >= n,
+            "n={n}: {}×{} grid cannot hold all knobs",
+            d.grid_cols, d.grid_rows
+        );
+    }
+}
+
+#[test]
+fn req_grid_has_no_empty_trailing_row() {
+    for n in 1..=300 {
+        let d = dims(n);
+        if d.grid_rows >= 2 {
+            assert!(
+                d.grid_cols * (d.grid_rows - 1) < n,
+                "n={n}: {}×{} grid has an empty trailing row",
+                d.grid_cols, d.grid_rows
+            );
+        }
+    }
+}
+
+#[test]
+fn req_rows_monotonic_in_count() {
+    let mut prev = 0;
+    for n in 0..=300 {
+        let r = grid_rows(n);
+        assert!(r >= prev, "n={n}: rows {r} < previous {prev}");
+        prev = r;
+    }
+}
+
+#[test]
+fn req_each_row_completely_filled_except_the_last() {
+    // For any n, n = (full_rows × cols) + remainder where
+    // 0 < remainder ≤ cols (or n == 0).
+    for n in 1..=300 {
+        let d = dims(n);
+        if d.grid_rows == 1 {
+            assert!(n <= d.grid_cols);
+        } else {
+            let full = (d.grid_rows - 1) * d.grid_cols;
+            assert!(full < n, "n={n}: full rows {full} should be < n");
+            let remainder = n - full;
+            assert!(remainder > 0 && remainder <= d.grid_cols);
+        }
+    }
+}
+
+// ── Requirement 5: inner panel must clip-safely hold every row ─
+// Bug 4: rows past `root.width / 4` rendered behind the footer.
+
+#[test]
+fn req_inner_panel_holds_last_row_with_clip_safe_margin() {
+    // The first row anchors at 0.54 × base_inner (the amp-head bottom).
+    // Successive rows step by ROW_STRIDE_PX. The inner panel height
+    // must be ≥ the y-coordinate of the LAST row's bottom edge.
+    for n in 0..=300 {
+        let d = dims(n);
+        if d.grid_rows == 0 {
+            continue;
+        }
+        let base_inner = d.window_width_px / 4.0;
+        let row0_y = base_inner * 0.54;
+        let last_row_bottom = row0_y
+            + (d.grid_rows.saturating_sub(1)) as f32 * ROW_STRIDE_PX
+            + ITEM_HEIGHT_PX;
+        assert!(
+            d.inner_panel_height_px >= last_row_bottom,
+            "n={n}: inner panel {} clips last row at {}",
+            d.inner_panel_height_px, last_row_bottom
+        );
+    }
+}
+
+// ── Requirement 6: minimums and floors ───────────────────────
+
+#[test]
+fn req_panel_width_respects_minimum_floor() {
+    for n in 0..=300 {
+        let w = dims(n).window_width_px;
+        assert!(
+            w >= MIN_PANEL_WIDTH_PX,
+            "n={n}: width {w} dropped below floor {MIN_PANEL_WIDTH_PX}"
+        );
+    }
+}
+
+#[test]
+fn req_zero_knobs_panel_still_has_baseline_dimensions() {
+    // Empty knob list (transient state during model switch) must not
+    // produce a 0×0 or NaN window.
+    let d = dims(0);
+    assert!(d.window_width_px >= MIN_PANEL_WIDTH_PX);
+    assert!(d.window_height_px >= BASE_PANEL_HEIGHT_PX);
+    assert!(d.window_width_px.is_finite());
+    assert!(d.window_height_px.is_finite());
+}
+
+#[test]
+fn req_single_row_uses_baseline_height() {
+    for n in 1..=MAX_COLS {
+        assert_eq!(
+            dims(n).window_height_px, BASE_PANEL_HEIGHT_PX,
+            "n={n}: single-row case inflated the baseline"
+        );
+    }
+}
+
+// ── Requirement 7: universal across block kinds ──────────────
+// User: "isso serve para qualquer tipo de bloco e para qualquer tipo.
+//        nam, nativo, lv2.. a regra tem que ser igual".
+
+#[test]
+fn req_layout_does_not_depend_on_knob_origin() {
+    // Whether the caller derived the count from `block_knob_overlays`
+    // (curated NAM/native overlay) or `block_parameter_items` (LV2-
+    // synthesized control ports) must produce identical dimensions —
+    // both feed the same `knob_count` field.
+    for n in 0..=200 {
+        let a = compute(PanelInputs {
+            knob_count: n,
+            use_panel_editor: true,
+            has_eq_widget: false,
+        });
+        let b = compute(PanelInputs {
+            knob_count: n,
+            use_panel_editor: true,
+            has_eq_widget: false,
+        });
+        assert_eq!(a, b, "n={n}");
+    }
+}
+
+// ── Requirement 8: special modes short-circuit cleanly ───────
+
+#[test]
+fn req_form_editor_uses_fixed_fallback_dimensions() {
+    // Native form blocks bypass the wrap math.
+    for n in [0, 1, 27, 64, 1_000] {
+        let d = compute(PanelInputs {
+            knob_count: n,
+            use_panel_editor: false,
+            has_eq_widget: false,
+        });
+        assert_eq!(d.grid_rows, 0, "n={n}");
+        assert_eq!(d.window_width_px, FORM_EDITOR_WIDTH_PX, "n={n}");
+        assert_eq!(d.window_height_px, FORM_EDITOR_HEIGHT_PX, "n={n}");
+    }
+}
+
+#[test]
+fn req_eq_mode_does_not_open_the_param_grid() {
+    // EQ widgets own their own geometry (CurveEditor / MultiSlider).
+    // The param grid must collapse so the window does not inflate
+    // for an empty grid that never renders.
+    for n in [0, 1, 27, 64] {
+        let d = compute(PanelInputs {
+            knob_count: n,
+            use_panel_editor: true,
+            has_eq_widget: true,
+        });
+        assert_eq!(d.grid_cols, 0, "n={n}");
+        assert_eq!(d.grid_rows, 0, "n={n}");
+        // The Slint EQ branch sizes its own width/height; we only
+        // assert the param grid was bypassed (cols/rows = 0).
+    }
+}
+
+// ── Requirement 9: continuous correctness over a wide range ──
+// User: "300000 se forem necessario.. com todos os tipos de prametros".
+// 1..=300 covers every realistic plugin and a 4× safety margin
+// (largest catalogued plugin: fat1_autotune at 64).
+
+#[test]
+fn req_every_count_zero_to_three_hundred_is_well_formed() {
+    for n in 0..=300 {
+        let d = dims(n);
+        assert!(d.window_width_px.is_finite() && d.window_width_px > 0.0);
+        assert!(d.window_height_px.is_finite() && d.window_height_px > 0.0);
+        assert!(d.inner_panel_height_px.is_finite() && d.inner_panel_height_px >= 0.0);
+        if n > 0 {
+            assert!(d.grid_cols >= 1);
+            assert!(d.grid_rows >= 1);
+        }
+    }
+}

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -9,6 +9,7 @@ mod block_drawer_close_wiring;
 mod block_drawer_save_delete_wiring;
 mod block_editor_window_lifecycle;
 mod block_editor_window_params;
+mod block_panel_dimensions;
 mod block_editor_window_setup;
 mod block_editor_window_wiring;
 mod block_insert_callbacks;

--- a/crates/adapter-gui/ui/components/block_panel_parameter_item.slint
+++ b/crates/adapter-gui/ui/components/block_panel_parameter_item.slint
@@ -301,15 +301,16 @@ export component BlockPanelParameterItem inherits Rectangle {
     }
 
     // ── Boolean toggle (sprite) ──
-    // The toggle sprite is 33:45 (W:H ratio). Picking width=26 gives
-    // sprite-h ≈ 35, matching the 36×36 PanelKnob sprite. y=28 lines up
-    // the sprite top with the knob top so all 3 widget kinds (knob,
-    // toggle, selector) share the same vertical baseline.
+    // The toggle sprite is 33:45 (W:H ratio). width=32 gives a
+    // sprite-h ≈ 44 (closer to the 56px PanelKnob without dominating
+    // the cell). y=24 keeps the sprite top a few pixels above the knob
+    // top so the bigger switch reads as a deliberate stompbox stomp
+    // instead of a clipped knob.
     if root.param.widget_kind == "bool" : ToggleSwitch {
-        x: (parent.width - 26px) / 2;
-        y: 28px;
-        width: 26px;
-        height: 50px;
+        x: (parent.width - 32px) / 2;
+        y: 24px;
+        width: 32px;
+        height: 62px;
         checked: root.param.bool_value;
         toggled => { root.update-bool(root.param.path, !root.param.bool_value); }
     }

--- a/crates/adapter-gui/ui/pages/block_panel_editor.slint
+++ b/crates/adapter-gui/ui/pages/block_panel_editor.slint
@@ -112,7 +112,18 @@ export component BlockPanelEditor inherits Rectangle {
     private property <length> brand-strip-height: 0px;
     // EQ blocks: compact panel (no brand strip, just POWER button pinned to top).
     private property <bool> has-eq-widget: root.curve-editor-points.length > 0 || root.multi-slider-points.length > 0;
-    private property <length> panel-height: self.has-eq-widget ? 76px : root.width / 4;
+    // Parameter grid drives panel growth (issue #500 follow-up): keep the
+    // amp-head 4:1 aspect for the first row of knobs (`base-panel-height`),
+    // then add 90px per extra wrapped row so rows 2+ stay INSIDE the panel
+    // rectangle instead of being clipped by the footer/drawer below it.
+    private property <int> grid-max-cols: 6;
+    private property <int> grid-count: root.block-parameter-items.length;
+    private property <int> grid-cols: self.grid-count > 0 ? Math.min(self.grid-count, self.grid-max-cols) : 0;
+    private property <int> grid-rows: self.grid-cols > 0 ? Math.floor((self.grid-count - 1) / self.grid-cols) + 1 : 0;
+    private property <length> base-panel-height: root.width / 4;
+    private property <length> panel-height:
+        self.has-eq-widget ? 76px
+            : self.base-panel-height + Math.max(0, self.grid-rows - 1) * 90px;
     private property <length> footer-height: root.block-drawer-edit-mode ? 0px : 52px;
 
     background: #0a0a0e;
@@ -230,33 +241,28 @@ export component BlockPanelEditor inherits Rectangle {
 
         // ── All parameters (grid, wraps into rows when many params, when no knob overlays) ──
         // LV2 plugins ship arbitrary control-port counts (ZaMultiComp = 27,
-        // ZamGEQ31 = 30) — the original single-row HorizontalLayout forced
-        // the host window past 1800px wide and squashed each knob to ~64px,
-        // so the user perceived "no parameters" (issue #500). We now wrap
-        // into a fixed-column grid: `max-cols` per row, vertically stacked.
-        // When stream data is active (tuner etc.), push the grid to the
-        // right side and keep the single-row look (stream blocks are
-        // never the dense LV2 case).
+        // ZamGEQ31 = 30). Wrap into a fixed-column grid (`grid-max-cols`
+        // per row, vertically stacked). Row 0 anchors at the original
+        // amp-head bottom (0.54 of `base-panel-height`); extra rows stack
+        // 90px below. The owning panel rectangle grew accordingly so
+        // rows 2+ are not clipped by the footer/drawer (issue #500 follow-up).
+        // When a stream is active (tuner etc.) the grid is pushed to the
+        // right edge and rendered as a single dense row.
         property <bool> has-stream: root.block-stream-data.stream-kind != ""
             && root.block-stream-data.stream-kind != "spectrum";
         property <bool> params-visible:
             root.block-knob-overlays.length == 0
             && root.curve-editor-points.length == 0
             && root.multi-slider-points.length == 0;
-        property <int> param-count: root.block-parameter-items.length;
-        // Must match `secondary_windows_block.slint`'s `max-cols` — they
-        // jointly drive the window width and the grid columns.
-        property <int> max-cols: 12;
-        property <int> grid-cols: param-count > 0 ? Math.min(param-count, max-cols) : 0;
         property <length> grid-area-x: has-stream ? parent.width - 220px : 60px;
         property <length> grid-area-w: has-stream ? 212px : parent.width - 68px;
-        property <length> grid-cell-w: grid-cols > 0 ? grid-area-w / grid-cols : 64px;
-        property <length> grid-base-y: parent.height * 0.54;
+        property <length> grid-cell-w: root.grid-cols > 0 ? grid-area-w / root.grid-cols : 64px;
+        property <length> grid-base-y: root.base-panel-height * 0.54;
 
         for param[pi] in root.block-parameter-items : BlockPanelParameterItem {
             visible: parent.params-visible;
-            x: parent.grid-area-x + mod(pi, parent.grid-cols) * parent.grid-cell-w;
-            y: parent.grid-base-y + Math.floor(pi / parent.grid-cols) * 90px;
+            x: parent.grid-area-x + mod(pi, root.grid-cols) * parent.grid-cell-w;
+            y: parent.grid-base-y + Math.floor(pi / root.grid-cols) * 90px;
             width: parent.grid-cell-w;
             height: 90px;
             param: param;

--- a/crates/adapter-gui/ui/pages/block_panel_editor.slint
+++ b/crates/adapter-gui/ui/pages/block_panel_editor.slint
@@ -35,6 +35,11 @@ export component BlockPanelEditor inherits Rectangle {
     in property <[string]> eq-band-curves;
     in property <string> block-drawer-confirm-label: @tr("btn-add");
     in property <BlockStreamData> block-stream-data;
+    // Knob-grid dimensions — driven by Rust (`block_panel_dimensions`).
+    // See secondary_windows_block.slint for the source of truth.
+    in property <length> panel-knob-inner-height: 225px;
+    in property <int> panel-grid-cols: 0;
+    in property <int> panel-grid-rows: 0;
 
     callback choose-block-model(int);
     callback choose-block-model-by-id(string);
@@ -112,21 +117,17 @@ export component BlockPanelEditor inherits Rectangle {
     private property <length> brand-strip-height: 0px;
     // EQ blocks: compact panel (no brand strip, just POWER button pinned to top).
     private property <bool> has-eq-widget: root.curve-editor-points.length > 0 || root.multi-slider-points.length > 0;
-    // Parameter grid drives panel growth (issue #500 follow-up): keep the
-    // amp-head 4:1 aspect for the first row of knobs (`base-panel-height`),
-    // then add `grid-row-stride` per extra wrapped row so rows 2+ stay
-    // INSIDE the panel rectangle instead of being clipped by the footer/
-    // drawer below it. Stride > item height (90px) leaves a vertical gap
-    // between rows so wrapped knobs do not feel cramped.
-    private property <int> grid-max-cols: 6;
+    // Panel-height is driven by the Rust knob-grid policy
+    // (`block_panel_dimensions`): the inner Rectangle grows past the
+    // amp-head 4:1 aspect so wrapped rows (knob overlays OR param
+    // items, the count source does not matter) stay inside it instead
+    // of being clipped by the footer / drawer below.
+    // `grid-row-stride` is the vertical step between wrapped rows;
+    // must match `block_panel_dimensions::ROW_STRIDE_PX`.
     private property <length> grid-row-stride: 100px;
-    private property <int> grid-count: root.block-parameter-items.length;
-    private property <int> grid-cols: self.grid-count > 0 ? Math.min(self.grid-count, self.grid-max-cols) : 0;
-    private property <int> grid-rows: self.grid-cols > 0 ? Math.floor((self.grid-count - 1) / self.grid-cols) + 1 : 0;
     private property <length> base-panel-height: root.width / 4;
     private property <length> panel-height:
-        self.has-eq-widget ? 76px
-            : self.base-panel-height + Math.max(0, self.grid-rows - 1) * self.grid-row-stride;
+        self.has-eq-widget ? 76px : root.panel-knob-inner-height;
     private property <length> footer-height: root.block-drawer-edit-mode ? 0px : 52px;
 
     background: #0a0a0e;
@@ -202,70 +203,60 @@ export component BlockPanelEditor inherits Rectangle {
             model-font: root.model-font;
         }
 
-        // ── Knob overlays (distributed like table columns) ──
-        HorizontalLayout {
-            visible: root.block-knob-overlays.length > 0;
-            alignment: stretch;
-            padding-left: 60px;
-            padding-right: 8px;
-            x: 0;
-            y: parent.height * 0.54;
-            width: parent.width;
-            height: 90px;
-
-            for knob[ki] in root.block-knob-overlays : Rectangle {
-                horizontal-stretch: 1;
-                height: 90px;
-
-                Text {
-                    x: 0; y: 0; width: parent.width; height: 14px;
-                    text: knob.label;
-                    color: root.panel-text;
-                    font-family: "Bebas Neue";
-                    font-size: 10px;
-                    letter-spacing: 1.5px;
-                    horizontal-alignment: center;
-                    overflow: elide;
-                }
-
-                PanelKnob {
-                    x: (parent.width - 36px) / 2; y: 28px;
-                    width: 36px;
-                    height: 56px;
-                    value: knob.value;
-                    min-val: knob.min_val;
-                    max-val: knob.max_val;
-                    step: knob.step;
-                    path: knob.path;
-                    changed(p, v) => { root.update-block-parameter-number(p, v); }
-                }
-            }
-        }
-
-        // ── All parameters (grid, wraps into rows when many params, when no knob overlays) ──
-        // LV2 plugins ship arbitrary control-port counts (ZaMultiComp = 27,
-        // ZamGEQ31 = 30). Wrap into a fixed-column grid (`grid-max-cols`
-        // per row, vertically stacked). Row 0 anchors at the original
-        // amp-head bottom (0.54 of `base-panel-height`); extra rows stack
-        // 90px below. The owning panel rectangle grew accordingly so
-        // rows 2+ are not clipped by the footer/drawer (issue #500 follow-up).
-        // When a stream is active (tuner etc.) the grid is pushed to the
-        // right edge and rendered as a single dense row.
+        // ── Knob grid (overlays OR params, never both) ──
+        // The wrap policy is universal: knob_overlays (curated NAM /
+        // native layouts) and block_parameter_items (LV2-synthesized
+        // ControlIn ports) feed into the same grid with the same
+        // `panel-grid-cols` / `panel-grid-rows` chosen by Rust.
+        // When a stream is active (tuner etc.) the grid is pushed to
+        // the right edge and rendered as a single dense row.
         property <bool> has-stream: root.block-stream-data.stream-kind != ""
             && root.block-stream-data.stream-kind != "spectrum";
-        property <bool> params-visible:
-            root.block-knob-overlays.length == 0
+        property <bool> show-overlays: root.block-knob-overlays.length > 0;
+        property <bool> show-params:
+            !self.show-overlays
             && root.curve-editor-points.length == 0
             && root.multi-slider-points.length == 0;
         property <length> grid-area-x: has-stream ? parent.width - 220px : 60px;
         property <length> grid-area-w: has-stream ? 212px : parent.width - 68px;
-        property <length> grid-cell-w: root.grid-cols > 0 ? grid-area-w / root.grid-cols : 64px;
+        property <length> grid-cell-w:
+            root.panel-grid-cols > 0 ? self.grid-area-w / root.panel-grid-cols : 64px;
         property <length> grid-base-y: root.base-panel-height * 0.54;
 
+        for knob[ki] in root.block-knob-overlays : Rectangle {
+            visible: parent.show-overlays;
+            x: parent.grid-area-x + mod(ki, root.panel-grid-cols) * parent.grid-cell-w;
+            y: parent.grid-base-y + Math.floor(ki / root.panel-grid-cols) * root.grid-row-stride;
+            width: parent.grid-cell-w;
+            height: 90px;
+
+            Text {
+                x: 0; y: 0; width: parent.width; height: 14px;
+                text: knob.label;
+                color: root.panel-text;
+                font-family: "Bebas Neue";
+                font-size: 10px;
+                letter-spacing: 1.5px;
+                horizontal-alignment: center;
+                overflow: elide;
+            }
+            PanelKnob {
+                x: (parent.width - 36px) / 2; y: 28px;
+                width: 36px;
+                height: 56px;
+                value: knob.value;
+                min-val: knob.min_val;
+                max-val: knob.max_val;
+                step: knob.step;
+                path: knob.path;
+                changed(p, v) => { root.update-block-parameter-number(p, v); }
+            }
+        }
+
         for param[pi] in root.block-parameter-items : BlockPanelParameterItem {
-            visible: parent.params-visible;
-            x: parent.grid-area-x + mod(pi, root.grid-cols) * parent.grid-cell-w;
-            y: parent.grid-base-y + Math.floor(pi / root.grid-cols) * root.grid-row-stride;
+            visible: parent.show-params;
+            x: parent.grid-area-x + mod(pi, root.panel-grid-cols) * parent.grid-cell-w;
+            y: parent.grid-base-y + Math.floor(pi / root.panel-grid-cols) * root.grid-row-stride;
             width: parent.grid-cell-w;
             height: 90px;
             param: param;

--- a/crates/adapter-gui/ui/pages/block_panel_editor.slint
+++ b/crates/adapter-gui/ui/pages/block_panel_editor.slint
@@ -36,10 +36,31 @@ export component BlockPanelEditor inherits Rectangle {
     in property <string> block-drawer-confirm-label: @tr("btn-add");
     in property <BlockStreamData> block-stream-data;
     // Knob-grid dimensions — driven by Rust (`block_panel_dimensions`).
-    // See secondary_windows_block.slint for the source of truth.
+    // See secondary_windows_block.slint for the source of truth. Defaults
+    // are a safety net: if Rust pushes before first render (the happy
+    // path), they are overwritten; if the first paint races ahead, the
+    // fallback below recomputes from the model lengths so we never
+    // divide by zero or render NaN positions.
     in property <length> panel-knob-inner-height: 225px;
     in property <int> panel-grid-cols: 0;
     in property <int> panel-grid-rows: 0;
+
+    // Fallback constants — keep in sync with
+    // `block_panel_dimensions::MAX_COLS` / `ROW_STRIDE_PX`. The Rust
+    // policy is the source of truth (gated by unit tests); the Slint
+    // formula below only fires when the Rust value has not been
+    // pushed yet.
+    private property <int> grid-max-cols-fallback: 6;
+    private property <int> knob-count-fallback:
+        root.block-knob-overlays.length > 0
+            ? root.block-knob-overlays.length
+            : root.block-parameter-items.length;
+    private property <int> effective-grid-cols:
+        root.panel-grid-cols > 0
+            ? root.panel-grid-cols
+            : (self.knob-count-fallback > 0
+                ? Math.min(self.knob-count-fallback, self.grid-max-cols-fallback)
+                : 1);
 
     callback choose-block-model(int);
     callback choose-block-model-by-id(string);
@@ -220,13 +241,13 @@ export component BlockPanelEditor inherits Rectangle {
         property <length> grid-area-x: has-stream ? parent.width - 220px : 60px;
         property <length> grid-area-w: has-stream ? 212px : parent.width - 68px;
         property <length> grid-cell-w:
-            root.panel-grid-cols > 0 ? self.grid-area-w / root.panel-grid-cols : 64px;
+            root.effective-grid-cols > 0 ? self.grid-area-w / root.effective-grid-cols : 64px;
         property <length> grid-base-y: root.base-panel-height * 0.54;
 
         for knob[ki] in root.block-knob-overlays : Rectangle {
             visible: parent.show-overlays;
-            x: parent.grid-area-x + mod(ki, root.panel-grid-cols) * parent.grid-cell-w;
-            y: parent.grid-base-y + Math.floor(ki / root.panel-grid-cols) * root.grid-row-stride;
+            x: parent.grid-area-x + mod(ki, root.effective-grid-cols) * parent.grid-cell-w;
+            y: parent.grid-base-y + Math.floor(ki / root.effective-grid-cols) * root.grid-row-stride;
             width: parent.grid-cell-w;
             height: 90px;
 
@@ -255,8 +276,8 @@ export component BlockPanelEditor inherits Rectangle {
 
         for param[pi] in root.block-parameter-items : BlockPanelParameterItem {
             visible: parent.show-params;
-            x: parent.grid-area-x + mod(pi, root.panel-grid-cols) * parent.grid-cell-w;
-            y: parent.grid-base-y + Math.floor(pi / root.panel-grid-cols) * root.grid-row-stride;
+            x: parent.grid-area-x + mod(pi, root.effective-grid-cols) * parent.grid-cell-w;
+            y: parent.grid-base-y + Math.floor(pi / root.effective-grid-cols) * root.grid-row-stride;
             width: parent.grid-cell-w;
             height: 90px;
             param: param;

--- a/crates/adapter-gui/ui/pages/block_panel_editor.slint
+++ b/crates/adapter-gui/ui/pages/block_panel_editor.slint
@@ -114,16 +114,19 @@ export component BlockPanelEditor inherits Rectangle {
     private property <bool> has-eq-widget: root.curve-editor-points.length > 0 || root.multi-slider-points.length > 0;
     // Parameter grid drives panel growth (issue #500 follow-up): keep the
     // amp-head 4:1 aspect for the first row of knobs (`base-panel-height`),
-    // then add 90px per extra wrapped row so rows 2+ stay INSIDE the panel
-    // rectangle instead of being clipped by the footer/drawer below it.
+    // then add `grid-row-stride` per extra wrapped row so rows 2+ stay
+    // INSIDE the panel rectangle instead of being clipped by the footer/
+    // drawer below it. Stride > item height (90px) leaves a vertical gap
+    // between rows so wrapped knobs do not feel cramped.
     private property <int> grid-max-cols: 6;
+    private property <length> grid-row-stride: 100px;
     private property <int> grid-count: root.block-parameter-items.length;
     private property <int> grid-cols: self.grid-count > 0 ? Math.min(self.grid-count, self.grid-max-cols) : 0;
     private property <int> grid-rows: self.grid-cols > 0 ? Math.floor((self.grid-count - 1) / self.grid-cols) + 1 : 0;
     private property <length> base-panel-height: root.width / 4;
     private property <length> panel-height:
         self.has-eq-widget ? 76px
-            : self.base-panel-height + Math.max(0, self.grid-rows - 1) * 90px;
+            : self.base-panel-height + Math.max(0, self.grid-rows - 1) * self.grid-row-stride;
     private property <length> footer-height: root.block-drawer-edit-mode ? 0px : 52px;
 
     background: #0a0a0e;
@@ -262,7 +265,7 @@ export component BlockPanelEditor inherits Rectangle {
         for param[pi] in root.block-parameter-items : BlockPanelParameterItem {
             visible: parent.params-visible;
             x: parent.grid-area-x + mod(pi, root.grid-cols) * parent.grid-cell-w;
-            y: parent.grid-base-y + Math.floor(pi / root.grid-cols) * 90px;
+            y: parent.grid-base-y + Math.floor(pi / root.grid-cols) * root.grid-row-stride;
             width: parent.grid-cell-w;
             height: 90px;
             param: param;

--- a/crates/adapter-gui/ui/secondary_windows_block.slint
+++ b/crates/adapter-gui/ui/secondary_windows_block.slint
@@ -52,17 +52,19 @@ export component BlockEditorWindow inherits Window {
         && root.block-type-options[root.block-drawer-selected-type-index].use_panel_editor;
 
     // Parameter grid: knobs wrap into multiple rows when more than
-    // `max-cols` arrive (LV2 plugins like ZaMultiComp ship 27 control
-    // ports — without wrapping the window opened ~1800px wide and the
-    // knobs squashed to invisibility, issue #500).
-    // - cell width 64px (matches BlockPanelParameterItem layout)
-    // - margins: 60px (power button) + 8px (right padding) = 68px
-    // - max-cols 12 caps the row at 12*64 + 68 = 836px, well under the
-    //   900px minimum panel width below.
+    // `max-cols` arrive (issue #500 — LV2 plugins like ZaMultiComp = 27
+    // ports). Six columns per row is a deliberate UX choice: a 10-knob
+    // pedal renders as 5+5 / 6+4, not a single ultra-wide strip.
+    // - `max-cols` must match `block_panel_editor.slint`'s `grid-max-cols`.
+    // - `param-rows` uses int-safe ceil — Slint's `int / int` truncates,
+    //   so naive `Math.ceil(param-count / param-cols)` returned 2 for
+    //   27 params instead of 5, leaving rows 3-5 clipped (the bug behind
+    //   the all-empty ZaMultiComp window in the issue #500 follow-up).
     property <int> param-count: root.block-parameter-items.length;
-    property <int> max-cols: 12;
+    property <int> max-cols: 6;
     property <int> param-cols: param-count > 0 ? Math.min(param-count, max-cols) : 0;
-    property <int> param-rows: param-cols > 0 ? Math.ceil(param-count / param-cols) : 0;
+    property <int> param-rows:
+        param-cols > 0 ? Math.floor((param-count - 1) / param-cols) + 1 : 0;
     property <length> needed-width: param-cols > 0 ? param-cols * 64px + 68px : 520px;
     private property <bool> has-eq-widget:
         root.curve-editor-points.length > 0 || root.multi-slider-points.length > 0;
@@ -89,8 +91,11 @@ export component BlockEditorWindow inherits Window {
     // Extra rows of parameters (beyond the first) each add 90px — the
     // BlockPanelParameterItem row height. Without this, wrapped rows
     // would render below the window's bottom edge and be invisible.
+    // EQ blocks render via a dedicated widget (CurveEditor / MultiSlider)
+    // instead of the parameter grid — `param-rows` would otherwise inflate
+    // the window for an empty grid that is never shown.
     private property <length> param-rows-extra-height:
-        param-rows > 1 ? (param-rows - 1) * 90px : 0px;
+        (has-eq-widget || param-rows <= 1) ? 0px : (param-rows - 1) * 90px;
     out property <length> panel-height:
         root.use-panel-editor ? (eq-extra-height + param-rows-extra-height) : 820px;
     // EQ widget heights: CurveEditor = 280px, MultiSlider = 240px.

--- a/crates/adapter-gui/ui/secondary_windows_block.slint
+++ b/crates/adapter-gui/ui/secondary_windows_block.slint
@@ -51,55 +51,40 @@ export component BlockEditorWindow inherits Window {
         && root.block-drawer-selected-type-index < root.block-type-options.length
         && root.block-type-options[root.block-drawer-selected-type-index].use_panel_editor;
 
-    // Parameter grid: knobs wrap into multiple rows when more than
-    // `max-cols` arrive (issue #500 — LV2 plugins like ZaMultiComp = 27
-    // ports). Six columns per row is a deliberate UX choice: a 10-knob
-    // pedal renders as 5+5 / 6+4, not a single ultra-wide strip.
-    // - `max-cols` must match `block_panel_editor.slint`'s `grid-max-cols`.
-    // - `param-rows` uses int-safe ceil — Slint's `int / int` truncates,
-    //   so naive `Math.ceil(param-count / param-cols)` returned 2 for
-    //   27 params instead of 5, leaving rows 3-5 clipped (the bug behind
-    //   the all-empty ZaMultiComp window in the issue #500 follow-up).
-    property <int> param-count: root.block-parameter-items.length;
-    property <int> max-cols: 6;
-    property <int> param-cols: param-count > 0 ? Math.min(param-count, max-cols) : 0;
-    property <int> param-rows:
-        param-cols > 0 ? Math.floor((param-count - 1) / param-cols) + 1 : 0;
-    property <length> needed-width: param-cols > 0 ? param-cols * 64px + 68px : 520px;
+    // Knob-grid dimensions come from Rust (`block_panel_dimensions::compute`).
+    // The wrap policy is universal: NAM, native, IR, LV2 — every block
+    // kind that uses the panel editor goes through the same Rust formula
+    // and reads back the result via these `in` properties. The math is
+    // covered by `block_panel_dimensions_tests`; do not re-derive it here.
+    in property <length> panel-knob-window-width: 900px;
+    in property <length> panel-knob-window-height: 275px;
+    in property <length> panel-knob-inner-height: 225px;
+    in property <int> panel-grid-cols: 0;
+    in property <int> panel-grid-rows: 0;
+
     private property <bool> has-eq-widget:
         root.curve-editor-points.length > 0 || root.multi-slider-points.length > 0;
     // EQ width: ~35px per band for MultiSlider, ~200px per band for CurveEditor (few bands).
-    // (panel-height = panel-width/4; minimum 600px keeps the power-button label visible.)
     private property <length> eq-panel-width:
         multi-slider-points.length > 0 ?
             Math.max(600px, Math.min(1400px, multi-slider-points.length * 35px + 80px)) :
         curve-editor-points.length > 0 ?
             Math.max(600px, Math.min(1200px, curve-editor-points.length * 200px + 80px)) :
             600px;
-    // `out` so the Rust side can read the computed size and call
-    // window().set_size() explicitly. Without an explicit set_size some
-    // Linux WMs ignore min/max/preferred-* and open the window huge
-    // (issue #479); the main AppWindow already sets its size in Rust.
+    // Outer-window dimensions. EQ branch keeps its dedicated widget
+    // formula; everything else reads the Rust-computed knob-grid sizes
+    // (single source of truth for #500). Rust calls `window().set_size()`
+    // with these values right after populating the param/overlay model
+    // — Linux WMs ignore min/max/preferred-* without that explicit call
+    // (#479).
     out property <length> panel-width:
         root.use-panel-editor ?
-            (has-eq-widget ? eq-panel-width : Math.max(900px, needed-width)) :
+            (has-eq-widget ? eq-panel-width : panel-knob-window-width) :
             520px;
-    // Non-panel editor (form/knob blocks): 640px clipped the lower
-    // controls once the size was applied explicitly (#479) — the Linux
-    // WM used to over-size the window and hid the shortfall. 820px
-    // fits the model picker + parameter grid + drawer with margin.
-    // Extra rows of parameters (beyond the first) each add `row-stride`.
-    // Must match `block_panel_editor.slint`'s `grid-row-stride` — they
-    // jointly position rows and size the outer window. Stride > item
-    // height (90px) leaves visible breathing room between wrapped rows.
-    // EQ blocks render via a dedicated widget (CurveEditor / MultiSlider)
-    // instead of the parameter grid — `param-rows` would otherwise inflate
-    // the window for an empty grid that is never shown.
-    private property <length> row-stride: 100px;
-    private property <length> param-rows-extra-height:
-        (has-eq-widget || param-rows <= 1) ? 0px : (param-rows - 1) * row-stride;
     out property <length> panel-height:
-        root.use-panel-editor ? (eq-extra-height + param-rows-extra-height) : 820px;
+        root.use-panel-editor ?
+            (has-eq-widget ? eq-extra-height : panel-knob-window-height) :
+            820px;
     // EQ widget heights: CurveEditor = 280px, MultiSlider = 240px.
     // Total = header(48) + panel-height(width/4) + gap(8) + widget-height + margin(8).
     // 200px / 180px were too tight for the full -24..+24 dB range — the cap of
@@ -148,6 +133,9 @@ export component BlockEditorWindow inherits Window {
         eq-band-curves: root.eq-band-curves;
         block-drawer-confirm-label: root.block-drawer-confirm-label;
         block-stream-data: root.block-stream-data;
+        panel-knob-inner-height: root.panel-knob-inner-height;
+        panel-grid-cols: root.panel-grid-cols;
+        panel-grid-rows: root.panel-grid-rows;
         choose-block-model(i) => { root.choose-block-model(i); }
         choose-block-model-by-id(mid) => { root.choose-block-model-by-id(mid); }
         search-block-model(text) => { root.search-block-model(text); }

--- a/crates/adapter-gui/ui/secondary_windows_block.slint
+++ b/crates/adapter-gui/ui/secondary_windows_block.slint
@@ -88,14 +88,16 @@ export component BlockEditorWindow inherits Window {
     // controls once the size was applied explicitly (#479) — the Linux
     // WM used to over-size the window and hid the shortfall. 820px
     // fits the model picker + parameter grid + drawer with margin.
-    // Extra rows of parameters (beyond the first) each add 90px — the
-    // BlockPanelParameterItem row height. Without this, wrapped rows
-    // would render below the window's bottom edge and be invisible.
+    // Extra rows of parameters (beyond the first) each add `row-stride`.
+    // Must match `block_panel_editor.slint`'s `grid-row-stride` — they
+    // jointly position rows and size the outer window. Stride > item
+    // height (90px) leaves visible breathing room between wrapped rows.
     // EQ blocks render via a dedicated widget (CurveEditor / MultiSlider)
     // instead of the parameter grid — `param-rows` would otherwise inflate
     // the window for an empty grid that is never shown.
+    private property <length> row-stride: 100px;
     private property <length> param-rows-extra-height:
-        (has-eq-widget || param-rows <= 1) ? 0px : (param-rows - 1) * 90px;
+        (has-eq-widget || param-rows <= 1) ? 0px : (param-rows - 1) * row-stride;
     out property <length> panel-height:
         root.use-panel-editor ? (eq-extra-height + param-rows-extra-height) : 820px;
     // EQ widget heights: CurveEditor = 280px, MultiSlider = 240px.


### PR DESCRIPTION
## Summary

Follow-up to PR #501. The first fix lived in Slint where the formula could not be unit-tested, and each follow-up regression (window 1808px wide → int-truncated rows → clipped inner panel → 18 knobs in a strip → NaN positions on first paint) was discovered by the user testing in the running app. Moving the policy into Rust with a property-based test suite stops that loop.

## Changes

- `crates/adapter-gui/src/block_panel_dimensions.rs` (new) — pure function `compute(PanelInputs) -> PanelDimensions`. Single source of truth for grid_cols, grid_rows, window width/height, inner panel height. Universal across NAM, native, IR, LV2, VST3.
- `crates/adapter-gui/src/block_panel_dimensions_tests.rs` (new) — 21 property tests built from the user's requirements and the bug catalogue, not from the chosen constants. Sweeps 0..=300 knobs.
- `crates/adapter-gui/src/block_editor_window_lifecycle.rs` — `apply_panel_dimensions(&win)` computes dims, pushes them as Slint `in` properties, then resizes the OS window. Called from initial setup AND model-switch callback.
- `crates/adapter-gui/ui/pages/block_panel_editor.slint` — `knob_overlays` now uses the SAME grid as `block_parameter_items` (was a separate `HorizontalLayout` — the cause of the Dragonfly Hall 18-in-one-row regression). `effective-grid-cols` falls back to a Slint-side count if Rust's setter races the first paint (the NaN-position bug from the Cathedral screenshot).
- `crates/adapter-gui/ui/secondary_windows_block.slint` — window-width / height read Rust-set `in` properties for the panel-editor branch; EQ branch keeps its dedicated formula.

## Layout policy (encoded in unit tests)

- `MAX_COLS = 6` — a 10-knob plugin renders 6+4, never one strip.
- `ROW_STRIDE_PX = 100` — 10px breathing room between wrapped rows (item is 90px tall).
- `BASE_PANEL_HEIGHT_PX = 275`, grows by `(rows - 1) * stride`.
- `MIN_PANEL_WIDTH_PX = 900`, never exceeds `MAX_COLS * 64 + 68 = 452` floored at 900.
- Inner panel grows past `width / 4` so wrapped rows are not clipped by the footer.

## Window-size table

| Knobs | Layout | Window |
|---|---|---|
| ≤ 6 | 1 row | 900 × 275 |
| 7–12 | 2 rows | 900 × 375 |
| 13–18 | 3 rows | 900 × 475 |
| 27 (ZaMultiComp) | 5 rows | 900 × 675 |
| 30 (ZamGEQ31) | 5 rows | 900 × 675 |
| 64 (fat1_autotune) | 11 rows | 900 × 1275 |

## Test plan

- [x] `cargo build -p adapter-gui` → exit 0
- [x] `cargo test -p adapter-gui block_panel_dimensions` → 21 passed
- [ ] Open Cathedral (native reverb, 4 params) → 4 knobs visible in a single row
- [ ] Open Dragonfly Plate Reverb (LV2, 9 params) → 6 + 3 wrap
- [ ] Open Dragonfly Hall (18 params) → 6 + 6 + 6 wrap
- [ ] Open ZaMultiComp (27 params) → 5 rows
- [ ] Switch model inside an already-open editor → window resizes to the new knob count

QG can be skipped per user request — this change is GUI layout only.