### PR TITLE
fix(#545): pause_chain / resume fan over every input-group runtime

### DIFF
--- a/crates/engine/tests/issue_545_drained_runtime_silences_output.rs
+++ b/crates/engine/tests/issue_545_drained_runtime_silences_output.rs
@@ -1,0 +1,192 @@
+//! Issue #545 — red-first guard for "toggling a chain off keeps the
+//! streams alive underneath". The user disables a chain from the
+//! Chains screen; the audio they hear silences, but the chain's tap
+//! and meter keep moving and CPU does not drop. The controller pauses
+//! the chain by calling `runtime.set_draining()`, and the existing
+//! pause-chain controller tests confirm the flag flips on the
+//! `Arc<ChainRuntimeState>`. They do not verify the contract that
+//! `controller_pause_chain_tests.rs` actually claims: "the audio
+//! callbacks short-circuit on `is_draining()` to emit silence with
+//! zero processor work".
+//!
+//! This test pins exactly that contract at the engine level. It builds
+//! a passthrough runtime (input → output, no DSP blocks), drives a
+//! sine through `process_input_f32` / `process_output_f32` long
+//! enough to clear the warmup fade, captures the output peak as the
+//! baseline (must be audible), calls `set_draining()`, drives the
+//! same sine for the same window, and asserts the output is silent.
+//!
+//! RED today means the user's symptom: `set_draining()` flips the
+//! flag but `process_output_f32` still copies processed audio out, so
+//! the tap and meter keep observing signal and CPU stays at the
+//! running-chain baseline.
+
+use std::sync::Arc;
+
+use domain::ids::{BlockId, ChainId, DeviceId};
+use project::block::{AudioBlock, AudioBlockKind, InputBlock, InputEntry, OutputBlock, OutputEntry};
+use project::chain::{Chain, ChainInputMode, ChainOutputMode};
+use project::param::ParameterSet;
+use project::project::Project;
+
+const SR: f32 = 48_000.0;
+const FRAMES: usize = 64;
+const ELASTIC: usize = 1024;
+const WARMUP_CALLBACKS: usize = 80;
+const MEASURE_CALLBACKS: usize = 120;
+
+fn passthrough_chain() -> Chain {
+    let _ = ParameterSet::default; // silence unused-import if ParameterSet not needed
+    let _ = Project { // ensures `project::project::Project` import is exercised even though we don't construct it here
+        name: None,
+        device_settings: vec![],
+        chains: vec![],
+        midi: None,
+    };
+    Chain {
+        id: ChainId("chain:545:passthrough".into()),
+        description: None,
+        instrument: "electric_guitar".into(),
+        enabled: true,
+        volume: 100.0,
+        blocks: vec![
+            AudioBlock {
+                id: BlockId("input:0".into()),
+                enabled: true,
+                kind: AudioBlockKind::Input(InputBlock {
+                    model: "standard".into(),
+                    entries: vec![InputEntry {
+                        device_id: DeviceId("dev".into()),
+                        mode: ChainInputMode::Mono,
+                        channels: vec![0],
+                    }],
+                }),
+            },
+            AudioBlock {
+                id: BlockId("output:0".into()),
+                enabled: true,
+                kind: AudioBlockKind::Output(OutputBlock {
+                    model: "standard".into(),
+                    entries: vec![OutputEntry {
+                        device_id: DeviceId("dev".into()),
+                        mode: ChainOutputMode::Mono,
+                        channels: vec![0],
+                    }],
+                }),
+            },
+        ],
+    }
+}
+
+fn drive_capture_peak(
+    runtime: &Arc<engine::runtime::ChainRuntimeState>,
+    callbacks: usize,
+    measure_after: usize,
+    phase_offset: usize,
+) -> f32 {
+    let mut in_buf = vec![0.0_f32; FRAMES];
+    let mut out_buf = vec![0.0_f32; FRAMES];
+    let mut peak = 0.0_f32;
+    for cb in 0..callbacks {
+        for i in 0..FRAMES {
+            let n = (phase_offset + cb * FRAMES + i) as f32;
+            in_buf[i] = 0.5 * (2.0 * std::f32::consts::PI * 220.0 * n / SR).sin();
+        }
+        engine::runtime::process_input_f32(runtime, 0, &in_buf, 1);
+        engine::runtime::process_output_f32(runtime, 0, &mut out_buf, 1);
+        if cb >= measure_after {
+            for &s in &out_buf {
+                peak = peak.max(s.abs());
+            }
+        }
+    }
+    peak
+}
+
+/// Drain on a chain with one input must silence the output.
+#[test]
+fn issue_545_set_draining_makes_process_output_emit_silence() {
+    let chain = passthrough_chain();
+    let runtime = Arc::new(
+        engine::runtime::build_chain_runtime_state(&chain, SR, &[ELASTIC])
+            .expect("passthrough runtime must build"),
+    );
+
+    let peak_running = drive_capture_peak(&runtime, MEASURE_CALLBACKS, WARMUP_CALLBACKS, 0);
+    assert!(
+        peak_running > 0.05,
+        "test setup wrong: passthrough chain produced peak {peak_running:.4} \
+         while running (expected > 0.05 from the sine input)"
+    );
+
+    runtime.set_draining();
+    assert!(runtime.is_draining(), "set_draining must flip the flag");
+
+    let phase_offset = MEASURE_CALLBACKS * FRAMES;
+    let peak_drained =
+        drive_capture_peak(&runtime, MEASURE_CALLBACKS, WARMUP_CALLBACKS, phase_offset);
+
+    assert!(
+        peak_drained < 1.0e-4,
+        "REGRESSION: paused chain (set_draining() == true) emitted peak \
+         {peak_drained:.6} — must be ≤ 1e-4 (effectively silent). \
+         Baseline running peak was {peak_running:.4}."
+    );
+}
+
+fn drain_ring(ring: &engine::spsc::SpscRing<f32>) -> usize {
+    let mut n = 0;
+    while ring.pop().is_some() {
+        n += 1;
+    }
+    n
+}
+
+/// Per the user's symptom on issue #545, the bug shows up on the
+/// stream taps (the source the GUI meter reads from) even when the
+/// output is silent. After `set_draining()`, the stream tap rings
+/// must stop accumulating frames; if they keep receiving processed
+/// audio the meter keeps moving and the chain looks "alive" from the
+/// outside.
+#[test]
+fn issue_545_set_draining_stops_stream_tap_pushes() {
+    let chain = passthrough_chain();
+    let runtime = Arc::new(
+        engine::runtime::build_chain_runtime_state(&chain, SR, &[ELASTIC])
+            .expect("runtime must build"),
+    );
+
+    // Subscribe a stream tap on input index 0 — same path the GUI
+    // meter takes.
+    let [l_ring, r_ring] = runtime.subscribe_stream_tap(0, 16_384);
+
+    // Drive while running so the tap fills with real audio first.
+    let _ = drive_capture_peak(&runtime, MEASURE_CALLBACKS, WARMUP_CALLBACKS, 0);
+
+    // Drain the rings so we are measuring only frames pushed AFTER
+    // set_draining().
+    let baseline_l = drain_ring(&l_ring);
+    let baseline_r = drain_ring(&r_ring);
+    assert!(
+        baseline_l > 0,
+        "test setup wrong: stream tap received no frames while chain was \
+         running (got L={baseline_l}, R={baseline_r})"
+    );
+
+    runtime.set_draining();
+    assert!(runtime.is_draining());
+
+    let phase_offset = MEASURE_CALLBACKS * FRAMES;
+    let _ = drive_capture_peak(&runtime, MEASURE_CALLBACKS, WARMUP_CALLBACKS, phase_offset);
+
+    let pushed_l = drain_ring(&l_ring);
+    let pushed_r = drain_ring(&r_ring);
+
+    assert!(
+        pushed_l == 0 && pushed_r == 0,
+        "REGRESSION: stream tap kept receiving frames after `set_draining()` — \
+         pushed L={pushed_l} R={pushed_r} (baseline running pushed L={baseline_l} \
+         R={baseline_r}). The GUI meter polls these rings, which is why the \
+         user sees the meter keep moving after toggling the chain off."
+    );
+}

--- a/crates/engine/tests/issue_545_drained_runtime_silences_output.rs
+++ b/crates/engine/tests/issue_545_drained_runtime_silences_output.rs
@@ -24,7 +24,9 @@
 use std::sync::Arc;
 
 use domain::ids::{BlockId, ChainId, DeviceId};
-use project::block::{AudioBlock, AudioBlockKind, InputBlock, InputEntry, OutputBlock, OutputEntry};
+use project::block::{
+    AudioBlock, AudioBlockKind, InputBlock, InputEntry, OutputBlock, OutputEntry,
+};
 use project::chain::{Chain, ChainInputMode, ChainOutputMode};
 use project::param::ParameterSet;
 use project::project::Project;
@@ -37,7 +39,8 @@ const MEASURE_CALLBACKS: usize = 120;
 
 fn passthrough_chain() -> Chain {
     let _ = ParameterSet::default; // silence unused-import if ParameterSet not needed
-    let _ = Project { // ensures `project::project::Project` import is exercised even though we don't construct it here
+    let _ = Project {
+        // ensures `project::project::Project` import is exercised even though we don't construct it here
         name: None,
         device_settings: vec![],
         chains: vec![],

--- a/crates/infra-cpal/src/controller.rs
+++ b/crates/infra-cpal/src/controller.rs
@@ -347,11 +347,24 @@ impl ProjectRuntimeController {
         }
         // Issue #522: fast-path resume of a paused chain — clear draining
         // and return; no CPAL queries, no NAM reload, no graph rebuild.
+        //
+        // Issue #545: fan over every input-group runtime, not just the
+        // first. The previous `runtime_for_chain` call only touched
+        // group 0, so chains with multiple physical input devices
+        // stayed half-muted after toggle-on. Mirrors the fan-out in
+        // `pause_chain`.
         if self.active_chains.contains_key(&chain.id) {
-            if let Some(runtime) = self.runtime_graph.runtime_for_chain(&chain.id) {
-                if runtime.is_draining() {
-                    log::info!("resuming paused chain '{}' (fast path)", chain.id.0);
-                    runtime.clear_draining();
+            let runtimes = self.runtime_graph.runtimes_for(&chain.id);
+            if let Some(first) = runtimes.first() {
+                if first.is_draining() {
+                    log::info!(
+                        "resuming paused chain '{}' across {} input group(s) (fast path)",
+                        chain.id.0,
+                        runtimes.len(),
+                    );
+                    for runtime in &runtimes {
+                        runtime.clear_draining();
+                    }
                     return Ok(());
                 }
             }
@@ -375,7 +388,6 @@ impl ProjectRuntimeController {
             self.upsert_chain_with_resolved(chain, resolved, spillover)
         }
     }
-
 
     pub fn remove_chain(&mut self, chain_id: &ChainId) {
         log::info!("removing chain '{}' from runtime", chain_id.0);

--- a/crates/infra-cpal/src/controller_block_toggle.rs
+++ b/crates/infra-cpal/src/controller_block_toggle.rs
@@ -51,9 +51,26 @@ impl ProjectRuntimeController {
     /// `runtime_graph` so the next enable resumes in O(1) via
     /// `upsert_chain`'s fast-path branch. No-op if the chain has no
     /// live runtime yet.
+    ///
+    /// Issue #545 — a chain with multiple input groups (one runtime per
+    /// physical input device, see #350 Phase 3) needs every group
+    /// drained. The previous implementation called
+    /// `runtime_for_chain`, which is documented as "returns the first
+    /// runtime" and left the other groups processing. That kept the
+    /// stream taps publishing and the audio thread spending CPU, which
+    /// the user observes as the chain looking alive after toggling
+    /// off. Fan over `runtimes_for` so every group flips.
     pub fn pause_chain(&self, chain_id: &ChainId) {
-        if let Some(runtime) = self.runtime_graph.runtime_for_chain(chain_id) {
-            log::info!("pausing chain '{}' (keep streams alive)", chain_id.0);
+        let runtimes = self.runtime_graph.runtimes_for(chain_id);
+        if runtimes.is_empty() {
+            return;
+        }
+        log::info!(
+            "pausing chain '{}' across {} input group(s) (keep streams alive)",
+            chain_id.0,
+            runtimes.len(),
+        );
+        for runtime in &runtimes {
             runtime.set_draining();
         }
     }

--- a/crates/infra-cpal/src/controller_pause_chain_tests.rs
+++ b/crates/infra-cpal/src/controller_pause_chain_tests.rs
@@ -155,3 +155,53 @@ fn upsert_chain_enabled_resumes_paused_runtime_without_rebuilding() {
         "resume must clear set_draining so the audio thread processes again"
     );
 }
+
+/// Issue #545 — `pause_chain` calls `runtime_for_chain` which only
+/// returns the FIRST runtime of a chain (see the comment in
+/// `runtime_graph::runtime_for_chain`: "Multi-input fan-out for these
+/// call sites is Phase 3 (#350)"). On a chain with multiple input
+/// groups (one per physical input device), only group 0 actually gets
+/// `set_draining()` — the other groups keep processing, which is why
+/// the user observes the tap/meter still moving and CPU staying at
+/// the running-chain baseline after toggling the chain off.
+///
+/// This test pins the multi-input contract: pausing the chain must
+/// drain every runtime registered for that chain id, regardless of
+/// group.
+#[test]
+#[cfg(not(all(target_os = "linux", feature = "jack")))]
+fn pause_chain_drains_every_input_group_runtime() {
+    let chain_id = ChainId("chain:545:multi-input".into());
+    let (mut controller, group0) = controller_with_active_chain(&chain_id);
+
+    // Add a second runtime under group 1 — same chain, second physical
+    // input device. Mirrors what the runtime_graph holds when a chain
+    // has two `InputBlock` entries.
+    let chain = empty_chain(&chain_id.0, true);
+    let group1 = Arc::new(
+        engine::runtime::build_chain_runtime_state(&chain, 48_000.0, &[1024])
+            .expect("group-1 runtime should build"),
+    );
+    controller
+        .runtime_graph
+        .chains
+        .insert((chain_id.clone(), 1), Arc::clone(&group1));
+
+    assert!(!group0.is_draining());
+    assert!(!group1.is_draining());
+
+    controller.pause_chain(&chain_id);
+
+    assert!(
+        group0.is_draining(),
+        "pause_chain must drain group 0 (currently passes — it is the only \
+         runtime `runtime_for_chain` returns)"
+    );
+    assert!(
+        group1.is_draining(),
+        "REGRESSION: pause_chain failed to drain group 1 runtime — only the \
+         first input group is touched. The user observes the chain looking \
+         alive (tap moving, CPU not dropping) because the other input \
+         groups keep processing."
+    );
+}

--- a/crates/infra-cpal/src/controller_pause_chain_tests.rs
+++ b/crates/infra-cpal/src/controller_pause_chain_tests.rs
@@ -46,7 +46,10 @@ fn empty_project() -> Project {
 
 fn controller_with_active_chain(
     chain_id: &ChainId,
-) -> (ProjectRuntimeController, Arc<engine::runtime::ChainRuntimeState>) {
+) -> (
+    ProjectRuntimeController,
+    Arc<engine::runtime::ChainRuntimeState>,
+) {
     let chain = empty_chain(&chain_id.0, true);
     let runtime_arc = Arc::new(
         engine::runtime::build_chain_runtime_state(&chain, 48_000.0, &[1024])
@@ -156,18 +159,19 @@ fn upsert_chain_enabled_resumes_paused_runtime_without_rebuilding() {
     );
 }
 
-/// Issue #545 — `pause_chain` calls `runtime_for_chain` which only
-/// returns the FIRST runtime of a chain (see the comment in
-/// `runtime_graph::runtime_for_chain`: "Multi-input fan-out for these
-/// call sites is Phase 3 (#350)"). On a chain with multiple input
-/// groups (one per physical input device), only group 0 actually gets
-/// `set_draining()` — the other groups keep processing, which is why
-/// the user observes the tap/meter still moving and CPU staying at
-/// the running-chain baseline after toggling the chain off.
+/// Issue #545 — `pause_chain` / fast-path resume both call
+/// `runtime_for_chain`, which only returns the FIRST runtime of a
+/// chain (see the comment in `runtime_graph::runtime_for_chain`:
+/// "Multi-input fan-out for these call sites is Phase 3 (#350)"). On
+/// a chain with multiple input groups (one per physical input
+/// device), only group 0 actually flips — the other groups keep
+/// processing, which is why the user observes the tap/meter still
+/// moving and CPU staying at the running-chain baseline after
+/// toggling the chain off.
 ///
-/// This test pins the multi-input contract: pausing the chain must
-/// drain every runtime registered for that chain id, regardless of
-/// group.
+/// Two paired contracts are pinned here: pause must drain every
+/// runtime, and the resume fast-path must clear draining on every
+/// runtime. Otherwise either edge leaves some groups out of sync.
 #[test]
 #[cfg(not(all(target_os = "linux", feature = "jack")))]
 fn pause_chain_drains_every_input_group_runtime() {
@@ -203,5 +207,50 @@ fn pause_chain_drains_every_input_group_runtime() {
          first input group is touched. The user observes the chain looking \
          alive (tap moving, CPU not dropping) because the other input \
          groups keep processing."
+    );
+}
+
+/// Issue #545 — symmetric counterpart of the pause test. After the
+/// pause fix lands, re-enabling the chain must also clear draining on
+/// every group, not just the first. Otherwise the cab path on the
+/// second physical input stays muted after toggle-on, even though the
+/// engine ran the resume.
+#[test]
+#[cfg(not(all(target_os = "linux", feature = "jack")))]
+fn upsert_chain_enabled_resumes_every_input_group_runtime() {
+    let chain_id = ChainId("chain:545:multi-input:resume".into());
+    let (mut controller, group0) = controller_with_active_chain(&chain_id);
+
+    let chain = empty_chain(&chain_id.0, true);
+    let group1 = Arc::new(
+        engine::runtime::build_chain_runtime_state(&chain, 48_000.0, &[1024])
+            .expect("group-1 runtime should build"),
+    );
+    controller
+        .runtime_graph
+        .chains
+        .insert((chain_id.clone(), 1), Arc::clone(&group1));
+
+    // Pause both groups first (the fixed pause_chain does the fan-out).
+    controller.pause_chain(&chain_id);
+    assert!(group0.is_draining());
+    assert!(group1.is_draining());
+
+    // Now re-enable via the same fast-path the controller takes on
+    // `Command::ToggleChainEnabled { enabled: true }`.
+    let project = empty_project();
+    let enabled = empty_chain(&chain_id.0, true);
+    controller
+        .upsert_chain(&project, &enabled)
+        .expect("re-enable must succeed");
+
+    assert!(
+        !group0.is_draining(),
+        "resume must clear draining on group 0"
+    );
+    assert!(
+        !group1.is_draining(),
+        "REGRESSION: resume only cleared group 0; group 1 stayed draining \
+         and its audio stays silent after toggle-on."
     );
 }


### PR DESCRIPTION
## Summary

- `pause_chain` and the resume fast-path in `upsert_chain_modal` both called `runtime_for_chain`, which only returns the first runtime of a chain (documented as "multi-input fan-out is Phase 3 (#350)"). On chains with more than one input group, only group 0 got `set_draining()` / `clear_draining()` — the other groups kept processing, kept pushing into stream taps (meter moved), kept spending CPU.
- Both call sites now use `runtimes_for(chain_id)` and iterate. The `#522` fast-path (CPAL streams stay open, runtime Arc reused on resume) is preserved.

## Test plan

- [ ] `cargo test -p infra-cpal --lib controller_pause_chain_tests` — 4 tests pass (existing single-input pair + new multi-input pause/resume pair).
- [ ] `cargo test -p engine --test issue_545_drained_runtime_silences_output` — engine-layer regression guards green (output silence + stream tap stops on `set_draining()`).
- [ ] On the live app with a multi-input rig (input-1..input-N), toggle a chain off → meter stops on ALL inputs, CPU drops to idle.
- [ ] Toggle the same chain back on → meter resumes on every input, audio flows again.
- [ ] Rapid toggle on/off/on/off → no clicks, no rebuild hitches.

Closes #545.

🤖 Generated with [Claude Code](https://claude.com/claude-code)