### PR TITLE
fix(#574): NAM amps actually run in offline render + loud fail on faulted blocks

### DIFF
--- a/crates/adapter-render/src/lib.rs
+++ b/crates/adapter-render/src/lib.rs
@@ -35,6 +35,12 @@ pub enum RenderError {
     InvalidArgs(String),
     /// The engine refused to build a runtime for the chain.
     EngineBuild(anyhow::Error),
+    /// One or more blocks in the chain could not be built into runtime
+    /// processors and would have been silently bypassed. Refusing to
+    /// claim success — otherwise different presets render to identical
+    /// bytes because every failing block disappears from the signal path
+    /// (issue #574). Each entry is `(block_id, effect_type, model, error)`.
+    BlocksFailed(Vec<engine::offline::FaultedBlock>),
     /// Live capture was requested but `--duration` was not supplied (or
     /// cpal could not open the requested input device).
     Capture(anyhow::Error),
@@ -48,6 +54,24 @@ impl std::fmt::Display for RenderError {
             Self::OutputWrite(e) => write!(f, "failed to write output wav: {e}"),
             Self::InvalidArgs(msg) => write!(f, "invalid render args: {msg}"),
             Self::EngineBuild(e) => write!(f, "engine failed to build chain runtime: {e}"),
+            Self::BlocksFailed(faulted) => {
+                writeln!(
+                    f,
+                    "{} block(s) in the chain failed to build and would have been silently bypassed:",
+                    faulted.len()
+                )?;
+                for fb in faulted {
+                    writeln!(
+                        f,
+                        "  - block '{}' ({}/{}): {}",
+                        fb.block_id, fb.effect_type, fb.model, fb.error
+                    )?;
+                }
+                write!(
+                    f,
+                    "refusing to write a WAV that would be missing those blocks' contribution"
+                )
+            }
             Self::Capture(e) => write!(f, "live capture failed: {e}"),
         }
     }
@@ -87,7 +111,7 @@ pub fn render(args: &RenderArgs) -> Result<RenderSummary, RenderError> {
     let tail_frames = (u64::from(args.tail_ms) * u64::from(args.sample_rate_hz) / 1000) as usize;
 
     // 4. Drive the chain offline through the engine.
-    let output_frames = engine::offline::render_chain(
+    let outcome = engine::offline::render_chain(
         &chain,
         args.sample_rate_hz as f32,
         &input_frames,
@@ -96,15 +120,24 @@ pub fn render(args: &RenderArgs) -> Result<RenderSummary, RenderError> {
     )
     .map_err(RenderError::EngineBuild)?;
 
+    // Issue #574: the engine returns a best-effort render even when some
+    // blocks could not be built (the GUI relies on that to keep running
+    // with a partial chain). The CLI must NOT inherit that policy — a
+    // WAV that silently drops the user's amp/cab/effect is worse than no
+    // WAV. Fail loud before writing anything.
+    if !outcome.faulted_blocks.is_empty() {
+        return Err(RenderError::BlocksFailed(outcome.faulted_blocks));
+    }
+
     // 5. Atomic write: temp file + rename.
     let tmp = tmp_output_path(&args.output);
-    write_wav_stereo(&tmp, &output_frames, args.sample_rate_hz, bit_depth)
+    write_wav_stereo(&tmp, &outcome.samples, args.sample_rate_hz, bit_depth)
         .map_err(RenderError::OutputWrite)?;
     std::fs::rename(&tmp, &args.output)
         .map_err(|e| RenderError::OutputWrite(wav::WavError::Io(e)))?;
 
     Ok(RenderSummary {
-        frames_written: output_frames.len() as u64,
+        frames_written: outcome.samples.len() as u64,
         sample_rate_hz: args.sample_rate_hz,
         output: args.output.clone(),
         captured_input,

--- a/crates/adapter-render/tests/issue_574_amp_contribution.rs
+++ b/crates/adapter-render/tests/issue_574_amp_contribution.rs
@@ -1,0 +1,258 @@
+//! Regression test for issue #574: amp block contributions being silently lost.
+//! Two different preset YAMLs produced byte-identical output despite different amp models/params.
+
+use adapter_render::cli::RenderArgs;
+use adapter_render::render;
+use adapter_render::wav::{write_wav_stereo, BitDepth};
+use std::path::PathBuf;
+
+fn workdir(test: &str) -> PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "openrig-issue-574-{}-{test}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&p);
+    std::fs::create_dir_all(&p).unwrap();
+    p
+}
+
+fn write_dc_wav(path: &std::path::Path, sample_rate: u32, frames: usize, value: f32) {
+    let buf: Vec<[f32; 2]> = (0..frames).map(|_| [value, value]).collect();
+    write_wav_stereo(path, &buf, sample_rate, BitDepth::Bits32Float).unwrap();
+}
+
+fn base_args(chain: PathBuf, input: PathBuf, output: PathBuf) -> RenderArgs {
+    RenderArgs {
+        chain,
+        input,
+        output,
+        start_s: None,
+        end_s: None,
+        duration_s: None,
+        input_device: None,
+        sample_rate_hz: 48_000,
+        block_size: 256,
+        bit_depth: 32,
+        tail_ms: 0,
+    }
+}
+
+/// Test that identical chains produce identical output (baseline).
+#[test]
+fn identical_chains_produce_identical_output() {
+    let dir = workdir("identical");
+    let chain = dir.join("chain.yaml");
+    std::fs::write(
+        &chain,
+        r#"id: gain-test-100
+name: gain test 100
+blocks:
+- type: gain
+  model: volume
+  enabled: true
+  params:
+    volume: 100.0
+    mute: false
+"#,
+    )
+    .unwrap();
+
+    let input = dir.join("input.wav");
+    let out_a = dir.join("a.wav");
+    let out_b = dir.join("b.wav");
+    write_dc_wav(&input, 48_000, 2_400, 0.3);
+
+    render(&base_args(chain.clone(), input.clone(), out_a.clone())).expect("first render");
+    render(&base_args(chain, input, out_b.clone())).expect("second render");
+
+    let bytes_a = std::fs::read(&out_a).unwrap();
+    let bytes_b = std::fs::read(&out_b).unwrap();
+    assert_eq!(
+        bytes_a, bytes_b,
+        "identical chains should produce byte-identical output"
+    );
+}
+
+/// Test that different gain blocks produce different output (BUG #574).
+/// This test reproduces the core issue: two chains with different parameters
+/// render to identical bytes, which should never happen.
+#[test]
+fn different_gain_should_produce_different_output() {
+    let dir = workdir("amp_models");
+    let input = dir.join("input.wav");
+    write_dc_wav(&input, 48_000, 2_400, 0.3);
+
+    // Chain A: simple volume passthrough at 100%
+    let chain_a = dir.join("chain_a.yaml");
+    std::fs::write(
+        &chain_a,
+        r#"id: chain-a
+name: Chain A - passthrough
+blocks:
+- type: gain
+  model: volume
+  enabled: true
+  params:
+    volume: 100.0
+    mute: false
+"#,
+    )
+    .unwrap();
+
+    // Chain B: same block type but different gain (50%)
+    let chain_b = dir.join("chain_b.yaml");
+    std::fs::write(
+        &chain_b,
+        r#"id: chain-b
+name: Chain B - with gain reduction
+blocks:
+- type: gain
+  model: volume
+  enabled: true
+  params:
+    volume: 50.0
+    mute: false
+"#,
+    )
+    .unwrap();
+
+    let out_a = dir.join("out_a.wav");
+    let out_b = dir.join("out_b.wav");
+
+    render(&base_args(chain_a, input.clone(), out_a.clone())).expect("render chain A");
+    render(&base_args(chain_b, input, out_b.clone())).expect("render chain B");
+
+    let bytes_a = std::fs::read(&out_a).unwrap();
+    let bytes_b = std::fs::read(&out_b).unwrap();
+
+    assert_ne!(
+        bytes_a, bytes_b,
+        "REGRESSION #574: chains with different gain should produce different bytes, but got identical output"
+    );
+}
+
+/// Test that toggling block enabled flag produces different output.
+/// Per issue #574, toggling amp enabled/disabled produced the SAME bytes.
+#[test]
+fn toggling_block_enabled_should_change_output() {
+    let dir = workdir("enabled_toggle");
+    let input = dir.join("input.wav");
+    write_dc_wav(&input, 48_000, 2_400, 0.3);
+
+    // Chain A: block enabled with 50% gain
+    let chain_enabled = dir.join("chain_enabled.yaml");
+    std::fs::write(
+        &chain_enabled,
+        r#"id: chain-enabled
+name: Block enabled
+blocks:
+- type: gain
+  model: volume
+  enabled: true
+  params:
+    volume: 50.0
+    mute: false
+"#,
+    )
+    .unwrap();
+
+    // Chain B: same block but disabled (should pass through 100%)
+    let chain_disabled = dir.join("chain_disabled.yaml");
+    std::fs::write(
+        &chain_disabled,
+        r#"id: chain-disabled
+name: Block disabled
+blocks:
+- type: gain
+  model: volume
+  enabled: false
+  params:
+    volume: 50.0
+    mute: false
+"#,
+    )
+    .unwrap();
+
+    let out_enabled = dir.join("out_enabled.wav");
+    let out_disabled = dir.join("out_disabled.wav");
+
+    render(&base_args(chain_enabled, input.clone(), out_enabled.clone()))
+        .expect("render enabled");
+    render(&base_args(chain_disabled, input, out_disabled.clone())).expect("render disabled");
+
+    let bytes_enabled = std::fs::read(&out_enabled).unwrap();
+    let bytes_disabled = std::fs::read(&out_disabled).unwrap();
+
+    assert_ne!(
+        bytes_enabled, bytes_disabled,
+        "REGRESSION #574: enabled block vs disabled block should produce different bytes, but got identical output"
+    );
+}
+
+/// Test with bundled input using real DI to see if it reproduces the issue.
+/// This is closer to the real scenario reported in issue #574.
+#[test]
+fn render_with_bundled_input_different_gain() {
+    let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let repo_root = manifest_dir.parent().unwrap().parent().unwrap();
+    let bundled_input = repo_root.join("assets/audio/input.wav");
+
+    // If assets don't exist, skip this test gracefully
+    if !bundled_input.exists() {
+        eprintln!("Skipping: bundled input.wav not found at {:?}", bundled_input);
+        return;
+    }
+
+    let dir = std::env::temp_dir().join(format!("openrig-issue-574-bundled-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    // Chain A: simple passthrough
+    let chain_a = dir.join("chain_a.yaml");
+    std::fs::write(
+        &chain_a,
+        r#"id: chain-a-passthrough
+name: Chain A - passthrough
+blocks:
+- type: gain
+  model: volume
+  enabled: true
+  params:
+    volume: 100.0
+    mute: false
+"#,
+    )
+    .unwrap();
+
+    // Chain B: with gain reduction
+    let chain_b = dir.join("chain_b.yaml");
+    std::fs::write(
+        &chain_b,
+        r#"id: chain-b-reduced
+name: Chain B - gain reduced
+blocks:
+- type: gain
+  model: volume
+  enabled: true
+  params:
+    volume: 50.0
+    mute: false
+"#,
+    )
+    .unwrap();
+
+    let out_a = dir.join("out_a.wav");
+    let out_b = dir.join("out_b.wav");
+
+    render(&base_args(chain_a, bundled_input.clone(), out_a.clone())).expect("render chain A");
+    render(&base_args(chain_b, bundled_input, out_b.clone())).expect("render chain B");
+
+    let bytes_a = std::fs::read(&out_a).unwrap();
+    let bytes_b = std::fs::read(&out_b).unwrap();
+
+    assert_ne!(
+        bytes_a, bytes_b,
+        "Renders with different gain should produce different bytes. If identical, this indicates issue #574."
+    );
+}

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -30,9 +30,9 @@ block-reverb = { path = "../block-reverb" }
 block-util = { path = "../block-util" }
 project = { path = "../project" }
 vst3-host = { path = "../vst3" }
+plugin-loader = { path = "../plugin-loader" }
 
 [dev-dependencies]
-plugin-loader = { path = "../plugin-loader" }
 domain = { path = "../domain" }
 nam = { path = "../nam" }
 ir = { path = "../ir" }

--- a/crates/engine/src/offline.rs
+++ b/crates/engine/src/offline.rs
@@ -22,6 +22,36 @@ use crate::runtime_audio_frame::AudioFrame;
 use crate::runtime_block_builders::build_runtime_block_nodes;
 use crate::runtime_state::{BlockRuntimeNode, RuntimeProcessor};
 
+/// One block that could not be built into a runtime processor.
+///
+/// `render_chain` does not fail the whole render when an individual block
+/// fails to build (the GUI relies on the same code path and must keep
+/// running with a partial chain). Instead the block is replaced with a
+/// pass-through bypass node and the failure is reported here so the
+/// caller can decide whether the render is still acceptable. Issue #574:
+/// the previous behavior dropped the error on the floor, producing
+/// misleading WAV output where different presets rendered to identical
+/// bytes because their amp blocks had silently been removed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FaultedBlock {
+    pub block_id: String,
+    pub effect_type: String,
+    pub model: String,
+    pub error: String,
+}
+
+/// Result of a successful offline render.
+///
+/// `samples` always contains a best-effort render — even when blocks
+/// were silently bypassed because they could not be built. Callers that
+/// need an "all blocks ran" guarantee (the CLI, regression tests) MUST
+/// inspect `faulted_blocks` and treat a non-empty list as failure.
+#[derive(Debug, Clone)]
+pub struct RenderOutcome {
+    pub samples: Vec<[f32; 2]>,
+    pub faulted_blocks: Vec<FaultedBlock>,
+}
+
 /// Process a chain offline: input stereo frames in, output stereo frames out.
 ///
 /// The output is `input.len() + tail_frames` frames long: the tail window
@@ -39,12 +69,14 @@ pub fn render_chain(
     input: &[[f32; 2]],
     block_size: usize,
     tail_frames: usize,
-) -> Result<Vec<[f32; 2]>> {
+) -> Result<RenderOutcome> {
     if block_size == 0 {
         anyhow::bail!("block_size must be > 0");
     }
     let (mut nodes, _output_layout) =
         build_runtime_block_nodes(chain, AudioChannelLayout::Stereo, sample_rate, None, None)?;
+
+    let faulted_blocks = collect_faulted_blocks(&nodes);
 
     let total_frames = input.len() + tail_frames;
     let mut output: Vec<[f32; 2]> = Vec::with_capacity(total_frames);
@@ -77,7 +109,29 @@ pub fn render_chain(
         }
         frame_idx += chunk_size;
     }
-    Ok(output)
+    Ok(RenderOutcome {
+        samples: output,
+        faulted_blocks,
+    })
+}
+
+fn collect_faulted_blocks(nodes: &[BlockRuntimeNode]) -> Vec<FaultedBlock> {
+    nodes
+        .iter()
+        .filter_map(|node| {
+            let reason = node.fault_reason.as_ref()?;
+            let (effect_type, model) = match node.block_snapshot.model_ref() {
+                Some(m) => (m.effect_type.to_string(), m.model.to_string()),
+                None => (node.block_snapshot.kind.label().to_string(), String::new()),
+            };
+            Some(FaultedBlock {
+                block_id: node.block_id.0.clone(),
+                effect_type,
+                model,
+                error: reason.clone(),
+            })
+        })
+        .collect()
 }
 
 fn apply_block_offline(node: &mut BlockRuntimeNode, frames: &mut [AudioFrame]) {

--- a/crates/engine/src/runtime_block_builders.rs
+++ b/crates/engine/src/runtime_block_builders.rs
@@ -123,14 +123,20 @@ pub(crate) fn build_runtime_block_nodes(
                 blocks.push(node);
             }
             Err(e) => {
-                // Don't fail the whole chain — bypass this block and keep going
+                // Don't fail the whole chain — bypass this block and keep going,
+                // but record the reason so offline-render callers (and any
+                // diagnostic surface) can refuse to claim success. Issue #574:
+                // without this, the failure was log-only and invisible to the
+                // CLI, producing misleading WAV output for different presets.
+                let reason = e.to_string();
                 log::error!(
-                    "[engine] block {:?} (id={}) build failed: {e} — inserting faulted bypass",
+                    "[engine] block {:?} (id={}) build failed: {reason} — inserting faulted bypass",
                     block.model_ref().map(|m| m.model.to_string()),
                     block.id.0
                 );
                 let mut node = bypass_runtime_node(block, current_layout);
                 node.faulted = true;
+                node.fault_reason = Some(reason);
                 blocks.push(node);
             }
         }
@@ -349,6 +355,7 @@ fn build_select_runtime_node(
         },
         fade_dry_buffer: Vec::new(),
         faulted: false,
+        fault_reason: None,
     })
 }
 
@@ -368,6 +375,7 @@ pub(crate) fn bypass_runtime_node(
         fade_state: FadeState::Bypassed,
         fade_dry_buffer: Vec::new(),
         faulted: false,
+        fault_reason: None,
     }
 }
 
@@ -391,6 +399,7 @@ pub(crate) fn audio_block_runtime_node(
         },
         fade_dry_buffer: Vec::new(),
         faulted: false,
+        fault_reason: None,
     }
 }
 

