### PR TITLE
fix(plugin-loader,ir): per-capture output_gain_db reaches the audio path (#514)

### DIFF
--- a/crates/ir/src/from_package.rs
+++ b/crates/ir/src/from_package.rs
@@ -69,15 +69,29 @@ pub fn build_from_package(
             package.manifest.id
         ),
     };
-    // Issue #491: aplica `manifest.output_gain_db` (baseline objetivo do
-    // audit, em dB) como wrapper estático pós-convolução. IR pura é
-    // gain-passive, mas o ganho efetivo perceptual varia bastante
-    // (cab/body shapers atenuam graves diferente) — o offset nivela.
-    Ok(wrap_with_output_gain_db(
-        processor,
-        package.manifest.output_gain_db,
-    ))
+    // Issue #491 + #514: aplica o baseline do audit (em dB) como
+    // wrapper estático pós-convolução. IR pura é gain-passive, mas o
+    // ganho efetivo perceptual varia bastante (cab/body shapers
+    // atenuam graves diferente). Capturas IR carregam um valor por
+    // arquivo (`capture.output_gain_db`); o top-level
+    // `manifest.output_gain_db` é fallback pra plugins de baseline
+    // único.
+    let audit_db = select_audit_db(capture.output_gain_db, package.manifest.output_gain_db);
+    Ok(wrap_with_output_gain_db(processor, audit_db))
 }
+
+/// Choose the audit-baseline dB to apply, preferring the per-capture
+/// value over the manifest-level fallback. Issue #514.
+pub(crate) fn select_audit_db(
+    capture_db: Option<f32>,
+    manifest_db: Option<f32>,
+) -> Option<f32> {
+    capture_db.or(manifest_db)
+}
+
+#[cfg(test)]
+#[path = "from_package_tests.rs"]
+mod tests;
 
 /// Register this crate's builder in the global package-builders table.
 pub fn register_builder() {

--- a/crates/ir/src/from_package_tests.rs
+++ b/crates/ir/src/from_package_tests.rs
@@ -1,0 +1,28 @@
+//! Unit tests for `from_package` audit-baseline selection. Issue #514.
+
+use super::select_audit_db;
+
+#[test]
+fn per_capture_audit_takes_precedence_over_top_level() {
+    // Manifest says +6 dB top-level, but the matched capture overrides
+    // it with -10 dB. The wrapper must use the capture's value.
+    assert_eq!(select_audit_db(Some(-10.0), Some(6.0)), Some(-10.0));
+}
+
+#[test]
+fn top_level_audit_is_used_when_capture_lacks_value() {
+    // IR plugins with a uniform baseline (old format) still work.
+    assert_eq!(select_audit_db(None, Some(-4.5)), Some(-4.5));
+}
+
+#[test]
+fn capture_audit_used_when_top_level_missing() {
+    // Current shape of IR manifests in OpenRig-plugins — audit lives
+    // only on the capture.
+    assert_eq!(select_audit_db(Some(2.5), None), Some(2.5));
+}
+
+#[test]
+fn no_audit_anywhere_returns_none() {
+    assert_eq!(select_audit_db(None, None), None);
+}

--- a/crates/plugin-loader/src/dispatch_tests.rs
+++ b/crates/plugin-loader/src/dispatch_tests.rs
@@ -9,6 +9,7 @@ fn cap(values: &[(&str, f64)], file: &str) -> GridCapture {
             .map(|(k, v)| ((*k).to_string(), ManifestParameterValue::Number(*v)))
             .collect(),
         file: file.into(),
+        output_gain_db: None,
     }
 }
 

--- a/crates/plugin-loader/src/manifest.rs
+++ b/crates/plugin-loader/src/manifest.rs
@@ -273,7 +273,7 @@ pub struct GridParameter {
 }
 
 /// One cell of the NAM/IR capture grid.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GridCapture {
     /// Map of parameter name → value identifying this cell on the grid.
     /// Empty for IR plugins that have no parametric variation.
@@ -281,6 +281,14 @@ pub struct GridCapture {
     pub values: BTreeMap<String, ParameterValue>,
     /// Path to the asset (`.nam` or `.wav`) relative to the plugin folder.
     pub file: PathBuf,
+    /// Per-capture loudness audit baseline (issue #514). IR plugins
+    /// ship one value per capture because each impulse has a different
+    /// perceived level; falls back to
+    /// [`PluginManifest::output_gain_db`] when absent. Same unit/sign
+    /// convention as the top-level field (`+6.0` = +6 dB at output,
+    /// `-6.0` = −6 dB).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_gain_db: Option<f32>,
 }
 
 /// Build target slot for an LV2 binary.

--- a/crates/plugin-loader/src/manifest_tests.rs
+++ b/crates/plugin-loader/src/manifest_tests.rs
@@ -192,6 +192,7 @@ fn round_trip_nam_preserves_data() {
             captures: vec![GridCapture {
                 values: BTreeMap::from([("gain".to_string(), ParameterValue::Number(10.0))]),
                 file: PathBuf::from("captures/g10.nam"),
+                output_gain_db: None,
             }],
         },
     };
