### PR TITLE
ci(525): build qa_audit before pack_plugins so release workflow runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,13 @@ jobs:
           key: bundle-plugins-cargo-${{ hashFiles('openrig-plugins/Cargo.lock') }}
           restore-keys: bundle-plugins-cargo-
 
+      # Issue #525: pack_plugins shells out to qa_audit (loudness-audit) to
+      # verify per-capture loudness budgets. Build the binary first so the
+      # following Validate step finds it under target/release/.
+      - name: Build qa_audit (required by pack_plugins)
+        working-directory: openrig-plugins
+        run: cargo build --release -p loudness-audit --bin qa_audit
+
       - name: Validate plugins
         working-directory: openrig-plugins
         # pack_plugins iterates plugins/source/, validates every package's


### PR DESCRIPTION
## Summary

\`pack_plugins\` started shelling out to a sibling \`qa_audit\` binary (loudness-audit) between dev.22 and dev.23, but the release workflow was never updated to build it. The \`v0.1.0-dev.23\` release run failed in \`bundle-plugins → Validate plugins\` with:

\`\`\`
pack_plugins: qa_audit binary not found at openrig-plugins/target/release/qa_audit
\`\`\`

Every downstream platform build was skipped and no GitHub Release was published — \`v0.1.0-dev.23\` currently is a tag without a release behind it.

Fix: build \`qa_audit\` in the same job, same working directory, same cache, right before \`pack_plugins\`.

## Test plan

- [x] Workflow change is mechanical (single \`cargo build\` step that mirrors the error message's suggested command).
- [ ] After merge: delete the existing \`v0.1.0-dev.23\` tag, re-tag develop's tip, push the tag. The release workflow re-runs end-to-end and the artifacts land.

Closes #525