--- a/crates/engine/src/runtime_block_builders.rs
+++ b/crates/engine/src/runtime_block_builders.rs
@@ -529,17 +529,34 @@ fn build_nam_audio_processor(
     input_layout: AudioChannelLayout,
     sample_rate: f32,
 ) -> Result<ProcessorBuildOutcome> {
-    let _ = (
-        optional_string(&stage.params, "ir_path"),
-        required_string(&stage.params, "model_path")?,
-    );
     build_audio_processor_for_model(
         chain,
         block_core::EFFECT_TYPE_NAM,
         &stage.model,
         input_layout,
-        |layout| build_nam_processor_for_layout(&stage.model, &stage.params, sample_rate, layout),
+        |layout| build_nam_processor_via_dispatch(&stage.model, &stage.params, sample_rate, layout),
     )
+}
+
+/// Resolve a NAM block via the plugin loader (issue #574) and fall back
+/// to the legacy `model_path`-in-params path only for callers that
+/// inject the path themselves. Without this, YAML presets never built
+/// because they don't carry `model_path`.
+fn build_nam_processor_via_dispatch(
+    model: &str,
+    params: &ParameterSet,
+    sample_rate: f32,
+    layout: AudioChannelLayout,
+) -> Result<BlockProcessor> {
+    if let Some(package) = plugin_loader::registry::find(model) {
+        return package.build_processor(params, sample_rate, layout);
+    }
+    if params.get_string("model_path").is_some() {
+        return build_nam_processor_for_layout(model, params, sample_rate, layout);
+    }
+    Err(anyhow!(
+        "no NAM plugin package registered for model '{model}' and no `model_path` in params"
+    ))
 }
 
 fn expect_mono_processor(
@@ -574,20 +591,6 @@ fn expect_stereo_processor(
             model
         )),
     }
