### PR TITLE
ci(525): point cargo-checkout LFS pull at github.com directly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,10 +68,15 @@ jobs:
           CARGO_NET_GIT_FETCH_WITH_CLI: "true"
         run: cargo fetch
       - name: Pull LFS files inside the OpenRig cargo checkout
+        # Cargo's git db is a bare clone that does NOT carry LFS objects, so
+        # an unmodified `git lfs pull` from the checkout would try the file://
+        # origin and exit with "remote missing object". Point `lfs.url` at
+        # github.com directly so the pull fetches from the real LFS server.
         run: |
           for dir in ~/.cargo/git/checkouts/openrig-*/*/; do
             echo "Pulling LFS in $dir"
             git -C "$dir" lfs install --local
+            git -C "$dir" config lfs.url https://github.com/jpfaria/OpenRig.git/info/lfs
             git -C "$dir" lfs pull
           done
       - name: Build qa_audit (required by pack_plugins)


### PR DESCRIPTION
## Summary

Fourth attempt. #528 ran \`git lfs pull\` inside cargo's OpenRig checkout, but the cargo \"db\" is a bare clone that does not carry LFS objects — the pull dutifully tried the \`file://\` origin (cargo db) and exited with \`remote missing object\` for every dylib hash:

\`\`\`
error transferring "9eab5a10…": [0] remote missing object 9eab5a10…
…
Failed to fetch some objects from 'file:///home/runner/.cargo/git/db/openrig-…'
\`\`\`

Fix: override \`lfs.url\` to the real github.com endpoint (\`https://github.com/jpfaria/OpenRig.git/info/lfs\`) before \`git lfs pull\`, so the dylibs come from the upstream LFS server.

## Test plan

- [ ] After merge: delete \`v0.1.0-dev.23\` tag, re-tag develop's tip, push. Workflow runs end-to-end.

Refs: #525