### PR TITLE
fix(#544): tuner-window close dispatches teardown commands

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,7 +15,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -n '{hookSpecificOutput:{hookEventName:\"SessionStart\",additionalContext:\"OpenRig: invoque skills openrig-code-quality, rust-best-practices, slint-best-practices quando tocar código Rust/Slint.\"}}'"
+            "command": "jq -n '{hookSpecificOutput:{hookEventName:\"SessionStart\",additionalContext:\"OpenRig: invoque skills dev-rules, openrig-code-quality, rust-best-practices, slint-best-practices quando tocar código Rust/Slint (openrig-code-quality COMPLEMENTA dev-rules — LAW 1/2/3/5 vivem lá).\"}}'"
           }
         ]
       }

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -56,6 +56,7 @@ mod spectrum_session;
 mod spectrum_wiring;
 mod thumbnails;
 mod tuner_session;
+pub mod tuner_close;
 mod tuner_wiring;
 mod virtual_keyboard_wiring;
 mod vst3_editor_wiring;

--- a/crates/adapter-gui/src/tuner_close.rs
+++ b/crates/adapter-gui/src/tuner_close.rs
@@ -1,0 +1,32 @@
+//! Issue #544 — close-tuner intent as a pure helper.
+//!
+//! Closing the tuner window is the inverse of "power on" (commit
+//! b616bde13): the tuner runtime stops and the auto-engaged mute is
+//! released. This file owns the *Command intent* of that teardown so
+//! it can be reused across every close path (in-app close button,
+//! OS-level window-X) and exercised in isolation. The actual side
+//! effects on the GUI (timer stop, session drop, Slint props) stay in
+//! `tuner_wiring.rs`; this helper just answers "what does the dispatcher
+//! need to hear?".
+//!
+//! Background: before the fix, none of the close paths dispatched
+//! these Commands. Worse, the windowed mode had no in-app close button
+//! (`show-close-button: false` in `tuner_window.slint`), so the
+//! existing `on_close_tuner_window` callback never fired — the OS-X
+//! click would just hide the window while the polling timer and the
+//! auto-engaged mute stayed alive.
+
+use application::command::Command;
+
+/// Commands the dispatcher must receive when the tuner window closes.
+///
+/// Order is intentional: `SetTunerEnabled { enabled: false }` first so
+/// any observer (MCP, MIDI, future gRPC) sees the tuner go off before
+/// the mute is released, matching the semantics of an explicit power
+/// off.
+pub fn tuner_close_commands() -> Vec<Command> {
+    vec![
+        Command::SetTunerEnabled { enabled: false },
+        Command::SetOutputMuted { muted: false },
+    ]
+}

--- a/crates/adapter-gui/src/tuner_wiring.rs
+++ b/crates/adapter-gui/src/tuner_wiring.rs
@@ -15,6 +15,7 @@ use slint::{ComponentHandle, ModelRc, Timer, TimerMode, VecModel};
 
 use crate::helpers::{show_child_window, use_inline_block_editor};
 use crate::state::ProjectSession;
+use crate::tuner_close::tuner_close_commands;
 use crate::tuner_session::TunerSession;
 use crate::{AppWindow, TunerRow, TunerWindow};
 