-}
-
-fn required_string(params: &ParameterSet, path: &str) -> Result<String> {
-    params
-        .get_string(path)
-        .map(ToString::to_string)
-        .ok_or_else(|| anyhow!("missing or invalid string parameter '{}'", path))
-}
-
-fn optional_string(params: &ParameterSet, path: &str) -> Option<String> {
-    params
-        .get_optional_string(path)
-        .flatten()
-        .map(ToString::to_string)
 }
 
 pub(crate) fn next_block_instance_serial() -> u64 {

--- a/crates/engine/src/runtime_state.rs
+++ b/crates/engine/src/runtime_state.rs
@@ -178,9 +178,17 @@ pub(crate) struct BlockRuntimeNode {
     /// extends only realloc if capacity is exceeded — which after the
     /// first frame is no longer the case for fixed-buffer audio backends.
     pub(crate) fade_dry_buffer: Vec<AudioFrame>,
-    /// Set to true if this block panicked during audio processing.
-    /// Once faulted, the block is permanently bypassed to prevent repeated crashes.
+    /// Set to true if this block panicked during audio processing OR if
+    /// its runtime build failed at setup time. Once faulted, the block is
+    /// permanently bypassed to prevent repeated crashes.
     pub(crate) faulted: bool,
+    /// Human-readable explanation when [`Self::faulted`] is set due to a
+    /// build-time failure. `None` for runtime panics (the panic site logs
+    /// separately) and for healthy blocks. Surfaced via
+    /// `engine::offline::RenderOutcome::faulted_blocks` so offline-render
+    /// callers can refuse to claim success when a block was silently
+    /// bypassed. Issue #574.
+    pub(crate) fault_reason: Option<String>,
 }
 
 pub(crate) struct SelectRuntimeState {

--- a/crates/engine/src/runtime_tests.rs
+++ b/crates/engine/src/runtime_tests.rs
@@ -889,6 +889,7 @@ fn panicking_block_node() -> BlockRuntimeNode {
         fade_state: FadeState::Active,
         fade_dry_buffer: Vec::new(),
         faulted: false,
+        fault_reason: None,
     }
 }
 
@@ -917,6 +918,7 @@ fn counting_block_node(
         fade_state: FadeState::Active,
         fade_dry_buffer: Vec::new(),
         faulted: false,
+        fault_reason: None,
     }
 }
 

