### PR TITLE
fix(#535): reset active_scene on SwitchPreset to stop scene leak across bank presets

### DIFF
--- a/crates/adapter-gui/src/chain_rig_nav_tests.rs
+++ b/crates/adapter-gui/src/chain_rig_nav_tests.rs
@@ -437,6 +437,33 @@ fn switching_scene_projects_that_scenes_volume() {
     );
 }
 
+// Issue #535: the SceneBar reads `scene_count` per chain row from the
+// ACTIVE preset only. Adding a scene to A must not change the count the
+// row exposes once the user switches the combobox to a sibling preset B.
+#[test]
+fn nav_row_scene_count_follows_active_preset_after_a_sibling_grew() {
+    // Bank {1:clean, 2:drive, 3:lead}; start active=clean (slot 1), scene 1.
+    let mut r = rig();
+    r.inputs.get_mut("input-1").unwrap().active_preset = 1;
+    r.inputs.get_mut("input-1").unwrap().active_scene = 1;
+
+    // 1. + scene on "clean" (active). Row must now read 2.
+    r.add_scene_to_input("input-1").expect("scene added on clean");
+    let rows = rig_nav_rows(&r, &rig_to_legacy_project(&r, &BTreeSet::new()));
+    assert_eq!(rows[0].scene_count, 2, "active preset 'clean' has 2 scenes");
+
+    // 2. Combobox switch to "drive" (slot 2 — never touched).
+    switch_and_project_input(&mut r, "input-1", Some(2), None).expect("switched");
+
+    // 3. Row's scene_count MUST reflect drive's pool entry (= 1), NOT a
+    //    stale 2 from clean nor a leaked sibling.
+    let rows = rig_nav_rows(&r, &rig_to_legacy_project(&r, &BTreeSet::new()));
+    assert_eq!(
+        rows[0].scene_count, 1,
+        "after switching to a sibling preset that never had a scene added, the row must show 1 scene"
+    );
+}
+
 #[test]
 fn non_rig_chain_yields_empty_row() {
     let r = rig();

--- a/crates/application/src/local_dispatcher_rig_tests.rs
+++ b/crates/application/src/local_dispatcher_rig_tests.rs
@@ -423,3 +423,116 @@ fn rig_to_legacy_project_after_capture_reflects_persisted_chain_order() {
         "the rig→project projection must honour the persisted chain order"
     );
 }
+
+// ── Issue #535: AddScene on the active preset must not bleed into siblings ──
+
+#[test]
+fn apply_rig_nav_add_scene_only_grows_active_preset_not_other_bank_presets() {
+    // User repro (#535): chain "in" has presets A (slot 1) and B (slot 2);
+    // A is active. Adding a 2nd scene must grow ONLY preset A — preset B
+    // sits idle in the same bank and must keep its single scene.
+    let rig = Rc::new(RefCell::new(rig())); // bank {1: "p1", 2: "p2"}, active=1
+    let project = Rc::new(RefCell::new(engine::rig_runtime::rig_to_legacy_project(
+        &rig.borrow(),
+        &std::collections::BTreeSet::new(),
+    )));
+    let dispatcher = LocalDispatcher::new(Rc::clone(&project));
+    dispatcher.attach_rig(Rc::clone(&rig));
+
+    assert_eq!(rig.borrow().presets["p1"].scene_count(), 1, "A starts at 1");
+    assert_eq!(rig.borrow().presets["p2"].scene_count(), 1, "B starts at 1");
+
+    // GUI's "+" on the scene bar dispatches this exact sentinel.
+    dispatcher
+        .dispatch(Command::ApplyRigNav {
+            chain: ChainId("rig:in".into()),
+            kind: RigNavKind::Scene(-1),
+        })
+        .expect("dispatch ok");
+
+    assert_eq!(
+        rig.borrow().presets["p1"].scene_count(),
+        2,
+        "active preset A must grow to 2 scenes"
+    );
+    assert_eq!(
+        rig.borrow().presets["p2"].scene_count(),
+        1,
+        "sibling preset B must NOT receive a scene — it is not the active preset"
+    );
+}
+
+#[test]
+fn add_scene_on_a_then_switch_to_b_keeps_b_at_one_scene_in_the_pool() {
+    // User repro (#535) on the full flow: from the Chains screen, add a
+    // 2nd scene to preset A, then switch the combobox to preset B. The
+    // preset pool entry for B must keep its single scene (no sibling
+    // contamination from the AddScene call, no re-projection side effect).
+    let rig = Rc::new(RefCell::new(rig())); // bank {1: "p1", 2: "p2"}, active=1
+    let project = Rc::new(RefCell::new(engine::rig_runtime::rig_to_legacy_project(
+        &rig.borrow(),
+        &std::collections::BTreeSet::new(),
+    )));
+    let dispatcher = LocalDispatcher::new(Rc::clone(&project));
+    dispatcher.attach_rig(Rc::clone(&rig));
+
+    dispatcher
+        .dispatch(Command::ApplyRigNav {
+            chain: ChainId("rig:in".into()),
+            kind: RigNavKind::Scene(-1),
+        })
+        .expect("add scene ok");
+    dispatcher
+        .dispatch(Command::ApplyRigNav {
+            chain: ChainId("rig:in".into()),
+            kind: RigNavKind::Preset(1),
+        })
+        .expect("switch ok");
+
+    assert_eq!(
+        rig.borrow().presets["p2"].scene_count(),
+        1,
+        "preset B must still expose a single scene after the round-trip"
+    );
+}
+
+#[test]
+fn add_scene_on_a_switch_to_b_then_save_keeps_b_at_one_scene() {
+    // User repro (#535): the leak surfaces only after a save round-trip
+    // ("entro e saio do projeto ele aparece"). The save path dispatches
+    // CaptureRigEdits → sync_synthetic_into_rig, which calls
+    // write_back_processing_blocks on the new active preset using the
+    // STALE active_scene carried over from the previous preset (A's
+    // scene 2). That call's `preset.scenes.entry(scene_idx).or_default()`
+    // materializes a spurious scene 2 in B.
+    let rig = Rc::new(RefCell::new(rig())); // bank {1: "p1", 2: "p2"}, active=1
+    let project = Rc::new(RefCell::new(engine::rig_runtime::rig_to_legacy_project(
+        &rig.borrow(),
+        &std::collections::BTreeSet::new(),
+    )));
+    let dispatcher = LocalDispatcher::new(Rc::clone(&project));
+    dispatcher.attach_rig(Rc::clone(&rig));
+
+    dispatcher
+        .dispatch(Command::ApplyRigNav {
+            chain: ChainId("rig:in".into()),
+            kind: RigNavKind::Scene(-1),
+        })
+        .expect("add scene ok");
+    dispatcher
+        .dispatch(Command::ApplyRigNav {
+            chain: ChainId("rig:in".into()),
+            kind: RigNavKind::Preset(1),
+        })
+        .expect("switch ok");
+    // The save path runs CaptureRigEdits before serializing.
+    dispatcher
+        .dispatch(Command::CaptureRigEdits)
+        .expect("capture ok");
+
+    assert_eq!(
+        rig.borrow().presets["p2"].scene_count(),
+        1,
+        "after add-scene-on-A → switch-to-B → save, preset B must still have a single scene"
+    );
+}

