### PR TITLE
fix(#540): persist SetPresetsPath / SetPluginsPath into config.yaml

### DIFF
--- a/crates/adapter-gui/tests/issue_540_set_paths_persists.rs
+++ b/crates/adapter-gui/tests/issue_540_set_paths_persists.rs
@@ -1,0 +1,126 @@
+//! Issue #540 — Settings → Caminhos must persist the picked folder
+//! to `config.yaml` so the choice survives a restart.
+//!
+//! User reproduction:
+//!   1. Configurar projeto → CAMINHOS → ESCOLHER... pick a folder for
+//!      "Pasta de plugins" (or "Pasta de presets").
+//!   2. Inspect `~/Library/Application Support/OpenRig/config.yaml`.
+//!   3. `paths.plugins_path` (or `paths.presets_path`) is still `null`.
+//!
+//! The dispatcher's existing tests
+//! (`set_plugins_path_emits_paths_saved`,
+//!  `set_presets_path_emits_paths_saved`) only check that
+//! `Event::PathsSaved` is emitted — they don't observe filesystem
+//! state. So they keep passing while the user's pick never reaches
+//! disk.
+//!
+//! This test exercises the full intended contract: dispatch the
+//! Command, then load `config.yaml` from the same location the app
+//! writes/reads at runtime, and assert the path is present.
+//!
+//! It is RED today: `Command::SetPluginsPath` and
+//! `Command::SetPresetsPath` are wired to emit the event only; nothing
+//! persists. Fix forward by wiring the persistence into the system
+//! command's handler (or by adding the adapter-side listener).
+
+use std::cell::RefCell;
+use std::path::PathBuf;
+use std::rc::Rc;
+use std::sync::Mutex;
+
+use application::command::Command;
+use application::dispatcher::CommandDispatcher;
+use application::local_dispatcher::LocalDispatcher;
+use infra_filesystem::FilesystemStorage;
+use project::project::Project;
+
+/// HOME is process-global; serialize tests that swap it.
+static HOME_LOCK: Mutex<()> = Mutex::new(());
+
+fn empty_project_rc() -> Rc<RefCell<Project>> {
+    Rc::new(RefCell::new(Project {
+        name: None,
+        device_settings: vec![],
+        midi: None,
+        chains: vec![],
+    }))
+}
+
+/// Run `f` with HOME redirected at a unique tempdir. Cleans up on
+/// success or panic.
+fn with_temp_home<F: FnOnce(&PathBuf)>(label: &str, f: F) {
+    let _g = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let tmp = std::env::temp_dir().join(format!(
+        "openrig-540-{label}-{}-{now}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&tmp).expect("mkdir tempdir");
+    let prev = std::env::var_os("HOME");
+    std::env::set_var("HOME", &tmp);
+    let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(&tmp)));
+    if let Some(prev) = prev {
+        std::env::set_var("HOME", prev);
+    } else {
+        std::env::remove_var("HOME");
+    }
+    let _ = std::fs::remove_dir_all(&tmp);
+    if let Err(p) = res {
+        std::panic::resume_unwind(p);
+    }
+}
+
+#[test]
+fn issue_540_set_plugins_path_persists_to_config_yaml() {
+    with_temp_home("plugins", |_| {
+        let project = empty_project_rc();
+        let dispatcher = LocalDispatcher::new(Rc::clone(&project));
+        let picked = PathBuf::from("/tmp/openrig-540-picked-plugins");
+
+        let events = dispatcher
+            .dispatch(Command::SetPluginsPath {
+                path: Some(picked.clone()),
+            })
+            .expect("dispatch must succeed");
+
+        assert!(!events.is_empty(), "dispatch must emit at least one event");
+
+        let loaded = FilesystemStorage::load_app_config()
+            .expect("load_app_config from fresh HOME must succeed");
+        assert_eq!(
+            loaded.paths.plugins_path,
+            Some(picked),
+            "REGRESSION: Command::SetPluginsPath did not persist into config.yaml — \
+             user pick survives in memory only and is lost on restart"
+        );
+    });
+}
+
+#[test]
+fn issue_540_set_presets_path_persists_to_config_yaml() {
+    with_temp_home("presets", |_| {
+        let project = empty_project_rc();
+        let dispatcher = LocalDispatcher::new(Rc::clone(&project));
+        let picked = PathBuf::from("/tmp/openrig-540-picked-presets");
+
+        let events = dispatcher
+            .dispatch(Command::SetPresetsPath {
+                path: Some(picked.clone()),
+            })
+            .expect("dispatch must succeed");
+
+        assert!(!events.is_empty(), "dispatch must emit at least one event");
+
+        let loaded = FilesystemStorage::load_app_config()
+            .expect("load_app_config from fresh HOME must succeed");
+        assert_eq!(
+            loaded.paths.presets_path,
+            Some(picked),
+            "REGRESSION: Command::SetPresetsPath did not persist into config.yaml — \
+             user pick survives in memory only and is lost on restart"
+        );
+    });
+}

--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -33,5 +33,9 @@ pub mod validate;
 mod local_dispatcher_tests;
 
 #[cfg(test)]
+#[path = "local_dispatcher_paths_tests.rs"]
+mod local_dispatcher_paths_tests;
+
+#[cfg(test)]
 #[path = "local_dispatcher_rig_tests.rs"]
 mod local_dispatcher_rig_tests;

--- a/crates/application/src/local_dispatcher.rs
+++ b/crates/application/src/local_dispatcher.rs
@@ -266,12 +266,28 @@ impl LocalDispatcher {
         }
     }
 