--- a/crates/engine/tests/issue_574_faulted_blocks_reported.rs
+++ b/crates/engine/tests/issue_574_faulted_blocks_reported.rs
@@ -1,0 +1,104 @@
+//! Regression test for issue #574: blocks whose runtime build fails are
+//! silently replaced with pass-through bypass nodes, hiding the failure
+//! from offline-render callers and producing misleading WAV output
+//! (different presets, identical bytes).
+//!
+//! Contract under test (new in #574 fix):
+//!   `engine::offline::render_chain` returns a `RenderOutcome` whose
+//!   `faulted_blocks` field lists every block that could not be built.
+//!   The render still produces samples (best-effort behavior preserved
+//!   for the GUI) but the caller can no longer claim success when a
+//!   block has been silently bypassed.
+
+use block_core::param::ParameterSet;
+use domain::ids::{BlockId, ChainId};
+use engine::offline::render_chain;
+use project::block::{AudioBlock, AudioBlockKind, NamBlock};
+use project::chain::Chain;
+
+fn chain_with_blocks(id: &str, blocks: Vec<AudioBlock>) -> Chain {
+    Chain {
+        id: ChainId(id.into()),
+        description: Some("issue-574 regression".into()),
+        instrument: "electric_guitar".into(),
+        enabled: true,
+        volume: 100.0,
+        blocks,
+    }
+}
+
+fn nam_block(block_id: &str, model: &str) -> AudioBlock {
+    AudioBlock {
+        id: BlockId(block_id.into()),
+        enabled: true,
+        kind: AudioBlockKind::Nam(NamBlock {
+            model: model.into(),
+            params: ParameterSet::default(),
+        }),
+    }
+}
+
+#[test]
+fn nam_block_with_unbuildable_model_is_reported_via_faulted_blocks() {
+    // A NAM model id that is guaranteed to fail registry lookup (no plugin
+    // registered under this name; missing `model_path` param either way).
+    // Before the fix, render_chain would silently replace this block with
+    // a faulted bypass node and return Ok(samples) with no signal back to
+    // the caller — see crates/engine/src/runtime_block_builders.rs:120-135.
+    let chain = chain_with_blocks(
+        "issue-574-faulted-nam",
+        vec![nam_block(
+            "unbuildable-amp",
+            "nonexistent_nam_model_that_was_never_registered",
+        )],
+    );
+
+    let input = vec![[0.3_f32, 0.3_f32]; 1024];
+    let outcome = render_chain(&chain, 48_000.0, &input, 256, 0)
+        .expect("render_chain must still produce best-effort output (samples Ok)");
+
+    assert!(
+        !outcome.faulted_blocks.is_empty(),
+        "BUG #574: a NAM block whose runtime build fails must be reported \
+         via RenderOutcome::faulted_blocks; instead got an empty list which \
+         means the failure was silently hidden from the caller"
+    );
+
+    let faulted = outcome
+        .faulted_blocks
+        .iter()
+        .find(|f| f.block_id == "unbuildable-amp")
+        .expect("the failing block must be identified by its block id");
+
+    assert!(
+        !faulted.error.is_empty(),
+        "faulted block must carry a non-empty error explaining why the \
+         build failed; otherwise the caller cannot help the user diagnose \
+         their preset"
+    );
+}
+
+#[test]
+fn chain_with_only_healthy_blocks_reports_no_faulted_blocks() {
+    // Sanity baseline: an empty chain (or one whose blocks all build) must
+    // not produce phantom faulted_blocks entries — the field is reserved
+    // for genuine build failures.
+    let chain = chain_with_blocks("issue-574-healthy-empty", vec![]);
+
+    let input = vec![[0.3_f32, 0.3_f32]; 1024];
+    let outcome = render_chain(&chain, 48_000.0, &input, 256, 0)
+        .expect("empty chain must render successfully");
+
+    assert!(
+        outcome.faulted_blocks.is_empty(),
+        "a chain with no failing blocks must report no faulted_blocks; \
+         got {:?}",
+        outcome.faulted_blocks
+    );
+    assert_eq!(
+        outcome.samples.len(),
+        input.len(),
+        "the rendered output length must match input length when there is \
+         no tail"
+    );
+}

