### PR TITLE
fix(#546): spectrum-window close dispatches teardown command

### DIFF
--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -52,6 +52,7 @@ mod recent_projects_wiring;
 mod runtime_lifecycle;
 mod select_chain_block_callback;
 pub(crate) mod settings;
+pub mod spectrum_close;
 mod spectrum_session;
 mod spectrum_wiring;
 mod thumbnails;

--- a/crates/adapter-gui/src/spectrum_close.rs
+++ b/crates/adapter-gui/src/spectrum_close.rs
@@ -1,0 +1,22 @@
+//! Issue #546 — close-spectrum intent as a pure helper.
+//!
+//! Sibling of `tuner_close.rs` (#544). Closing the spectrum window is
+//! the inverse of "power on", but spectrum is a passive analyzer — it
+//! does not auto-engage mute on power-on, so there is nothing extra to
+//! release on close. The intent is a single command: tell the
+//! dispatcher (and every observer routed through it) that the analyzer
+//! went off.
+//!
+//! Background: before the fix, none of the close paths dispatched a
+//! `SetSpectrumEnabled { enabled: false }`. Worse, the windowed
+//! `SpectrumWindow` renders with `show-close-button: false`, so the
+//! existing `on_close_spectrum_window` callback never fires — the
+//! OS-X click would just hide the window while the polling timer and
+//! per-output stream taps stayed alive.
+
+use application::command::Command;
+
+/// Command the dispatcher must receive when the spectrum window closes.
+pub fn spectrum_close_commands() -> Vec<Command> {
+    vec![Command::SetSpectrumEnabled { enabled: false }]
+}

--- a/crates/adapter-gui/src/spectrum_wiring.rs
+++ b/crates/adapter-gui/src/spectrum_wiring.rs
@@ -14,6 +14,7 @@ use infra_cpal::ProjectRuntimeController;
 use slint::{ComponentHandle, ModelRc, Timer, TimerMode, VecModel};
 
 use crate::helpers::{show_child_window, use_inline_block_editor};
+use crate::spectrum_close::spectrum_close_commands;
 use crate::spectrum_session::SpectrumSession;
 use crate::state::ProjectSession;
 use crate::{AppWindow, SpectrumRow, SpectrumWindow};
@@ -32,9 +33,16 @@ pub fn wire_spectrum(
     spectrum_timer: &Rc<Timer>,
 ) {
     wire_open(window, spectrum_window);
-    wire_close_inline(window, project_runtime, spectrum_session, spectrum_timer);
+    wire_close_inline(
+        window,
+        project_session,
+        project_runtime,
+        spectrum_session,
+        spectrum_timer,
+    );
     wire_close_windowed(
         spectrum_window,
+        project_session,
         project_runtime,
         spectrum_session,
         spectrum_timer,
@@ -83,38 +91,108 @@ fn wire_open(window: &AppWindow, spectrum_window: &SpectrumWindow) {
 
 fn wire_close_inline(
     window: &AppWindow,
+    project_session: &Rc<RefCell<Option<ProjectSession>>>,
     project_runtime: &Rc<RefCell<Option<ProjectRuntimeController>>>,
     spectrum_session: &Rc<RefCell<Option<SpectrumSession>>>,
     spectrum_timer: &Rc<Timer>,
 ) {
+    let project_session = project_session.clone();
     let project_runtime = project_runtime.clone();
     let spectrum_session = spectrum_session.clone();
     let spectrum_timer = spectrum_timer.clone();
     let main_window_weak = window.as_weak();
     window.on_close_spectrum(move || {
+        dispatch_close_commands(&project_session);
         teardown_session(&spectrum_timer, &spectrum_session, &project_runtime);
         if let Some(mw) = main_window_weak.upgrade() {
             mw.set_show_spectrum(false);
+            // #546: keep the Slint power state in sync with the backend
+            // going off. Without this, the toggle could stay lit on the
+            // next inline render until wire_open's reset runs.
+            mw.set_spectrum_enabled(false);
         }
     });
 }
 
 fn wire_close_windowed(
     spectrum_window: &SpectrumWindow,
+    project_session: &Rc<RefCell<Option<ProjectSession>>>,
     project_runtime: &Rc<RefCell<Option<ProjectRuntimeController>>>,
     spectrum_session: &Rc<RefCell<Option<SpectrumSession>>>,
     spectrum_timer: &Rc<Timer>,
 ) {
-    let project_runtime = project_runtime.clone();
-    let spectrum_session = spectrum_session.clone();
-    let spectrum_timer = spectrum_timer.clone();
-    let spectrum_window_weak = spectrum_window.as_weak();
-    spectrum_window.on_close_spectrum_window(move || {
-        teardown_session(&spectrum_timer, &spectrum_session, &project_runtime);
-        if let Some(sw) = spectrum_window_weak.upgrade() {
-            let _ = sw.hide();
+    // Mirrors `tuner_wiring::wire_close_windowed` (#544). The windowed
+    // SpectrumWindow renders with `show-close-button: false`, so
+    // `on_close_spectrum_window` never fires today; the only way to
+    // close that window is the OS chrome (X / Cmd-W), which Slint
+    // routes through `Window::on_close_requested`. Wire BOTH so neither
+    // path leaves the FFT polling timer + stream taps alive (#546).
+    {
+        let project_session = project_session.clone();
+        let project_runtime = project_runtime.clone();
+        let spectrum_session = spectrum_session.clone();
+        let spectrum_timer = spectrum_timer.clone();
+        let spectrum_window_weak = spectrum_window.as_weak();
+        spectrum_window.on_close_spectrum_window(move || {
+            close_spectrum_windowed_impl(
+                &project_session,
+                &project_runtime,
+                &spectrum_session,
+                &spectrum_timer,
+                &spectrum_window_weak,
+            );
+            if let Some(sw) = spectrum_window_weak.upgrade() {
+                let _ = sw.hide();
+            }
+        });
+    }
+    {
+        let project_session = project_session.clone();
+        let project_runtime = project_runtime.clone();
+        let spectrum_session = spectrum_session.clone();
+        let spectrum_timer = spectrum_timer.clone();
+        let spectrum_window_weak = spectrum_window.as_weak();
+        spectrum_window.window().on_close_requested(move || {
+            close_spectrum_windowed_impl(
+                &project_session,
+                &project_runtime,
+                &spectrum_session,
+                &spectrum_timer,
+                &spectrum_window_weak,
+            );
+            slint::CloseRequestResponse::HideWindow
+        });
+    }
+}
+
+fn close_spectrum_windowed_impl(
+    project_session: &Rc<RefCell<Option<ProjectSession>>>,
+    project_runtime: &Rc<RefCell<Option<ProjectRuntimeController>>>,
+    spectrum_session: &Rc<RefCell<Option<SpectrumSession>>>,
+    spectrum_timer: &Rc<Timer>,
+    spectrum_window_weak: &slint::Weak<SpectrumWindow>,
+) {
+    dispatch_close_commands(project_session);
+    teardown_session(spectrum_timer, spectrum_session, project_runtime);
+    if let Some(sw) = spectrum_window_weak.upgrade() {
+        sw.set_spectrum_enabled(false);
+    }
+}
+
+fn dispatch_close_commands(project_session: &Rc<RefCell<Option<ProjectSession>>>) {
+    // #546 + architectural law "every state change is a Command": close
+    // routes through the shared dispatcher so MCP / MIDI / future gRPC
+    // see Event::SpectrumEnabledChanged { false } instead of the adapter
+    // mutating runtime state silently.
+    let pj = project_session.borrow();
+    let Some(session) = pj.as_ref() else {
+        return;
+    };
+    for cmd in spectrum_close_commands() {
+        if let Err(e) = session.dispatcher.dispatch(cmd) {
+            log::warn!("[spectrum.close] dispatch falhou: {e}");
         }
-    });
+    }
 }
 
 fn wire_power(

--- a/crates/adapter-gui/tests/issue_546_spectrum_close_dispatches_disable.rs
+++ b/crates/adapter-gui/tests/issue_546_spectrum_close_dispatches_disable.rs
@@ -1,0 +1,39 @@
+//! Issue #546 — closing the spectrum window leaves the FFT polling
+//! timer + per-output stream taps alive.
+//!
+//! Sibling of #544 (tuner). Same architectural gap: the windowed
+//! `SpectrumWindow` renders with `show-close-button: false`, so the
+//! `on_close_spectrum_window` callback never fires. No
+//! `Window::on_close_requested` handler is wired either, so closing via
+//! the OS chrome (X / Cmd-W) skips `teardown_session` entirely. CPU
+//! keeps burning and the dispatcher never sees
+//! `Event::SpectrumEnabledChanged { false }`.
+//!
+//! Unlike the tuner there is no auto-engaged mute to release on close
+//! — spectrum is a passive analyzer. The close intent is therefore a
+//! single command: tell the dispatcher (and every observer that listens
+//! through it) that the analyzer went off.
+//!
+//! Contract under test:
+//!   `spectrum_close_commands()` returns a Vec containing
+//!   `Command::SetSpectrumEnabled { enabled: false }` so every close
+//!   path routes the same intent through the dispatcher.
+//!
+//! This test is RED today: `adapter_gui::spectrum_close` does not
+//! exist. Fix forward by extracting the helper and wiring both the
+//! explicit close callback and the OS-level `on_close_requested`
+//! handler, mirroring the #544 fix.
+
+use adapter_gui::spectrum_close::spectrum_close_commands;
+use application::command::Command;
+
+#[test]
+fn close_intent_disables_spectrum() {
+    let cmds = spectrum_close_commands();
+    assert!(
+        cmds.iter()
+            .any(|c| matches!(c, Command::SetSpectrumEnabled { enabled: false })),
+        "closing the spectrum window must dispatch SetSpectrumEnabled(false); \
+         got {cmds:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- Sibling of #544 (tuner). The windowed `SpectrumWindow` renders with `show-close-button: false`, so its `on_close_spectrum_window` callback never fires; no `Window::on_close_requested` was wired. Closing via the OS chrome left the FFT polling timer + per-output stream taps alive (CPU burn on a hidden analyzer) and the dispatcher silent (`Event::SpectrumEnabledChanged { false }` never emitted — MCP / future gRPC blind).
- Adds pure helper `spectrum_close::spectrum_close_commands()` returning `[Command::SetSpectrumEnabled { false }]`. Single command (vs. #544 which also releases auto-engaged mute) — spectrum has no mute coupling.
- Wires `spectrum_window.window().on_close_requested(...)` mirroring the explicit callback. Both close paths dispatch the command and reset the Slint `spectrum_enabled` property.

## Test plan

- [ ] `cargo test -p adapter-gui --test issue_546_spectrum_close_dispatches_disable` — 1/1 pass.
- [ ] `cargo test -p adapter-gui --lib` — 445 pass (pre-existing 3 `#[ignore]`).
- [ ] Manual: open spectrum window, POWER on, watch bars, close via OS X — no zombie polling on Activity Monitor, MCP observer sees `Event::SpectrumEnabledChanged { false }`.
- [ ] Manual: same flow in inline (touch / fullscreen) mode.
- [ ] Regression: explicit POWER → OFF on the window still tears down cleanly; reopen shows clean OFF.

## Notes

- Depends in spirit on #549 (#544 fix) — same pattern, separate files. Either order of merge is safe.

Fixes #546