-    /// #513: system-level paths overrides (presets, plugins). Mirrors
-    /// `handle_midi_system`: no project mutation, just signal the intent.
-    /// The adapter persists `config.yaml` on `Event::PathsSaved` (ADR 0003).
+    /// #513 / #540: system-level paths overrides (presets, plugins).
+    /// The command owns the persistence: write the picked path into
+    /// `config.yaml` (ADR 0003 — system setting), then emit
+    /// `Event::PathsSaved` so listeners (GUI label refresh, MCP, gRPC)
+    /// can pick up the change without re-reading from disk.
+    ///
+    /// The previous handler (#513) emitted the event only and relied on
+    /// "the adapter persists on PathsSaved" — but the event carries no
+    /// path payload and no listener was wired, so the user's pick
+    /// survived only in memory and reset to default on the next launch
+    /// (issue #540).
     pub(crate) fn handle_paths_system(&self, cmd: Command) -> Result<Vec<Event>> {
+        use infra_filesystem::FilesystemStorage;
         match cmd {
-            Command::SetPresetsPath { .. } | Command::SetPluginsPath { .. } => {
+            Command::SetPresetsPath { path } => {
+                FilesystemStorage::save_presets_path(path)
+                    .map_err(|e| anyhow::anyhow!("save_presets_path failed: {e}"))?;
+                Ok(vec![Event::PathsSaved])
+            }
+            Command::SetPluginsPath { path } => {
+                FilesystemStorage::save_plugins_path(path)
+                    .map_err(|e| anyhow::anyhow!("save_plugins_path failed: {e}"))?;
                 Ok(vec![Event::PathsSaved])
             }
             other => {

--- a/crates/application/src/local_dispatcher_paths_tests.rs
+++ b/crates/application/src/local_dispatcher_paths_tests.rs
@@ -1,0 +1,117 @@
+//! Dispatcher tests for `Command::SetPresetsPath` /
+//! `Command::SetPluginsPath` (#513, #540).
+//!
+//! Pulled out of `local_dispatcher_tests.rs` so that file does not grow
+//! past its size cap (per `validate.sh`). #540 made the handler write
+//! `config.yaml` directly via `FilesystemStorage::save_*_path`, so each
+//! test redirects `$HOME` to a unique tempdir to keep the FS write out
+//! of the developer's real `~/Library/Application Support/OpenRig/`.
+//!
+//! Loaded as a sibling test module from `lib.rs` via
+//! `#[cfg(test)] #[path = "local_dispatcher_paths_tests.rs"] mod ...`.
+
+use std::path::PathBuf;
+use std::rc::Rc;
+
+use crate::command::Command;
+use crate::dispatcher::CommandDispatcher;
+use crate::event::Event;
+use crate::local_dispatcher::LocalDispatcher;
+use crate::local_dispatcher_tests::empty_project_rc;
+
+/// `$HOME` is process-global; serialise tests that swap it so they
+/// don't see each other's tempdir.
+static HOME_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Run `f` with `$HOME` pointed at a fresh tempdir. Restores the
+/// previous `$HOME` (or removes it) and deletes the tempdir whether
+/// `f` panics or returns normally.
+fn with_tmp_home<F: FnOnce()>(label: &str, f: F) {
+    let _g = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let tmp = std::env::temp_dir().join(format!(
+        "openrig-paths-{label}-{}-{now}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&tmp).expect("mkdir tempdir");
+    let prev = std::env::var_os("HOME");
+    std::env::set_var("HOME", &tmp);
+    let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
+    if let Some(prev) = prev {
+        std::env::set_var("HOME", prev);
+    } else {
+        std::env::remove_var("HOME");
+    }
+    let _ = std::fs::remove_dir_all(&tmp);
+    if let Err(p) = res {
+        std::panic::resume_unwind(p);
+    }
+}
+
+#[test]
+fn set_presets_path_emits_paths_saved() {
+    with_tmp_home("presets-emit", || {
+        let project = empty_project_rc();
+        let dispatcher = LocalDispatcher::new(Rc::clone(&project));
+        let path = PathBuf::from("/tmp/openrig-test-presets");
+
+        let events = dispatcher
+            .dispatch(Command::SetPresetsPath {
+                path: Some(path.clone()),
+            })
+            .unwrap();
+
+        assert_eq!(events, vec![Event::PathsSaved]);
+        // System command must not touch the project itself.
+        assert!(project.borrow().chains.is_empty());
+        assert!(project.borrow().midi.is_none());
+    });
+}
+
+#[test]
+fn set_plugins_path_emits_paths_saved() {
+    with_tmp_home("plugins-emit", || {
+        let project = empty_project_rc();
+        let dispatcher = LocalDispatcher::new(Rc::clone(&project));
+        let path = PathBuf::from("/tmp/openrig-test-plugins");
+
+        let events = dispatcher
+            .dispatch(Command::SetPluginsPath {
+                path: Some(path.clone()),
+            })
+            .unwrap();
+
+        assert_eq!(events, vec![Event::PathsSaved]);
+        assert!(project.borrow().chains.is_empty());
+        assert!(project.borrow().midi.is_none());
+    });
+}
+
+#[test]
+fn set_presets_path_none_resets_to_default_and_still_emits() {
+    with_tmp_home("presets-none", || {
+        let project = empty_project_rc();
+        let dispatcher = LocalDispatcher::new(Rc::clone(&project));
+
+        let events = dispatcher
+            .dispatch(Command::SetPresetsPath { path: None })
+            .unwrap();
+        assert_eq!(events, vec![Event::PathsSaved]);
+    });
+}
+
+#[test]
+fn set_plugins_path_none_resets_to_default_and_still_emits() {
+    with_tmp_home("plugins-none", || {
+        let project = empty_project_rc();
+        let dispatcher = LocalDispatcher::new(Rc::clone(&project));
+
+        let events = dispatcher
+            .dispatch(Command::SetPluginsPath { path: None })
+            .unwrap();
+        assert_eq!(events, vec![Event::PathsSaved]);
+    });
+}

--- a/crates/application/src/local_dispatcher_tests.rs
+++ b/crates/application/src/local_dispatcher_tests.rs
@@ -3028,7 +3028,7 @@ fn set_chain_volume_passes_extreme_values_verbatim() {
 
 // ── #513 / #493: MIDI device + mapping + learn commands ──────────────────────
 
-fn empty_project_rc() -> Rc<RefCell<Project>> {
+pub(super) fn empty_project_rc() -> Rc<RefCell<Project>> {
     Rc::new(RefCell::new(Project {
         name: None,
         device_settings: vec![],
@@ -3123,65 +3123,7 @@ fn publish_midi_event_passthrough_emits_midi_event_received() {
     assert_eq!(events, vec![Event::MidiEventReceived { source }]);
 }
 
-// ── #513: System / Paths (presets + plugins) ─────────────────────────────────
-//
-// RED-FIRST tests: SetPresetsPath and SetPluginsPath are user-visible Settings
-// commands that update the system-level AssetPaths snapshot. They emit
-// PathsSaved so the adapter can persist config.yaml.
-
-#[test]
-fn set_presets_path_emits_paths_saved() {
-    let project = empty_project_rc();
-    let dispatcher = LocalDispatcher::new(Rc::clone(&project));
-    let path = std::path::PathBuf::from("/tmp/openrig-test-presets");
-
-    let events = dispatcher
-        .dispatch(Command::SetPresetsPath {
-            path: Some(path.clone()),
-        })
-        .unwrap();
-
-    assert_eq!(events, vec![Event::PathsSaved]);
-    // System command must not touch the project itself.
-    assert!(project.borrow().chains.is_empty());
-    assert!(project.borrow().midi.is_none());
-}
-
-#[test]
-fn set_plugins_path_emits_paths_saved() {
-    let project = empty_project_rc();
-    let dispatcher = LocalDispatcher::new(Rc::clone(&project));
-    let path = std::path::PathBuf::from("/tmp/openrig-test-plugins");
-
-    let events = dispatcher
-        .dispatch(Command::SetPluginsPath {
-            path: Some(path.clone()),
-        })
-        .unwrap();
-
-    assert_eq!(events, vec![Event::PathsSaved]);
-    assert!(project.borrow().chains.is_empty());
-    assert!(project.borrow().midi.is_none());
-}
-
-#[test]
-fn set_presets_path_none_resets_to_default_and_still_emits() {
-    let project = empty_project_rc();
-    let dispatcher = LocalDispatcher::new(Rc::clone(&project));
-
-    let events = dispatcher
-        .dispatch(Command::SetPresetsPath { path: None })
-        .unwrap();
-    assert_eq!(events, vec![Event::PathsSaved]);
-}
-
-#[test]
-fn set_plugins_path_none_resets_to_default_and_still_emits() {
-    let project = empty_project_rc();
-    let dispatcher = LocalDispatcher::new(Rc::clone(&project));
-
-    let events = dispatcher
-        .dispatch(Command::SetPluginsPath { path: None })
-        .unwrap();
-    assert_eq!(events, vec![Event::PathsSaved]);
-}
+// #513 / #540: System / Paths (presets + plugins) tests moved to
+// `local_dispatcher_paths_tests.rs` so this file does not grow further
+// (already over the per-file size cap) and so the FS-sandboxing helper
+// (`$HOME` redirect) stays scoped to the tests that need it.


### PR DESCRIPTION
## Summary

- `handle_paths_system` now writes the picked path through `FilesystemStorage::save_*_path` before emitting `Event::PathsSaved`, closing the gap where the Command emitted-only and the user's pick survived in memory only.
- The Settings → Caminhos selection now survives a restart for every transport that dispatches the command (GUI picker, MCP, future gRPC) — ADR 0003: persistence is the Command's responsibility.
- Moved the four pre-existing dispatcher unit tests for `Set*Path` into a new `local_dispatcher_paths_tests.rs` so they can sandbox `$HOME` without growing the already-oversized `local_dispatcher_tests.rs`.

Closes #540.

## Test plan

- [ ] `cargo test -p application --lib paths` — 4 dispatcher tests green under sandboxed `$HOME`.
- [ ] `cargo test --package adapter-gui --test issue_540_set_paths_persists` — integration test (RED pre-fix) green.
- [ ] Manual: pick a folder in Settings → Caminhos → confirm `~/Library/Application Support/OpenRig/config.yaml` now stores the path (was `null`).
- [ ] Manual: restart the app → Settings shows the persisted path; RESET clears just that field.
- [ ] Manual regression: save audio settings after picking a path → the path is not clobbered by `save_app_config`.