@@ -276,5 +277,89 @@ captures:
             assert_eq!(captures.len(), 6);
         }
         other => panic!("expected NAM backend, got {other:?}"),
+    }
+}
+
+// Issue #514 — per-capture output_gain_db on IR captures.
+
+#[test]
+fn parses_ir_manifest_with_per_capture_output_gain_db() {
+    let yaml = r#"
+manifest_version: 1
+id: my_body
+display_name: My Body
+type: body
+backend: ir
+parameters:
+  - name: voicing
+    display_name: Voicing
+    values: [bright, dark]
+captures:
+  - values: { voicing: bright }
+    file: ir/bright.wav
+    output_gain_db: -3.5
+  - values: { voicing: dark }
+    file: ir/dark.wav
+    output_gain_db: 1.25
+"#;
+
+    let m = parse(yaml);
+
+    match m.backend {
+        Backend::Ir { captures, .. } => {
+            assert_eq!(captures.len(), 2);
+            assert_eq!(captures[0].output_gain_db, Some(-3.5));
+            assert_eq!(captures[1].output_gain_db, Some(1.25));
+        }
+        other => panic!("expected IR backend, got {other:?}"),
+    }
+}
+
+#[test]
+fn ir_capture_without_output_gain_db_is_none() {
+    let yaml = r#"
+manifest_version: 1
+id: my_cab
+display_name: My Cab
+type: cab
+backend: ir
+captures:
+  - values: {}
+    file: ir/cab.wav
+"#;
+
+    let m = parse(yaml);
+
+    match m.backend {
+        Backend::Ir { captures, .. } => {
+            assert_eq!(captures.len(), 1);
+            assert_eq!(captures[0].output_gain_db, None);
+        }
+        other => panic!("expected IR backend, got {other:?}"),
+    }
+}
+
+#[test]
+fn per_capture_output_gain_db_round_trips_through_serde() {
+    let yaml = r#"
+manifest_version: 1
+id: rt
+display_name: Round Trip
+type: body
+backend: ir
+captures:
+  - values: {}
+    file: ir/one.wav
+    output_gain_db: -7.875
+"#;
+    let m = parse(yaml);
+    let serialized = serde_yaml::to_string(&m).expect("manifest serializes");
+    let reparsed: PluginManifest = serde_yaml::from_str(&serialized).expect("re-parse");
+
+    match reparsed.backend {
+        Backend::Ir { captures, .. } => {
+            assert_eq!(captures[0].output_gain_db, Some(-7.875));
+        }
+        other => panic!("expected IR backend, got {other:?}"),
     }
 }

--- a/crates/plugin-loader/src/package_tests.rs
+++ b/crates/plugin-loader/src/package_tests.rs
@@ -83,6 +83,7 @@ fn capture(values: &[(&str, f64)], file: &str) -> GridCapture {
             .map(|(name, value)| ((*name).to_string(), ParameterValue::Number(*value)))
             .collect(),
         file: PathBuf::from(file),
+        output_gain_db: None,
     }
 }
 

--- a/crates/plugin-loader/src/validate_tests.rs
+++ b/crates/plugin-loader/src/validate_tests.rs
@@ -62,6 +62,7 @@ fn capture_with(values: &[(&str, f64)], file: &str) -> GridCapture {
             .iter()
             .map(|(name, value)| ((*name).to_string(), ParameterValue::Number(*value)))
             .collect(),
+        output_gain_db: None,
         file: PathBuf::from(file),
     }
 }
@@ -272,6 +273,7 @@ fn accepts_sparse_grid() {
                     ),
                 ]),
                 file: PathBuf::from("a.wav"),
+                output_gain_db: None,
             },
             GridCapture {
                 values: BTreeMap::from([
@@ -282,6 +284,7 @@ fn accepts_sparse_grid() {
                     ),
                 ]),
                 file: PathBuf::from("b.wav"),
+                output_gain_db: None,
             },
             GridCapture {
                 values: BTreeMap::from([
@@ -292,6 +295,7 @@ fn accepts_sparse_grid() {
                     ),
                 ]),
                 file: PathBuf::from("c.wav"),
+                output_gain_db: None,
             },
         ],
     );


### PR DESCRIPTION
## Summary

- `GridCapture.output_gain_db: Option<f32>` (additive, backward-compatible) — the audit pipeline writes per-capture values into IR manifests but the schema dropped them silently.
- `ir::from_package` now resolves the matched capture first and wraps with `select_audit_db(capture.output_gain_db, manifest.output_gain_db)` (per-capture wins, top-level is fallback for legacy uniform-baseline plugins).
- 7 red-first tests: 3 in `manifest_tests.rs` (parse, default-None, serde round-trip) + 4 in `from_package_tests.rs` (`select_audit_db` precedence matrix).

Refs #514.

## Test plan

- [x] `cargo test -p plugin-loader --lib` (64 pass)
- [x] `cargo test -p ir --lib` (35 pass)
- [x] `cargo check --workspace --tests` clean
- [ ] Load a preset whose matched IR capture has `output_gain_db != 0.0` in the current `OpenRig-plugins` manifests and confirm the offset is audible vs. baseline.