### PR TITLE
feat(#561): hot-reload + per-plugin ops + search for the plugin catalog

### DIFF
--- a/crates/adapter-console/src/main.rs
+++ b/crates/adapter-console/src/main.rs
@@ -168,6 +168,7 @@ fn main() -> Result<()> {
                 // pure helpers MCP would call (process-wide registry).
                 QueryKind::ListPluginCatalog => Ok(application::query::list_plugin_catalog()),
                 QueryKind::GetPlugin { id } => Ok(application::query::get_plugin(id)),
+                QueryKind::FindPlugins { query } => Ok(application::query::find_plugins(query)),
             },
             64,
         );

--- a/crates/adapter-console/src/main.rs
+++ b/crates/adapter-console/src/main.rs
@@ -164,6 +164,10 @@ fn main() -> Result<()> {
                     }
                     Ok(out)
                 }
+                // #561 (expanded scope): plugin catalog reads — same
+                // pure helpers MCP would call (process-wide registry).
+                QueryKind::ListPluginCatalog => Ok(application::query::list_plugin_catalog()),
+                QueryKind::GetPlugin { id } => Ok(application::query::get_plugin(id)),
             },
             64,
         );

--- a/crates/adapter-gui/src/desktop_app.rs
+++ b/crates/adapter-gui/src/desktop_app.rs
@@ -972,6 +972,9 @@ pub fn run_desktop_app(
                             application::bridge::QueryKind::GetPlugin { id } => {
                                 Ok(application::query::get_plugin(id))
                             }
+                            application::bridge::QueryKind::FindPlugins { query } => {
+                                Ok(application::query::find_plugins(query))
+                            }
                         },
                         32,
                     );

--- a/crates/adapter-gui/src/desktop_app.rs
+++ b/crates/adapter-gui/src/desktop_app.rs
@@ -963,6 +963,15 @@ pub fn run_desktop_app(
                                 }
                                 Ok(out)
                             }
+                            // #561 (expanded scope): plugin catalog
+                            // reads — same pure helpers MCP would call
+                            // (process-wide registry, no project state).
+                            application::bridge::QueryKind::ListPluginCatalog => {
+                                Ok(application::query::list_plugin_catalog())
+                            }
+                            application::bridge::QueryKind::GetPlugin { id } => {
+                                Ok(application::query::get_plugin(id))
+                            }
                         },
                         32,
                     );

--- a/crates/adapter-gui/src/settings/paths.rs
+++ b/crates/adapter-gui/src/settings/paths.rs
@@ -22,6 +22,7 @@ use slint::ComponentHandle;
 
 use application::command::Command;
 use application::dispatcher::CommandDispatcher;
+use application::event::Event;
 use infra_filesystem::FilesystemStorage;
 
 use crate::state::ProjectSession;
@@ -79,6 +80,62 @@ fn apply_plugins_path(
     }
 }
 
+/// #561: dispatch `Command::ReloadPluginCatalog` and return a
+/// human-readable summary of the new totals (or an error message
+/// suitable for the status text). Both `install` and `install_secondary`
+/// share this helper so the success/failure path is one place.
+///
+/// When no project session is attached we still dispatch through a
+/// fresh in-process dispatcher snapshot — the catalog is process-wide
+/// state, not project-scoped. This mirrors the boot path
+/// (`init_many`), which runs before any project is loaded.
+fn run_reload_plugin_catalog(project_session: &Rc<RefCell<Option<ProjectSession>>>) -> String {
+    // Use the session's dispatcher when available so other listeners
+    // (publishing fan-out) see the event; fall back to a one-shot
+    // local dispatcher when no project is loaded (still triggers the
+    // registry reload because the handler reaches the same process-
+    // wide `plugin_loader::registry`).
+    let events_result: anyhow::Result<Vec<Event>> = {
+        let borrow = project_session.borrow();
+        if let Some(session) = borrow.as_ref() {
+            session.dispatcher.dispatch(Command::ReloadPluginCatalog)
+        } else {
+            drop(borrow);
+            // No project session — run the side-effect directly via a
+            // throwaway LocalDispatcher tied to an empty project. The
+            // registry is process-wide so the reload still takes
+            // effect for any future project session.
+            let project = Rc::new(std::cell::RefCell::new(project::project::Project {
+                name: None,
+                device_settings: Vec::new(),
+                chains: Vec::new(),
+                midi: None,
+            }));
+            application::local_dispatcher::LocalDispatcher::new(project)
+                .dispatch(Command::ReloadPluginCatalog)
+        }
+    };
+    match events_result {
+        Ok(events) => events
+            .iter()
+            .find_map(|e| match e {
+                Event::PluginCatalogReloaded {
+                    native_count,
+                    disk_count,
+                    total_count,
+                } => Some(format!(
+                    "{total_count} plugin(s) loaded ({native_count} native, {disk_count} disk)"
+                )),
+                _ => None,
+            })
+            .unwrap_or_else(|| "plugin catalog reloaded".to_string()),
+        Err(e) => {
+            log::warn!("[paths] Command::ReloadPluginCatalog failed: {e}");
+            format!("reload failed: {e}")
+        }
+    }
+}
+
 /// Install the Paths section callbacks on the primary `AppWindow`.
 /// Each Choose… opens the native folder dialog, persists into
 /// `config.yaml`, and updates the Slint property so the UI reflects
@@ -127,6 +184,16 @@ pub fn install(win: &AppWindow, project_session: Rc<RefCell<Option<ProjectSessio
         apply_plugins_path(&session, None);
         if let Some(w) = win_weak.upgrade() {
             w.set_plugins_path(slint::SharedString::default());
+        }
+    });
+
+    // ── #561 reload plugin catalog ──────────────────────────────────
+    let win_weak = win.as_weak();
+    let session = project_session.clone();
+    win.on_reload_plugin_catalog(move || {
+        let status = run_reload_plugin_catalog(&session);
+        if let Some(w) = win_weak.upgrade() {
+            w.set_plugin_catalog_status(status.into());
         }
     });
 }
@@ -178,6 +245,16 @@ pub fn install_secondary(
         apply_plugins_path(&session, None);
         if let Some(w) = win_weak.upgrade() {
             w.set_plugins_path(slint::SharedString::default());
+        }
+    });
+
+    // ── #561 reload plugin catalog (secondary window) ───────────────
+    let win_weak = win.as_weak();
+    let session = project_session.clone();
+    win.on_reload_plugin_catalog(move || {
+        let status = run_reload_plugin_catalog(&session);
+        if let Some(w) = win_weak.upgrade() {
+            w.set_plugin_catalog_status(status.into());
         }
     });
 }

--- a/crates/adapter-gui/translations/en_US/LC_MESSAGES/adapter-gui.po
+++ b/crates/adapter-gui/translations/en_US/LC_MESSAGES/adapter-gui.po
@@ -598,3 +598,15 @@ msgstr "Save project"
 
 msgid "btn-save-audio-settings"
 msgstr "Apply"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint
+msgid "label-plugin-catalog"
+msgstr "Plugin catalog"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint
+msgid "btn-reload-plugin-catalog"
+msgstr "Reload"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint
+msgid "status-plugin-catalog-idle"
+msgstr "Not reloaded yet"

--- a/crates/adapter-gui/translations/es_ES/LC_MESSAGES/adapter-gui.po
+++ b/crates/adapter-gui/translations/es_ES/LC_MESSAGES/adapter-gui.po
@@ -611,3 +611,15 @@ msgstr "Guardar proyecto"
 
 msgid "btn-save-audio-settings"
 msgstr "Aplicar"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint
+msgid "label-plugin-catalog"
+msgstr "Catálogo de plugins"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint
+msgid "btn-reload-plugin-catalog"
+msgstr "Recargar"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint
+msgid "status-plugin-catalog-idle"
+msgstr "Aún no recargado"

--- a/crates/adapter-gui/translations/pt_BR/LC_MESSAGES/adapter-gui.po
+++ b/crates/adapter-gui/translations/pt_BR/LC_MESSAGES/adapter-gui.po
@@ -619,3 +619,15 @@ msgstr "Salvar projeto"
 
 msgid "btn-save-audio-settings"
 msgstr "Aplicar"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint
+msgid "label-plugin-catalog"
+msgstr "Catálogo de plugins"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint
+msgid "btn-reload-plugin-catalog"
+msgstr "Recarregar"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint
+msgid "status-plugin-catalog-idle"
+msgstr "Ainda não recarregado"

