### PR TITLE
ci(525): explicit git lfs pull inside cargo's OpenRig checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,24 +47,33 @@ jobs:
           restore-keys: bundle-plugins-cargo-
 
       # Issue #525: pack_plugins shells out to qa_audit (loudness-audit) to
-      # verify per-capture loudness budgets. Build the binary first so the
-      # following Validate step finds it under target/release/.
+      # verify per-capture loudness budgets. qa_audit links against `nam`
+      # from the OpenRig git dep, which ships NeuralAudioCAPI as a Git LFS
+      # asset. Cargo's git checkout (even with CARGO_NET_GIT_FETCH_WITH_CLI)
+      # does not run LFS smudge on the working tree it writes to
+      # ~/.cargo/git/checkouts/, so the linker sees a 1-line LFS pointer
+      # and exits with `unknown directive: version` on libNeuralAudioCAPI.so.
       #
-      # qa_audit links against `nam` from the OpenRig git dep, which carries
-      # the NeuralAudioCAPI dylib as a Git LFS file. Cargo's default git
-      # backend (libgit2) does NOT run LFS smudge, so the cached checkout
-      # would receive a 1-line LFS pointer and the linker would fail with
-      # `unknown directive: version` on `libNeuralAudioCAPI.so`. Configure
-      # git-lfs filters system-wide and force cargo to fetch git deps via
-      # the git CLI so LFS smudge runs on the cargo checkout too.
-      - name: Configure git-lfs for cargo fetches
+      # Workaround: drop any stale OpenRig cargo-git checkout, run
+      # `cargo fetch` to materialise a fresh one (forced via git CLI), then
+      # run `git lfs pull` inside that checkout BEFORE invoking the build —
+      # by the time the linker reads the dylib, it is the real binary.
+      - name: Configure git-lfs system filters
         run: git lfs install --system --skip-repo
       - name: Drop stale OpenRig cargo-git checkout (LFS pointers in cache)
-        # The cargo cache restored above may carry an OpenRig checkout that
-        # was fetched WITHOUT LFS smudge — those `libNeuralAudioCAPI.so`
-        # pointer files survive cache restore and re-poison the linker.
-        # Force a fresh, LFS-aware fetch on every run.
         run: rm -rf ~/.cargo/git/checkouts/openrig-* ~/.cargo/git/db/openrig-*
+      - name: Fetch cargo deps (materialise OpenRig checkout)
+        working-directory: openrig-plugins
+        env:
+          CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+        run: cargo fetch
+      - name: Pull LFS files inside the OpenRig cargo checkout
+        run: |
+          for dir in ~/.cargo/git/checkouts/openrig-*/*/; do
+            echo "Pulling LFS in $dir"
+            git -C "$dir" lfs install --local
+            git -C "$dir" lfs pull
+          done
       - name: Build qa_audit (required by pack_plugins)
         working-directory: openrig-plugins
         env:


### PR DESCRIPTION
## Summary

Third attempt at unblocking the release. #526 added the qa_audit build; #527 enabled \`CARGO_NET_GIT_FETCH_WITH_CLI\` and system-wide LFS filters. Empirically, neither makes cargo run LFS smudge on the working tree it writes to \`~/.cargo/git/checkouts/openrig-*/\` — the linker keeps seeing 1-line pointer files for \`libNeuralAudioCAPI.so\` and failing with \`unknown directive: version\`.

Fix: do the LFS pull ourselves, explicitly, between fetch and build.

1. \`cargo fetch\` (force git-CLI) — materialises the OpenRig checkout under \`~/.cargo/git/checkouts/openrig-*/\`.
2. \`for dir in ~/.cargo/git/checkouts/openrig-*/*/; do git -C "\$dir" lfs install --local && git -C "\$dir" lfs pull; done\` — replaces pointer files with the real binaries.
3. \`cargo build -p loudness-audit --bin qa_audit\` — the linker now sees the real \`libNeuralAudioCAPI.so\`.

## Test plan

- [ ] After merge: delete \`v0.1.0-dev.23\` tag, re-tag develop's tip, push. Workflow runs end-to-end and produces the release.

Refs: #525