--- a/crates/engine/tests/issue_574_nam_amp_runs_via_render_chain.rs
+++ b/crates/engine/tests/issue_574_nam_amp_runs_via_render_chain.rs
@@ -1,0 +1,127 @@
+//! Issue #574 — root cause: NAM amps don't actually run through
+//! `engine::offline::render_chain` because `build_nam_audio_processor`
+//! takes the legacy "model_path in stage.params" path instead of
+//! routing through `LoadedPackage::build_processor` (which would
+//! inject the path from the discovered manifest). Every NAM block
+//! therefore fails to build, gets replaced with a pass-through
+//! bypass node, and the WAV is byte-identical to a chain that
+//! never had the amp.
+//!
+//! This test asserts the symptom the user reported: a NAM amp that
+//! exists in the plugin registry must process audio when its chain
+//! is rendered via `engine::offline::render_chain`. The previous fix
+//! (commit `bab0e8d1`) made the failure visible — this test will
+//! pass only once the actual dispatch is wired through
+//! `LoadedPackage::build_processor`.
+
+use std::path::PathBuf;
+use std::sync::Once;
+
+use block_core::param::ParameterSet;
+use domain::ids::{BlockId, ChainId};
+use domain::value_objects::ParameterValue;
+use engine::offline::render_chain;
+use project::block::{AudioBlock, AudioBlockKind, NamBlock};
+use project::chain::Chain;
+
+const SR: f32 = 48_000.0;
+
+fn fixture_plugins_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/plugins")
+}
+
+fn init_test_registry() {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        nam::register_builder();
+        ir::register_builder();
+        plugin_loader::registry::init(&fixture_plugins_root());
+    });
+}
+
+fn chain_with_blocks(id: &str, blocks: Vec<AudioBlock>) -> Chain {
+    Chain {
+        id: ChainId(id.into()),
+        description: Some("issue-574 nam dispatch regression".into()),
+        instrument: "electric_guitar".into(),
+        enabled: true,
+        volume: 100.0,
+        blocks,
+    }
+}
+
+fn nam_amp_block(block_id: &str, model: &str, preset: &str) -> AudioBlock {
+    let mut params = ParameterSet::default();
+    params.insert("preset", ParameterValue::String(preset.into()));
+    AudioBlock {
+        id: BlockId(block_id.into()),
+        enabled: true,
+        kind: AudioBlockKind::Nam(NamBlock {
+            model: model.into(),
+            params,
+        }),
+    }
+}
+
+/// Steady-state guitar-ish sine that the amp's neural model can actually
+/// react to. Pure silence would also "differ from passthrough" if the
+/// amp adds DC, which is not a meaningful test of "the amp processes
+/// audio".
+fn sine_input(frames: usize) -> Vec<[f32; 2]> {
+    (0..frames)
+        .map(|n| {
+            let t = n as f32 / SR;
+            let s = 0.2 * (2.0 * std::f32::consts::PI * 220.0 * t).sin();
+            [s, s]
+        })
+        .collect()
+}
+
+#[test]
+fn nam_amp_from_loaded_package_actually_processes_audio_in_render_chain() {
+    init_test_registry();
+
+    // Sanity: the fixture package is in the registry. If this fails the
+    // test setup is broken, not the bug under test.
+    assert!(
+        plugin_loader::registry::find("nam_marshall_plexi").is_some(),
+        "fixture plugin nam_marshall_plexi must be discoverable in \
+         crates/engine/tests/fixtures/plugins/nam/marshall_plexi/"
+    );
+
+    let input = sine_input(1024);
+
+    // Chain A — empty (passthrough). Output equals input.
+    let chain_a = chain_with_blocks("issue-574-passthrough", vec![]);
+    let outcome_a =
+        render_chain(&chain_a, SR, &input, 256, 0).expect("passthrough chain must render");
+
+    // Chain B — same input, but with the NAM amp from the registry.
+    // The amp MUST build via the LoadedPackage dispatch path; the chain
+    // must contain a real processor, not a faulted bypass.
+    let chain_b = chain_with_blocks(
+        "issue-574-with-nam-amp",
+        vec![nam_amp_block("amp", "nam_marshall_plexi", "angus")],
+    );
+    let outcome_b = render_chain(&chain_b, SR, &input, 256, 0)
+        .expect("NAM-amp chain must render (best-effort) even before the dispatch fix");
+
+    assert!(
+        outcome_b.faulted_blocks.is_empty(),
+        "BUG #574 root cause: the NAM amp `nam_marshall_plexi` exists in \
+         the plugin registry but `engine::offline::render_chain` still \
+         reports it as faulted, which means `build_nam_audio_processor` \
+         is NOT routing through `LoadedPackage::build_processor`. \
+         Faulted: {:?}",
+        outcome_b.faulted_blocks
+    );
+
+    assert_ne!(
+        outcome_a.samples, outcome_b.samples,
+        "BUG #574: a NAM amp resolved through the plugin registry MUST \
+         contribute audio when rendered via `engine::offline::render_chain`. \
+         Same input + with-amp == without-amp means the amp is a \
+         pass-through, which is the byte-identical-WAV symptom the user \
+         reported."
+    );
+}

