### PR TITLE
ci(525): pull LFS for cargo-fetched OpenRig dep so qa_audit links

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,8 +49,26 @@ jobs:
       # Issue #525: pack_plugins shells out to qa_audit (loudness-audit) to
       # verify per-capture loudness budgets. Build the binary first so the
       # following Validate step finds it under target/release/.
+      #
+      # qa_audit links against `nam` from the OpenRig git dep, which carries
+      # the NeuralAudioCAPI dylib as a Git LFS file. Cargo's default git
+      # backend (libgit2) does NOT run LFS smudge, so the cached checkout
+      # would receive a 1-line LFS pointer and the linker would fail with
+      # `unknown directive: version` on `libNeuralAudioCAPI.so`. Configure
+      # git-lfs filters system-wide and force cargo to fetch git deps via
+      # the git CLI so LFS smudge runs on the cargo checkout too.
+      - name: Configure git-lfs for cargo fetches
+        run: git lfs install --system --skip-repo
+      - name: Drop stale OpenRig cargo-git checkout (LFS pointers in cache)
+        # The cargo cache restored above may carry an OpenRig checkout that
+        # was fetched WITHOUT LFS smudge — those `libNeuralAudioCAPI.so`
+        # pointer files survive cache restore and re-poison the linker.
+        # Force a fresh, LFS-aware fetch on every run.
+        run: rm -rf ~/.cargo/git/checkouts/openrig-* ~/.cargo/git/db/openrig-*
       - name: Build qa_audit (required by pack_plugins)
         working-directory: openrig-plugins
+        env:
+          CARGO_NET_GIT_FETCH_WITH_CLI: "true"
         run: cargo build --release -p loudness-audit --bin qa_audit
 
       - name: Validate plugins


### PR DESCRIPTION
## Summary

Follow-up to #526. \`qa_audit\` now builds, but linking fails:

\`\`\`
rust-lld: error: libNeuralAudioCAPI.so:1: unknown directive: version
>>> version https://git-lfs.github.com/spec/v1
\`\`\`

Cargo's default git backend (libgit2) does not run git-lfs smudge filters. The cached OpenRig checkout under \`~/.cargo/git/checkouts/openrig-*/\` ends up with a 1-line LFS pointer instead of the real \`libNeuralAudioCAPI.so\`, and the linker chokes.

Three changes:
1. \`git lfs install --system --skip-repo\` — global smudge filters cargo's CLI git path will honor.
2. Drop any stale OpenRig cargo-git checkout before building (cache may carry pointer files).
3. \`CARGO_NET_GIT_FETCH_WITH_CLI=true\` on the build step so cargo shells out to git instead of libgit2.

## Test plan

- [ ] After merge: delete \`v0.1.0-dev.23\` tag, re-tag develop's tip, push tag. Workflow runs end-to-end and produces the release.

Refs: #525