--- a/crates/infra-yaml/src/rig_yaml_tests.rs
+++ b/crates/infra-yaml/src/rig_yaml_tests.rs
@@ -357,3 +357,73 @@ fn load_project_any_rejects_future_version() {
     let err = load_project_any(&path).unwrap_err().to_string();
     assert!(err.contains("999"), "got: {err}");
 }
+
+// Issue #535 — save + reopen of a 2-preset bank must keep scenes per preset.
+// Repro: chain has presets A (slot 1, 2 scenes) and B (slot 2, 1 scene).
+// Round-tripping through serialize_rig_project + parse_rig_project must
+// leave B with exactly its own 1 scene — no leak from A.
+#[test]
+fn round_trip_keeps_scenes_isolated_per_preset_in_the_same_bank() {
+    use project::rig::{RigInput, RigPreset, RigProject, RigScene};
+    use std::collections::BTreeMap;
+
+    let mut preset_a = RigPreset {
+        id: "a".into(),
+        name: Some("A".into()),
+        blocks: Vec::new(),
+        scene_params: Vec::new(),
+        scenes: BTreeMap::from([
+            (1, RigScene::default()),
+            (2, RigScene::default()),
+        ]),
+        volume: 100.0,
+    };
+    preset_a.scenes.entry(1).or_insert_with(RigScene::default);
+    let preset_b = RigPreset {
+        id: "b".into(),
+        name: Some("B".into()),
+        blocks: Vec::new(),
+        scene_params: Vec::new(),
+        scenes: BTreeMap::from([(1, RigScene::default())]),
+        volume: 100.0,
+    };
+
+    let mut presets = BTreeMap::new();
+    presets.insert("a".into(), preset_a);
+    presets.insert("b".into(), preset_b);
+
+    let mut inputs = BTreeMap::new();
+    inputs.insert(
+        "input-1".into(),
+        RigInput {
+            label: None,
+            sources: Vec::new(),
+            bank: BTreeMap::from([(1, "a".into()), (2, "b".into())]),
+            active_preset: 1,
+            active_scene: 1,
+            routing: Vec::new(),
+        },
+    );
+    let rig = RigProject {
+        name: None,
+        inputs,
+        outputs: BTreeMap::new(),
+        presets,
+        midi: None,
+        chain_order: Vec::new(),
+    };
+
+    let yaml = serialize_rig_project(&rig).expect("serialize");
+    let restored = parse_rig_project(&yaml).expect("parse");
+
+    assert_eq!(
+        restored.presets["a"].scene_count(),
+        2,
+        "preset A round-trips with 2 scenes",
+    );
+    assert_eq!(
+        restored.presets["b"].scene_count(),
+        1,
+        "preset B must round-trip with exactly 1 scene — no leak from A",
+    );
+}

