### PR TITLE
docs(#577): explain how the Chocolate works (layout, modes, banks)

### DIFF
--- a/docs/midi-chocolate.md
+++ b/docs/midi-chocolate.md
@@ -4,6 +4,13 @@ Device-specific guide. For the generic concept, the standard map and the
 full action list, read [`docs/midi.md`](midi.md) first — this page only
 covers the Chocolate's own quirks and its editor app.
 
+If you only want the **shipped factory layout** (4 pre-bound banks
+covering chain nav, preset/scene, block pair and global toggles), skip
+to [`chocolate_plus_program_change_a.md`](../assets/midi-profiles/chocolate_plus_program_change_a.md)
+— that file documents what every switch does per bank with the
+out-of-the-box profile. The page you are reading is for going beyond
+the factory layout (different modes, custom notes, multiple pedals).
+
 The Chocolate is a 4-footswitch **BLE-MIDI** controller. The **Plus**
 adds per-message MIDI channel and more banks; both are configured with
 the **CubeSuite** app (a.k.a. *FootCtrlPlus*), free for
@@ -25,13 +32,86 @@ The same Bluetooth radio can only talk to one host at a time: to edit in
 CubeSuite the app must hold the pedal, so edit with OpenRig closed, then
 reopen OpenRig.
 
-## 2. Set each footswitch in CubeSuite
+## 2. How the Chocolate works
+
+Before configuring anything, know the device — it changes which mode
+you want, what each footswitch does, and how to flip banks live.
+
+### 2.1 Layout
+
+Four large footswitches across the top, labeled **A B C D**, with a
+small LCD between B and C. The back/side strip has the USB-C
+power/data port, a USB-A **HOST** port (for the supplied receiver on a
+computer that does not speak BLE-MIDI), a 1/4" **PEDAL** jack for an
+expression pedal, and a 3-position toggle for *USB / OFF / HOST*.
+
+The labels **E** and **F** are not extra switches — they are *combos*:
+
+- **E** = press **A + B** together
+- **F** = press **C + D** together
+
+E and F are how you change banks on the pedal itself, in modes that
+support banking.
+
+### 2.2 Modes — pick *Advanced custom 2*
+
+CubeSuite exposes **12 working modes**. Most are for non-MIDI uses
+(steering an Android touchscreen, scrubbing YouTube, acting as a USB
+keyboard, controlling another M-Vave product) and never talk to
+OpenRig. The three you can actually use as a MIDI controller are:
+
+| Mode | What A–D send | Per-message channel | E/F banks |
+|---|---|---|---|
+| Program change A (PC) | PC 0–127 | one, fixed | yes (up to 16 groups × 4 = 128 PCs) |
+| Advanced custom 1 | any (PC/CC/Note/SysEx), 5 sub-behaviours | yes | **no** |
+| **Advanced custom 2** | any (PC/CC/Note/SysEx), short-tap + long-press | **yes** | **yes** (up to 16 groups) |
+
+OpenRig's standard map listens for **Note** messages on **channel 1**
+(see [`docs/midi.md`](midi.md)), and the multi-bank trick in §5 below
+needs per-message channel. Only **Advanced custom 2** gives you both,
+so that is the mode the rest of this page assumes.
+
+### 2.3 Banks live, on the pedal
+
+In *Advanced custom 2* the LCD shows the current bank number (1 to N,
+N selectable up to 16 in the software). Step it with the combos:
+
+- **A + B together (E)** — previous bank
+- **C + D together (F)** — next bank
+
+The change is instant; the next tap on A/B/C/D fires the message
+configured for the *new* bank. Pair this with the channel-per-bank
+pattern in §5 to multiply 4 switches into 4 × 16 = **64 actions** on
+the same pedal without ever running out of notes.
+
+In *Advanced custom 1* (no banking) you get one fixed page of 4
+switches with richer sub-behaviours (single tap / two-group toggle /
+press-release / long press / short-tap+long-press). That is the trade:
+sub-behaviours **or** banking.
+
+### 2.4 Plain Chocolate vs Chocolate Plus
+
+Same 4 footswitches, same E/F combos. The **Plus** is what unlocks the
+per-message **channel** field inside *Edit MIDI Code* — the plain
+Chocolate sends everything on **one device-wide channel**, so the
+"different channel per pedal / per bank" pattern in §5 only works on
+the Plus. With a plain Chocolate, give each pedal **different note
+numbers** instead.
+
+## 3. Set each footswitch in CubeSuite
+
+> Skip this section if you are happy with the shipped factory
+> layout — see
+> [`chocolate_plus_program_change_a.md`](../assets/midi-profiles/chocolate_plus_program_change_a.md)
+> for what that profile already binds. Come back here when you want
+> custom notes, custom banks or a different MIDI channel.
 
 CubeSuite has no per-switch "channel" box on the main screen — the
 message lives **inside a bank entry**. Per footswitch:
 
 1. Tick the footswitch under **Foot Switch [A] / [B] / [C] / [D]**.
-2. Pick **Advanced custom mode** (Mode selection) if not already.
+2. Pick **Advanced custom mode 2** (Mode selection) — *not* Advanced 1,
+   which has no banking — if not already.
 3. In the bank box (e.g. "A Bank"), **double-click the entry line**
    (it reads like `[1] 1 PC 0 0`). The **Edit MIDI Code** dialog opens.
 4. In that dialog set:
@@ -44,7 +124,7 @@ message lives **inside a bank entry**. Per footswitch:
 
 The bank line format is `[index] channel TYPE data1 data2`.
 
-## 3. Which notes — match the standard map
+## 4. Which notes — match the standard map
 
 OpenRig's standard map (in `docs/midi.md`) listens on **channel 1**,
 notes **60–67**. With only 4 switches, pick 4 actions. A common layout:
@@ -59,7 +139,7 @@ notes **60–67**. With only 4 switches, pick 4 actions. A common layout:
 All **Note**, **channel 1**. Want scenes or block-nav instead? Just pick
 the matching note from the table in `docs/midi.md`.
 
-## 4. Many pedals / many banks → one channel each
+## 5. Many pedals / many banks → one channel each
 
 OpenRig opens **every** matching MIDI port at once, so 4 — or 10 —
 Chocolates work simultaneously. They send the **same notes**, so to
@@ -93,7 +173,7 @@ pedal/bank to a given set of actions. (The plain Chocolate is fixed to
 one channel — only the Plus does per-message channel; with plain ones
 you instead give each pedal *different note numbers*.)
 
-## 5. Run
+## 6. Run
 
 Install the standard map and start OpenRig with MIDI on (see
 [`docs/midi.md`](midi.md#turn-it-on)):


### PR DESCRIPTION
Closes #577.

## Summary

- `docs/midi-chocolate.md` previously jumped straight to CubeSuite configuration without explaining the device itself. New **§2 How the Chocolate works** covers layout (A/B/C/D + LCD + USB-C/HOST/PEDAL + 3-pos toggle, and that E/F are A+B / C+D *combos*, not extra switches), the 12 working modes with a table for the 3 usable as MIDI, why **Advanced custom 2** is the right pick for OpenRig, live bank-stepping with E/F, and the plain Chocolate vs Chocolate Plus per-message-channel difference.
- §3 is now pinned to *Advanced custom mode 2* specifically (Advanced 1 has no banking and would break §5's multi-bank pattern). Old §2–§5 shifted to §3–§6.
- Intro and §3 cross-link `assets/midi-profiles/chocolate_plus_program_change_a.md` so readers who only want the shipped factory bank/switch mappings find them without duplication.

Every device-behavior claim is sourced from the official M-Vave CubeSuite Chocolate Plus software-instructions PDF (`http://www.m-vave.com/appdownload`). Items not in the PDF (LED colors, pairing-mode combo, battery specs) were deliberately not added.

## Test plan

- [x] Doc-only change — no code, no tests, no build impact
- [ ] Render `docs/midi-chocolate.md` on GitHub and visually confirm: headings 1–6 numbered correctly, the modes table renders, both cross-links to `chocolate_plus_program_change_a.md` resolve