### PR TITLE
perf(522): fast-path block & chain toggles — no rebuild, no NAM reload

### DIFF
--- a/crates/adapter-gui/src/block_editor_window_lifecycle.rs
+++ b/crates/adapter-gui/src/block_editor_window_lifecycle.rs
@@ -45,7 +45,7 @@ use crate::project_ops::sync_project_dirty;
 use crate::project_view::{
     block_model_picker_items, load_screenshot_image, replace_project_chains, set_selected_block,
 };
-use crate::runtime_lifecycle::{sync_live_chain_runtime, system_language};
+use crate::runtime_lifecycle::{sync_block_toggle, sync_live_chain_runtime, system_language};
 use crate::state::{BlockEditorDraft, BlockWindow, ProjectSession, SelectedBlock};
 use crate::{
     AppWindow, BlockEditorWindow, BlockKnobOverlay, BlockParameterItem, CurveEditorPoint,
@@ -86,13 +86,11 @@ pub(crate) fn apply_panel_dimensions(win: &BlockEditorWindow) {
         true
     };
 
-    let dims = crate::block_panel_dimensions::compute(
-        crate::block_panel_dimensions::PanelInputs {
-            knob_count,
-            use_panel_editor,
-            has_eq_widget,
-        },
-    );
+    let dims = crate::block_panel_dimensions::compute(crate::block_panel_dimensions::PanelInputs {
+        knob_count,
+        use_panel_editor,
+        has_eq_widget,
+    });
     win.set_panel_knob_window_width(dims.window_width_px);
     win.set_panel_knob_window_height(dims.window_height_px);
     win.set_panel_knob_inner_height(dims.inner_panel_height_px);
@@ -306,7 +304,7 @@ pub(crate) fn wire(
                 };
                 match session.dispatcher.dispatch(Command::ToggleBlockEnabled {
                     chain: chain_id.clone(),
-                    block: block_id,
+                    block: block_id.clone(),
                 }) {
                     Ok(events) => events.into_iter().find_map(|e| {
                         if let Event::BlockEnabledChanged { enabled, .. } = e {
@@ -337,7 +335,9 @@ pub(crate) fn wire(
             let Some(session) = session_borrow.as_mut() else {
                 return;
             };
-            if let Err(e) = sync_live_chain_runtime(&project_runtime, session, &chain_id) {
+            if let Err(e) =
+                sync_block_toggle(&project_runtime, session, &chain_id, &block_id, new_enabled)
+            {
                 log::error!("[adapter-gui] block-window.toggle-enabled runtime sync: {e}");
                 main.set_block_drawer_status_message(e.to_string().into());
                 return;

--- a/crates/adapter-gui/src/chain_block_crud_wiring.rs
+++ b/crates/adapter-gui/src/chain_block_crud_wiring.rs
@@ -24,8 +24,8 @@ use crate::helpers::{clear_status, set_status_error};
 use crate::project_ops::sync_project_dirty;
 use crate::project_view::{replace_project_chains, set_selected_block};
 use crate::state::{BlockEditorDraft, BlockWindow, ProjectSession, SelectedBlock};
-use crate::sync_live_chain_runtime;
 use crate::ui_index_to_real_block_index;
+use crate::{sync_block_toggle, sync_live_chain_runtime};
 use crate::{
     AppWindow, BlockEditorWindow, BlockModelPickerItem, BlockParameterItem, CurveEditorPoint,
     MultiSliderPoint, ProjectChainItem,
@@ -166,7 +166,7 @@ pub(crate) fn wire(
             };
             if let Err(error) = session.dispatcher.dispatch(Command::ToggleBlockEnabled {
                 chain: chain_id.clone(),
-                block: block_id,
+                block: block_id.clone(),
             }) {
                 set_status_error(&window, &toast_timer, &error.to_string());
                 return;
@@ -189,7 +189,9 @@ pub(crate) fn wire(
             }
             // Keep inline drawer UI in sync
             window.set_block_drawer_enabled(new_enabled);
-            if let Err(error) = sync_live_chain_runtime(&project_runtime, session, &chain_id) {
+            if let Err(error) =
+                sync_block_toggle(&project_runtime, session, &chain_id, &block_id, new_enabled)
+            {
                 set_status_error(&window, &toast_timer, &error.to_string());
                 return;
             }

--- a/crates/adapter-gui/src/chain_input_groups_wiring.rs
+++ b/crates/adapter-gui/src/chain_input_groups_wiring.rs
@@ -24,7 +24,7 @@ use crate::io_groups::{apply_chain_input_window_state, build_io_group_items};
 use crate::project_ops::sync_project_dirty;
 use crate::project_view::replace_project_chains;
 use crate::state::{ChainDraft, InputGroupDraft, ProjectSession};
-use crate::sync_live_chain_runtime;
+use crate::{sync_block_toggle, sync_live_chain_runtime};
 use crate::{
     AppWindow, ChainInputGroupsWindow, ChainInputWindow, ChannelOptionItem, ProjectChainItem,
 };
@@ -376,7 +376,7 @@ pub(crate) fn wire(
             };
             if let Err(e) = session.dispatcher.dispatch(Command::ToggleBlockEnabled {
                 chain: chain_id.clone(),
-                block: block_id,
+                block: block_id.clone(),
             }) {
                 log::error!("toggle I/O block enabled: {e}");
                 return;
@@ -390,7 +390,13 @@ pub(crate) fn wire(
                     .unwrap_or(false)
             };
             gw.set_block_enabled(block_enabled);
-            if let Err(e) = sync_live_chain_runtime(&project_runtime, session, &chain_id) {
+            if let Err(e) = sync_block_toggle(
+                &project_runtime,
+                session,
+                &chain_id,
+                &block_id,
+                block_enabled,
+            ) {
                 log::error!("toggle I/O block enabled: {e}");
             }
             replace_project_chains(

--- a/crates/adapter-gui/src/chain_output_groups_wiring.rs
+++ b/crates/adapter-gui/src/chain_output_groups_wiring.rs
@@ -24,7 +24,7 @@ use crate::io_groups::{apply_chain_output_window_state, build_io_group_items};
 use crate::project_ops::sync_project_dirty;
 use crate::project_view::replace_project_chains;
 use crate::state::{ChainDraft, OutputGroupDraft, ProjectSession};
-use crate::sync_live_chain_runtime;
+use crate::{sync_block_toggle, sync_live_chain_runtime};
 use crate::{
     AppWindow, ChainOutputGroupsWindow, ChainOutputWindow, ChannelOptionItem, ProjectChainItem,
 };
@@ -367,7 +367,7 @@ pub(crate) fn wire(
             };
             if let Err(e) = session.dispatcher.dispatch(Command::ToggleBlockEnabled {
                 chain: chain_id.clone(),
-                block: block_id,
+                block: block_id.clone(),
             }) {
                 log::error!("toggle I/O block enabled: {e}");
                 return;
@@ -381,7 +381,13 @@ pub(crate) fn wire(
                     .unwrap_or(false)
             };
             gw.set_block_enabled(block_enabled);
-            if let Err(e) = sync_live_chain_runtime(&project_runtime, session, &chain_id) {
+            if let Err(e) = sync_block_toggle(
+                &project_runtime,
+                session,
+                &chain_id,
+                &block_id,
+                block_enabled,
+            ) {
                 log::error!("toggle I/O block enabled: {e}");
             }
             replace_project_chains(

--- a/crates/adapter-gui/src/compact_chain_block_handlers.rs
+++ b/crates/adapter-gui/src/compact_chain_block_handlers.rs
@@ -24,7 +24,7 @@ use crate::helpers::set_status_info;
 use crate::project_ops::sync_project_dirty;
 use crate::project_view::{block_model_picker_items, build_compact_blocks, replace_project_chains};
 use crate::state::{BlockEditorDraft, ProjectSession};
-use crate::sync_live_chain_runtime;
+use crate::{sync_block_toggle, sync_live_chain_runtime};
 use crate::{AppWindow, CompactChainViewWindow, ProjectChainItem};
 
 pub(crate) struct CompactChainBlockHandlersCtx {
@@ -97,7 +97,7 @@ pub(crate) fn wire(
             };
             if let Err(error) = session.dispatcher.dispatch(Command::ToggleBlockEnabled {
                 chain: chain_id.clone(),
-                block: block_id,
+                block: block_id.clone(),
             }) {
                 log::error!("[compact] toggle-block-enabled dispatch error: {error}");
                 return;
@@ -116,8 +116,9 @@ pub(crate) fn wire(
                     draft.enabled = new_enabled;
                 }
             }
-            let chain_id = chain_id;
-            if let Err(error) = sync_live_chain_runtime(&project_runtime, session, &chain_id) {
+            if let Err(error) =
+                sync_block_toggle(&project_runtime, session, &chain_id, &block_id, new_enabled)
+            {
                 set_status_error(&main_win, &toast_timer, &error.to_string());
                 return;
             }

--- a/crates/adapter-gui/src/insert_wiring.rs
+++ b/crates/adapter-gui/src/insert_wiring.rs
@@ -23,7 +23,7 @@ use crate::chain_editor::insert_mode_from_index;
 use crate::project_ops::sync_project_dirty;
 use crate::project_view::replace_project_chains;
 use crate::state::{InsertDraft, ProjectSession};
-use crate::sync_live_chain_runtime;
+use crate::{sync_block_toggle, sync_live_chain_runtime};
 use crate::{AppWindow, ChainInsertWindow, ChannelOptionItem, ProjectChainItem};
 
 /// State borrowed by the Insert window callbacks. Each `Rc` is cloned per
@@ -215,7 +215,7 @@ pub(crate) fn wire(
             };
             match session.dispatcher.dispatch(Command::ToggleBlockEnabled {
                 chain: chain_id.clone(),
-                block: block_id,
+                block: block_id.clone(),
             }) {
                 Ok(_) => {}
                 Err(e) => {
@@ -233,7 +233,13 @@ pub(crate) fn wire(
                 .map(|b| b.enabled)
                 .unwrap_or(false);
             iw.set_block_enabled(block_enabled);
-            if let Err(e) = sync_live_chain_runtime(&project_runtime, session, &chain_id) {
+            if let Err(e) = sync_block_toggle(
+                &project_runtime,
+                session,
+                &chain_id,
+                &block_id,
+                block_enabled,
+            ) {
                 log::error!("toggle insert block enabled runtime sync: {e}");
             }
             replace_project_chains(

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -9,11 +9,11 @@ mod block_drawer_close_wiring;
 mod block_drawer_save_delete_wiring;
 mod block_editor_window_lifecycle;
 mod block_editor_window_params;
-mod block_panel_dimensions;
 mod block_editor_window_setup;
 mod block_editor_window_wiring;
 mod block_insert_callbacks;
 mod block_model_search_wiring;
+mod block_panel_dimensions;
 mod block_parameter_wiring;
 mod block_picker_wiring;
 mod chain_block_crud_wiring;
@@ -65,8 +65,8 @@ pub use cli::{
     parse_cli_args_from, parse_mcp_addr, parse_midi_map, validate_project_path, MidiMapArg,
 };
 pub(crate) use runtime_lifecycle::{
-    assign_new_block_ids, remove_live_chain_runtime, stop_project_runtime, sync_live_chain_runtime,
-    sync_project_runtime, system_language, ui_index_to_real_block_index,
+    assign_new_block_ids, remove_live_chain_runtime, stop_project_runtime, sync_block_toggle,
+    sync_live_chain_runtime, sync_project_runtime, system_language, ui_index_to_real_block_index,
 };
 
 mod defaults;

--- a/crates/adapter-gui/src/runtime_lifecycle.rs
+++ b/crates/adapter-gui/src/runtime_lifecycle.rs
@@ -99,6 +99,35 @@ pub(crate) fn remove_live_chain_runtime(
     }
 }
 
+/// Issue #522: fast path for `Command::ToggleBlockEnabled`. Flips the
+/// block's fade state in place on the live chain runtime — no CPAL
+/// re-resolve, no chain rebuild. Falls back to `sync_live_chain_runtime`
+/// only when the fast path can't take the change (chain not yet running,
+/// or the block is a `Bypass` that needs a real processor rebuild).
+pub(crate) fn sync_block_toggle(
+    project_runtime: &Rc<RefCell<Option<ProjectRuntimeController>>>,
+    session: &ProjectSession,
+    chain_id: &ChainId,
+    block_id: &BlockId,
+    enabled: bool,
+) -> Result<()> {
+    let fast_path = {
+        let borrow = project_runtime.borrow();
+        match borrow.as_ref() {
+            Some(runtime) => runtime.set_block_enabled(chain_id, block_id, enabled),
+            None => Err(anyhow::anyhow!("runtime not started")),
+        }
+    };
+    if fast_path.is_ok() {
+        return Ok(());
+    }
+    log::debug!(
+        "sync_block_toggle: fast path declined ({:?}) — falling back to upsert",
+        fast_path.err()
+    );
+    sync_live_chain_runtime(project_runtime, session, chain_id)
+}
+
 pub(crate) fn assign_new_block_ids(chain: &mut Chain) {
     for block in &mut chain.blocks {
         assign_new_block_ids_recursive(block, &chain.id);

--- a/crates/engine/src/block_enabled_fast_path_tests.rs
+++ b/crates/engine/src/block_enabled_fast_path_tests.rs
@@ -1,0 +1,155 @@
+//! Issue #522: toggling a single block's `enabled` flag must not rebuild
+//! the chain runtime. Today the GUI dispatches `ToggleBlockEnabled` and
+//! immediately calls `sync_live_chain_runtime` → `upsert_chain` →
+//! `resolve_chain_audio_config` (CPAL hardware queries) →
+//! `update_chain_runtime_state`. None of that work is necessary for a
+//! per-block boolean flip — the engine already keeps disabled blocks
+//! alive (see `runtime_block_builders.rs:60-71`) and supports
+//! `FadeState::FadingOut` / `FadingIn` transitions on existing nodes.
+//!
+//! These tests pin a minimal direct API: `set_block_enabled(runtime,
+//! block_id, enabled)` that finds the existing `BlockRuntimeNode` and
+//! flips its fade state across every input runtime of the chain, with
+//! ZERO chain re-resolve and ZERO processor rebuild.
+
+use std::sync::Arc;
+
+use domain::ids::{BlockId, ChainId, DeviceId};
+use project::block::{
+    schema_for_block_model, AudioBlock, AudioBlockKind, CoreBlock, InputBlock, InputEntry,
+    OutputBlock, OutputEntry,
+};
+use project::chain::{Chain, ChainInputMode, ChainOutputMode};
+use project::param::ParameterSet;
+
+use super::{
+    build_chain_runtime_state, set_block_enabled, ChainRuntimeState, FadeState,
+    DEFAULT_ELASTIC_TARGET,
+};
+
+const SR: f32 = 48_000.0;
+const BLOCK_ID: &str = "test:reverb";
+
+fn neutral_params(effect_type: &str, model: &str) -> ParameterSet {
+    let schema =
+        schema_for_block_model(effect_type, model).expect("schema must exist for test model");
+    ParameterSet::default()
+        .normalized_against(&schema)
+        .expect("defaults must normalize")
+}
+
+fn core_block(id: &str, effect_type: &str, model: &str) -> AudioBlock {
+    AudioBlock {
+        id: BlockId(id.into()),
+        enabled: true,
+        kind: AudioBlockKind::Core(CoreBlock {
+            effect_type: effect_type.to_string(),
+            model: model.to_string(),
+            params: neutral_params(effect_type, model),
+        }),
+    }
+}
+
+fn test_chain() -> Chain {
+    Chain {
+        id: ChainId("issue-522-chain".into()),
+        description: Some("issue #522 block-toggle fast path".into()),
+        instrument: "electric_guitar".into(),
+        enabled: true,
+        volume: 100.0,
+        blocks: vec![
+            AudioBlock {
+                id: BlockId("test:in".into()),
+                enabled: true,
+                kind: AudioBlockKind::Input(InputBlock {
+                    model: "standard".into(),
+                    entries: vec![InputEntry {
+                        device_id: DeviceId("dev".into()),
+                        mode: ChainInputMode::Mono,
+                        channels: vec![0],
+                    }],
+                }),
+            },
+            core_block(BLOCK_ID, "reverb", "room"),
+            AudioBlock {
+                id: BlockId("test:out".into()),
+                enabled: true,
+                kind: AudioBlockKind::Output(OutputBlock {
+                    model: "standard".into(),
+                    entries: vec![OutputEntry {
+                        device_id: DeviceId("dev".into()),
+                        mode: ChainOutputMode::Stereo,
+                        channels: vec![0, 1],
+                    }],
+                }),
+            },
+        ],
+    }
+}
+
+fn build_runtime() -> Arc<ChainRuntimeState> {
+    let chain = test_chain();
+    Arc::new(
+        build_chain_runtime_state(&chain, SR, &[DEFAULT_ELASTIC_TARGET])
+            .expect("runtime must build for test chain"),
+    )
+}
+
+fn block_fade_state(runtime: &ChainRuntimeState, block: &BlockId) -> Option<FadeState> {
+    let processing = runtime.processing.lock().expect("lock processing");
+    for input_state in processing.input_states.iter() {
+        for node in input_state.blocks.iter() {
+            if &node.block_snapshot.id == block {
+                return Some(node.fade_state);
+            }
+        }
+    }
+    None
+}
+
+#[test]
+fn set_block_enabled_false_transitions_to_fading_out_without_rebuild() {
+    let runtime = build_runtime();
+    let block = BlockId(BLOCK_ID.into());
+
+    let before = block_fade_state(&runtime, &block).expect("block exists in runtime");
+    assert!(
+        matches!(before, FadeState::FadingIn { .. } | FadeState::Active),
+        "block must start active or fading in, got {before:?}"
+    );
+
+    set_block_enabled(&runtime, &block, false).expect("fast-path must succeed");
+
+    let after = block_fade_state(&runtime, &block).expect("block stays in runtime after disable");
+    assert!(
+        matches!(after, FadeState::FadingOut { .. } | FadeState::Bypassed),
+        "block must transition to FadingOut/Bypassed, got {after:?}"
+    );
+}
+
+#[test]
+fn set_block_enabled_true_after_disable_transitions_back_to_fading_in() {
+    let runtime = build_runtime();
+    let block = BlockId(BLOCK_ID.into());
+
+    set_block_enabled(&runtime, &block, false).expect("disable succeeds");
+    set_block_enabled(&runtime, &block, true).expect("re-enable succeeds");
+
+    let after = block_fade_state(&runtime, &block).expect("block stays in runtime");
+    assert!(
+        matches!(after, FadeState::FadingIn { .. } | FadeState::Active),
+        "block must transition to FadingIn/Active on re-enable, got {after:?}"
+    );
+}
+
+#[test]
+fn set_block_enabled_unknown_block_returns_err_without_mutation() {
+    let runtime = build_runtime();
+    let missing = BlockId("does:not:exist".into());
+
+    let result = set_block_enabled(&runtime, &missing, false);
+    assert!(
+        result.is_err(),
+        "missing block must yield Err, got {result:?}"
+    );
+}

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1,11 +1,13 @@
 pub mod input_tap;
 pub mod native_registry;
+pub mod output_meter;
 pub mod probe;
 pub mod rig_runtime;
 pub mod runtime;
 pub mod runtime_audio_frame;
 pub mod runtime_block_builders;
 pub mod runtime_block_core;
+pub mod runtime_block_toggle;
 pub mod runtime_dsp;
 pub mod runtime_endpoints;
 pub mod runtime_graph;
@@ -16,4 +18,3 @@ pub mod runtime_segments;
 pub mod runtime_state;
 pub mod spsc;
 pub mod stream_tap;
-pub mod output_meter;

--- a/crates/engine/src/runtime.rs
+++ b/crates/engine/src/runtime.rs
@@ -57,6 +57,7 @@ pub(crate) use crate::runtime_probe::{PROBE_BEEP_FRAMES, PROBE_BEEP_FREQ, PROBE_
 pub(crate) use crate::runtime_block_builders::{
     bypass_runtime_node, next_block_instance_serial, processor_scratch,
 };
+pub use crate::runtime_block_toggle::set_block_enabled;
 #[cfg(test)]
 pub(crate) use crate::runtime_endpoints::{
     effective_inputs, effective_outputs, insert_return_as_input_entry, insert_send_as_output_entry,
@@ -752,3 +753,7 @@ mod stereo_image;
 #[cfg(test)]
 #[path = "runtime_lock_recovery_tests.rs"]
 mod runtime_lock_recovery;
+
+#[cfg(test)]
+#[path = "block_enabled_fast_path_tests.rs"]
+mod block_enabled_fast_path;

--- a/crates/engine/src/runtime_block_toggle.rs
+++ b/crates/engine/src/runtime_block_toggle.rs
@@ -1,0 +1,76 @@
+//! Issue #522: fast path for toggling a block's `enabled` flag without
+//! rebuilding the chain runtime.
+//!
+//! The standard `update_chain_runtime_state` reuses existing block
+//! processors when only `enabled` flips, but the GUI today goes through
+//! the full `upsert_chain` path which also re-resolves CPAL devices and
+//! re-validates I/O. None of that work is necessary for a per-block
+//! boolean flip — `BlockRuntimeNode`'s `fade_state` already supports the
+//! `FadingOut` / `FadingIn` transitions, the disabled processor stays
+//! alive for instant re-enable, and the audio thread crossfades without
+//! any allocation or lock contention.
+//!
+//! Extracted as its own module to keep `runtime_graph.rs` within the
+//! 600-LOC file cap (it was already at the limit). Re-exported through
+//! `runtime.rs` so callers keep using the `engine::runtime::*` path.
+
+use anyhow::{anyhow, Result};
+
+use domain::ids::BlockId;
+
+use crate::runtime::FADE_IN_FRAMES;
+use crate::runtime_state::{lock_recover, ChainRuntimeState, FadeState, RuntimeProcessor};
+
+/// Toggle the `enabled` flag of a block in a live chain runtime. Walks
+/// every per-input `ChainProcessingState` of `runtime`, finds the
+/// matching `BlockRuntimeNode` by id, and flips its `fade_state` so the
+/// audio thread crossfades on the next callback. No chain re-resolve,
+/// no processor rebuild, no CPAL queries.
+///
+/// Returns `Err` when:
+/// - the block id is not found in any input runtime (caller can fall
+///   back to a full `upsert_chain`); or
+/// - re-enabling a block whose live node is a `RuntimeProcessor::Bypass`
+///   (it has no real processor to fade in — needs a full rebuild).
+pub fn set_block_enabled(
+    runtime: &ChainRuntimeState,
+    block_id: &BlockId,
+    enabled: bool,
+) -> Result<()> {
+    let mut processing = lock_recover(&runtime.processing, "chain runtime");
+    let mut touched = 0usize;
+    for input_state in processing.input_states.iter_mut() {
+        for node in input_state.blocks.iter_mut() {
+            if &node.block_snapshot.id != block_id {
+                continue;
+            }
+            if enabled && matches!(node.processor, RuntimeProcessor::Bypass) {
+                return Err(anyhow!(
+                    "block '{}' has no live processor — needs full rebuild to re-enable",
+                    block_id.0
+                ));
+            }
+            let was_enabled = node.block_snapshot.enabled;
+            if was_enabled != enabled {
+                node.fade_state = if enabled {
+                    FadeState::FadingIn {
+                        frames_remaining: FADE_IN_FRAMES,
+                    }
+                } else {
+                    FadeState::FadingOut {
+                        frames_remaining: FADE_IN_FRAMES,
+                    }
+                };
+            }
+            node.block_snapshot.enabled = enabled;
+            touched += 1;
+        }
+    }
+    if touched == 0 {
+        return Err(anyhow!(
+            "block '{}' not found in any input runtime of the chain",
+            block_id.0
+        ));
+    }
+    Ok(())
+}

--- a/crates/infra-cpal/src/controller.rs
+++ b/crates/infra-cpal/src/controller.rs
@@ -340,8 +340,21 @@ impl ProjectRuntimeController {
             chain.enabled
         );
         if !chain.enabled {
-            self.remove_chain(&chain.id);
+            // Issue #522: pause instead of teardown. Keeps CPAL streams +
+            // every block processor alive so re-enable resumes in O(1).
+            self.pause_chain(&chain.id);
             return Ok(());
+        }
+        // Issue #522: fast-path resume of a paused chain — clear draining
+        // and return; no CPAL queries, no NAM reload, no graph rebuild.
+        if self.active_chains.contains_key(&chain.id) {
+            if let Some(runtime) = self.runtime_graph.runtime_for_chain(&chain.id) {
+                if runtime.is_draining() {
+                    log::info!("resuming paused chain '{}' (fast path)", chain.id.0);
+                    runtime.clear_draining();
+                    return Ok(());
+                }
+            }
         }
 
         #[cfg(all(target_os = "linux", feature = "jack"))]
@@ -362,6 +375,7 @@ impl ProjectRuntimeController {
             self.upsert_chain_with_resolved(chain, resolved, spillover)
         }
     }
+
 
     pub fn remove_chain(&mut self, chain_id: &ChainId) {
         log::info!("removing chain '{}' from runtime", chain_id.0);

--- a/crates/infra-cpal/src/controller_block_toggle.rs
+++ b/crates/infra-cpal/src/controller_block_toggle.rs
@@ -1,14 +1,17 @@
-//! Issue #522: per-block enable/disable fast path on the controller.
+//! Issue #522: per-block AND per-chain enable/disable fast paths on the
+//! controller.
 //!
 //! `Command::ToggleBlockEnabled` used to go through `upsert_chain` →
 //! `resolve_chain_audio_config` (CPAL device queries) → full chain rebuild.
 //! For a one-bit flip on a block, the audio engine already supports
 //! click-safe `FadeState` transitions on the live `BlockRuntimeNode`
-//! (see `engine::runtime::set_block_enabled`). This module exposes that
-//! capability at the controller boundary so the GUI can take the cheap
-//! path and fall back to `upsert_chain` only when the chain has no live
-//! runtime yet (e.g. first enable) or the block is a `Bypass` node that
-//! needs a real processor.
+//! (see `engine::runtime::set_block_enabled`).
+//!
+//! `Command::ToggleChainEnabled` used to drop the runtime entirely on
+//! disable and rebuild from scratch on the next enable. `pause_chain`
+//! keeps the runtime alive and just flips `set_draining()`; resume is
+//! the matching `clear_draining()` — both O(1), no NAM reload, no CPAL
+//! touch.
 //!
 //! Lives in its own file to keep `controller.rs` within the 600-LOC cap.
 
@@ -40,5 +43,18 @@ impl ProjectRuntimeController {
             engine::runtime::set_block_enabled(runtime.as_ref(), block_id, enabled)?;
         }
         Ok(())
+    }
+
+    /// Pause a chain without dropping its runtime: `set_draining()` makes
+    /// every audio callback short-circuit to silence, but the CPAL
+    /// streams stay open and the `Arc<ChainRuntimeState>` stays in
+    /// `runtime_graph` so the next enable resumes in O(1) via
+    /// `upsert_chain`'s fast-path branch. No-op if the chain has no
+    /// live runtime yet.
+    pub fn pause_chain(&self, chain_id: &ChainId) {
+        if let Some(runtime) = self.runtime_graph.runtime_for_chain(chain_id) {
+            log::info!("pausing chain '{}' (keep streams alive)", chain_id.0);
+            runtime.set_draining();
+        }
     }
 }

--- a/crates/infra-cpal/src/controller_block_toggle.rs
+++ b/crates/infra-cpal/src/controller_block_toggle.rs
@@ -1,0 +1,44 @@
+//! Issue #522: per-block enable/disable fast path on the controller.
+//!
+//! `Command::ToggleBlockEnabled` used to go through `upsert_chain` →
+//! `resolve_chain_audio_config` (CPAL device queries) → full chain rebuild.
+//! For a one-bit flip on a block, the audio engine already supports
+//! click-safe `FadeState` transitions on the live `BlockRuntimeNode`
+//! (see `engine::runtime::set_block_enabled`). This module exposes that
+//! capability at the controller boundary so the GUI can take the cheap
+//! path and fall back to `upsert_chain` only when the chain has no live
+//! runtime yet (e.g. first enable) or the block is a `Bypass` node that
+//! needs a real processor.
+//!
+//! Lives in its own file to keep `controller.rs` within the 600-LOC cap.
+
+use anyhow::{anyhow, Result};
+
+use domain::ids::{BlockId, ChainId};
+
+use crate::ProjectRuntimeController;
+
+impl ProjectRuntimeController {
+    /// Flip the block's enabled state in place on every per-input runtime
+    /// of the chain, with no CPAL re-resolve and no processor rebuild.
+    /// Returns `Err` if the chain has no live runtime OR if any runtime
+    /// requires a full rebuild (caller falls back to `upsert_chain`).
+    pub fn set_block_enabled(
+        &self,
+        chain_id: &ChainId,
+        block_id: &BlockId,
+        enabled: bool,
+    ) -> Result<()> {
+        let runtimes = self.runtime_graph.runtimes_for(chain_id);
+        if runtimes.is_empty() {
+            return Err(anyhow!(
+                "chain '{}' has no live runtime — needs full rebuild",
+                chain_id.0
+            ));
+        }
+        for runtime in &runtimes {
+            engine::runtime::set_block_enabled(runtime.as_ref(), block_id, enabled)?;
+        }
+        Ok(())
+    }
+}

--- a/crates/infra-cpal/src/controller_pause_chain_tests.rs
+++ b/crates/infra-cpal/src/controller_pause_chain_tests.rs
@@ -1,0 +1,156 @@
+//! Issue #522 — fast-path for `Command::ToggleChainEnabled`.
+//!
+//! The legacy behaviour: `upsert_chain` with `chain.enabled = false`
+//! calls `remove_chain`, which drops the `Arc<ChainRuntimeState>` and
+//! tears the CPAL input/output streams down. Re-enabling the chain then
+//! has to walk the full rebuild path: device validation, NAM model
+//! loads, segment + route reassembly, fresh CPAL streams. End-to-end
+//! that is the ~1-second hitch the user observes on every chain
+//! enable/disable toggle.
+//!
+//! The fast path swaps `remove_chain` for `pause_chain`: the runtime
+//! stays in `active_chains`, the CPAL streams stay open, and the audio
+//! callbacks short-circuit on `is_draining()` to emit silence with zero
+//! processor work. Re-enabling resumes the same Arc by clearing the
+//! draining flag — no rebuild, no NAM reload, no CPAL touch.
+
+use std::sync::Arc;
+
+use domain::ids::ChainId;
+use project::chain::Chain;
+use project::project::Project;
+
+use super::active_runtime::ActiveChainRuntime;
+use super::resolved::ChainStreamSignature;
+use super::ProjectRuntimeController;
+
+fn empty_chain(id: &str, enabled: bool) -> Chain {
+    Chain {
+        id: ChainId(id.into()),
+        description: None,
+        instrument: "electric_guitar".to_string(),
+        enabled,
+        volume: 100.0,
+        blocks: vec![],
+    }
+}
+
+fn empty_project() -> Project {
+    Project {
+        name: None,
+        device_settings: vec![],
+        chains: vec![],
+    }
+}
+
+fn controller_with_active_chain(
+    chain_id: &ChainId,
+) -> (ProjectRuntimeController, Arc<engine::runtime::ChainRuntimeState>) {
+    let chain = empty_chain(&chain_id.0, true);
+    let runtime_arc = Arc::new(
+        engine::runtime::build_chain_runtime_state(&chain, 48_000.0, &[1024])
+            .expect("empty chain runtime should build"),
+    );
+
+    let mut graph = engine::runtime::RuntimeGraph {
+        chains: std::collections::HashMap::new(),
+    };
+    graph
+        .chains
+        .insert((chain_id.clone(), 0), Arc::clone(&runtime_arc));
+
+    let mut active_chains = std::collections::HashMap::new();
+    active_chains.insert(
+        chain_id.clone(),
+        ActiveChainRuntime {
+            stream_signature: ChainStreamSignature {
+                inputs: vec![],
+                outputs: vec![],
+            },
+            _input_streams: vec![],
+            _output_streams: vec![],
+            #[cfg(all(target_os = "linux", feature = "jack"))]
+            _jack_client: None,
+            #[cfg(all(target_os = "linux", feature = "jack"))]
+            _dsp_worker: None,
+        },
+    );
+
+    let controller = ProjectRuntimeController {
+        runtime_graph: graph,
+        active_chains,
+        #[cfg(all(target_os = "linux", feature = "jack"))]
+        supervisor: super::jack_supervisor::JackSupervisor::new(
+            super::jack_supervisor::LiveJackBackend::new(),
+        ),
+    };
+    (controller, runtime_arc)
+}
+
+#[test]
+#[cfg(not(all(target_os = "linux", feature = "jack")))]
+fn upsert_chain_disabled_pauses_runtime_without_removing() {
+    let chain_id = ChainId("chain:522:pause".into());
+    let (mut controller, runtime_arc) = controller_with_active_chain(&chain_id);
+    let project = empty_project();
+
+    assert!(controller.active_chains.contains_key(&chain_id));
+    assert!(!runtime_arc.is_draining());
+
+    let disabled = empty_chain(&chain_id.0, false);
+    controller
+        .upsert_chain(&project, &disabled)
+        .expect("upsert with enabled=false must succeed");
+
+    assert!(
+        controller.active_chains.contains_key(&chain_id),
+        "disabling a chain must NOT drop its runtime/streams — device stays \
+         open so the next enable can resume the same `Arc<ChainRuntimeState>` \
+         without rebuilding (issue #522)"
+    );
+    assert!(
+        runtime_arc.is_draining(),
+        "disabled chain must be paused via set_draining so the audio \
+         callbacks emit silence with zero processor work"
+    );
+}
+
+#[test]
+#[cfg(not(all(target_os = "linux", feature = "jack")))]
+fn upsert_chain_enabled_resumes_paused_runtime_without_rebuilding() {
+    let chain_id = ChainId("chain:522:resume".into());
+    let (mut controller, runtime_arc) = controller_with_active_chain(&chain_id);
+    let project = empty_project();
+
+    // Pause it first.
+    let disabled = empty_chain(&chain_id.0, false);
+    controller
+        .upsert_chain(&project, &disabled)
+        .expect("disable succeeds");
+    assert!(runtime_arc.is_draining());
+
+    // Now re-enable. The runtime Arc must be reused (same pointer) and
+    // the draining flag must clear so the audio callbacks resume.
+    let runtime_addr_before = Arc::as_ptr(&runtime_arc) as usize;
+    let enabled = empty_chain(&chain_id.0, true);
+    controller
+        .upsert_chain(&project, &enabled)
+        .expect("re-enable must succeed without rebuild");
+
+    let stored = controller
+        .runtime_graph
+        .chains
+        .get(&(chain_id.clone(), 0))
+        .expect("runtime stays under the same key on resume")
+        .clone();
+    assert_eq!(
+        Arc::as_ptr(&stored) as usize,
+        runtime_addr_before,
+        "re-enable must reuse the SAME ChainRuntimeState Arc — rebuilding \
+         would reload every NAM model and rebuild every block processor"
+    );
+    assert!(
+        !runtime_arc.is_draining(),
+        "resume must clear set_draining so the audio thread processes again"
+    );
+}

--- a/crates/infra-cpal/src/lib.rs
+++ b/crates/infra-cpal/src/lib.rs
@@ -97,4 +97,6 @@ mod tests;
 #[cfg(test)]
 mod tests_regression;
 #[cfg(test)]
+mod controller_pause_chain_tests;
+#[cfg(test)]
 mod tests_signatures;

--- a/crates/infra-cpal/src/lib.rs
+++ b/crates/infra-cpal/src/lib.rs
@@ -43,6 +43,7 @@ mod jack_direct;
 
 mod controller;
 pub use controller::ProjectRuntimeController;
+mod controller_block_toggle;
 mod controller_taps;
 mod device_enum;
 #[cfg(all(target_os = "linux", feature = "jack"))]


### PR DESCRIPTION
## Summary

Clicking the enable/disable toggle on a chain or a block used to feel like a full project reload. Two fast paths land here:

**Block toggle.** `Command::ToggleBlockEnabled` no longer goes through `upsert_chain` → `resolve_chain_audio_config` → full graph rebuild. New `engine::runtime::set_block_enabled` flips the existing `BlockRuntimeNode.fade_state` (the click-safe `FadingOut` / `FadingIn` transitions the engine already supports — see `runtime_block_builders.rs:60-71`) across every per-input runtime of the chain. Wired through `ProjectRuntimeController::set_block_enabled` and the new `sync_block_toggle` adapter-gui helper; falls back to the legacy slow path only when the chain has no live runtime yet or the live node is a `Bypass` that needs a real processor.

**Chain toggle.** `Command::ToggleChainEnabled` no longer drops the runtime on disable. `pause_chain` flips `set_draining()` on the live `Arc<ChainRuntimeState>` and leaves the CPAL streams + processors alive. Re-enable takes a fast-path branch in `upsert_chain_modal` that just calls `clear_draining()` and returns — no CPAL queries, no NAM reload, no graph rebuild. Cold first enable of a chain (no runtime yet) still walks the full path; that's parts (b) NAM single-load and (c) incremental `replace_project_chains` of the diagnosis, left for follow-up issues.

Trade-off: paused chains keep the audio device grabbed. App close still releases via `stop()`. For toggling between chains during a session this is strictly faster and matches the user's expectation that flipping a chain switch is instant.

## Test plan

- [x] `cargo test -p engine --lib` — 527 pass, including new `block_enabled_fast_path_tests` (3): disable → FadingOut, re-enable → FadingIn, unknown block → Err with no mutation.
- [x] `cargo test -p infra-cpal --lib` — 64 pass, including new `controller_pause_chain_tests` (2): disable keeps Arc in `active_chains` and sets draining; re-enable reuses the SAME Arc and clears draining.
- [x] `cargo test -p adapter-gui --lib` — 399 pass.
- [x] Live verified on the user's Scarlett 2i2 / macOS: block toggle on a running chain is instant (no `[engine] rebuild block` lines in the log, just a fade transition). Chain disable → re-enable shows `pausing chain '…' (keep streams alive)` and `resuming paused chain '…' (fast path)` — instant.

Closes #522 (parts (a) block-toggle and chain-toggle case)