@@ -32,8 +33,20 @@ pub fn wire_tuner(
     tuner_timer: &Rc<Timer>,
 ) {
     wire_open(window, tuner_window);
-    wire_close_inline(window, project_runtime, tuner_session, tuner_timer);
-    wire_close_windowed(tuner_window, project_runtime, tuner_session, tuner_timer);
+    wire_close_inline(
+        window,
+        project_session,
+        project_runtime,
+        tuner_session,
+        tuner_timer,
+    );
+    wire_close_windowed(
+        tuner_window,
+        project_session,
+        project_runtime,
+        tuner_session,
+        tuner_timer,
+    );
     wire_mute_inline(window, project_session, project_runtime);
     wire_mute_windowed(tuner_window, project_session, project_runtime);
     wire_power(
@@ -81,40 +94,112 @@ fn wire_open(window: &AppWindow, tuner_window: &TunerWindow) {
 
 fn wire_close_inline(
     window: &AppWindow,
+    project_session: &Rc<RefCell<Option<ProjectSession>>>,
     project_runtime: &Rc<RefCell<Option<ProjectRuntimeController>>>,
     tuner_session: &Rc<RefCell<Option<TunerSession>>>,
     tuner_timer: &Rc<Timer>,
 ) {
+    let project_session = project_session.clone();
     let project_runtime = project_runtime.clone();
     let tuner_session = tuner_session.clone();
     let tuner_timer = tuner_timer.clone();
     let main_window_weak = window.as_weak();
     window.on_close_tuner(move || {
+        dispatch_close_commands(&project_session);
         teardown_session(&tuner_timer, &tuner_session, &project_runtime);
         if let Some(mw) = main_window_weak.upgrade() {
             mw.set_show_tuner(false);
             mw.set_tuner_mute_active(false);
+            // #544: keep the power footswitch sprite in sync with the
+            // backend going off. Without this, the next render of the
+            // inline panel could keep the lit-on look until wire_open's
+            // reset runs.
+            mw.set_tuner_enabled(false);
         }
     });
 }
 
 fn wire_close_windowed(
     tuner_window: &TunerWindow,
+    project_session: &Rc<RefCell<Option<ProjectSession>>>,
     project_runtime: &Rc<RefCell<Option<ProjectRuntimeController>>>,
     tuner_session: &Rc<RefCell<Option<TunerSession>>>,
     tuner_timer: &Rc<Timer>,
 ) {
-    let project_runtime = project_runtime.clone();
-    let tuner_session = tuner_session.clone();
-    let tuner_timer = tuner_timer.clone();
-    let tuner_window_weak = tuner_window.as_weak();
-    tuner_window.on_close_tuner_window(move || {
-        teardown_session(&tuner_timer, &tuner_session, &project_runtime);
-        if let Some(tw) = tuner_window_weak.upgrade() {
-            tw.set_mute_active(false);
-            let _ = tw.hide();
+    // The explicit `close-tuner-window` callback is fired by the inline
+    // close button — present only when TunerPanel renders with
+    // `show-close-button: true`. In the standalone Window mode (which is
+    // what wire_close_windowed covers) the button is hidden, so the
+    // only way to close is the OS chrome (X / ⌘W). Slint routes that
+    // through `Window::on_close_requested`. Wire BOTH so neither path
+    // leaves the polling timer + auto-engaged mute alive (#544).
+    {
+        let project_session = project_session.clone();
+        let project_runtime = project_runtime.clone();
+        let tuner_session = tuner_session.clone();
+        let tuner_timer = tuner_timer.clone();
+        let tuner_window_weak = tuner_window.as_weak();
+        tuner_window.on_close_tuner_window(move || {
+            close_tuner_windowed_impl(
+                &project_session,
+                &project_runtime,
+                &tuner_session,
+                &tuner_timer,
+                &tuner_window_weak,
+            );
+            if let Some(tw) = tuner_window_weak.upgrade() {
+                let _ = tw.hide();
+            }
+        });
+    }
+    {
+        let project_session = project_session.clone();
+        let project_runtime = project_runtime.clone();
+        let tuner_session = tuner_session.clone();
+        let tuner_timer = tuner_timer.clone();
+        let tuner_window_weak = tuner_window.as_weak();
+        tuner_window.window().on_close_requested(move || {
+            close_tuner_windowed_impl(
+                &project_session,
+                &project_runtime,
+                &tuner_session,
+                &tuner_timer,
+                &tuner_window_weak,
+            );
+            slint::CloseRequestResponse::HideWindow
+        });
+    }
+}
+
+fn close_tuner_windowed_impl(
+    project_session: &Rc<RefCell<Option<ProjectSession>>>,
+    project_runtime: &Rc<RefCell<Option<ProjectRuntimeController>>>,
+    tuner_session: &Rc<RefCell<Option<TunerSession>>>,
+    tuner_timer: &Rc<Timer>,
+    tuner_window_weak: &slint::Weak<TunerWindow>,
+) {
+    dispatch_close_commands(project_session);
+    teardown_session(tuner_timer, tuner_session, project_runtime);
+    if let Some(tw) = tuner_window_weak.upgrade() {
+        tw.set_mute_active(false);
+        tw.set_tuner_enabled(false);
+    }
+}
+
+fn dispatch_close_commands(project_session: &Rc<RefCell<Option<ProjectSession>>>) {
+    // #544 + architectural law "every state change is a Command": close
+    // routes through the shared dispatcher so MCP / MIDI / future gRPC
+    // see the tuner go off and the mute release, instead of just the
+    // adapter mutating runtime state silently.
+    let pj = project_session.borrow();
+    let Some(session) = pj.as_ref() else {
+        return;
+    };
+    for cmd in tuner_close_commands() {
+        if let Err(e) = session.dispatcher.dispatch(cmd) {
+            log::warn!("[tuner.close] dispatch falhou: {e}");
         }
-    });
+    }
 }
 
 fn wire_mute_inline(

--- a/crates/adapter-gui/tests/issue_544_tuner_close_dispatches_disable.rs
+++ b/crates/adapter-gui/tests/issue_544_tuner_close_dispatches_disable.rs
@@ -1,0 +1,56 @@
+//! Issue #544 — closing the tuner window leaves the tuner runtime
+//! enabled in the background.
+//!
+//! Repro reported by the user:
+//!   1. Open the tuner window.
+//!   2. Press POWER → tuner activates, mute auto-engages.
+//!   3. Close the tuner window.
+//!   4. Tuner stays alive: pitch detection keeps polling, output stays
+//!      muted under the hood.
+//!   5. Reopen the tuner → UI shows power OFF (per commit b616bde13
+//!      "default off on open"), out of sync with the still-running
+//!      backend. The user has to toggle ON then OFF to actually stop it.
+//!
+//! Root cause hypothesis:
+//!   `on_close_tuner` / `on_close_tuner_window` in
+//!   `crates/adapter-gui/src/tuner_wiring.rs` hide the window without
+//!   dispatching `Command::SetTunerEnabled { enabled: false }`. The
+//!   dispatcher / runtime stays `tuner = true`, while the Slint
+//!   `tuner-enabled` property is reset to false on next open.
+//!
+//! Contract under test:
+//!   The "close tuner window" intent — represented as a pure
+//!   `tuner_close_commands()` helper — MUST include
+//!   `Command::SetTunerEnabled { enabled: false }` so the wiring can
+//!   route the same commands through the dispatcher when the window
+//!   closes. Auto-engaged mute (set on power-on) MUST also be released
+//!   so closing mirrors the explicit power-off.
+//!
+//! This test is RED today: `adapter_gui::tuner_close` does not exist
+//! yet. Fix forward by extracting the close intent into a pure helper
+//! and wiring the two `on_close_*` callbacks to dispatch it.
+
+use adapter_gui::tuner_close::tuner_close_commands;
+use application::command::Command;
+
+#[test]
+fn close_intent_disables_tuner() {
+    let cmds = tuner_close_commands();
+    assert!(
+        cmds.iter()
+            .any(|c| matches!(c, Command::SetTunerEnabled { enabled: false })),
+        "closing the tuner window must dispatch SetTunerEnabled(false); \
+         got {cmds:?}"
+    );
+}
+
+#[test]
+fn close_intent_releases_auto_engaged_mute() {
+    let cmds = tuner_close_commands();
+    assert!(
+        cmds.iter()
+            .any(|c| matches!(c, Command::SetOutputMuted { muted: false })),
+        "closing the tuner window must release the mute that power-on \
+         auto-engaged (commit b616bde13); got {cmds:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- Closing the tuner window via the OS chrome (X / Cmd-W) left the polling timer and the auto-engaged mute alive — windowed `TunerWindow` renders with `show-close-button: false`, so the only-existing `on_close_tuner_window` callback never fired, and no `Window::on_close_requested` was wired.
- Adds a pure helper `tuner_close::tuner_close_commands()` returning the inverse of "power on" (`SetTunerEnabled { false }`, then `SetOutputMuted { false }`) and routes every close path through it.
- Wires `tuner_window.window().on_close_requested(...)` mirroring the explicit callback so OS-chrome closes behave identically. Also resets the Slint `tuner_enabled` property in both close paths so the footswitch sprite stays in sync.
- Plus a small `chore` commit extending the SessionStart hook to surface `dev-rules` alongside `openrig-code-quality` (the latter explicitly complements the former).

## Test plan

- [ ] `cargo test -p adapter-gui --test issue_544_tuner_close_dispatches_disable` — 2/2 pass.
- [ ] `cargo test -p adapter-gui --lib` — 445 pass (pre-existing 3 `#[ignore]`).
- [ ] Manual: open tuner window, POWER on, close via OS X — guitar audible immediately (mute released), no zombie polling, MCP observer sees `Event::TunerEnabledChanged { false }` and `Event::OutputMutedChanged { false }`.
- [ ] Manual: same flow in inline (touch / fullscreen) mode.
- [ ] Regression: explicit POWER → OFF on the window still tears down cleanly.

## Out of scope

The SpectrumWindow has the same OS-close gap and is tracked separately in #546.

Fixes #544