### PR TITLE
ui(#559): widen compact view + per-stream IN/OUT meter rows

### DIFF
--- a/crates/adapter-gui/src/compact_chain_callbacks.rs
+++ b/crates/adapter-gui/src/compact_chain_callbacks.rs
@@ -442,6 +442,7 @@ pub(crate) fn wire(window: &AppWindow, ctx: CompactChainCallbacksCtx) {
                     if let Some(row) = chains.row_data(ci) {
                         cw.set_meter_in_dbfs(row.meter_in_dbfs);
                         cw.set_meter_out_dbfs(row.meter_out_dbfs);
+                        cw.set_stream_meters(row.stream_meters.clone());
                         cw.set_volume(row.volume);
                         cw.set_chain_enabled(row.enabled);
                         cw.set_chain_title(row.title.clone());

--- a/crates/adapter-gui/ui/pages/compact_chain_view.slint
+++ b/crates/adapter-gui/ui/pages/compact_chain_view.slint
@@ -1,5 +1,5 @@
 import { ScrollView } from "std-widgets.slint";
-import { CompactBlockItem, BlockTypePickerItem, ChainRigNav } from "../models.slint";
+import { CompactBlockItem, BlockTypePickerItem, ChainRigNav, StreamMeter } from "../models.slint";
 import { EffectTypeIcon } from "../components/effect_type_icon.slint";
 import { PowerSwitch } from "../components/power_switch.slint";
 import { ChainTitlePreset } from "../components/chain_title_preset.slint";
@@ -21,6 +21,11 @@ export component CompactChainViewPage inherits Rectangle {
     // Per-chain peak meters (#496) — same range as the main row.
     in property <float> meter-in-dbfs: -120.0;
     in property <float> meter-out-dbfs: -120.0;
+    // Per-stream IN/OUT meter rows. Empty ⇒ fall back to the single
+    // aggregate `meter-in-dbfs` / `meter-out-dbfs` pair so old wiring
+    // keeps working. Non-empty ⇒ render one IN/OUT bar per stream
+    // (multi-input chains, same shape `ChainRow` uses on the main page).
+    in property <[StreamMeter]> stream-meters;
     // Chain output volume %, 0..200 (#440). Hooked to the volume button.
     in property <int> volume: 100;
 
@@ -205,12 +210,18 @@ export component CompactChainViewPage inherits Rectangle {
         }
     }
 
+    // Footer reservation: one 22 px row per stream meter (multi-input
+    // chains stack), minimum one row so the IN/OUT pair always fits.
+    property <int> meter-row-count:
+        root.stream-meters.length > 0 ? root.stream-meters.length : 1;
+    property <length> meter-footer-height: root.meter-row-count * 22px + 6px;
+
     // Block rows with insert slots between them
     Flickable {
         x: 0; y: 66px;
         width: parent.width;
-        // Leave room at the bottom for the IN/OUT dBFS meters footer.
-        height: parent.height - 66px - 28px;
+        // Leave room at the bottom for the per-stream IN/OUT meter rows.
+        height: parent.height - 66px - root.meter-footer-height;
         viewport-height: root.compact-blocks.length * 112px + 24px;
         interactive: false;
 
@@ -442,8 +453,127 @@ export component CompactChainViewPage inherits Rectangle {
         }
     }
 
-    // ── Footer: per-chain IN / OUT peak meters (#496) ─────────────────
-    Rectangle {
+    // ── Footer: per-stream IN / OUT peak meter rows (#496 / #559) ─────
+    // One IN/OUT pair per `stream-meters` entry. Multi-input chains
+    // (e.g. a 3-input chain) get 3 stacked rows here. Empty list ⇒
+    // fall back to the single aggregate `meter-in-dbfs` /
+    // `meter-out-dbfs` pair so old wiring keeps working.
+    for stream[i] in root.stream-meters: Rectangle {
+        x: 0px;
+        y: parent.height - 22px
+            - (root.stream-meters.length - 1 - i) * 22px;
+        width: parent.width;
+        height: 16px;
+
+        Rectangle {
+            x: 60px; y: 0px;
+            width: 220px; height: 16px;
+            Text {
+                x: 0px; y: 0px;
+                width: 44px; height: parent.height;
+                text: "INPUT";
+                font-size: 8px; font-weight: 700;
+                color: #9ca3af;
+                horizontal-alignment: right;
+                vertical-alignment: center;
+            }
+            Rectangle {
+                x: 48px; y: 2px;
+                width: 130px; height: 12px;
+                border-width: 1px;
+                border-color: stream.in_dbfs > 0.0 ? #f87171 : #2a313a;
+                border-radius: 2px;
+                background: @linear-gradient(90deg,
+                    #facc1560 0%,
+                    #facc15 6%,
+                    #facc15 35%,
+                    #4ade80 50%,
+                    #4ade80 88%,
+                    #f87171 95%,
+                    #f87171 100%);
+                Rectangle {
+                    x: parent.width * Math.max(0.0,
+                        Math.min(1.0, (stream.in_dbfs + 60.0) / 60.0));
+                    y: 0px;
+                    width: parent.width * (1.0 - Math.max(0.0,
+                        Math.min(1.0, (stream.in_dbfs + 60.0) / 60.0)));
+                    height: parent.height;
+                    background: #0b0e13e8;
+                }
+            }
+            Text {
+                x: 182px; y: 0px;
+                width: 36px; height: parent.height;
+                text: stream.in_dbfs <= -119.0
+                    ? "—"
+                    : Math.round(stream.in_dbfs) + " dB";
+                font-size: 9px; font-weight: 700;
+                color: stream.in_dbfs <= -119.0 ? #6b7280
+                     : stream.in_dbfs > -3.0     ? #f87171
+                     : stream.in_dbfs >= -30.0   ? #4ade80
+                     :                              #facc15;
+                horizontal-alignment: left;
+                vertical-alignment: center;
+            }
+        }
+
+        Rectangle {
+            x: parent.width - 240px; y: 0px;
+            width: 230px; height: 16px;
+            Text {
+                x: 0px; y: 0px;
+                width: 50px; height: parent.height;
+                text: "OUTPUT";
+                font-size: 8px; font-weight: 700;
+                color: #9ca3af;
+                horizontal-alignment: right;
+                vertical-alignment: center;
+            }
+            Rectangle {
+                x: 54px; y: 2px;
+                width: 130px; height: 12px;
+                border-width: 1px;
+                border-color: stream.out_dbfs > 0.0 ? #f87171 : #2a313a;
+                border-radius: 2px;
+                background: @linear-gradient(90deg,
+                    #facc1560 0%,
+                    #facc15 6%,
+                    #facc15 35%,
+                    #4ade80 50%,
+                    #4ade80 88%,
+                    #f87171 95%,
+                    #f87171 100%);
+                Rectangle {
+                    x: parent.width * Math.max(0.0,
+                        Math.min(1.0, (stream.out_dbfs + 60.0) / 60.0));
+                    y: 0px;
+                    width: parent.width * (1.0 - Math.max(0.0,
+                        Math.min(1.0, (stream.out_dbfs + 60.0) / 60.0)));
+                    height: parent.height;
+                    background: #0b0e13e8;
+                }
+            }
+            Text {
+                x: 188px; y: 0px;
+                width: 40px; height: parent.height;
+                text: stream.out_dbfs <= -119.0
+                    ? "—"
+                    : Math.round(stream.out_dbfs) + " dB";
+                font-size: 9px; font-weight: 700;
+                color: stream.out_dbfs <= -119.0 ? #6b7280
+                     : stream.out_dbfs > -3.0     ? #f87171
+                     : stream.out_dbfs >= -30.0   ? #4ade80
+                     :                               #facc15;
+                horizontal-alignment: left;
+                vertical-alignment: center;
+            }
+        }
+    }
+
+    // Fallback: when `stream-meters` is empty, render the legacy
+    // single aggregate IN/OUT pair so wiring that hasn't migrated
+    // to per-stream meters still shows something at the footer.
+    if root.stream-meters.length == 0 : Rectangle {
         x: 60px;
         y: parent.height - 22px;
         width: 220px;
@@ -496,7 +626,7 @@ export component CompactChainViewPage inherits Rectangle {
             vertical-alignment: center;
         }
     }
-    Rectangle {
+    if root.stream-meters.length == 0 : Rectangle {
         x: parent.width - 240px;
         y: parent.height - 22px;
         width: 230px;

--- a/crates/adapter-gui/ui/secondary_windows_block.slint
+++ b/crates/adapter-gui/ui/secondary_windows_block.slint
@@ -223,15 +223,13 @@ export component CompactChainViewWindow inherits Window {
     default-font-family: Locale.font-family;
     default-font-size: 13px;
     title: @tr("title-window-chain-view");
-    // Defaults match the size the user pinned in #559: ~1200×860 so the
-    // full block strip renders (selector at x=158, brand at x=432,
-    // right-aligned knobs) and the per-stream IN/OUT meter rows fit at
-    // the footer without clipping. `min-width` keeps the row layout
-    // legible; below ~1000 px the per-block knobs collide.
+    // Defaults pinned to the screenshot the user attached in #559:
+    // 1305×840. `min-width` keeps the row layout legible; below
+    // ~1000 px the per-block knobs collide with the brand logo.
     min-width: 1000px;
     min-height: 480px;
-    preferred-width: 1200px;
-    preferred-height: 860px;
+    preferred-width: 1305px;
+    preferred-height: 840px;
     background: #0a0c10;
 
     in property <string> chain-title;

--- a/crates/adapter-gui/ui/secondary_windows_block.slint
+++ b/crates/adapter-gui/ui/secondary_windows_block.slint
@@ -223,10 +223,15 @@ export component CompactChainViewWindow inherits Window {
     default-font-family: Locale.font-family;
     default-font-size: 13px;
     title: @tr("title-window-chain-view");
-    min-width: 800px;
-    min-height: 260px;
-    preferred-width: 1000px;
-    preferred-height: 460px;
+    // Defaults wide enough to fit a full block row (model selector at
+    // x=158px, brand logo at x=432px, parameter strip right-aligned).
+    // Below ~1280px the per-block knobs overlap the stream display, and
+    // the user only perceives the IN/OUT footer as "the content" — the
+    // block list looks empty. Issue #559.
+    min-width: 1280px;
+    min-height: 480px;
+    preferred-width: 1800px;
+    preferred-height: 760px;
     background: #0a0c10;
 
     in property <string> chain-title;

--- a/crates/adapter-gui/ui/secondary_windows_block.slint
+++ b/crates/adapter-gui/ui/secondary_windows_block.slint
@@ -1,4 +1,4 @@
-import { ChannelOptionItem, BlockKnobOverlay, BlockParameterItem, BlockTypePickerItem, BlockModelPickerItem, BlockStreamData, MultiSliderPoint, CurveEditorPoint, CompactBlockItem, ChainRigNav } from "models.slint";
+import { ChannelOptionItem, BlockKnobOverlay, BlockParameterItem, BlockTypePickerItem, BlockModelPickerItem, BlockStreamData, MultiSliderPoint, CurveEditorPoint, CompactBlockItem, ChainRigNav, StreamMeter } from "models.slint";
 import { Locale } from "locale_globals.slint";
 import { BlockEditorPanel, BlockPanelEditor, CompactChainViewPage } from "pages/pages.slint";
 import { Toast } from "components/toast.slint";
@@ -223,15 +223,15 @@ export component CompactChainViewWindow inherits Window {
     default-font-family: Locale.font-family;
     default-font-size: 13px;
     title: @tr("title-window-chain-view");
-    // Defaults wide enough to fit a full block row (model selector at
-    // x=158px, brand logo at x=432px, parameter strip right-aligned).
-    // Below ~1280px the per-block knobs overlap the stream display, and
-    // the user only perceives the IN/OUT footer as "the content" — the
-    // block list looks empty. Issue #559.
-    min-width: 1280px;
+    // Defaults match the size the user pinned in #559: ~1200×860 so the
+    // full block strip renders (selector at x=158, brand at x=432,
+    // right-aligned knobs) and the per-stream IN/OUT meter rows fit at
+    // the footer without clipping. `min-width` keeps the row layout
+    // legible; below ~1000 px the per-block knobs collide.
+    min-width: 1000px;
     min-height: 480px;
-    preferred-width: 1800px;
-    preferred-height: 760px;
+    preferred-width: 1200px;
+    preferred-height: 860px;
     background: #0a0c10;
 
     in property <string> chain-title;
@@ -244,6 +244,10 @@ export component CompactChainViewWindow inherits Window {
     in property <ChainRigNav> rig-nav;
     in property <float> meter-in-dbfs: -120.0;
     in property <float> meter-out-dbfs: -120.0;
+    // Per-stream meter rows — mirrors `ProjectChainItem.stream_meters`.
+    // Multi-input chain (e.g. 3 inputs) ⇒ 3 entries ⇒ 3 IN/OUT bars at
+    // the footer (parity with the main `ChainRow`).
+    in property <[StreamMeter]> stream-meters;
     in property <int> volume: 100;
 
     // I/O device configuration
@@ -302,6 +306,7 @@ export component CompactChainViewWindow inherits Window {
         rig-nav: root.rig-nav;
         meter-in-dbfs: root.meter-in-dbfs;
         meter-out-dbfs: root.meter-out-dbfs;
+        stream-meters: root.stream-meters;
         volume: root.volume;
         configure-input(ci) => { root.configure-input(ci); }
         configure-output(ci) => { root.configure-output(ci); }


### PR DESCRIPTION
Closes #559.

## Summary

- `CompactChainViewWindow` defaults pinned to 1305×840 (matches the screenshot the user attached), `min 1000×480`. Below ~1000 px the per-block knob strip collides with the brand logo.
- Footer now renders **one IN/OUT meter row per stream** (parity with `ChainRow` on the main chains screen). Multi-input chains stack N rows upward from the bottom; the Flickable above shrinks just enough to host them without clipping the block strip.

## Files

- `crates/adapter-gui/ui/secondary_windows_block.slint` — window defaults; `StreamMeter` import; `stream-meters` property forwarded to the page.
- `crates/adapter-gui/ui/pages/compact_chain_view.slint` — `stream-meters` property + `for stream in stream-meters` loop in the footer; `meter-footer-height = N * 22 + 6`; legacy single-pair render kept as fallback when `stream-meters` is empty.
- `crates/adapter-gui/src/compact_chain_callbacks.rs` — polling timer copies `row.stream_meters.clone()` into `cw.set_stream_meters` each tick.

## Test plan

- [x] `cargo build -p adapter-gui` — clean.
- [x] `cargo test -p adapter-gui --lib` — `443 passed; 0 failed; 3 ignored`. `i18n::tests::every_tr_key_has_translation_in_en_pt_es` ✅.
- [x] Quality gate (Rust): `passed` — fmt `36 → 20` improved, lint/build/test/complexity/coverage all same.
- [x] Open Compact View on a chain → window opens at 1305×840.
- [x] Mono-input chain → one IN/OUT pair at the footer.
- [x] Multi-input chain (e.g. 3 inputs) → 3 IN/OUT pairs stacked at the footer, each driven by its own stream.
- [x] Shrink window → blocks still legible down to ~1000 px; resize is blocked below `min`.
- [x] Chain editor (main page) → footer unchanged (same data source).

## Out of scope

- Responsive multi-column flow → tracked in #361.
- Opening compact view from fullscreen → tracked in #378.