### PR TITLE
feat(#554): Query::ListChainPresets + ListProjectPresets — expose preset bank to MCP/gRPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,7 @@ dependencies = [
  "anyhow",
  "application",
  "axum",
+ "domain",
  "futures",
  "infra-cpal",
  "infra-yaml",

--- a/crates/adapter-gui/src/desktop_app.rs
+++ b/crates/adapter-gui/src/desktop_app.rs
@@ -963,6 +963,18 @@ pub fn run_desktop_app(
                                 }
                                 Ok(out)
                             }
+                            application::bridge::QueryKind::ListChainPresets { chain } => {
+                                // #554: the chain's preset bank, served
+                                // from the in-memory RigProject so MCP /
+                                // gRPC see the same list the GUI shows
+                                // in the chain-title combobox.
+                                match session.rig.as_ref() {
+                                    Some(rig) => {
+                                        application::query::list_chain_presets(&rig.borrow(), chain)
+                                    }
+                                    None => Err("no rig attached to the session".to_string()),
+                                }
+                            }
                         },
                         32,
                     );

--- a/crates/adapter-gui/src/desktop_app.rs
+++ b/crates/adapter-gui/src/desktop_app.rs
@@ -975,6 +975,18 @@ pub fn run_desktop_app(
                                     None => Err("no rig attached to the session".to_string()),
                                 }
                             }
+                            application::bridge::QueryKind::ListProjectPresets => {
+                                // #554 follow-up: project-level preset
+                                // pool (RigProject.presets in memory).
+                                // A preset can sit here without being
+                                // wired to any input bank yet.
+                                match session.rig.as_ref() {
+                                    Some(rig) => {
+                                        Ok(application::query::list_project_presets(&rig.borrow()))
+                                    }
+                                    None => Err("no rig attached to the session".to_string()),
+                                }
+                            }
                         },
                         32,
                     );

--- a/crates/adapter-mcp/Cargo.toml
+++ b/crates/adapter-mcp/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 [dependencies]
 anyhow.workspace = true
 application = { path = "../application" }
+domain = { path = "../domain" }
 project = { path = "../project" }
 infra-yaml = { path = "../infra-yaml" }
 infra-cpal = { path = "../infra-cpal" }

--- a/crates/adapter-mcp/src/resources.rs
+++ b/crates/adapter-mcp/src/resources.rs
@@ -4,12 +4,16 @@
 
 use anyhow::Result;
 use application::bridge::{CommandBridge, QueryKind};
+use domain::ids::ChainId;
 use rmcp::model::{Annotated, RawResource, ReadResourceResult, Resource, ResourceContents};
 
 pub const URI_PROJECT: &str = "openrig://project";
 pub const URI_DEVICES: &str = "openrig://devices";
 pub const URI_IDS: &str = "openrig://ids";
 pub const URI_METERS: &str = "openrig://meters";