--- a/docs/render.md
+++ b/docs/render.md
@@ -67,8 +67,30 @@ renderer exits with `1` and the message
 | Code | Meaning |
 |---|---|
 | `0` | Render succeeded; `--output` written |
-| `1` | Render failed (bad chain, bad input WAV, capture failed, engine error, IO error). No partial output file remains |
+| `1` | Render failed (bad chain, bad input WAV, capture failed, engine error, **one or more chain blocks could not be built**, IO error). No partial output file remains |
 | `2` | Argument error (missing required flag, invalid value such as `--bit-depth 19`, unknown flag) |
+
+### Failing-block policy (issue #574)
+
+`engine::offline::render_chain` is best-effort: when an individual block
+fails to build at setup time (missing plugin file, unresolvable model
+id, invalid params), the engine replaces it with a pass-through bypass
+node and keeps rendering. The GUI relies on this — the user must be
+able to keep working with a partial chain. **The CLI does not inherit
+that policy.** If any block in the chain ends up bypassed because it
+could not be built, `openrig-render` exits with code `1` and stderr
+lists every failing block:
+
+```
+openrig-render: 1 block(s) in the chain failed to build and would have been silently bypassed:
+  - block 'preset:Coldplay - Clocks (rhythm):block:3' (nam/nam_fender_twin_reverb): missing or invalid string parameter 'model_path'
+refusing to write a WAV that would be missing those blocks' contribution
+```
+
+Before #574 the same render exited `0` with a WAV that silently omitted
+the failing blocks' contribution — two different presets could produce
+byte-identical output. Refusing to claim success is the only honest
+outcome for an offline render.
 
 ## Scope
 