--- a/crates/adapter-gui/ui/app-window.slint
+++ b/crates/adapter-gui/ui/app-window.slint
@@ -114,6 +114,8 @@ export component AppWindow inherits Window {
     // System / Paths section (#513). Empty string = use OS default.
     in property <string> presets-path;
     in property <string> plugins-path;
+    // #561: status text for the plugin catalog reload row.
+    in property <string> plugin-catalog-status;
     // Fullscreen inline chain editor
     in property <[IoGroupItem]> chain-editor-input-groups;
     in property <[IoGroupItem]> chain-editor-output-groups;
@@ -238,6 +240,8 @@ export component AppWindow inherits Window {
     callback reset-presets-path();
     callback pick-plugins-path();
     callback reset-plugins-path();
+    // #561: re-scan the plugin packages directories without restart.
+    callback reload-plugin-catalog();
     // Fullscreen inline chain editor callbacks
     callback edit-chain-input(int);
     callback remove-chain-input(int);
@@ -521,10 +525,12 @@ export component AppWindow inherits Window {
         edit-project-name(t) => { root.edit-project-name(t); }
         presets-path: root.presets-path;
         plugins-path: root.plugins-path;
+        plugin-catalog-status: root.plugin-catalog-status;
         pick-presets-path => { root.pick-presets-path(); }
         reset-presets-path => { root.reset-presets-path(); }
         pick-plugins-path => { root.pick-plugins-path(); }
         reset-plugins-path => { root.reset-plugins-path(); }
+        reload-plugin-catalog => { root.reload-plugin-catalog(); }
         edit-chain-input(index) => { root.edit-chain-input(index); }
         remove-chain-input(index) => { root.remove-chain-input(index); }
         add-chain-input => { root.add-chain-input(); }
@@ -706,10 +712,12 @@ export component AppWindow inherits Window {
         edit-project-name(t) => { root.edit-project-name(t); }
         presets-path: root.presets-path;
         plugins-path: root.plugins-path;
+        plugin-catalog-status: root.plugin-catalog-status;
         pick-presets-path => { root.pick-presets-path(); }
         reset-presets-path => { root.reset-presets-path(); }
         pick-plugins-path => { root.pick-plugins-path(); }
         reset-plugins-path => { root.reset-plugins-path(); }
+        reload-plugin-catalog => { root.reload-plugin-catalog(); }
         virtual-key-pressed(label) => { root.virtual-key-pressed(label); }
         show-preset-picker: root.show-preset-picker;
         preset-picker-items: root.preset-picker-items;

--- a/crates/adapter-gui/ui/desktop_main.slint
+++ b/crates/adapter-gui/ui/desktop_main.slint
@@ -85,10 +85,13 @@ export component DesktopMain inherits Rectangle {
     // System / Paths section (#513). Empty = OS default.
     in property <string> presets-path;
     in property <string> plugins-path;
+    // #561: plugin catalog reload row in the Paths section.
+    in property <string> plugin-catalog-status;
     callback pick-presets-path();
     callback reset-presets-path();
     callback pick-plugins-path();
     callback reset-plugins-path();
+    callback reload-plugin-catalog();
     // Fullscreen inline chain editor
     in property <[IoGroupItem]> chain-editor-input-groups;
     in property <[IoGroupItem]> chain-editor-output-groups;
@@ -391,10 +394,12 @@ export component DesktopMain inherits Rectangle {
             cancel-midi-binding-draft(i) => { root.cancel-midi-binding-draft(i); }
             presets-path: root.presets-path;
             plugins-path: root.plugins-path;
+            plugin-catalog-status: root.plugin-catalog-status;
             pick-presets-path => { root.pick-presets-path(); }
             reset-presets-path => { root.reset-presets-path(); }
             pick-plugins-path => { root.pick-plugins-path(); }
             reset-plugins-path => { root.reset-plugins-path(); }
+            reload-plugin-catalog => { root.reload-plugin-catalog(); }
         }
 
         // Fullscreen inline tuner overlay (windowed mode uses TunerWindow instead)
@@ -563,10 +568,12 @@ export component DesktopMain inherits Rectangle {
         cancel-midi-binding-draft(i) => { root.cancel-midi-binding-draft(i); }
         presets-path: root.presets-path;
         plugins-path: root.plugins-path;
+        plugin-catalog-status: root.plugin-catalog-status;
         pick-presets-path => { root.pick-presets-path(); }
         reset-presets-path => { root.reset-presets-path(); }
         pick-plugins-path => { root.pick-plugins-path(); }
         reset-plugins-path => { root.reset-plugins-path(); }
+        reload-plugin-catalog => { root.reload-plugin-catalog(); }
     }
 
     // Floating language selector — top-right of every screen EXCEPT the

--- a/crates/adapter-gui/ui/pages/settings.slint
+++ b/crates/adapter-gui/ui/pages/settings.slint
@@ -94,6 +94,9 @@ export component SettingsPage inherits Rectangle {
     // System / Paths section (#513). Empty string = use OS default.
     in property <string> presets-path;
     in property <string> plugins-path;
+    // #561: status text for the plugin catalog reload row in the
+    // Paths section. Empty until the user runs the action.
+    in property <string> plugin-catalog-status;
     // Default-bind to project-name-draft so SettingsPage shows the
     // current project name inside the secondary ProjectSettingsWindow
     // (which only forwards project-name-draft).
@@ -126,6 +129,8 @@ export component SettingsPage inherits Rectangle {
     callback reset-presets-path();
     callback pick-plugins-path();
     callback reset-plugins-path();
+    // #561: hot-reload the plugin catalog (no payload).
+    callback reload-plugin-catalog();
 
     // Active section index (sidebar selection). 0 = Audio, default.
     in-out property <int> selected-section: 0;
@@ -288,10 +293,12 @@ export component SettingsPage inherits Rectangle {
                     if root.selected-section == 3 : SectionSystemPaths {
                         presets-path: root.presets-path;
                         plugins-path: root.plugins-path;
+                        plugin-catalog-status: root.plugin-catalog-status;
                         pick-presets-path => { root.pick-presets-path(); }
                         reset-presets-path => { root.reset-presets-path(); }
                         pick-plugins-path => { root.pick-plugins-path(); }
                         reset-plugins-path => { root.reset-plugins-path(); }
+                        reload-plugin-catalog => { root.reload-plugin-catalog(); }
                     }
                     if root.selected-section == 4 : SectionProjectMeta {
                         project-name: root.project-name;

--- a/crates/adapter-gui/ui/pages/settings/section_system_paths.slint
+++ b/crates/adapter-gui/ui/pages/settings/section_system_paths.slint
@@ -2,17 +2,29 @@
 // plugins directory — each a label + current path + Choose…/Reset.
 // Empty path means "use OS default" (the resolver handles it). Both
 // rows share a fixed-width label column so they line up vertically.
+//
+// #561 adds a third row for the plugin catalog: a "Reload" button
+// that dispatches `Command::ReloadPluginCatalog`, plus a status text
+// showing the post-reload counts. Lives in the same section because
+// the action is bound to the plugins directory above it.
 
 import { Button } from "std-widgets.slint";
 
 export component SectionSystemPaths inherits Rectangle {
     in property <string> presets-path;
     in property <string> plugins-path;
+    // #561: status string filled by the wiring after the reload
+    // completes — "12 plugins loaded (8 native, 4 disk)" etc. Empty
+    // when no reload has run yet.
+    in property <string> plugin-catalog-status;
 
     callback pick-presets-path();
     callback reset-presets-path();
     callback pick-plugins-path();
     callback reset-plugins-path();
+    // #561: re-scan the plugin packages directories without
+    // restarting the process.
+    callback reload-plugin-catalog();
 
     background: transparent;
 
@@ -81,6 +93,34 @@ export component SectionSystemPaths inherits Rectangle {
             Button {
                 text: @tr("btn-reset-path");
                 clicked => { root.reset-plugins-path(); }
+            }
+        }
+
+        // ── Plugin catalog reload row (#561) ──────────────────────
+        HorizontalLayout {
+            spacing: 8px;
+            alignment: start;
+            height: 32px;
+            Text {
+                text: @tr("label-plugin-catalog");
+                color: #cfd5e0;
+                font-size: 16px;
+                width: 140px;
+                vertical-alignment: center;
+            }
+            Text {
+                text: root.plugin-catalog-status == ""
+                    ? @tr("status-plugin-catalog-idle")
+                    : root.plugin-catalog-status;
+                color: root.plugin-catalog-status == "" ? #8a92a3 : #dde3ec;
+                font-size: 14px;
+                horizontal-stretch: 1;
+                vertical-alignment: center;
+                overflow: elide;
+            }
+            Button {
+                text: @tr("btn-reload-plugin-catalog");
+                clicked => { root.reload-plugin-catalog(); }
             }
         }
     }

--- a/crates/adapter-gui/ui/secondary_windows_chain.slint
+++ b/crates/adapter-gui/ui/secondary_windows_chain.slint
@@ -48,10 +48,13 @@ export component ProjectSettingsWindow inherits Window {
     // System / Paths section (#513). Empty = OS default.
     in property <string> presets-path;
     in property <string> plugins-path;
+    // #561: plugin catalog reload row in the Paths section.
+    in property <string> plugin-catalog-status;
     callback pick-presets-path();
     callback reset-presets-path();
     callback pick-plugins-path();
     callback reset-plugins-path();
+    callback reload-plugin-catalog();
     title: @tr("title-window-project-settings");
     min-width: 860px;
     min-height: 540px;
@@ -95,10 +98,12 @@ export component ProjectSettingsWindow inherits Window {
         edit-project-name(t) => { root.edit-project-name(t); }
         presets-path: root.presets-path;
         plugins-path: root.plugins-path;
+        plugin-catalog-status: root.plugin-catalog-status;
         pick-presets-path => { root.pick-presets-path(); }
         reset-presets-path => { root.reset-presets-path(); }
         pick-plugins-path => { root.pick-plugins-path(); }
         reset-plugins-path => { root.reset-plugins-path(); }
+        reload-plugin-catalog => { root.reload-plugin-catalog(); }
     }
 }
 

--- a/crates/adapter-gui/ui/touch_main.slint
+++ b/crates/adapter-gui/ui/touch_main.slint
@@ -80,10 +80,13 @@ export component TouchMain inherits Rectangle {
     // System / Paths section (#513). Empty = OS default.
     in property <string> presets-path;
     in property <string> plugins-path;
+    // #561: plugin catalog reload row in the Paths section.
+    in property <string> plugin-catalog-status;
     callback pick-presets-path();
     callback reset-presets-path();
     callback pick-plugins-path();
     callback reset-plugins-path();
+    callback reload-plugin-catalog();
     callback toggle-input-device(int, bool);
     callback toggle-output-device(int, bool);
     callback update-input-sample-rate(int, string);
@@ -417,10 +420,12 @@ export component TouchMain inherits Rectangle {
         cancel-midi-binding-draft(i) => { root.cancel-midi-binding-draft(i); }
         presets-path: root.presets-path;
         plugins-path: root.plugins-path;
+        plugin-catalog-status: root.plugin-catalog-status;
         pick-presets-path => { root.pick-presets-path(); }
         reset-presets-path => { root.reset-presets-path(); }
         pick-plugins-path => { root.pick-plugins-path(); }
         reset-plugins-path => { root.reset-plugins-path(); }
+        reload-plugin-catalog => { root.reload-plugin-catalog(); }
     }
 
     // Inline chain editor overlay (fullscreen mode)

--- a/crates/adapter-mcp/src/resources.rs
+++ b/crates/adapter-mcp/src/resources.rs
@@ -12,6 +12,11 @@ pub const URI_IDS: &str = "openrig://ids";
 pub const URI_METERS: &str = "openrig://meters";
 /// #561 (expanded scope): full plugin catalog as JSON.
 pub const URI_PLUGINS: &str = "openrig://plugins";
+/// #561 (expanded scope): URI template for text search.
+/// Concrete URIs look like `openrig://plugins/search/<query>`.
+/// Matched BEFORE [`URI_PLUGIN_PREFIX`] so `search` is never read
+/// as a manifest id.
+pub const URI_PLUGIN_SEARCH_PREFIX: &str = "openrig://plugins/search/";
 /// #561 (expanded scope): URI template for a single plugin by id.
 /// Concrete URIs look like `openrig://plugins/<manifest_id>`.
 pub const URI_PLUGIN_PREFIX: &str = "openrig://plugins/";
@@ -50,6 +55,9 @@ pub async fn read(bridge: &CommandBridge, uri: &str) -> Result<ReadResourceResul
         URI_IDS => QueryKind::Ids,
         URI_METERS => QueryKind::ChainMeters,
         URI_PLUGINS => QueryKind::ListPluginCatalog,
+        other if other.starts_with(URI_PLUGIN_SEARCH_PREFIX) => QueryKind::FindPlugins {
+            query: other[URI_PLUGIN_SEARCH_PREFIX.len()..].to_string(),
+        },
         other if other.starts_with(URI_PLUGIN_PREFIX) => QueryKind::GetPlugin {
             id: other[URI_PLUGIN_PREFIX.len()..].to_string(),
         },

--- a/crates/adapter-mcp/src/resources.rs
+++ b/crates/adapter-mcp/src/resources.rs
@@ -10,6 +10,11 @@ pub const URI_PROJECT: &str = "openrig://project";
 pub const URI_DEVICES: &str = "openrig://devices";
 pub const URI_IDS: &str = "openrig://ids";
 pub const URI_METERS: &str = "openrig://meters";
+/// #561 (expanded scope): full plugin catalog as JSON.
+pub const URI_PLUGINS: &str = "openrig://plugins";
+/// #561 (expanded scope): URI template for a single plugin by id.
+/// Concrete URIs look like `openrig://plugins/<manifest_id>`.
+pub const URI_PLUGIN_PREFIX: &str = "openrig://plugins/";
 
 /// Static list of resources this server exposes.
 pub fn resources() -> Vec<Resource> {
@@ -30,6 +35,10 @@ pub fn resources() -> Vec<Resource> {
             RawResource::new(URI_METERS, "Per-chain peak meters (dBFS)"),
             None,
         ),
+        Annotated::new(
+            RawResource::new(URI_PLUGINS, "Plugin catalog (id, kind, backend)"),
+            None,
+        ),
     ]
 }
 
@@ -40,6 +49,10 @@ pub async fn read(bridge: &CommandBridge, uri: &str) -> Result<ReadResourceResul
         URI_DEVICES => QueryKind::Devices,
         URI_IDS => QueryKind::Ids,
         URI_METERS => QueryKind::ChainMeters,
+        URI_PLUGINS => QueryKind::ListPluginCatalog,
+        other if other.starts_with(URI_PLUGIN_PREFIX) => QueryKind::GetPlugin {
+            id: other[URI_PLUGIN_PREFIX.len()..].to_string(),
+        },
         other => anyhow::bail!("unknown resource: {other}"),
     };
     let text = bridge

--- a/crates/adapter-mcp/src/tools.rs
+++ b/crates/adapter-mcp/src/tools.rs
@@ -73,7 +73,9 @@ mod tests {
     /// `SaveMidiMapping`, `StartMidiLearn`, `StopMidiLearn`, and
     /// `PublishMidiEvent`. Each adds one MCP tool automatically via
     /// `command_schema` (single source of truth — the `Command` enum).
-    const COMMAND_VARIANT_COUNT: usize = 49;
+    /// #513 (paths overrides) bumped to 51 with `SetPresetsPath` and
+    /// `SetPluginsPath`. #561 bumped to 52 with `ReloadPluginCatalog`.
+    const COMMAND_VARIANT_COUNT: usize = 52;
 
     #[test]
     fn parity_guard_every_command_variant_is_a_tool() {

--- a/crates/adapter-mcp/src/tools.rs
+++ b/crates/adapter-mcp/src/tools.rs
@@ -74,8 +74,10 @@ mod tests {
     /// `PublishMidiEvent`. Each adds one MCP tool automatically via
     /// `command_schema` (single source of truth — the `Command` enum).
     /// #513 (paths overrides) bumped to 51 with `SetPresetsPath` and
-    /// `SetPluginsPath`. #561 bumped to 52 with `ReloadPluginCatalog`.
-    const COMMAND_VARIANT_COUNT: usize = 52;
+    /// `SetPluginsPath`. #561 bumped to 52 with `ReloadPluginCatalog`,
+    /// then to 54 with `LoadPlugin` and `UnloadPlugin` (expanded scope:
+    /// per-plugin load / unload).
+    const COMMAND_VARIANT_COUNT: usize = 54;
 
     #[test]
     fn parity_guard_every_command_variant_is_a_tool() {

--- a/crates/application/src/bridge.rs
+++ b/crates/application/src/bridge.rs
@@ -57,6 +57,14 @@ pub enum QueryKind {
     /// one record per line). Same numbers the GUI's IN/OUT bars read —
     /// every transport gets the same view (`openrig-code-quality` lei).
     ChainMeters,
+    /// #561 (expanded scope): full plugin catalog as a JSON listing.
+    /// See [`crate::query::list_plugin_catalog`]. Read parity for the
+    /// reload / load / unload Commands so any transport can show the
+    /// agent / user what is currently addressable.
+    ListPluginCatalog,
+    /// #561 (expanded scope): single plugin by manifest id, or
+    /// `{"plugin": null}` when absent. See [`crate::query::get_plugin`].
+    GetPlugin { id: String },
 }
 
 struct QueryRequest {

--- a/crates/application/src/bridge.rs
+++ b/crates/application/src/bridge.rs
@@ -65,6 +65,10 @@ pub enum QueryKind {
     /// #561 (expanded scope): single plugin by manifest id, or
     /// `{"plugin": null}` when absent. See [`crate::query::get_plugin`].
     GetPlugin { id: String },
+    /// #561 (expanded scope): text search across the catalog
+    /// (case-insensitive substring on id / display_name / brand).
+    /// Empty query = all entries. See [`crate::query::find_plugins`].
+    FindPlugins { query: String },
 }
 
 struct QueryRequest {

--- a/crates/application/src/command.rs
+++ b/crates/application/src/command.rs
@@ -410,6 +410,19 @@ pub enum Command {
     /// "import a new NAM" and "build a preset that uses it" without a
     /// session break.
     ReloadPluginCatalog,
+
+    /// #561 (expanded scope): bring a single disk plugin into the
+    /// in-memory catalog by manifest id. Re-scans the known plugin
+    /// roots and adds the one whose id matches. Errors when no disk
+    /// package with that id is discoverable; no-op when the plugin
+    /// is already loaded. Emits `Event::PluginLoaded { id }`.
+    LoadPlugin { id: String },
+
+    /// #561 (expanded scope): remove a single disk plugin from the
+    /// in-memory catalog by manifest id. Refuses natives — they are
+    /// compiled-in and cannot be dropped without restarting the
+    /// process. Emits `Event::PluginUnloaded { id }`.
+    UnloadPlugin { id: String },
 }
 
 /// What [`Command::ApplyRigNav`] does to the chain's rig input.

--- a/crates/application/src/command.rs
+++ b/crates/application/src/command.rs
@@ -399,6 +399,17 @@ pub enum Command {
     /// setting per ADR 0003 — the adapter writes it into `config.yaml`
     /// on `Event::PathsSaved`.
     SetPluginsPath { path: Option<PathBuf> },
+
+    /// #561: re-scan the plugin packages directories without restarting
+    /// the process. Same path resolution as boot
+    /// (`detect_data_root().join("plugins")` + `plugins_root_from_config`),
+    /// natives are preserved. The dispatcher emits
+    /// `Event::PluginCatalogReloaded { native_count, disk_count,
+    /// total_count }` so adapters can surface the new totals to the
+    /// user (GUI toast, MCP tool response). Closes the gap between
+    /// "import a new NAM" and "build a preset that uses it" without a
+    /// session break.
+    ReloadPluginCatalog,
 }
 
 /// What [`Command::ApplyRigNav`] does to the chain's rig input.

--- a/crates/application/src/event.rs
+++ b/crates/application/src/event.rs
@@ -247,6 +247,20 @@ pub enum Event {
         total_count: usize,
     },
 
+    /// #561 (expanded scope): emitted after `Command::LoadPlugin`
+    /// brought a single plugin into the catalog (or confirmed it was
+    /// already there). `id` mirrors the request.
+    PluginLoaded {
+        id: String,
+    },
+
+    /// #561 (expanded scope): emitted after `Command::UnloadPlugin`
+    /// dropped a single disk plugin from the catalog. `id` mirrors
+    /// the request.
+    PluginUnloaded {
+        id: String,
+    },
+
     /// An error occurred while processing a command.
     Error {
         message: String,
@@ -314,6 +328,9 @@ impl Event {
             | Event::PathsSaved
             // #561: catalog-wide reload, never tied to a single chain.
             | Event::PluginCatalogReloaded { .. }
+            // #561 (expanded scope): per-plugin load/unload, also catalog-scope.
+            | Event::PluginLoaded { .. }
+            | Event::PluginUnloaded { .. }
             | Event::Error { .. } => None,
         }
     }

--- a/crates/application/src/event.rs
+++ b/crates/application/src/event.rs
@@ -237,6 +237,16 @@ pub enum Event {
     /// `config.yaml` on receipt. System-level event per ADR 0003.
     PathsSaved,
 
+    /// #561: emitted after `Command::ReloadPluginCatalog` re-scanned
+    /// the plugin packages directories. Carries the post-reload totals
+    /// so adapters can show the user what changed (GUI toast, MCP
+    /// response). `total_count == native_count + disk_count`.
+    PluginCatalogReloaded {
+        native_count: usize,
+        disk_count: usize,
+        total_count: usize,
+    },
+
     /// An error occurred while processing a command.
     Error {
         message: String,
@@ -302,6 +312,8 @@ impl Event {
             | Event::MidiEventReceived { .. }
             // #513: system-level paths event, never tied to a chain.
             | Event::PathsSaved
+            // #561: catalog-wide reload, never tied to a single chain.
+            | Event::PluginCatalogReloaded { .. }
             | Event::Error { .. } => None,
         }
     }

--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -18,6 +18,7 @@ mod local_dispatcher_close;
 mod local_dispatcher_diagnostic;
 mod local_dispatcher_language;
 mod local_dispatcher_output;
+mod local_dispatcher_plugin_catalog;
 mod local_dispatcher_preset;
 mod local_dispatcher_project;
 mod local_dispatcher_recent;

--- a/crates/application/src/local_dispatcher.rs
+++ b/crates/application/src/local_dispatcher.rs
@@ -220,6 +220,9 @@ impl CommandDispatcher for LocalDispatcher {
             Command::SetPresetsPath { .. } | Command::SetPluginsPath { .. } => {
                 self.handle_paths_system(cmd)
             }
+
+            // #561: hot-reload the plugin catalog (no payload).
+            Command::ReloadPluginCatalog => self.handle_reload_plugin_catalog(),
         }
     }
 

--- a/crates/application/src/local_dispatcher.rs
+++ b/crates/application/src/local_dispatcher.rs
@@ -223,6 +223,9 @@ impl CommandDispatcher for LocalDispatcher {
 
             // #561: hot-reload the plugin catalog (no payload).
             Command::ReloadPluginCatalog => self.handle_reload_plugin_catalog(),
+            // #561 (expanded scope): per-plugin load / unload.
+            Command::LoadPlugin { id } => self.handle_load_plugin(id),
+            Command::UnloadPlugin { id } => self.handle_unload_plugin(id),
         }
     }
 

--- a/crates/application/src/local_dispatcher_plugin_catalog.rs
+++ b/crates/application/src/local_dispatcher_plugin_catalog.rs
@@ -1,0 +1,45 @@
+//! #561 — `Command::ReloadPluginCatalog`: hot-reload the plugin catalog
+//! without restarting OpenRig.
+//!
+//! Resolves the plugin roots the same way the boot path does
+//! (`detect_data_root().join("plugins")` for the bundled tree,
+//! `plugins_root_from_config(app_config_path)` for the user tree),
+//! calls [`plugin_loader::registry::reload`] to rebuild the catalog,
+//! and emits `Event::PluginCatalogReloaded` with the new totals.
+//!
+//! `SaveProject` precedent: side-effects (re-scanning disk, swapping
+//! the registry slice) happen here, the adapter just renders the
+//! emitted event. MCP/gRPC inherit the same tool surface for free via
+//! the schema-derived Command name.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+
+use infra_filesystem::FilesystemStorage;
+
+use crate::event::Event;
+use crate::local_dispatcher::LocalDispatcher;
+
+impl LocalDispatcher {
+    /// `Command::ReloadPluginCatalog` — re-scan the bundled + user
+    /// plugin roots, rebuild the catalog, emit
+    /// `Event::PluginCatalogReloaded { native_count, disk_count,
+    /// total_count }`.
+    ///
+    /// Errors out cleanly if the app config path cannot be resolved
+    /// (`FilesystemStorage::app_config_path` failed) — we'd otherwise
+    /// have no way to compute the user-installed plugins root.
+    pub(crate) fn handle_reload_plugin_catalog(&self) -> Result<Vec<Event>> {
+        let bundled_root: PathBuf = infra_filesystem::detect_data_root().join("plugins");
+        let user_root = FilesystemStorage::app_config_path()
+            .map(|cfg| plugin_loader::plugins_root_from_config(&cfg))
+            .map_err(|e| anyhow::anyhow!("resolve app_config_path failed: {e}"))?;
+        let stats = plugin_loader::registry::reload(&[bundled_root, user_root]);
+        Ok(vec![Event::PluginCatalogReloaded {
+            native_count: stats.native_count,
+            disk_count: stats.disk_count,
+            total_count: stats.total_count,
+        }])
+    }
+}

--- a/crates/application/src/local_dispatcher_plugin_catalog.rs
+++ b/crates/application/src/local_dispatcher_plugin_catalog.rs
@@ -1,16 +1,15 @@
-//! #561 — `Command::ReloadPluginCatalog`: hot-reload the plugin catalog
-//! without restarting OpenRig.
+//! #561 — plugin-catalog Commands: hot-reload the whole catalog, plus
+//! per-plugin load / unload, without restarting OpenRig.
 //!
-//! Resolves the plugin roots the same way the boot path does
-//! (`detect_data_root().join("plugins")` for the bundled tree,
-//! `plugins_root_from_config(app_config_path)` for the user tree),
-//! calls [`plugin_loader::registry::reload`] to rebuild the catalog,
-//! and emits `Event::PluginCatalogReloaded` with the new totals.
+//! All three operations resolve the plugin roots the same way the
+//! boot path does (`detect_data_root().join("plugins")` for the
+//! bundled tree, `plugins_root_from_config(app_config_path)` for the
+//! user tree). The registry layer is the single source of truth for
+//! the mutation; this handler is just the bus-side glue.
 //!
-//! `SaveProject` precedent: side-effects (re-scanning disk, swapping
-//! the registry slice) happen here, the adapter just renders the
-//! emitted event. MCP/gRPC inherit the same tool surface for free via
-//! the schema-derived Command name.
+//! `SaveProject` precedent: side-effects happen here, the adapter
+//! just renders the emitted event. MCP/gRPC inherit the same tool
+//! surface for free via the schema-derived Command name.
 
 use std::path::PathBuf;
 
@@ -22,24 +21,46 @@ use crate::event::Event;
 use crate::local_dispatcher::LocalDispatcher;
 
 impl LocalDispatcher {
-    /// `Command::ReloadPluginCatalog` — re-scan the bundled + user
-    /// plugin roots, rebuild the catalog, emit
-    /// `Event::PluginCatalogReloaded { native_count, disk_count,
-    /// total_count }`.
-    ///
-    /// Errors out cleanly if the app config path cannot be resolved
-    /// (`FilesystemStorage::app_config_path` failed) — we'd otherwise
-    /// have no way to compute the user-installed plugins root.
-    pub(crate) fn handle_reload_plugin_catalog(&self) -> Result<Vec<Event>> {
+    /// Resolve the two plugin roots boot uses. Shared by reload /
+    /// load / unload so all three flows scan the same locations.
+    fn plugin_roots(&self) -> Result<Vec<PathBuf>> {
         let bundled_root: PathBuf = infra_filesystem::detect_data_root().join("plugins");
         let user_root = FilesystemStorage::app_config_path()
             .map(|cfg| plugin_loader::plugins_root_from_config(&cfg))
             .map_err(|e| anyhow::anyhow!("resolve app_config_path failed: {e}"))?;
-        let stats = plugin_loader::registry::reload(&[bundled_root, user_root]);
+        Ok(vec![bundled_root, user_root])
+    }
+
+    /// `Command::ReloadPluginCatalog` — re-scan the bundled + user
+    /// plugin roots, rebuild the catalog, emit
+    /// `Event::PluginCatalogReloaded { native_count, disk_count,
+    /// total_count }`.
+    pub(crate) fn handle_reload_plugin_catalog(&self) -> Result<Vec<Event>> {
+        let roots = self.plugin_roots()?;
+        let stats = plugin_loader::registry::reload(&roots);
         Ok(vec![Event::PluginCatalogReloaded {
             native_count: stats.native_count,
             disk_count: stats.disk_count,
             total_count: stats.total_count,
         }])
+    }
+
+    /// `Command::LoadPlugin { id }` — bring a single disk plugin
+    /// into the in-memory catalog. Re-scans the known roots, adds
+    /// the one whose manifest id matches `id`. Errors when no
+    /// package with that id is discoverable; no-op when already
+    /// loaded. Emits `Event::PluginLoaded { id }` on success.
+    pub(crate) fn handle_load_plugin(&self, id: String) -> Result<Vec<Event>> {
+        let roots = self.plugin_roots()?;
+        plugin_loader::registry::load_one(&id, &roots).map_err(|e| anyhow::anyhow!("{e}"))?;
+        Ok(vec![Event::PluginLoaded { id }])
+    }
+
+    /// `Command::UnloadPlugin { id }` — remove a single disk plugin
+    /// from the in-memory catalog. Refuses natives. Emits
+    /// `Event::PluginUnloaded { id }` on success.
+    pub(crate) fn handle_unload_plugin(&self, id: String) -> Result<Vec<Event>> {
+        plugin_loader::registry::unload(&id).map_err(|e| anyhow::anyhow!("{e}"))?;
+        Ok(vec![Event::PluginUnloaded { id }])
     }
 }

--- a/crates/application/src/query.rs
+++ b/crates/application/src/query.rs
@@ -134,6 +134,36 @@ pub fn get_plugin(id: &str) -> String {
     }
 }
 
+/// #561 (expanded scope): text search across the catalog.
+/// Case-insensitive substring match against `id`, `display_name`, and
+/// `brand`. Empty query returns every entry (same as
+/// [`list_plugin_catalog`]) — lets the agent treat search and listing
+/// as one tool. Same JSON envelope as the listing.
+pub fn find_plugins(query: &str) -> String {
+    let needle = query.to_lowercase();
+    let mut out = String::from("{\"plugins\": [");
+    let mut first = true;
+    for p in plugin_loader::registry::packages() {
+        let matches = needle.is_empty()
+            || p.manifest.id.to_lowercase().contains(&needle)
+            || p.manifest.display_name.to_lowercase().contains(&needle)
+            || p.manifest
+                .brand
+                .as_deref()
+                .is_some_and(|b| b.to_lowercase().contains(&needle));
+        if !matches {
+            continue;
+        }
+        if !first {
+            out.push_str(", ");
+        }
+        first = false;
+        plugin_entry_json(p, &mut out);
+    }
+    out.push_str("]}");
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/application/src/query.rs
+++ b/crates/application/src/query.rs
@@ -6,6 +6,7 @@
 
 use std::fmt::Write;
 
+use plugin_loader::manifest::Backend;
 use project::project::Project;
 
 /// Human-readable, copy-paste-ready listing of every chain and block with
@@ -36,6 +37,101 @@ pub fn list_ids(project: &Project) -> String {
     }
     let _ = writeln!(out, "(chains: {})", project.chains.len());
     out
+}
+
+/// JSON-escape a string for inclusion in a manually-built JSON literal.
+fn json_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => {
+                let _ = write!(out, "\\u{:04x}", c as u32);
+            }
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+/// Block-type label used in the plugin catalog JSON. Stable strings —
+/// adapters and clients pin against these.
+fn block_type_label(bt: &plugin_loader::manifest::BlockType) -> &'static str {
+    use plugin_loader::manifest::BlockType::*;
+    match bt {
+        GainPedal => "gain_pedal",
+        Preamp => "preamp",
+        Amp => "amp",
+        Cab => "cab",
+        Body => "body",
+        Reverb => "reverb",
+        Delay => "delay",
+        Mod => "mod",
+        Filter => "filter",
+        Dyn => "dyn",
+        Wah => "wah",
+        Pitch => "pitch",
+        Util => "util",
+    }
+}
+
+/// Serialize one `LoadedPackage` entry as a JSON object for the plugin
+/// catalog listing. Single source of truth for the shape (list and
+/// get share it).
+fn plugin_entry_json(p: &plugin_loader::LoadedPackage, out: &mut String) {
+    let backend = match p.manifest.backend {
+        Backend::Native { .. } => "native",
+        _ => "disk",
+    };
+    let _ = write!(
+        out,
+        "{{\"id\": \"{}\", \"display_name\": \"{}\", \"brand\": {}, \"block_type\": \"{}\", \"backend\": \"{}\"}}",
+        json_escape(&p.manifest.id),
+        json_escape(&p.manifest.display_name),
+        match p.manifest.brand.as_deref() {
+            Some(b) => format!("\"{}\"", json_escape(b)),
+            None => "null".to_string(),
+        },
+        block_type_label(&p.manifest.block_type),
+        backend,
+    );
+}
+
+/// #561 (expanded scope): JSON listing of every plugin currently in
+/// the process-wide catalog (`plugin_loader::registry::packages()`).
+/// Each entry carries id, display_name, brand (or null), block_type,
+/// backend ("native" / "disk"). Pure read — no mutation.
+pub fn list_plugin_catalog() -> String {
+    let mut out = String::from("{\"plugins\": [");
+    let mut first = true;
+    for p in plugin_loader::registry::packages() {
+        if !first {
+            out.push_str(", ");
+        }
+        first = false;
+        plugin_entry_json(p, &mut out);
+    }
+    out.push_str("]}");
+    out
+}
+
+/// #561 (expanded scope): JSON entry for the plugin with manifest id
+/// `id`, wrapped under a `plugin` key. Returns `{"plugin": null}` when
+/// no plugin in the catalog matches. Pure read.
+pub fn get_plugin(id: &str) -> String {
+    match plugin_loader::registry::find(id) {
+        Some(p) => {
+            let mut out = String::from("{\"plugin\": ");
+            plugin_entry_json(p, &mut out);
+            out.push('}');
+            out
+        }
+        None => "{\"plugin\": null}".to_string(),
+    }
 }
 
 #[cfg(test)]

--- a/crates/application/tests/issue_561_find_plugins.rs
+++ b/crates/application/tests/issue_561_find_plugins.rs
@@ -1,0 +1,86 @@
+//! Issue #561 (expanded scope, search): `Query::FindPlugins` — text
+//! search across the in-memory plugin catalog (id / display_name /
+//! brand, case-insensitive substring). Pairs with `ListPluginCatalog`
+//! / `GetPlugin` so the agent can "search" the catalog without paging
+//! the full list every time.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use project::project::Project;
+
+use application::command::Command;
+use application::dispatcher::CommandDispatcher;
+use application::local_dispatcher::LocalDispatcher;
+
+fn empty_project_rc() -> Rc<RefCell<Project>> {
+    Rc::new(RefCell::new(Project {
+        name: Some("test".into()),
+        device_settings: Vec::new(),
+        chains: Vec::new(),
+        midi: None,
+    }))
+}
+
+fn seed_natives_and_reload(dispatcher: &LocalDispatcher) {
+    engine::native_registry::register_all_natives();
+    let _ = dispatcher
+        .dispatch(Command::ReloadPluginCatalog)
+        .expect("reload to seed natives");
+}
+
+fn first_id_in_listing(json: &str) -> String {
+    let needle = "\"id\": \"";
+    let start = json.find(needle).expect("at least one id");
+    let after = &json[start + needle.len()..];
+    let end = after.find('"').expect("closing quote");
+    after[..end].to_string()
+}
+
+#[test]
+fn find_plugins_with_empty_query_returns_all_entries() {
+    let project = empty_project_rc();
+    let dispatcher = LocalDispatcher::new(Rc::clone(&project));
+    seed_natives_and_reload(&dispatcher);
+
+    let all = application::query::list_plugin_catalog();
+    let found = application::query::find_plugins("");
+
+    assert_eq!(
+        all, found,
+        "empty query must behave the same as list_plugin_catalog"
+    );
+}
+
+#[test]
+fn find_plugins_matches_native_id_substring_case_insensitive() {
+    let project = empty_project_rc();
+    let dispatcher = LocalDispatcher::new(Rc::clone(&project));
+    seed_natives_and_reload(&dispatcher);
+
+    let listing = application::query::list_plugin_catalog();
+    let id = first_id_in_listing(&listing);
+    // Slice the first 3 chars of an id we know exists — guaranteed
+    // to match at least that one entry. Bumping to upper-case proves
+    // the matcher is case-insensitive.
+    let needle: String = id.chars().take(3).collect::<String>().to_uppercase();
+
+    let json = application::query::find_plugins(&needle);
+    assert!(
+        json.contains(&format!("\"id\": \"{id}\"")),
+        "find_plugins({needle:?}) must include {id}, got: {json}"
+    );
+}
+
+#[test]
+fn find_plugins_with_no_match_returns_empty_array() {
+    let project = empty_project_rc();
+    let dispatcher = LocalDispatcher::new(Rc::clone(&project));
+    seed_natives_and_reload(&dispatcher);
+
+    let json = application::query::find_plugins("definitely_not_a_real_substring_561_xyz");
+    assert!(
+        json.contains("\"plugins\": []"),
+        "no-match query must emit an empty plugins array, got: {json}"
+    );
+}

--- a/crates/application/tests/issue_561_plugin_catalog_ops.rs
+++ b/crates/application/tests/issue_561_plugin_catalog_ops.rs
@@ -1,0 +1,191 @@
+//! Issue #561 (expanded scope): list / get / load / unload individual
+//! plugins through the catalog without restarting.
+//!
+//! The reload Command (already in the bus) covers the whole-disk
+//! rescan flow. The agent-driven tone-builder flow also needs the
+//! finer-grained operations:
+//!
+//! * `Query::ListPluginCatalog` — enumerate every plugin (native +
+//!   disk) the running process knows about. Each entry carries id,
+//!   display_name, brand, block_type, backend ("native" / "disk").
+//! * `Query::GetPlugin { id }` — single entry by id, `null` when not
+//!   present. Lets the agent "find" or "get" without paging the full
+//!   list every time.
+//! * `Command::LoadPlugin { id }` — bring a single plugin into the
+//!   registry. Re-scans the known plugin roots and adds the one whose
+//!   manifest id matches. Errors cleanly when no package on disk
+//!   carries that id.
+//! * `Command::UnloadPlugin { id }` — remove a single disk plugin
+//!   from the in-memory registry. Refuses natives (compiled-in;
+//!   cannot be dropped without restarting the process).
+//!
+//! Per the architecture LAWs (`CLAUDE.md`):
+//! - Each Command is a variant on `application::command::Command` so
+//!   MCP/gRPC inherit the operation through the schema-derived tool
+//!   surface (`parity_guard_every_command_variant_is_a_tool`).
+//! - Each Query is a `pub` function in `application::query` so
+//!   adapters can call it directly OR through the bridge for cross-
+//!   thread reads (mirrors `list_project_presets`).
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use project::project::Project;
+
+use application::command::Command;
+use application::dispatcher::CommandDispatcher;
+use application::event::Event;
+use application::local_dispatcher::LocalDispatcher;
+
+fn empty_project_rc() -> Rc<RefCell<Project>> {
+    Rc::new(RefCell::new(Project {
+        name: Some("test".into()),
+        device_settings: Vec::new(),
+        chains: Vec::new(),
+        midi: None,
+    }))
+}
+
+/// Bring at least one native into the catalog so the listing/get
+/// tests have stable, non-empty fixtures without depending on disk.
+fn seed_natives_and_reload(dispatcher: &LocalDispatcher) {
+    engine::native_registry::register_all_natives();
+    let _ = dispatcher
+        .dispatch(Command::ReloadPluginCatalog)
+        .expect("reload to seed natives");
+}
+
+/// Extract the first `"id": "<x>"` value found in a JSON listing.
+/// Crude but sufficient for these tests — we don't want to pull a
+/// json crate into the integration test just to read one field.
+fn first_id_in_listing(json: &str) -> String {
+    let needle = "\"id\": \"";
+    let start = json.find(needle).expect("at least one id");
+    let after = &json[start + needle.len()..];
+    let end = after.find('"').expect("closing quote");
+    after[..end].to_string()
+}
+
+#[test]
+fn list_plugin_catalog_returns_an_array_with_at_least_one_native() {
+    let project = empty_project_rc();
+    let dispatcher = LocalDispatcher::new(Rc::clone(&project));
+    seed_natives_and_reload(&dispatcher);
+
+    let json = application::query::list_plugin_catalog();
+    assert!(
+        json.contains("\"plugins\""),
+        "listing must wrap entries under a `plugins` key, got: {json}"
+    );
+    assert!(
+        json.contains("\"backend\": \"native\""),
+        "at least one native must surface in the listing, got: {json}"
+    );
+}
+
+#[test]
+fn get_plugin_returns_entry_when_id_is_known() {
+    let project = empty_project_rc();
+    let dispatcher = LocalDispatcher::new(Rc::clone(&project));
+    seed_natives_and_reload(&dispatcher);
+
+    let listing = application::query::list_plugin_catalog();
+    let id = first_id_in_listing(&listing);
+
+    let json = application::query::get_plugin(&id);
+    assert!(
+        json.contains(&format!("\"id\": \"{id}\"")),
+        "get_plugin must return the entry for {id}, got: {json}"
+    );
+}
+
+#[test]
+fn get_plugin_returns_null_when_id_is_unknown() {
+    let json = application::query::get_plugin("definitely_not_a_real_plugin_id_561");
+    assert!(
+        json.contains("null"),
+        "get_plugin must surface a null when the id is unknown, got: {json}"
+    );
+}
+
+#[test]
+fn unload_plugin_command_errors_when_id_is_unknown() {
+    let project = empty_project_rc();
+    let dispatcher = LocalDispatcher::new(Rc::clone(&project));
+
+    let err = dispatcher
+        .dispatch(Command::UnloadPlugin {
+            id: "definitely_not_a_real_plugin_id_561".into(),
+        })
+        .expect_err("unloading an unknown id must error cleanly");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("not found") || msg.contains("unknown"),
+        "expected a 'not found / unknown' message, got: {msg}"
+    );
+}
+
+#[test]
+fn unload_plugin_command_refuses_to_drop_a_native() {
+    let project = empty_project_rc();
+    let dispatcher = LocalDispatcher::new(Rc::clone(&project));
+    seed_natives_and_reload(&dispatcher);
+
+    let listing = application::query::list_plugin_catalog();
+    let native_id = first_id_in_listing(&listing);
+
+    let err = dispatcher
+        .dispatch(Command::UnloadPlugin {
+            id: native_id.clone(),
+        })
+        .expect_err("unloading a native must error");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("native"),
+        "expected the error to mention 'native' (compiled-in, cannot unload), got: {msg}"
+    );
+}
+
+#[test]
+fn load_plugin_command_errors_when_id_is_unknown_on_disk() {
+    let project = empty_project_rc();
+    let dispatcher = LocalDispatcher::new(Rc::clone(&project));
+
+    let err = dispatcher
+        .dispatch(Command::LoadPlugin {
+            id: "definitely_not_a_real_plugin_id_561".into(),
+        })
+        .expect_err("loading an unknown id must error cleanly");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("not found") || msg.contains("unknown"),
+        "expected a 'not found / unknown' message, got: {msg}"
+    );
+}
+
+#[test]
+fn load_plugin_command_with_known_native_id_emits_plugin_loaded_event() {
+    // Natives are already in the registry (via register_all_natives
+    // + reload); LoadPlugin {id} on an already-loaded id must be a
+    // no-op that still emits the event so the caller can confirm.
+    let project = empty_project_rc();
+    let dispatcher = LocalDispatcher::new(Rc::clone(&project));
+    seed_natives_and_reload(&dispatcher);
+
+    let listing = application::query::list_plugin_catalog();
+    let id = first_id_in_listing(&listing);
+
+    let events = dispatcher
+        .dispatch(Command::LoadPlugin { id: id.clone() })
+        .expect("load known id");
+    let loaded = events.iter().any(|e| {
+        matches!(
+            e,
+            Event::PluginLoaded { id: ev_id } if ev_id == &id
+        )
+    });
+    assert!(
+        loaded,
+        "expected Event::PluginLoaded {{ id={id} }}, got: {events:?}"
+    );
+}

--- a/crates/application/tests/issue_561_reload_plugin_catalog.rs
+++ b/crates/application/tests/issue_561_reload_plugin_catalog.rs
@@ -1,0 +1,77 @@
+//! Issue #561: hot-reload the plugin catalog without restarting OpenRig.
+//!
+//! Today the catalog is loaded once at boot
+//! (`plugin_loader::registry::init_many`) in `crates/adapter-gui/src/desktop_app.rs`.
+//! After importing a new NAM/IR pack into `OpenRig-plugins` the new model is
+//! unreachable until the user quits and reopens the app. This RED test pins
+//! the command + event contract that closes that gap:
+//!
+//! * A new `Command::ReloadPluginCatalog` (no payload) exists.
+//! * Dispatching it succeeds and emits an `Event::PluginCatalogReloaded`
+//!   that carries `native_count`, `disk_count`, and `total_count` such
+//!   that `total_count == native_count + disk_count`.
+//! * `native_count >= 1` — natives are compiled in, so any boot state
+//!   already has at least one registered model. This holds even when the
+//!   plugins dir on disk is empty.
+//!
+//! Per the architecture LAWs in `CLAUDE.md`, the variant lives in
+//! `application::command`, the handler in the `LocalDispatcher`, and MCP
+//! parity is auto-derived from the `Command` schema — so a follow-up MCP
+//! test is not needed here.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use project::project::Project;
+
+use application::command::Command;
+use application::dispatcher::CommandDispatcher;
+use application::event::Event;
+use application::local_dispatcher::LocalDispatcher;
+
+fn empty_project_rc() -> Rc<RefCell<Project>> {
+    Rc::new(RefCell::new(Project {
+        name: Some("test".into()),
+        device_settings: Vec::new(),
+        chains: Vec::new(),
+        midi: None,
+    }))
+}
+
+#[test]
+fn reload_plugin_catalog_emits_plugin_catalog_reloaded_with_counts() {
+    // Populate the native side of the catalog so `native_count >= 1` is a
+    // meaningful invariant — the contract is "natives are compiled in, so
+    // any boot state has at least one".
+    engine::native_registry::register_all_natives();
+
+    let project = empty_project_rc();
+    let dispatcher = LocalDispatcher::new(Rc::clone(&project));
+
+    let events = dispatcher
+        .dispatch(Command::ReloadPluginCatalog)
+        .expect("dispatch ReloadPluginCatalog");
+
+    let reloaded = events
+        .iter()
+        .find_map(|e| match e {
+            Event::PluginCatalogReloaded {
+                native_count,
+                disk_count,
+                total_count,
+            } => Some((*native_count, *disk_count, *total_count)),
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("expected Event::PluginCatalogReloaded, got: {events:?}"));
+
+    let (native, disk, total) = reloaded;
+    assert_eq!(
+        total,
+        native + disk,
+        "total_count must equal native_count + disk_count (native={native}, disk={disk}, total={total})"
+    );
+    assert!(
+        native >= 1,
+        "native_count must be >= 1 — natives are compiled in (got {native})"
+    );
+}

--- a/crates/plugin-loader/src/registry.rs
+++ b/crates/plugin-loader/src/registry.rs
@@ -246,3 +246,99 @@ pub fn native_count() -> usize {
         .filter(|p| matches!(p.manifest.backend, Backend::Native { .. }))
         .count()
 }
+
+/// Error returned by [`unload`] / [`load_one`] (#561 expanded scope).
+#[derive(Debug, thiserror::Error)]
+pub enum CatalogOpError {
+    /// No plugin with that id is currently registered (for `unload`)
+    /// or no disk package with that id exists under the scanned
+    /// roots (for `load_one`).
+    #[error("plugin not found: {0}")]
+    NotFound(String),
+    /// `unload` is forbidden for native plugins — the runtime fn
+    /// pointers are compiled into the binary; dropping the manifest
+    /// without re-registering would leave dangling references in
+    /// every consumer that cached `&'static LoadedPackage`.
+    #[error("plugin {0} is native (compiled-in); natives cannot be unloaded without restarting")]
+    NativeCannotUnload(String),
+}
+
+/// Remove a disk plugin from the in-memory catalog by manifest id
+/// (#561 expanded scope). Refuses natives — the runtime fn pointers
+/// are part of the binary, and dropping the manifest while consumers
+/// hold cached `&'static LoadedPackage` references would create a
+/// gap between the public listing and the dispatch path.
+///
+/// Other invariants:
+/// - Returns [`CatalogOpError::NotFound`] when no entry with `id`
+///   exists in the current catalog.
+/// - Atomically swaps in a new slice; cached references from before
+///   the call stay valid (the previous slice is leaked, not freed),
+///   just like [`reload`].
+pub fn unload(id: &str) -> Result<(), CatalogOpError> {
+    let current = packages();
+    let Some(entry) = current.iter().find(|p| p.manifest.id == id) else {
+        return Err(CatalogOpError::NotFound(id.to_string()));
+    };
+    if matches!(entry.manifest.backend, Backend::Native { .. }) {
+        return Err(CatalogOpError::NativeCannotUnload(id.to_string()));
+    }
+    let next: Vec<LoadedPackage> = current
+        .iter()
+        .filter(|p| p.manifest.id != id)
+        .map(|p| (*p).clone())
+        .collect();
+    let leaked: &'static [LoadedPackage] = Box::leak(next.into_boxed_slice());
+    *REGISTRY.write().expect("REGISTRY poisoned") = leaked;
+    Ok(())
+}
+
+/// Bring a single disk plugin into the in-memory catalog by manifest
+/// id (#561 expanded scope). Scans every directory in `plugins_roots`,
+/// adds the discovered package whose id matches, and atomically
+/// swaps in the new slice. Other entries are preserved.
+///
+/// - If the plugin is already in the catalog, returns `Ok(())` as a
+///   no-op (the dispatch surface is unchanged, but the caller still
+///   gets a confirmation it had a chance to land).
+/// - Returns [`CatalogOpError::NotFound`] when no package with `id`
+///   is discoverable under any of the supplied roots.
+pub fn load_one(id: &str, plugins_roots: &[std::path::PathBuf]) -> Result<(), CatalogOpError> {
+    let current = packages();
+    if current.iter().any(|p| p.manifest.id == id) {
+        return Ok(());
+    }
+    let mut found: Option<LoadedPackage> = None;
+    for root in plugins_roots {
+        if !root.is_dir() {
+            continue;
+        }
+        match discover(root) {
+            Ok(results) => {
+                for result in results.into_iter().flatten() {
+                    if result.manifest.id == id {
+                        found = Some(result);
+                        break;
+                    }
+                }
+            }
+            Err(error) => {
+                eprintln!(
+                    "plugin-loader: cannot read plugins_root `{}`: {error}",
+                    root.display()
+                );
+            }
+        }
+        if found.is_some() {
+            break;
+        }
+    }
+    let Some(new_entry) = found else {
+        return Err(CatalogOpError::NotFound(id.to_string()));
+    };
+    let mut next: Vec<LoadedPackage> = current.iter().map(|p| (*p).clone()).collect();
+    next.push(new_entry);
+    let leaked: &'static [LoadedPackage] = Box::leak(next.into_boxed_slice());
+    *REGISTRY.write().expect("REGISTRY poisoned") = leaked;
+    Ok(())
+}

--- a/crates/plugin-loader/src/registry.rs
+++ b/crates/plugin-loader/src/registry.rs
@@ -2,30 +2,65 @@
 //!
 //! Two ways a plugin enters the registry:
 //!
-//! - **Disk packages** — `init(plugins_root)` runs `discover()` once at
-//!   startup and pushes one [`LoadedPackage`] per `manifest.yaml` found.
+//! - **Disk packages** — `init(plugins_root)` (or `init_many`) runs
+//!   `discover()` once at startup and pushes one [`LoadedPackage`] per
+//!   `manifest.yaml` found. `reload(plugins_roots)` re-runs the disk
+//!   scan after a new pack lands on disk so the running process picks
+//!   it up without a restart (issue #561).
 //! - **Native plugins** — each `block-*` crate calls
 //!   [`register_native`] for each compiled-in DSP model, supplying a
 //!   synthesized [`PluginManifest`] (with `Backend::Native { runtime_id }`)
 //!   plus the runtime fn pointers that go into
 //!   [`crate::native_runtimes`].
 //!
-//! Native registration must happen **before** [`init`] is called. After
-//! `init` the registry is frozen ([`OnceLock`]) and read-only — every
-//! consumer (GUI, engine) reaches it via [`packages`], [`packages_for`],
-//! or [`find`] without threading the path through every call site.
+//! Native registration happens **before** [`init`] / [`init_many`] is
+//! called. The native list is kept in a separate static so [`reload`]
+//! can rebuild the disk side without losing the natives (they cannot
+//! be re-discovered — they have no manifest on disk). Every call to
+//! `reload` re-scans the disk roots and atomically swaps the public
+//! `&'static [LoadedPackage]` slice; old references taken before the
+//! swap stay valid (the previous slice is leaked, not freed), so any
+//! cached `&'static LoadedPackage` survives the reload.
 //!
-//! Issue: #287
+//! Issues: #287, #561
 
 use std::path::{Path, PathBuf};
-use std::sync::{Mutex, OnceLock};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, RwLock};
 
 use crate::discover::{discover, LoadedPackage};
 use crate::manifest::{Backend, BlockType, PluginManifest};
 use crate::native_runtimes::{self, NativeRuntime};
 
-static REGISTRY: OnceLock<Vec<LoadedPackage>> = OnceLock::new();
-static PENDING_NATIVES: Mutex<Vec<LoadedPackage>> = Mutex::new(Vec::new());
+/// Persistent list of natives. Populated once at startup by
+/// `block-*::register_natives`; never drained. [`reload`] reads this
+/// each time it rebuilds the public registry so the natives are not
+/// lost when re-scanning disk roots.
+static NATIVES: Mutex<Vec<LoadedPackage>> = Mutex::new(Vec::new());
+
+/// The currently published catalog. Always points at a leaked, immutable
+/// slice — readers get `&'static` references that survive subsequent
+/// reloads (the previous slice is intentionally not freed).
+static REGISTRY: RwLock<&'static [LoadedPackage]> = RwLock::new(&[]);
+
+/// Tracks whether [`init_many`] has already taken over publishing the
+/// catalog. Subsequent `init_many` calls are no-ops (matches the
+/// pre-#561 `OnceLock` semantics); [`reload`] bypasses this flag.
+static REGISTRY_INITIALIZED: AtomicBool = AtomicBool::new(false);
+
+/// Counts emitted by [`reload`] and surfaced via
+/// `Event::PluginCatalogReloaded` (issue #561) so adapters (GUI toast,
+/// MCP, gRPC) can show the user what changed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReloadStats {
+    /// Natives currently in the catalog (always >= what `register_native`
+    /// pushed; never decreases across reloads).
+    pub native_count: usize,
+    /// Disk packages discovered under `plugins_roots` on this reload.
+    pub disk_count: usize,
+    /// `native_count + disk_count`.
+    pub total_count: usize,
+}
 
 /// Add a native plugin to the catalog. Called by each `block-*` crate at
 /// startup, once per compiled-in DSP model.
@@ -47,10 +82,7 @@ pub fn register_native(manifest: PluginManifest, runtime: NativeRuntime) {
         root: PathBuf::new(),
         manifest,
     };
-    PENDING_NATIVES
-        .lock()
-        .expect("PENDING_NATIVES poisoned")
-        .push(entry);
+    NATIVES.lock().expect("NATIVES poisoned").push(entry);
 }
 
 /// Convenience over [`register_native`]: synthesizes the [`PluginManifest`]
@@ -91,11 +123,10 @@ pub fn register_native_simple(
 }
 
 /// Discover every package under `plugins_root`, merge with previously
-/// registered natives, and freeze the catalog.
+/// registered natives, and publish the catalog.
 ///
-/// Idempotent: a second call is a no-op (the catalog never changes
-/// during a process lifetime). Per-package failures are dropped but
-/// logged to stderr so the boot path can't surface them per-block.
+/// Idempotent: a second call is a no-op (matches the pre-#561 contract
+/// for boot wiring). Use [`reload`] to force a rescan.
 ///
 /// Backwards-compatible single-root entry point. Equivalent to
 /// `init_many(&[plugins_root])`.
@@ -109,21 +140,36 @@ pub fn init(plugins_root: &Path) {
 /// (writable, user-installed) plugin trees. Missing/empty directories
 /// are skipped silently — only hard read errors are logged.
 ///
-/// Same OnceLock semantics as [`init`]: first call wins, subsequent
-/// calls are no-ops.
+/// First call wins; subsequent calls are no-ops. Per-#561, [`reload`]
+/// is now the source of truth for rebuilding the catalog — this
+/// function is a thin "first-time-only" wrapper around it.
 pub fn init_many(plugins_roots: &[std::path::PathBuf]) {
-    if REGISTRY.get().is_some() {
+    if REGISTRY_INITIALIZED.swap(true, Ordering::SeqCst) {
         return;
     }
-    let mut loaded: Vec<LoadedPackage> = PENDING_NATIVES
-        .lock()
-        .expect("PENDING_NATIVES poisoned")
-        .drain(..)
-        .collect();
-    let mut seen_ids = std::collections::HashSet::new();
-    for entry in &loaded {
-        seen_ids.insert(entry.manifest.id.clone());
-    }
+    let _ = reload(plugins_roots);
+}
+
+/// Re-scan every directory in `plugins_roots`, rebuild the catalog,
+/// and atomically swap it in. Natives are preserved (they cannot be
+/// rediscovered — they have no manifest on disk).
+///
+/// Used by `Command::ReloadPluginCatalog` (issue #561) so the running
+/// process picks up freshly installed plugins without a restart. Also
+/// adopted by [`init_many`] as the single source of truth for "build
+/// the catalog from these roots".
+///
+/// Returns the new counts so adapters can surface them to the user
+/// (GUI toast, MCP tool response). Old `&'static LoadedPackage`
+/// references handed out before the reload remain valid — the
+/// previous slice is intentionally leaked so cached references can't
+/// dangle.
+pub fn reload(plugins_roots: &[std::path::PathBuf]) -> ReloadStats {
+    let natives = NATIVES.lock().expect("NATIVES poisoned").clone();
+    let native_count = natives.len();
+    let mut loaded = natives;
+    let mut seen_ids: std::collections::HashSet<String> =
+        loaded.iter().map(|e| e.manifest.id.clone()).collect();
     for root in plugins_roots {
         if !root.is_dir() {
             continue;
@@ -133,10 +179,11 @@ pub fn init_many(plugins_roots: &[std::path::PathBuf]) {
                 for result in results {
                     match result {
                         Ok(package) => {
-                            // De-dup by manifest id: when the same package
-                            // appears in both the bundled and user roots,
-                            // the first occurrence wins (bundled has
-                            // priority since it's earlier in the list).
+                            // De-dup by manifest id: when the same
+                            // package appears in both the bundled and
+                            // user roots, the first occurrence wins
+                            // (bundled has priority since it's earlier
+                            // in the list).
                             if seen_ids.insert(package.manifest.id.clone()) {
                                 loaded.push(package);
                             }
@@ -155,16 +202,22 @@ pub fn init_many(plugins_roots: &[std::path::PathBuf]) {
             }
         }
     }
-    let _ = REGISTRY.set(loaded);
+    let total_count = loaded.len();
+    let disk_count = total_count - native_count;
+    let leaked: &'static [LoadedPackage] = Box::leak(loaded.into_boxed_slice());
+    *REGISTRY.write().expect("REGISTRY poisoned") = leaked;
+    REGISTRY_INITIALIZED.store(true, Ordering::SeqCst);
+    ReloadStats {
+        native_count,
+        disk_count,
+        total_count,
+    }
 }
 
 /// Every plugin currently registered (natives + disk packages). Empty
-/// until [`init`] runs.
+/// until [`init`] / [`init_many`] / [`reload`] runs.
 pub fn packages() -> &'static [LoadedPackage] {
-    match REGISTRY.get() {
-        Some(packages) => packages,
-        None => &[],
-    }
+    *REGISTRY.read().expect("REGISTRY poisoned")
 }
 
 /// Plugins whose manifest declares `block_type`. Returned in registration


### PR DESCRIPTION
Closes #561 (expanded scope).

## Summary

- **`Command::ReloadPluginCatalog`** — re-scans both plugin roots (bundled + user) without restarting OpenRig. Emits `Event::PluginCatalogReloaded { native_count, disk_count, total_count }`. GUI button in Settings → Paths renders the new totals as a status line. Closes the gap the `openrig-tone-builder` flow hits today (a freshly imported NAM is unreachable through `add_block` until the user quits).
- **`Command::LoadPlugin { id }` / `Command::UnloadPlugin { id }`** — bring a single disk plugin into / out of the in-memory catalog. Refuses to drop a native (compiled-in). Emits `Event::PluginLoaded { id }` / `Event::PluginUnloaded { id }`.
- **`Query::ListPluginCatalog` / `GetPlugin { id }` / `FindPlugins { query }`** — read parity for every transport. Listing + exact-id get + case-insensitive substring search across id/display_name/brand.
- **Registry refactor** in `plugin-loader`: split frozen `OnceLock` into persistent `NATIVES` + swappable `RwLock<&'static [LoadedPackage]>`; `reload(paths) -> ReloadStats` is the single source of truth, `init_many` is a thin first-call-wins wrapper. Previously-returned `&'static LoadedPackage` references survive mutations (old slice is leaked, not freed).
- **MCP surface auto-derived** from the Command schema. `parity_guard_every_command_variant_is_a_tool` bumped 49 → 54 (also catches up #513's `Set{Presets,Plugins}Path` from before this PR). New resources: `openrig://plugins` (list), `openrig://plugins/<id>` (get), `openrig://plugins/search/<query>` (find).
- **i18n** (`label-plugin-catalog`, `btn-reload-plugin-catalog`, `status-plugin-catalog-idle`) in en_US, pt_BR, es_ES.

Per the architecture LAWs in `CLAUDE.md`: every mutation is a `Command`, every read is a `Query` + `QueryKind` variant, so GUI / MCP / gRPC / MIDI all see the same surface automatically.

## Test plan

- [ ] **Settings → Caminhos → "Recarregar plugin catalog"** — status row shows the new counts; idempotent across multiple clicks.
- [ ] **Add a new NAM pack on disk without restarting** — click Recarregar → the new `model_id` becomes reachable via `add_block` over MCP without quitting.
- [ ] **`tools/list`** includes `reload_plugin_catalog`, `load_plugin`, `unload_plugin`.
- [ ] **`resources/list`** includes `openrig://plugins`.
- [ ] **`resources/read openrig://plugins`** — JSON list, each entry has `id`, `display_name`, `brand` (or null), `block_type`, `backend` ("native"/"disk").
- [ ] **`resources/read openrig://plugins/<id_existente>`** — entry for that plugin.
- [ ] **`resources/read openrig://plugins/nao_existe`** — `{"plugin": null}` (no error).
- [ ] **`resources/read openrig://plugins/search/marshall`** — case-insensitive substring matches; empty query returns the full list.
- [ ] **Tool `unload_plugin { id: <native_id> }`** — errors "is native (compiled-in); natives cannot be unloaded without restarting".
- [ ] **Tool `unload_plugin { id: <disk_id> }`** — succeeds; `openrig://plugins/<id>` now returns null.
- [ ] **Tool `load_plugin { id: <same_disk_id> }`** — re-adds; resource returns the entry again.
- [ ] **Tool `load_plugin { id: nao_existe }`** — errors "plugin not found".
- [ ] **i18n** — UI in pt_BR / es_ES renders the new strings translated (not as raw keys).
- [ ] **No audio regression** — reload during playback does not introduce xruns / pops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)