+/// #554: parameterised resource — the chain id replaces `{chain}` in the
+/// URI, e.g. `openrig://chains/rig:input-1/presets`.
+pub const URI_CHAIN_PRESETS_TEMPLATE: &str = "openrig://chains/{chain}/presets";
 
 /// Static list of resources this server exposes.
 pub fn resources() -> Vec<Resource> {
@@ -30,17 +34,30 @@ pub fn resources() -> Vec<Resource> {
             RawResource::new(URI_METERS, "Per-chain peak meters (dBFS)"),
             None,
         ),
+        Annotated::new(
+            RawResource::new(
+                URI_CHAIN_PRESETS_TEMPLATE,
+                "Chain preset bank (replace {chain} with a rig:<input> id) — JSON",
+            ),
+            None,
+        ),
     ]
 }
 
 /// Resolve a resource URI by querying the frontend.
 pub async fn read(bridge: &CommandBridge, uri: &str) -> Result<ReadResourceResult> {
-    let kind = match uri {
-        URI_PROJECT => QueryKind::ProjectYaml,
-        URI_DEVICES => QueryKind::Devices,
-        URI_IDS => QueryKind::Ids,
-        URI_METERS => QueryKind::ChainMeters,
-        other => anyhow::bail!("unknown resource: {other}"),
+    let kind = if let Some(chain_id) = parse_chain_presets_uri(uri) {
+        QueryKind::ListChainPresets {
+            chain: ChainId(chain_id),
+        }
+    } else {
+        match uri {
+            URI_PROJECT => QueryKind::ProjectYaml,
+            URI_DEVICES => QueryKind::Devices,
+            URI_IDS => QueryKind::Ids,
+            URI_METERS => QueryKind::ChainMeters,
+            other => anyhow::bail!("unknown resource: {other}"),
+        }
     };
     let text = bridge
         .query(kind)
@@ -50,4 +67,46 @@ pub async fn read(bridge: &CommandBridge, uri: &str) -> Result<ReadResourceResul
     Ok(ReadResourceResult::new(vec![ResourceContents::text(
         text, uri,
     )]))
+}
+
+/// Extract `<chain>` from `openrig://chains/<chain>/presets`. Returns
+/// `None` for any other URI shape.
+fn parse_chain_presets_uri(uri: &str) -> Option<String> {
+    uri.strip_prefix("openrig://chains/")
+        .and_then(|rest| rest.strip_suffix("/presets"))
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_chain_presets_uri;
+
+    #[test]
+    fn parses_rig_input_chain_id() {
+        assert_eq!(
+            parse_chain_presets_uri("openrig://chains/rig:input-1/presets"),
+            Some("rig:input-1".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_non_rig_chain_id() {
+        assert_eq!(
+            parse_chain_presets_uri("openrig://chains/standalone/presets"),
+            Some("standalone".to_string())
+        );
+    }
+
+    #[test]
+    fn rejects_missing_chain_segment() {
+        assert_eq!(parse_chain_presets_uri("openrig://chains//presets"), None);
+    }
+
+    #[test]
+    fn rejects_unrelated_uri() {
+        assert_eq!(parse_chain_presets_uri("openrig://project"), None);
+        assert_eq!(parse_chain_presets_uri("openrig://chains/rig:x"), None);
+        assert_eq!(parse_chain_presets_uri("openrig://chains/rig:x/foo"), None);
+    }
 }

--- a/crates/adapter-mcp/src/resources.rs
+++ b/crates/adapter-mcp/src/resources.rs
@@ -11,6 +11,7 @@ pub const URI_PROJECT: &str = "openrig://project";
 pub const URI_DEVICES: &str = "openrig://devices";
 pub const URI_IDS: &str = "openrig://ids";
 pub const URI_METERS: &str = "openrig://meters";
+pub const URI_PRESETS: &str = "openrig://presets";
 /// #554: parameterised resource — the chain id replaces `{chain}` in the
 /// URI, e.g. `openrig://chains/rig:input-1/presets`.
 pub const URI_CHAIN_PRESETS_TEMPLATE: &str = "openrig://chains/{chain}/presets";
@@ -36,6 +37,13 @@ pub fn resources() -> Vec<Resource> {
         ),
         Annotated::new(
             RawResource::new(
+                URI_PRESETS,
+                "Project preset pool (all names in RigProject.presets) — JSON",
+            ),
+            None,
+        ),
+        Annotated::new(
+            RawResource::new(
                 URI_CHAIN_PRESETS_TEMPLATE,
                 "Chain preset bank (replace {chain} with a rig:<input> id) — JSON",
             ),
@@ -56,6 +64,7 @@ pub async fn read(bridge: &CommandBridge, uri: &str) -> Result<ReadResourceResul
             URI_DEVICES => QueryKind::Devices,
             URI_IDS => QueryKind::Ids,
             URI_METERS => QueryKind::ChainMeters,
+            URI_PRESETS => QueryKind::ListProjectPresets,
             other => anyhow::bail!("unknown resource: {other}"),
         }
     };

--- a/crates/application/src/bridge.rs
+++ b/crates/application/src/bridge.rs
@@ -63,6 +63,11 @@ pub enum QueryKind {
     /// follow-up). Lets MCP / gRPC clients see the same preset list the
     /// GUI shows in the chain title combobox.
     ListChainPresets { chain: domain::ids::ChainId },
+    /// #554 follow-up: every preset name in the project's in-memory
+    /// `RigProject.presets` pool as JSON. A preset can sit in the pool
+    /// without being bound to any input bank; tone-builder Step 0
+    /// reads this to avoid silently overwriting an existing preset.
+    ListProjectPresets,
 }
 
 struct QueryRequest {

--- a/crates/application/src/bridge.rs
+++ b/crates/application/src/bridge.rs
@@ -57,6 +57,12 @@ pub enum QueryKind {
     /// one record per line). Same numbers the GUI's IN/OUT bars read —
     /// every transport gets the same view (`openrig-code-quality` lei).
     ChainMeters,
+    /// #554: the named preset bank of one chain (`rig:<input>`) as JSON.
+    /// Resolved from the in-memory `RigProject.inputs[input].bank` — the
+    /// disk-side preset library is a separate concept (different
+    /// follow-up). Lets MCP / gRPC clients see the same preset list the
+    /// GUI shows in the chain title combobox.
+    ListChainPresets { chain: domain::ids::ChainId },
 }
 
 struct QueryRequest {

--- a/crates/application/src/query.rs
+++ b/crates/application/src/query.rs
@@ -6,7 +6,9 @@
 
 use std::fmt::Write;
 
+use domain::ids::ChainId;
 use project::project::Project;
+use project::rig::RigProject;
 
 /// Human-readable, copy-paste-ready listing of every chain and block with
 /// its full ID, instrument/kind, and enabled state — the values that go
@@ -37,6 +39,89 @@ pub fn list_ids(project: &Project) -> String {
     let _ = writeln!(out, "(chains: {})", project.chains.len());
     out
 }
+
+/// #554: return the bank of chain-scoped presets for one chain as JSON.
+///
+/// The `chain_id` must be of the form `rig:<input-name>`. The input's
+/// `bank: BTreeMap<usize, String>` (slot → preset name) is emitted as a
+/// `slots` array sorted by slot index, plus the resolved `active_preset`
+/// name (or `null` when the bank is empty / the active slot is unbound).
+///
+/// Reads from the in-memory `RigProject` only — never the filesystem.
+/// The disk-side preset library (under `config.paths.presets_path`) is a
+/// separate concept tracked by a different follow-up.
+pub fn list_chain_presets(rig: &RigProject, chain_id: &ChainId) -> Result<String, String> {
+    let input_name = chain_id.0.strip_prefix("rig:").ok_or_else(|| {
+        format!(
+            "chain id '{}' is not a rig: input (expected 'rig:<input-name>')",
+            chain_id.0
+        )
+    })?;
+    let input = rig.inputs.get(input_name).ok_or_else(|| {
+        format!(
+            "input '{input_name}' not found in project (chain id '{}' references no live input)",
+            chain_id.0
+        )
+    })?;
+
+    let mut slots = String::new();
+    slots.push('[');
+    let mut first = true;
+    for (idx, preset_name) in input.bank.iter() {
+        if !first {
+            slots.push(',');
+        }
+        first = false;
+        let _ = write!(
+            slots,
+            "{{\"index\":{},\"name\":{}}}",
+            idx,
+            json_string(preset_name)
+        );
+    }
+    slots.push(']');
+
+    let active_preset = input
+        .bank
+        .get(&input.active_preset)
+        .map(|name| json_string(name))
+        .unwrap_or_else(|| "null".to_string());
+
+    Ok(format!(
+        "{{\"chain\":{},\"active_preset\":{},\"slots\":{}}}",
+        json_string(&chain_id.0),
+        active_preset,
+        slots
+    ))
+}
+
+/// Minimal JSON-string escaper for the small set of values this module
+/// emits. Avoids dragging `serde_json` into a pure listing helper —
+/// preset names and chain ids never carry control chars deeper than
+/// `"`, `\` or whitespace.
+fn json_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => {
+                let _ = write!(out, "\\u{:04x}", c as u32);
+            }
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+#[cfg(test)]
+#[path = "query_chain_presets_tests.rs"]
+mod chain_presets_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/application/src/query.rs
+++ b/crates/application/src/query.rs
@@ -67,16 +67,22 @@ pub fn list_chain_presets(rig: &RigProject, chain_id: &ChainId) -> Result<String
     let mut slots = String::new();
     slots.push('[');
     let mut first = true;
-    for (idx, preset_name) in input.bank.iter() {
+    for (idx, preset_key) in input.bank.iter() {
         if !first {
             slots.push(',');
         }
         first = false;
+        let label = rig
+            .presets
+            .get(preset_key)
+            .and_then(|p| p.name.clone())
+            .unwrap_or_else(|| preset_key.clone());
         let _ = write!(
             slots,
-            "{{\"index\":{},\"name\":{}}}",
+            "{{\"index\":{},\"name\":{},\"key\":{}}}",
             idx,
-            json_string(preset_name)
+            json_string(&label),
+            json_string(preset_key)
         );
     }
     slots.push(']');
@@ -84,7 +90,14 @@ pub fn list_chain_presets(rig: &RigProject, chain_id: &ChainId) -> Result<String
     let active_preset = input
         .bank
         .get(&input.active_preset)
-        .map(|name| json_string(name))
+        .map(|key| {
+            let label = rig
+                .presets
+                .get(key)
+                .and_then(|p| p.name.clone())
+                .unwrap_or_else(|| key.clone());
+            json_string(&label)
+        })
         .unwrap_or_else(|| "null".to_string());
 
     Ok(format!(
@@ -96,26 +109,45 @@ pub fn list_chain_presets(rig: &RigProject, chain_id: &ChainId) -> Result<String
 }
 
 /// #554 follow-up: list every named preset in `RigProject.presets` —
-/// the in-memory pool that the rig's input banks reference by name.
+/// the in-memory pool that the rig's input banks reference by key.
 /// A preset can sit in the pool without being bound to any input slot
 /// yet (e.g. the user saved it via the rig screen but hasn't wired it
 /// into a chain). The tone-builder skill's Step 0 reads this to make
 /// sure it doesn't silently overwrite an existing preset on save.
 ///
+/// Each entry returns the user-visible label (`RigPreset.name`,
+/// falling back to the pool key when the field is absent) AND the
+/// pool key — the key is what the bank slots reference and what
+/// `Command::DeleteChainPreset` / load operations take, so consumers
+/// need both. Sorted by display label so the GUI's combobox and the
+/// MCP read produce the same order.
+///
 /// Pure: `&RigProject` in, `String` out. Reads the in-memory rig
 /// only — the on-disk preset library (`config.paths.presets_path`)
 /// is a separate concern.
 pub fn list_project_presets(rig: &RigProject) -> String {
-    let mut names: Vec<&String> = rig.presets.keys().collect();
-    names.sort();
+    let mut entries: Vec<(&String, String)> = rig
+        .presets
+        .iter()
+        .map(|(key, preset)| {
+            let label = preset.name.clone().unwrap_or_else(|| key.clone());
+            (key, label)
+        })
+        .collect();
+    entries.sort_by(|(_, a), (_, b)| a.cmp(b));
     let mut out = String::from("{\"presets\":[");
     let mut first = true;
-    for name in names {
+    for (key, label) in entries {
         if !first {
             out.push(',');
         }
         first = false;
-        let _ = write!(out, "{{\"name\":{}}}", json_string(name));
+        let _ = write!(
+            out,
+            "{{\"name\":{},\"key\":{}}}",
+            json_string(&label),
+            json_string(key)
+        );
     }
     out.push_str("]}");
     out

--- a/crates/application/src/query.rs
+++ b/crates/application/src/query.rs
@@ -95,6 +95,32 @@ pub fn list_chain_presets(rig: &RigProject, chain_id: &ChainId) -> Result<String
     ))
 }
 
+/// #554 follow-up: list every named preset in `RigProject.presets` —
+/// the in-memory pool that the rig's input banks reference by name.
+/// A preset can sit in the pool without being bound to any input slot
+/// yet (e.g. the user saved it via the rig screen but hasn't wired it
+/// into a chain). The tone-builder skill's Step 0 reads this to make
+/// sure it doesn't silently overwrite an existing preset on save.
+///
+/// Pure: `&RigProject` in, `String` out. Reads the in-memory rig
+/// only — the on-disk preset library (`config.paths.presets_path`)
+/// is a separate concern.
+pub fn list_project_presets(rig: &RigProject) -> String {
+    let mut names: Vec<&String> = rig.presets.keys().collect();
+    names.sort();
+    let mut out = String::from("{\"presets\":[");
+    let mut first = true;
+    for name in names {
+        if !first {
+            out.push(',');
+        }
+        first = false;
+        let _ = write!(out, "{{\"name\":{}}}", json_string(name));
+    }
+    out.push_str("]}");
+    out
+}
+
 /// Minimal JSON-string escaper for the small set of values this module
 /// emits. Avoids dragging `serde_json` into a pure listing helper —
 /// preset names and chain ids never carry control chars deeper than
@@ -122,6 +148,10 @@ fn json_string(s: &str) -> String {
 #[cfg(test)]
 #[path = "query_chain_presets_tests.rs"]
 mod chain_presets_tests;
+
+#[cfg(test)]
+#[path = "query_project_presets_tests.rs"]
+mod project_presets_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/application/src/query_chain_presets_tests.rs
+++ b/crates/application/src/query_chain_presets_tests.rs
@@ -1,0 +1,124 @@
+//! Red-first (#554) tests for `Query::ListChainPresets`.
+
+use std::collections::BTreeMap;
+
+use domain::ids::ChainId;
+use project::rig::{RigInput, RigPreset, RigProject};
+
+use crate::query::list_chain_presets;
+
+fn rig_with_input(input_name: &str, bank: Vec<(usize, &str)>, active_preset: usize) -> RigProject {
+    let mut inputs = BTreeMap::new();
+    let mut presets = BTreeMap::new();
+    let mut input = RigInput {
+        label: None,
+        sources: Vec::new(),
+        bank: BTreeMap::new(),
+        active_preset,
+        active_scene: 1,
+        routing: Vec::new(),
+    };
+    for (idx, name) in bank {
+        input.bank.insert(idx, name.to_string());
+        presets
+            .entry(name.to_string())
+            .or_insert_with(|| RigPreset {
+                id: name.to_string(),
+                name: Some(name.to_string()),
+                blocks: Vec::new(),
+                scene_params: Vec::new(),
+                scenes: BTreeMap::new(),
+                volume: 100.0,
+            });
+    }
+    inputs.insert(input_name.to_string(), input);
+    RigProject {
+        name: None,
+        inputs,
+        outputs: BTreeMap::new(),
+        presets,
+        midi: None,
+        chain_order: Vec::new(),
+    }
+}
+
+#[test]
+fn list_chain_presets_returns_bank_in_slot_order() {
+    let rig = rig_with_input(
+        "input-1",
+        vec![(2, "Lead"), (1, "Clean strum"), (3, "Clocks — Coldplay")],
+        2,
+    );
+    let chain = ChainId("rig:input-1".to_string());
+    let json = list_chain_presets(&rig, &chain).expect("ok");
+    // Slots ordered by index: 1, 2, 3 — inspect the `slots:[...]`
+    // portion explicitly so the assertion isn't fooled by the
+    // active_preset field appearing earlier in the JSON.
+    let slots_start = json.find("\"slots\":").expect("slots field");
+    let slots = &json[slots_start..];
+    let pos_clean = slots.find("Clean strum").expect("Clean strum in slots");
+    let pos_lead = slots.find("Lead").expect("Lead in slots");
+    let pos_clocks = slots.find("Clocks — Coldplay").expect("Clocks in slots");
+    assert!(pos_clean < pos_lead, "slot 1 must come before slot 2");
+    assert!(pos_lead < pos_clocks, "slot 2 must come before slot 3");
+    assert!(
+        json.contains("\"active_preset\":\"Lead\""),
+        "active preset slot=2 resolves to 'Lead', got: {json}"
+    );
+}
+
+#[test]
+fn list_chain_presets_resolves_chain_id_to_input_name() {
+    let rig = rig_with_input("guitar", vec![(1, "Solo")], 1);
+    let chain = ChainId("rig:guitar".to_string());
+    let json = list_chain_presets(&rig, &chain).expect("ok");
+    assert!(json.contains("rig:guitar"), "chain id echoed: {json}");
+    assert!(json.contains("Solo"));
+}
+
+#[test]
+fn list_chain_presets_empty_bank_returns_empty_slots() {
+    let mut rig = rig_with_input("input-1", vec![], 0);
+    rig.inputs.get_mut("input-1").unwrap().active_preset = 0;
+    let chain = ChainId("rig:input-1".to_string());
+    let json = list_chain_presets(&rig, &chain).expect("empty bank is not an error");
+    assert!(
+        json.contains("\"slots\":[]"),
+        "empty slots array, got: {json}"
+    );
+    assert!(
+        json.contains("\"active_preset\":null"),
+        "no active preset when bank empty, got: {json}"
+    );
+}
+
+#[test]
+fn list_chain_presets_unknown_chain_returns_error() {
+    let rig = rig_with_input("input-1", vec![(1, "Clean")], 1);
+    let chain = ChainId("rig:does-not-exist".to_string());
+    let err = list_chain_presets(&rig, &chain).expect_err("unknown chain must err");
+    assert!(
+        err.contains("does-not-exist"),
+        "error mentions the missing input, got: {err}"
+    );
+}
+
+#[test]
+fn list_chain_presets_rejects_non_rig_chain_id() {
+    let rig = rig_with_input("input-1", vec![], 0);
+    let chain = ChainId("standalone-chain".to_string());
+    let err = list_chain_presets(&rig, &chain).expect_err("non-rig chain must err");
+    assert!(
+        err.contains("rig:"),
+        "error mentions the rig: prefix requirement, got: {err}"
+    );
+}
+
+#[test]
+fn list_chain_presets_is_deterministic() {
+    let rig = rig_with_input("input-1", vec![(3, "C"), (1, "A"), (2, "B")], 1);
+    let chain = ChainId("rig:input-1".to_string());
+    let a = list_chain_presets(&rig, &chain).unwrap();
+    let b = list_chain_presets(&rig, &chain).unwrap();
+    assert_eq!(a, b, "two reads must produce the same bytes");
+}

--- a/crates/application/src/query_project_presets_tests.rs
+++ b/crates/application/src/query_project_presets_tests.rs
@@ -1,0 +1,93 @@
+//! Red-first tests for `Query::ListProjectPresets` — the in-memory
+//! `RigProject.presets` pool (#554 follow-up). Presets in the pool
+//! can exist without being bound to any input bank yet; the disk
+//! library is a separate concept tracked elsewhere.
+
+use std::collections::BTreeMap;
+
+use project::rig::{RigPreset, RigProject};
+
+use crate::query::list_project_presets;
+
+fn rig_with_pool(presets: Vec<&str>) -> RigProject {
+    let mut pool = BTreeMap::new();
+    for name in presets {
+        pool.insert(
+            name.to_string(),
+            RigPreset {
+                id: name.to_string(),
+                name: Some(name.to_string()),
+                blocks: Vec::new(),
+                scene_params: Vec::new(),
+                scenes: BTreeMap::new(),
+                volume: 100.0,
+            },
+        );
+    }
+    RigProject {
+        name: None,
+        inputs: BTreeMap::new(),
+        outputs: BTreeMap::new(),
+        presets: pool,
+        midi: None,
+        chain_order: Vec::new(),
+    }
+}
+
+#[test]
+fn list_project_presets_returns_pool_sorted() {
+    let rig = rig_with_pool(vec!["Clean strum", "Coldplay - Clocks", "Lead"]);
+    let json = list_project_presets(&rig);
+    let pos_clean = json.find("Clean strum").expect("Clean strum");
+    let pos_clocks = json.find("Coldplay - Clocks").expect("Coldplay - Clocks");
+    let pos_lead = json.find("Lead").expect("Lead");
+    assert!(pos_clean < pos_clocks);
+    assert!(pos_clocks < pos_lead);
+}
+
+#[test]
+fn list_project_presets_includes_pool_entries_even_without_bank_reference() {
+    // The whole point of this query: a preset can sit in
+    // `RigProject.presets` without being referenced by any input's
+    // bank yet. Tone-builder Step 0 must see it anyway, otherwise it
+    // overwrites it on save.
+    let rig = rig_with_pool(vec!["Coldplay - Clocks"]);
+    let json = list_project_presets(&rig);
+    assert!(
+        json.contains("Coldplay - Clocks"),
+        "pool entry must be listed even with empty inputs, got: {json}"
+    );
+}
+
+#[test]
+fn list_project_presets_empty_pool_returns_empty_array() {
+    let rig = rig_with_pool(vec![]);
+    let json = list_project_presets(&rig);
+    assert!(
+        json.contains("\"presets\":[]"),
+        "empty pool yields empty array, got: {json}"
+    );
+}
+
+#[test]
+fn list_project_presets_is_deterministic() {
+    let rig = rig_with_pool(vec!["B", "A", "C"]);
+    let a = list_project_presets(&rig);
+    let b = list_project_presets(&rig);
+    assert_eq!(a, b, "two reads of the same rig produce identical bytes");
+}
+
+#[test]
+fn list_project_presets_escapes_special_chars_in_names() {
+    let rig = rig_with_pool(vec!["With \"quotes\"", "back\\slash", "tab\there"]);
+    let json = list_project_presets(&rig);
+    assert!(
+        json.contains("\\\"quotes\\\""),
+        "quotes escaped, got: {json}"
+    );
+    assert!(
+        json.contains("back\\\\slash"),
+        "backslash escaped, got: {json}"
+    );
+    assert!(json.contains("tab\\there"), "tab escaped, got: {json}");
+}


### PR DESCRIPTION
## Summary

Closes the read-side parity gap that kept the `openrig-tone-builder` skill from running its Step 0 ("does a preset for this song already exist?") without scraping the filesystem. Adds two pure `Query` helpers, wires them through the bridge, and exposes them as MCP resources.

- **`application::query::list_chain_presets(&RigProject, &ChainId)`** — bank slots of one chain (`rig:<input>`), serialised as `{chain, active_preset, slots:[{index, name, key}]}`. The bank stores pool *keys* (`New Preset 6`); the helper resolves each key to its `RigPreset.name` display label and returns both, so consumers can switch by index, recall by name, or address by key for delete/load commands.
- **`application::query::list_project_presets(&RigProject)`** — the project-level preset pool (`RigProject.presets`), sorted by display label. Returns `{presets: [{name, key}]}`. A preset can sit in the pool without being bound to any chain bank yet — `list_chain_presets` alone would miss it.
- **`QueryKind::ListChainPresets { chain }` + `QueryKind::ListProjectPresets`** on the bridge, resolved on the GUI thread against the in-memory `RigProject`.
- **MCP resources**: `openrig://chains/{chain}/presets` (parameterised) + `openrig://presets` (project-level pool).

## Tests

- `cargo test -p application --lib chain_presets` → 6 passed.
- `cargo test -p application --lib project_presets` → 5 passed.
- `cargo test -p adapter-mcp --lib resources` → 4 passed.
- `cargo test -p adapter-gui --lib` → 443 passed.
- Live MCP smoke validated in the build session: pool entries with auto-generated keys (`New Preset 6`) correctly resolved to display labels (`coldplay - CLOCKS`); the `openrig-tone-builder` flow used these queries throughout this session to verify pre-existing presets before creating new bank slots.

## Test plan

- [ ] `cargo build -p adapter-gui` clean.
- [ ] `cargo test -p application --lib presets` → 17 pass.
- [ ] `ReadMcpResourceTool { uri: "openrig://presets" }` → pool sorted by display name with `{name, key}` per entry.
- [ ] `ReadMcpResourceTool { uri: "openrig://chains/rig:input-1/presets" }` → `{chain, active_preset, slots:[{index, name, key}]}`; `active_preset` matches what the GUI's chain-title combobox shows.
- [ ] Unknown chain id (`openrig://chains/rig:bogus/presets`) → typed error mentioning the missing input.
- [ ] Non-`rig:` chain id (`openrig://chains/standalone/presets`) → typed error about the `rig:` prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)