### PR TITLE
fix(#532): clamp chain stream_meter row count to project state

### DIFF
--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -85,6 +85,8 @@ mod helpers;
 mod io_groups;
 mod latency_probe;
 mod meter_wiring;
+#[cfg(test)]
+mod meter_wiring_row_update_tests;
 mod midi_adapter_wiring;
 mod model_search;
 mod model_search_wiring;

--- a/crates/adapter-gui/src/meter_wiring.rs
+++ b/crates/adapter-gui/src/meter_wiring.rs
@@ -286,6 +286,57 @@ pub fn build_streams_from_taps<T: MeterTapApi>(
     ChainMeterStreams { streams }
 }
 
+/// Build the per-chain `stream_meters` row payload the GUI must show.
+///
+/// Issue #532: the row length is owned by the project state — one
+/// slot per input entry in the chain (with a min of 1 mirroring
+/// `replace_project_chains`'s `.max(1)` clamp) — NOT by the engine's
+/// transient per-tick stream count. If the engine reports more streams
+/// than the project owns (transient mid-rebuild after a preset switch),
+/// the extra readings are dropped. If it reports fewer (sibling chain
+/// re-spawning after a toggle), the missing slots stay [`SILENT_DBFS`].
+/// Both symptoms reported in #532 collapse to the same fix.
+///
+/// The OUTPUT reading is scaled by `apply_chain_volume_db` because the
+/// stream_tap reads the signal BEFORE the audio callback applies the
+/// chain volume slider (#496). INPUT is untouched.
+pub fn rebuild_stream_meters_row(
+    engine_readings: &[StreamMeterReading],
+    project_input_count: usize,
+    chain_volume: f32,
+) -> Vec<crate::StreamMeter> {
+    let len = project_input_count.max(1);
+    (0..len)
+        .map(|i| match engine_readings.get(i) {
+            Some(r) => crate::StreamMeter {
+                in_dbfs: r.in_dbfs,
+                out_dbfs: apply_chain_volume_db(r.out_dbfs, chain_volume),
+            },
+            None => crate::StreamMeter {
+                in_dbfs: SILENT_DBFS,
+                out_dbfs: SILENT_DBFS,
+            },
+        })
+        .collect()
+}
+
+/// Sum of `InputBlock.entries.len()` across a chain's blocks — the
+/// number of independent per-input runtimes the engine owns for the
+/// chain (issue #350). This is the GUI's source of truth for how many
+/// meter rows to render. Mirrors the count `replace_project_chains`
+/// uses when it first builds the row model.
+pub fn project_input_count(chain: &project::chain::Chain) -> usize {
+    use project::block::AudioBlockKind;
+    chain
+        .blocks
+        .iter()
+        .filter_map(|b| match &b.kind {
+            AudioBlockKind::Input(ib) => Some(ib.entries.len()),
+            _ => None,
+        })
+        .sum()
+}
+
 /// Drain the per-stream rings and return one `StreamMeterReading`
 /// per stream for every chain in the store.
 pub fn poll_per_stream(
@@ -411,22 +462,20 @@ pub fn start_meter_polling(
             };
             let chain_volume = project.chains[idx].volume;
             let out_db = apply_chain_volume_db(out_db_raw, chain_volume);
-            // Per-stream rows for the new multi-bar UI surface. Build
-            // them from the same `per_stream` data the max-aggregate
-            // came from above so they always agree.
-            let per_stream_rows: Vec<crate::StreamMeter> = per_stream
+            // Per-stream rows. Issue #532: the row length follows the
+            // project's input-entry count, NOT the engine's transient
+            // stream readings. Engine readings fill the project-owned
+            // slots; missing entries stay SILENT. Without this clamp
+            // a preset switch leaked extra rows into the footer and a
+            // sibling toggle collapsed the rest to zero rows.
+            let engine_streams: Vec<StreamMeterReading> = per_stream
                 .iter()
                 .find(|(c, _)| c == &cid)
-                .map(|(_, streams)| {
-                    streams
-                        .iter()
-                        .map(|r| crate::StreamMeter {
-                            in_dbfs: r.in_dbfs,
-                            out_dbfs: apply_chain_volume_db(r.out_dbfs, chain_volume),
-                        })
-                        .collect()
-                })
+                .map(|(_, streams)| streams.clone())
                 .unwrap_or_default();
+            let project_streams = project_input_count(&project.chains[idx]);
+            let per_stream_rows: Vec<crate::StreamMeter> =
+                rebuild_stream_meters_row(&engine_streams, project_streams, chain_volume);
             let stream_meters_changed = {
                 use slint::Model;
                 let current = row.stream_meters.iter().collect::<Vec<_>>();

--- a/crates/adapter-gui/src/meter_wiring_row_update_tests.rs
+++ b/crates/adapter-gui/src/meter_wiring_row_update_tests.rs
@@ -120,7 +120,11 @@ fn row_min_length_is_one_when_project_input_count_is_zero() {
     // that's mid-construction. Mirrors the `.max(1)` clamp in
     // `replace_project_chains`.
     let row: Vec<StreamMeter> = rebuild_stream_meters_row(&[], 0, 100.0);
-    assert_eq!(row.len(), 1, "min 1 silent slot mirrors replace_project_chains clamp");
+    assert_eq!(
+        row.len(),
+        1,
+        "min 1 silent slot mirrors replace_project_chains clamp"
+    );
     assert_eq!(row[0].in_dbfs, SILENT_DBFS);
     assert_eq!(row[0].out_dbfs, SILENT_DBFS);
 }
@@ -134,7 +138,10 @@ fn row_applies_chain_volume_to_output_only() {
     // — must be preserved here.
     let readings = vec![reading(-6.0, -12.0)];
     let row: Vec<StreamMeter> = rebuild_stream_meters_row(&readings, 1, 200.0);
-    assert!((row[0].in_dbfs - (-6.0)).abs() < 0.05, "input is not scaled");
+    assert!(
+        (row[0].in_dbfs - (-6.0)).abs() < 0.05,
+        "input is not scaled"
+    );
     // -12 dBFS + 20·log10(2.0) = -12 + 6 = -6 dBFS
     assert!(
         (row[0].out_dbfs - (-6.0)).abs() < 0.1,

--- a/crates/adapter-gui/src/meter_wiring_row_update_tests.rs
+++ b/crates/adapter-gui/src/meter_wiring_row_update_tests.rs
@@ -1,0 +1,144 @@
+//! Issue #532: chain stream_meter row count must reflect the project's
+//! input-entry count, not the engine's transient stream readings.
+//!
+//! Two user-observed symptoms in one screenshot:
+//!
+//! 1. After switching the preset on a chain, the chain's footer grows
+//!    new INPUT/OUTPUT rows on every switch (6+ stacked rows on a chain
+//!    that has a single XLR input).
+//! 2. After toggling/activating a chain, sibling chains lose their
+//!    INPUT/OUTPUT rows entirely.
+//!
+//! Both shapes point at the same logic gap in `start_meter_polling`:
+//! the timer writes `stream_meters = per_stream_rows` straight from
+//! the engine's per-stream readings (lines 417–453 of `meter_wiring.rs`).
+//! If the engine transiently reports a different stream count than the
+//! project's `InputBlock.entries.len()` sum (e.g. mid-rebuild after a
+//! preset switch, or 0 while a sibling re-spawns), the row's
+//! `stream_meters` model gets resized to the engine's number — which
+//! makes the UI duplicate or vanish rows that should be stable.
+//!
+//! The correct invariant: the meter row count is owned by the PROJECT
+//! state (one slot per input entry, min 1). The engine readings fill
+//! those slots; missing readings become SILENT. The timer never grows
+//! or shrinks the row past the project-derived count.
+//!
+//! These tests exercise a pure helper `rebuild_stream_meters_row`
+//! that the timer must use to produce the row payload. Writing this
+//! file first (against an API that does not exist yet) is the RED that
+//! gates the implementation, per CLAUDE.md / docs/testing.md.
+
+use super::meter_wiring::{rebuild_stream_meters_row, StreamMeterReading};
+use crate::StreamMeter;
+use engine::output_meter::SILENT_DBFS;
+
+fn reading(in_dbfs: f32, out_dbfs: f32) -> StreamMeterReading {
+    StreamMeterReading { in_dbfs, out_dbfs }
+}
+
+#[test]
+fn row_length_equals_project_input_count_when_engine_matches() {
+    // Steady state: project says 2 input entries, engine reports 2
+    // streams. Row is 2 entries with the engine values.
+    let readings = vec![reading(-6.0, -12.0), reading(-3.0, -9.0)];
+    let row: Vec<StreamMeter> = rebuild_stream_meters_row(&readings, 2, 100.0);
+    assert_eq!(row.len(), 2);
+    assert!((row[0].in_dbfs - (-6.0)).abs() < 0.05);
+    assert!((row[0].out_dbfs - (-12.0)).abs() < 0.05);
+    assert!((row[1].in_dbfs - (-3.0)).abs() < 0.05);
+    assert!((row[1].out_dbfs - (-9.0)).abs() < 0.05);
+}
+
+#[test]
+fn row_length_stays_at_project_count_when_engine_reports_more_streams() {
+    // User-observed bug A: after switching preset on the DEFAULT chain
+    // the footer accumulates extra INPUT/OUTPUT rows (6 visible in the
+    // screenshot for a chain with a single input). Engine reports
+    // more streams than the project owns — the UI must NOT grow past
+    // the project count, otherwise every preset switch leaks rows.
+    let readings = vec![
+        reading(-6.0, -12.0),
+        reading(-6.0, -12.0),
+        reading(-6.0, -12.0),
+        reading(-6.0, -12.0),
+        reading(-6.0, -12.0),
+        reading(-6.0, -12.0),
+    ];
+    let row: Vec<StreamMeter> = rebuild_stream_meters_row(&readings, 1, 100.0);
+    assert_eq!(
+        row.len(),
+        1,
+        "row count must follow project input count (1), \
+         not engine transient stream count (6) — issue #532 symptom A"
+    );
+}
+
+#[test]
+fn row_length_stays_at_project_count_when_engine_reports_zero_streams() {
+    // User-observed bug B: after activating one chain, sibling chains
+    // lose their INPUT/OUTPUT rows entirely. The engine transiently
+    // reports zero streams for the sibling while the controller is
+    // rebuilt; the UI must NOT collapse the row — it must keep
+    // project-derived slots showing SILENT.
+    let row: Vec<StreamMeter> = rebuild_stream_meters_row(&[], 1, 100.0);
+    assert_eq!(
+        row.len(),
+        1,
+        "row count must stay at project input count (1) when engine \
+         reports nothing — issue #532 symptom B"
+    );
+    assert_eq!(
+        row[0].in_dbfs, SILENT_DBFS,
+        "missing reading slot must read SILENT"
+    );
+    assert_eq!(
+        row[0].out_dbfs, SILENT_DBFS,
+        "missing reading slot must read SILENT"
+    );
+}
+
+#[test]
+fn row_pads_missing_slots_with_silent_when_engine_reports_fewer_streams() {
+    // Multi-input chain: project has 3 input entries, engine has
+    // only finished spinning up 1 stream so far. The active stream
+    // shows its reading; the remaining slots stay SILENT so the row
+    // stays at the project-derived 3 entries.
+    let readings = vec![reading(-6.0, -12.0)];
+    let row: Vec<StreamMeter> = rebuild_stream_meters_row(&readings, 3, 100.0);
+    assert_eq!(row.len(), 3, "row length follows project input count");
+    assert!((row[0].in_dbfs - (-6.0)).abs() < 0.05);
+    assert_eq!(row[1].in_dbfs, SILENT_DBFS);
+    assert_eq!(row[2].in_dbfs, SILENT_DBFS);
+    assert_eq!(row[1].out_dbfs, SILENT_DBFS);
+    assert_eq!(row[2].out_dbfs, SILENT_DBFS);
+}
+
+#[test]
+fn row_min_length_is_one_when_project_input_count_is_zero() {
+    // Defensive: project with no input entries yet still gets a single
+    // SILENT slot so the UI never shows "no meter" for a chain card
+    // that's mid-construction. Mirrors the `.max(1)` clamp in
+    // `replace_project_chains`.
+    let row: Vec<StreamMeter> = rebuild_stream_meters_row(&[], 0, 100.0);
+    assert_eq!(row.len(), 1, "min 1 silent slot mirrors replace_project_chains clamp");
+    assert_eq!(row[0].in_dbfs, SILENT_DBFS);
+    assert_eq!(row[0].out_dbfs, SILENT_DBFS);
+}
+
+#[test]
+fn row_applies_chain_volume_to_output_only() {
+    // Same volume-compensation rule the timer already enforces: the
+    // OUTPUT reading is scaled by `20·log10(volume_pct/100)` because
+    // the stream_tap reads BEFORE the audio callback applies the
+    // chain volume slider. The INPUT reading is untouched. Issue #496
+    // — must be preserved here.
+    let readings = vec![reading(-6.0, -12.0)];
+    let row: Vec<StreamMeter> = rebuild_stream_meters_row(&readings, 1, 200.0);
+    assert!((row[0].in_dbfs - (-6.0)).abs() < 0.05, "input is not scaled");
+    // -12 dBFS + 20·log10(2.0) = -12 + 6 = -6 dBFS
+    assert!(
+        (row[0].out_dbfs - (-6.0)).abs() < 0.1,
+        "output must compensate for chain volume (200% → +6 dB); got {}",
+        row[0].out_dbfs
+    );
+}


### PR DESCRIPTION
## Summary

- Chain footer's INPUT/OUTPUT meter row count now follows `project.chains[idx]`'s input-entry count, not the engine's transient per-tick stream readings.
- Fixes both reported symptoms: preset switch leaking extra rows in the chain footer; sibling chains losing all meter rows on chain toggle.
- Extracted `rebuild_stream_meters_row` (pure helper) so the row-length rule is unit-testable. Timer body becomes a thin caller.

## Root cause

`start_meter_polling` wrote `stream_meters` straight from `poll_per_stream`. Whatever the engine reported per tick — 6 mid-rebuild after preset switch, 0 mid-respawn for a sibling — became the row length. The fix moves ownership of the row count to the project state (`InputBlock.entries.len()` sum, min 1 — same clamp `replace_project_chains` uses).

## Test plan

- [x] `cargo test -p adapter-gui --lib meter_wiring` — 30 passed (6 new + 24 existing)
- [x] `cargo test -p adapter-gui --lib` — 405 passed, 3 ignored (pre-existing)
- [x] Quality gate `qg --base origin/develop` — `passed` (no metric regressed)
- [x] User validated locally on macOS — issue #532 confirmed fixed

## Invariants

Pure GUI/model wiring. Audio thread, DSP, stream isolation invariants untouched.

Issue: #532