### PR TITLE
fix(adapter-gui): preset save uses preset name, load stops duplicating I/O (#518)

### DIFF
--- a/crates/adapter-gui/src/chain_preset_wiring.rs
+++ b/crates/adapter-gui/src/chain_preset_wiring.rs
@@ -22,9 +22,11 @@ use slint::{ComponentHandle, ModelRc, SharedString, Timer, VecModel};
 
 use application::command::Command;
 use application::dispatcher::CommandDispatcher;
+use domain::ids::ChainId;
 use infra_cpal::{AudioDeviceDescriptor, ProjectRuntimeController};
 use project::block::{AudioBlock, AudioBlockKind};
 use project::chain::Chain;
+use project::rig::{humanize_preset_label, RigProject};
 
 use crate::assign_new_block_ids;
 use crate::helpers::{clear_status, set_status_error, set_status_info};
@@ -78,7 +80,7 @@ pub(crate) fn wire(window: &AppWindow, ctx: ChainPresetCtx) {
                 );
                 return;
             };
-            let (chain_desc, chain_clone) = {
+            let (chain_desc, chain_clone, chain_id) = {
                 let proj = session.project.borrow();
                 let Some(chain) = proj.chains.get(index as usize) else {
                     drop(proj);
@@ -91,9 +93,19 @@ pub(crate) fn wire(window: &AppWindow, ctx: ChainPresetCtx) {
                         .clone()
                         .unwrap_or_else(|| format!("chain_{}", index + 1)),
                     chain.clone(),
+                    chain.id.clone(),
                 )
             };
-            let default_name = chain_desc.replace(' ', "_").to_lowercase();
+            // Issue #518: filename = active preset's name (slug), not
+            // the chain's title (which is `input.label` after #436).
+            // Fall back to the chain's own slug for non-rig chains or
+            // when the rig is unavailable.
+            let preset_slug = session
+                .rig
+                .as_ref()
+                .and_then(|r| default_preset_filename_slug(&chain_id, &r.borrow()));
+            let default_name = preset_slug
+                .unwrap_or_else(|| chain_desc.replace(' ', "_").to_lowercase());
             let path = if window.get_touch_optimized() {
                 // Kiosk: auto-save to presets dir, no dialog
                 let _ = std::fs::create_dir_all(&session.presets_path);
@@ -209,36 +221,15 @@ pub(crate) fn wire(window: &AppWindow, ctx: ChainPresetCtx) {
             let chain_index = window.get_preset_picker_chain_index();
             match load_preset_file(&path) {
                 Ok(preset) => {
-                    // Build new block list: keep I/O blocks from current chain,
-                    // replace non-I/O with preset blocks. Assign new IDs.
+                    // Hand the dispatcher I/O-stripped blocks (issue #518):
+                    // it is the dispatcher's job to preserve the chain's
+                    // existing Input/Output across the swap. Wrapping I/O
+                    // here too would land two of each on the chain.
                     let dispatch_result = {
                         let proj = session.project.borrow();
                         if let Some(chain) = proj.chains.get(chain_index as usize) {
                             let chain_id = chain.id.clone();
-                            let first_input = chain
-                                .blocks
-                                .iter()
-                                .find(|b| matches!(b.kind, AudioBlockKind::Input(_)))
-                                .cloned();
-                            let last_output = chain
-                                .blocks
-                                .iter()
-                                .rev()
-                                .find(|b| matches!(b.kind, AudioBlockKind::Output(_)))
-                                .cloned();
-                            let mut new_blocks: Vec<AudioBlock> = Vec::new();
-                            if let Some(input) = first_input {
-                                new_blocks.push(input);
-                            }
-                            new_blocks.extend(preset.blocks.into_iter().filter(|b| {
-                                !matches!(
-                                    b.kind,
-                                    AudioBlockKind::Input(_) | AudioBlockKind::Output(_)
-                                )
-                            }));
-                            if let Some(output) = last_output {
-                                new_blocks.push(output);
-                            }
+                            let stripped = strip_io_blocks(preset.blocks);
                             // Assign fresh IDs via a temporary chain struct.
                             let mut tmp_chain = Chain {
                                 id: chain_id.clone(),
@@ -246,7 +237,7 @@ pub(crate) fn wire(window: &AppWindow, ctx: ChainPresetCtx) {
                                 instrument: String::new(),
                                 enabled: false,
                                 volume: 100.0,
-                                blocks: new_blocks,
+                                blocks: stripped,
                             };
                             assign_new_block_ids(&mut tmp_chain);
                             Some((chain_id, tmp_chain.blocks))
@@ -351,3 +342,42 @@ pub(crate) fn wire(window: &AppWindow, ctx: ChainPresetCtx) {
         });
     }
 }
+
+/// Drop Input/Output blocks from a preset's block list before it is
+/// dispatched onto a chain. The dispatcher owns the chain's I/O
+/// across a preset swap (it preserves the existing endpoints), so the
+/// adapter MUST hand it I/O-stripped blocks — otherwise both layers
+/// wrap I/O and the chain ends up with duplicates. Issue #518.
+pub(crate) fn strip_io_blocks(blocks: Vec<AudioBlock>) -> Vec<AudioBlock> {
+    blocks
+        .into_iter()
+        .filter(|b| !matches!(b.kind, AudioBlockKind::Input(_) | AudioBlockKind::Output(_)))
+        .collect()
+}
+
+/// Slug the active preset's name into a filesystem-safe stem for the
+/// save dialog / kiosk auto-save. The chain title moved to
+/// `input.label` after #436, so reusing `chain.description` for the
+/// filename now reflects the chain, not the preset. Issue #518.
+///
+/// Returns `None` for chains that are not projected from a rig input
+/// (i.e. no `rig:` prefix, or the input/preset is missing) — the
+/// caller decides the fallback (typically the chain's own slug).
+pub(crate) fn default_preset_filename_slug(
+    chain_id: &ChainId,
+    rig: &RigProject,
+) -> Option<String> {
+    let input_name = chain_id.0.strip_prefix("rig:")?;
+    let input = rig.inputs.get(input_name)?;
+    let preset_key = input.bank.get(&input.active_preset)?;
+    let preset = rig.presets.get(preset_key)?;
+    let display = preset
+        .name
+        .clone()
+        .unwrap_or_else(|| humanize_preset_label(preset_key));
+    Some(display.replace(' ', "_").to_lowercase())
+}
+
+#[cfg(test)]
+#[path = "chain_preset_wiring_tests.rs"]
+mod tests;

--- a/crates/adapter-gui/src/chain_preset_wiring_tests.rs
+++ b/crates/adapter-gui/src/chain_preset_wiring_tests.rs
@@ -1,0 +1,179 @@
+//! Unit tests for `chain_preset_wiring` helpers. Issue #518:
+//! - `strip_io_blocks`: the adapter must hand the dispatcher a
+//!   preset-blocks list with NO I/O blocks (the dispatcher owns the
+//!   chain's I/O across the swap; pre-wrapping here causes duplication).
+//! - `default_preset_filename_slug`: the save filename must be the
+//!   ACTIVE PRESET's name, not the chain's name (chain.description
+//!   moved to `input.label` after #436).
+//!
+//! Both helpers are pure and live in `chain_preset_wiring.rs`.
+
+use super::{default_preset_filename_slug, strip_io_blocks};
+
+use std::collections::BTreeMap;
+
+use domain::ids::{BlockId, ChainId, DeviceId};
+use project::block::{
+    AudioBlock, AudioBlockKind, CoreBlock, InputBlock, InputEntry, OutputBlock, OutputEntry,
+};
+use project::chain::{ChainInputMode, ChainOutputMode};
+use project::param::ParameterSet;
+use project::rig::{RigInput, RigPreset, RigProject};
+
+fn input_block(id: &str) -> AudioBlock {
+    AudioBlock {
+        id: BlockId(id.to_string()),
+        enabled: true,
+        kind: AudioBlockKind::Input(InputBlock {
+            model: "standard".to_string(),
+            entries: vec![InputEntry {
+                device_id: DeviceId(String::new()),
+                mode: ChainInputMode::Mono,
+                channels: vec![0],
+            }],
+        }),
+    }
+}
+
+fn output_block(id: &str) -> AudioBlock {
+    AudioBlock {
+        id: BlockId(id.to_string()),
+        enabled: true,
+        kind: AudioBlockKind::Output(OutputBlock {
+            model: "standard".to_string(),
+            entries: vec![OutputEntry {
+                device_id: DeviceId(String::new()),
+                mode: ChainOutputMode::Stereo,
+                channels: vec![0, 1],
+            }],
+        }),
+    }
+}
+
+fn core_block(id: &str, model: &str) -> AudioBlock {
+    AudioBlock {
+        id: BlockId(id.to_string()),
+        enabled: true,
+        kind: AudioBlockKind::Core(CoreBlock {
+            effect_type: "gain".to_string(),
+            model: model.to_string(),
+            params: ParameterSet::default(),
+        }),
+    }
+}
+
+// ── strip_io_blocks ──────────────────────────────────────────────
+
+#[test]
+fn strip_io_blocks_drops_input_and_output_keeps_order_of_core() {
+    let kept_a = core_block("a", "ts9");
+    let kept_b = core_block("b", "mesa");
+    let input = input_block("in");
+    let output = output_block("out");
+    let blocks = vec![input, kept_a.clone(), kept_b.clone(), output];
+
+    let stripped = strip_io_blocks(blocks);
+
+    assert_eq!(stripped.len(), 2);
+    assert_eq!(stripped[0].id.0, "a");
+    assert_eq!(stripped[1].id.0, "b");
+}
+
+#[test]
+fn strip_io_blocks_returns_empty_when_all_blocks_are_io() {
+    let blocks = vec![input_block("in"), output_block("out")];
+    assert!(strip_io_blocks(blocks).is_empty());
+}
+
+#[test]
+fn strip_io_blocks_passes_through_when_no_io_present() {
+    let a = core_block("a", "ts9");
+    let b = core_block("b", "mesa");
+    let stripped = strip_io_blocks(vec![a.clone(), b.clone()]);
+    assert_eq!(stripped.len(), 2);
+    assert_eq!(stripped[0].id.0, "a");
+    assert_eq!(stripped[1].id.0, "b");
+}
+
+// ── default_preset_filename_slug ─────────────────────────────────
+
+fn rig_with(input_label: Option<&str>, preset_name: Option<&str>) -> RigProject {
+    let preset_key = "silverchair-freak".to_string();
+    let mut presets = BTreeMap::new();
+    presets.insert(
+        preset_key.clone(),
+        RigPreset {
+            id: preset_key.clone(),
+            name: preset_name.map(|s| s.to_string()),
+            blocks: Vec::new(),
+            scene_params: Vec::new(),
+            scenes: BTreeMap::new(),
+            volume: 100.0,
+        },
+    );
+    let mut bank = BTreeMap::new();
+    bank.insert(1usize, preset_key);
+    let mut inputs = BTreeMap::new();
+    inputs.insert(
+        "input-1".to_string(),
+        RigInput {
+            label: input_label.map(|s| s.to_string()),
+            sources: vec![InputEntry {
+                device_id: DeviceId(String::new()),
+                mode: ChainInputMode::Mono,
+                channels: vec![0],
+            }],
+            bank,
+            active_preset: 1,
+            active_scene: 1,
+            routing: Vec::new(),
+        },
+    );
+    RigProject {
+        name: None,
+        inputs,
+        outputs: BTreeMap::new(),
+        presets,
+        midi: None,
+        chain_order: Vec::new(),
+    }
+}
+
+#[test]
+fn default_filename_uses_active_preset_name_not_chain_label() {
+    // chain label = "Scarlett Left" (which the GUI uses as the chain
+    // title), preset name = "Silverchair Freak". The save dialog must
+    // propose `silverchair_freak`, not `scarlett_left`.
+    let rig = rig_with(Some("Scarlett Left"), Some("Silverchair Freak"));
+    let slug = default_preset_filename_slug(&ChainId("rig:input-1".to_string()), &rig);
+    assert_eq!(slug.as_deref(), Some("silverchair_freak"));
+}
+
+#[test]
+fn default_filename_falls_back_to_humanized_preset_key_when_name_missing() {
+    // Legacy preset with no `name` field — slug from the bank key.
+    let rig = rig_with(Some("Scarlett Left"), None);
+    let slug = default_preset_filename_slug(&ChainId("rig:input-1".to_string()), &rig);
+    // humanize_preset_label("silverchair-freak") = "Silverchair Freak"
+    assert_eq!(slug.as_deref(), Some("silverchair_freak"));
+}
+
+#[test]
+fn default_filename_returns_none_for_non_rig_chain_id() {
+    // Non-projected chain (no `rig:` prefix) — caller must keep its
+    // own default; we don't invent one.
+    let rig = rig_with(Some("X"), Some("P"));
+    assert_eq!(
+        default_preset_filename_slug(&ChainId("standalone-chain".to_string()), &rig),
+        None,
+    );
+}
+
+#[test]
+fn default_filename_returns_none_when_input_missing_from_rig() {
+    let rig = rig_with(Some("X"), Some("P"));
+    assert_eq!(
+        default_preset_filename_slug(&ChainId("rig:input-999".to_string()), &rig),
+        None,
+    );
+}


### PR DESCRIPTION
## Summary

Two bugs share the same wiring file (`crates/adapter-gui/src/chain_preset_wiring.rs`):

- **Load**: the adapter wrapped `preset.blocks` with the chain's existing I/O before dispatching, and the dispatcher then wrapped them again — landing two `Input`s and two `Output`s on the chain. Fix: hand the dispatcher I/O-stripped blocks; let it own the wrap (its doc-comment already states the contract).
- **Save**: the default filename came from `chain.description`, but after #436 that's the chain's name (`input.label`), not the active preset's. Fix: resolve the active preset via `rig.inputs[name].bank[active_preset]` → `rig.presets[key].name` (with `humanize_preset_label` fallback for legacy presets) and slugify.

Two pure helpers (`strip_io_blocks`, `default_preset_filename_slug`) with 7 red-first unit tests in `chain_preset_wiring_tests.rs`.

Refs #518.

## Test plan

- [x] `cargo test -p adapter-gui --lib` → 390 pass, 3 ignored.
- [x] `cargo check -p adapter-gui --tests` clean.
- [ ] Save a preset on a rig chain whose preset name differs from the chain title → file is named after the preset.
- [ ] Load a preset onto a chain that already has I/O configured → chain ends with exactly one Input and one Output (no duplicates), preset blocks in between.