### PR DESCRIPTION
## Summary

- Offline `engine::offline::render_chain` now returns `RenderOutcome { samples, faulted_blocks }`. Best-effort rendering preserved for the GUI; the CLI refuses to write a WAV when any block was silently bypassed (issue #574).
- `AudioBlockKind::Nam` now routes through `plugin_loader::registry::find(model).build_processor(...)` — same path `adapter-gui` already used. The legacy `model_path`-in-params route is kept only for engine tests that construct chains without a populated plugin registry.

Root cause: `build_nam_audio_processor` required `model_path` in `stage.params`, which YAML presets never carry (it lives in the package manifest). Every disk-backed NAM block failed to build, became a faulted bypass, and silently dropped out of the rendered signal. Two presets sharing the same non-NAM blocks rendered to byte-identical WAVs because none of their NAM amps actually ran.

## Test plan

- [x] `cargo test -p engine --test issue_574_faulted_blocks_reported` — 2/2 green (RED→GREEN regression for the diagnostic surface).
- [x] `cargo test -p engine --test issue_574_nam_amp_runs_via_render_chain` — 1/1 green (RED→GREEN regression for the dispatch fix).
- [x] `cargo test -p adapter-render --test issue_574_amp_contribution --release` — 4/4 green (pre-existing sanity tests on the gain/volume native path).
- [x] `cargo test --workspace --tests` — exit 0.
- [x] `cargo test --workspace --lib` — exit 0 except for 2 flaky tests in `application/--lib` (`local_dispatcher_tests::set_block_parameter_number_non_existent_path_returns_err` and one of the `query::plugin_params_tests`), both confirmed pre-existing in `develop` and passing in isolation.
- [x] Manual end-to-end against the reporter's presets:

  ```
  before fix:
    MD5 (/tmp/clocks_repro.wav)     = 1b43dbf43b43bbdc35308654cdeb0d22
    MD5 (/tmp/basketcase_repro.wav) = 1b43dbf43b43bbdc35308654cdeb0d22  (same)

  after fix:
    MD5 (/tmp/clocks_fixed.wav)     = 15ea431ef20c8d7a06ea75de0d6a8b92
    MD5 (/tmp/basketcase_fixed.wav) = 55d120328887f7ca96191f544c7828b6  (different)
  ```

## Notes

- The CLI now prints `plugin-loader: skipping package: ...` to stderr for 4 NAM packages with malformed `manifest.yaml` in `OpenRig-plugins` (`mad_professor_double_barrel_{blue,green,red}`, `wampler_dual_fusion`). Those presets still get bypassed when used — a separate bug to fix on the plugins side.
- `crates/engine/Cargo.toml`: `plugin-loader` moved from `[dev-dependencies]` to `[dependencies]` so the dispatch lookup is callable from `src/`.
- `crates/engine/src/runtime_block_builders.rs` stayed at 598 lines (≤ 600 cap).