--- a/crates/project/src/rig_command.rs
+++ b/crates/project/src/rig_command.rs
@@ -37,7 +37,15 @@ impl RigCommand {
                 let key = rig.inputs.get(input)?.bank.keys().nth(*position).copied()?;
                 let name = rig.inputs.get(input)?.bank.get(&key)?.clone();
                 rig.presets.get(&name)?; // reject a dangling bank entry
-                rig.inputs.get_mut(input)?.active_preset = key;
+                let ri = rig.inputs.get_mut(input)?;
+                ri.active_preset = key;
+                // #535: scenes belong to the preset. Carrying the previous
+                // preset's active_scene leaks into the new preset on the
+                // next write_back_processing_blocks call (the save path
+                // runs CaptureRigEdits, which materializes a phantom scene
+                // via `scenes.entry(idx).or_default()`). Reset to 1 — same
+                // contract `add_preset_to_input` already enforces.
+                ri.active_scene = 1;
                 Some(())
             }
             RigCommand::AddPreset { input } => rig.add_preset_to_input(input).map(|_| ()),

--- a/crates/project/src/rig_command_tests.rs
+++ b/crates/project/src/rig_command_tests.rs
@@ -58,6 +58,29 @@ fn switch_preset_command_activates_the_selected_combobox_position() {
     assert_eq!(r.inputs["in"].active_preset, 2, "position 1 → bank key 2");
 }
 
+// #535: scenes are per-preset; switching preset must NOT carry the
+// previous preset's active_scene over (a stale index leaks into the
+// next preset on the very next write_back_processing_blocks call and
+// materializes a phantom scene there).
+#[test]
+fn switch_preset_command_resets_active_scene_to_one() {
+    let mut r = rig();
+    r.add_scene_to_input("in").expect("scene 2 in clean");
+    assert_eq!(r.inputs["in"].active_scene, 2, "we leave clean on scene 2");
+
+    RigCommand::SwitchPreset {
+        input: "in".into(),
+        position: 1, // → "drive"
+    }
+    .apply(&mut r)
+    .expect("valid");
+
+    assert_eq!(
+        r.inputs["in"].active_scene, 1,
+        "switching presets must reset active_scene so the new preset starts on its own scene 1"
+    );
+}
+
 #[test]
 fn add_preset_command_appends_and_activates() {
     let mut r = rig();

--- a/docs/projects/project-openrig-format.md
+++ b/docs/projects/project-openrig-format.md
@@ -127,7 +127,10 @@ the audio-thread contract:
   chain. Same I/O signature ⇒ the proven in-place lock-free update path: the
   `Arc<ChainRuntimeState>` is preserved, the new pipeline is built off the
   brief swap lock, and the existing per-segment cosine fade-in keeps the
-  switch click-free. Other inputs are untouched.
+  switch click-free. Other inputs are untouched. Switching presets also
+  resets `active_scene` to `1` — scenes are per-preset, so carrying the
+  previous preset's scene index over would leak a phantom scene into the
+  new preset on the next `write_back_processing_blocks` call (#535).
 
 Transport-agnostic (no Slint/cpal in `engine`); the host wires the resulting
 `RuntimeGraph` to its backend.


### PR DESCRIPTION
## Summary

- Adding a scene to preset A in a chain's bank made preset B grow a phantom scene after save+reopen ("entro e saio do projeto ele aparece") — `RigCommand::SwitchPreset` left `active_scene` stale, then the save path's `CaptureRigEdits → sync_synthetic_into_rig → write_back_processing_blocks` materialized that index in B via `scenes.entry(idx).or_default()`.
- Fix at the source: `SwitchPreset.apply()` resets `active_scene = 1`, matching the contract `add_preset_to_input` already enforces.
- Red-first regression at four layers (project model, LocalDispatcher full repro, GUI projection, YAML round-trip) so any future drift breaks loudly.

Closes #535.

## Test plan

- [ ] `git fetch && git checkout bugfix/issue-535 && git pull`
- [ ] Open the Chains screen on a chain with two presets A and B in the bank.
- [ ] With A active, click **+** on the scene bar → A shows `[1] [2]`.
- [ ] Switch combobox to B → SceneBar shows only `[1]` + the `+`.
- [ ] Save the project (Cmd+S), close, reopen.
- [ ] Reopen, navigate to the chain, select B → SceneBar still shows only `[1]` (previously showed a phantom `[1] [2]`).
- [ ] Toggle between A and B several times across saves — each keeps its own scenes.
- [ ] Footswitch / MIDI step-preset (if you use it) — same protection, since it routes through the same `SwitchPreset`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)