### PR TITLE
fix(#580): GUI/audio lock contention — clean audio at buffer=32 again

### DIFF
--- a/crates/engine/src/audio_alloc_invariant_tests.rs
+++ b/crates/engine/src/audio_alloc_invariant_tests.rs
@@ -1,0 +1,209 @@
+//! THE RULE (CLAUDE.md invariant #8, pinned)
+//! ═══════════════════════════════════════════
+//!
+//! The audio callback path must perform **zero heap allocations**.
+//! Every `Vec` it touches has been pre-grown to its maximum required
+//! capacity at runtime build / rebuild time; every scratch buffer is
+//! preallocated; every `Arc::clone` is reference-count-only.
+//!
+//! Why: an allocator call on the audio thread is a syscall path that
+//! can grab a process-wide allocator lock, page in fresh memory from
+//! the kernel, or stall the thread arbitrarily. At buffer = 32 frames
+//! @ 48 kHz (callback period ≈ 666 µs) a single page fault wipes the
+//! window. The symptom is an audible click that has no pattern from
+//! the user's perspective — it depends on the allocator's internal
+//! state, which depends on the rest of the process's heap traffic.
+//!
+//! How this test catches violations
+//! ────────────────────────────────
+//! - A custom `CountingAllocator` is installed as `#[global_allocator]`
+//!   for the test binary (gated under `#[cfg(test)]` — production
+//!   binaries keep the default `System` allocator). The wrapper
+//!   increments a global atomic counter on every `alloc` / `realloc`
+//!   call **but only when a thread-local guard is set**. Without the
+//!   guard active, the wrapper is a transparent pass-through; tests
+//!   that legitimately allocate during setup do not interfere.
+//! - The test warms up the runtime, drains any first-callback
+//!   allocations (fade-in scratch growth, cold caches), then sets the
+//!   guard for a measurement window of N callbacks and asserts the
+//!   counter delta is zero.
+//!
+//! If this test starts firing red, the most recent commit added code
+//! that allocates on the per-callback path. Common culprits:
+//!   - `Vec::push` past capacity (forgot to `Vec::with_capacity` at
+//!     build time, or `Vec::clear` cleared but the next push exceeds
+//!     the prior steady-state length).
+//!   - `format!` / `to_string` / `String::from` (typically slipped
+//!     into a log statement on the hot path).
+//!   - `Box::new` / `Arc::new` (a fresh `Arc::new` allocates; cloning
+//!     an existing `Arc` does not).
+//!   - `clone` on a heap-backed type (`Vec`, `HashMap`, `String`).
+//!   - A new processor crate that allocates inside `process` instead
+//!     of inside `build`.
+//!
+//! Fix at the source. Never silence this assertion.
+//!
+//! `#[ignore]` by default — the allocator wrapper changes the process
+//! allocator for the full test binary and the measurement is sensitive
+//! to parallel-thread allocator pressure. Run serially:
+//!
+//! ```text
+//! cargo test -p engine --release --lib audio_alloc_invariant \
+//!   -- --ignored --test-threads=1
+//! ```
+
+use crate::runtime::{
+    build_chain_runtime_state, process_input_f32, process_output_f32, DEFAULT_ELASTIC_TARGET,
+};
+use domain::ids::{BlockId, ChainId, DeviceId};
+use project::block::{
+    AudioBlock, AudioBlockKind, InputBlock, InputEntry, OutputBlock, OutputEntry,
+};
+use project::chain::{Chain, ChainInputMode, ChainOutputMode};
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::Cell;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+// ── Allocator instrumentation ────────────────────────────────────────
+//
+// The wrapper counts `alloc` and `realloc` calls but only when the
+// thread-local guard is set. `dealloc` is not counted: drops on the
+// hot path that release pre-allocated buffers happen by design (e.g.
+// when a frame Vec wraps around capacity); the invariant we care
+// about is "no NEW allocation".
+
+thread_local! {
+    static ALLOC_GUARD: Cell<bool> = Cell::new(false);
+}
+
+static ALLOC_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+struct CountingAllocator;
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if ALLOC_GUARD.with(|g| g.get()) {
+            ALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
+        }
+        System.alloc(layout)
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout)
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        if ALLOC_GUARD.with(|g| g.get()) {
+            ALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
+        }
+        System.alloc_zeroed(layout)
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        if ALLOC_GUARD.with(|g| g.get()) {
+            ALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
+        }
+        System.realloc(ptr, layout, new_size)
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAllocator = CountingAllocator;
+
+fn measure_allocs<F: FnOnce()>(f: F) -> usize {
+    ALLOC_COUNT.store(0, Ordering::Relaxed);
+    ALLOC_GUARD.with(|g| g.set(true));
+    f();
+    ALLOC_GUARD.with(|g| g.set(false));
+    ALLOC_COUNT.load(Ordering::Relaxed)
+}
+
+// ── Fixture ──────────────────────────────────────────────────────────
+
+fn chain() -> Chain {
+    Chain {
+        id: ChainId("issue580-alloc".into()),
+        description: Some("issue #580 audio-thread alloc invariant".into()),
+        instrument: "electric_guitar".into(),
+        enabled: true,
+        volume: 100.0,
+        blocks: vec![
+            AudioBlock {
+                id: BlockId("input:0".into()),
+                enabled: true,
+                kind: AudioBlockKind::Input(InputBlock {
+                    model: "standard".into(),
+                    entries: vec![InputEntry {
+                        device_id: DeviceId("dev".into()),
+                        mode: ChainInputMode::Stereo,
+                        channels: vec![0, 1],
+                    }],
+                }),
+            },
+            AudioBlock {
+                id: BlockId("output:0".into()),
+                enabled: true,
+                kind: AudioBlockKind::Output(OutputBlock {
+                    model: "standard".into(),
+                    entries: vec![OutputEntry {
+                        device_id: DeviceId("dev".into()),
+                        mode: ChainOutputMode::Stereo,
+                        channels: vec![0, 1],
+                    }],
+                }),
+            },
+        ],
+    }
+}
+
+#[test]
+#[ignore = "CLAUDE.md invariant #8: audio callback must not allocate. \
+ Allocator wrapper changes the process allocator and is sensitive to \
+ parallel-test pressure — run serially: `cargo test -p engine \
+ --release --lib audio_alloc_invariant -- --ignored --test-threads=1`."]
+fn audio_callback_does_not_allocate_at_buffer_32() {
+    let runtime = Arc::new(
+        build_chain_runtime_state(&chain(), 48_000.0_f32, &[DEFAULT_ELASTIC_TARGET])
+            .expect("runtime should build"),
+    );
+
+    let buffer_frames = 32_usize;
+    let input_total_channels = 2_usize;
+    let output_total_channels = 2_usize;
+    let input_buf = vec![0.5_f32; buffer_frames * input_total_channels];
+    let mut output_buf = vec![0.0_f32; buffer_frames * output_total_channels];
+
+    // Warm-up OUTSIDE the measurement guard. The first callbacks grow
+    // any frame buffers that were sized for `num_frames > capacity` and
+    // settle the fade-in ramp. Anything that needs to grow / cache /
+    // resolve handles must finish here — if a steady-state callback
+    // still allocates, that is the violation we are pinning.
+    for _ in 0..256 {
+        process_input_f32(&runtime, 0, &input_buf, input_total_channels);
+        process_output_f32(&runtime, 0, &mut output_buf, output_total_channels);
+    }
+
+    // Measurement window: 1000 callbacks of steady-state processing.
+    let allocs = measure_allocs(|| {
+        for _ in 0..1_000 {
+            process_input_f32(&runtime, 0, &input_buf, input_total_channels);
+            process_output_f32(&runtime, 0, &mut output_buf, output_total_channels);
+        }
+    });
+
+    eprintln!(
+        "[audio_alloc_invariant] 1000 callbacks at buffer=32 @ 48k: {allocs} allocations"
+    );
+
+    assert_eq!(
+        allocs, 0,
+        "CLAUDE.md invariant #8 broken: {allocs} heap allocations in \
+         1000 steady-state audio callbacks. Every alloc on the audio \
+         thread is a syscall-path / allocator-lock risk and is the \
+         most plausible source of buffer=32 clicks once GUI-thread \
+         contention (issue #580) is fixed. Read the module docstring \
+         for the common culprits and fix at the source — never relax \
+         this assertion."
+    );
+}

--- a/crates/engine/src/audio_deadline_tests.rs
+++ b/crates/engine/src/audio_deadline_tests.rs
@@ -86,6 +86,8 @@
 use super::{
     build_chain_runtime_state, process_input_f32, process_output_f32, DEFAULT_ELASTIC_TARGET,
 };
+use crate::runtime_state::ChainRuntimeState;
+use crate::spsc::SpscRing;
 use domain::ids::{BlockId, ChainId, DeviceId};
 use project::block::{
     AudioBlock, AudioBlockKind, InputBlock, InputEntry, OutputBlock, OutputEntry,
@@ -266,7 +268,29 @@ fn run_deadline(
         build_chain_runtime_state(chain, sample_rate_hz as f32, &[DEFAULT_ELASTIC_TARGET])
             .expect("runtime should build for deadline test"),
     );
+    measure_deadline(
+        label,
+        &runtime,
+        input_total_channels,
+        output_total_channels,
+        buffer_frames,
+        sample_rate_hz,
+        iterations,
+    )
+}
 
+/// Same loop as [`run_deadline`] but takes an already-built runtime so the
+/// caller can register taps (issue #580) or otherwise mutate runtime state
+/// before measurement.
+fn measure_deadline(
+    label: &'static str,
+    runtime: &Arc<ChainRuntimeState>,
+    input_total_channels: usize,
+    output_total_channels: usize,
+    buffer_frames: usize,
+    sample_rate_hz: u32,
+    iterations: usize,
+) -> DeadlineResult {
     let period_ns = (buffer_frames as u128 * 1_000_000_000) / sample_rate_hz as u128;
     let input_buf = vec![0.1_f32; buffer_frames * input_total_channels];
     let mut output_buf = vec![0.0_f32; buffer_frames * output_total_channels];
@@ -274,15 +298,15 @@ fn run_deadline(
     // Warm-up: a few iterations so caches/branch predictors stabilize and the
     // FADE_IN ramp completes. Not measured.
     for _ in 0..16 {
-        process_input_f32(&runtime, 0, &input_buf, input_total_channels);
-        process_output_f32(&runtime, 0, &mut output_buf, output_total_channels);
+        process_input_f32(runtime, 0, &input_buf, input_total_channels);
+        process_output_f32(runtime, 0, &mut output_buf, output_total_channels);
     }
 
     let mut elapsed: Vec<u128> = Vec::with_capacity(iterations);
     for _ in 0..iterations {
         let t0 = Instant::now();
-        process_input_f32(&runtime, 0, &input_buf, input_total_channels);
-        process_output_f32(&runtime, 0, &mut output_buf, output_total_channels);
+        process_input_f32(runtime, 0, &input_buf, input_total_channels);
+        process_output_f32(runtime, 0, &mut output_buf, output_total_channels);
         elapsed.push(t0.elapsed().as_nanos());
     }
 
@@ -423,4 +447,133 @@ fn pipe_only_mono_64_at_48000_meets_deadline() {
         N_ITERATIONS,
     );
     result.assert_meets();
+}
+
+// ── Issue #580: buffer = 32 + meter-style taps registered ──────────────
+//
+// User-reported regression: audio was clean at device buffer = 32 frames
+// @ 48 kHz before the per-chain meter / spectrum / tuner visualization
+// work landed; after, the buffer had to be raised to 256 frames to get
+// the same clean output. The 8× jump strongly suggests a per-callback
+// fixed cost was added on the audio thread.
+//
+// `adapter-gui/src/meter_wiring.rs::start_meter_polling` (wired from
+// `desktop_app.rs:353`) registers, **at app startup, for every enabled
+// chain, unconditionally — even with no meter / spectrum / tuner window
+// visible** — 3 SPSC rings per stream:
+//   - 1 ring via `subscribe_stream_input_tap` (per-stream INPUT meter)
+//   - 2 rings (L+R) via `subscribe_stream_tap`  (per-stream OUTPUT meter)
+//
+// The audio-thread dispatch loop then loads `runtime.input_taps` /
+// `stream_taps` via ArcSwap and pushes every sample of every frame into
+// each registered ring (one atomic store + two atomic loads per sample
+// per ring, via `SpscRing::push`). When no consumer was ever registered
+// the loaded `Vec` is empty and the dispatch costs only the ArcSwap load
+// — but the meter timer keeps the rings alive for the lifetime of the
+// session, so this cheap-path early-out never triggers in practice.
+//
+// The two tests below pin the regression at the deadline layer:
+//   1. `*_control_no_taps` — buffer = 32 with no taps registered.
+//      Establishes the baseline: if even this fails, the buffer is too
+//      tight for any work on this machine and we cannot conclude the
+//      regression is in the tap dispatch.
+//   2. `*_with_meter_taps` — same chain, with 1 input ring + 2 stream
+//      rings registered (mirroring one chain × one stream in the live
+//      app). Asserts the same thresholds.
+//
+// If (1) passes and (2) fails, the regression is the tap dispatch on
+// the audio thread — confirmed at this layer. Fix candidates:
+//   - Only register meter taps while a meter UI surface is actually
+//     visible (and tear them down on hide).
+//   - Coalesce the per-sample atomic pushes (batch into a single
+//     write of `num_frames` samples per callback).
+//
+// If both pass, the regression is below this test's resolution and
+// needs a different probe (full cpal-driven stream + real callback
+// thread + GUI in parallel).
+//
+// `RING_CAPACITY` matches `meter_wiring::start_meter_polling::RING_CAPACITY`.
+const ISSUE_580_RING_CAPACITY: usize = 4096;
+
+fn stereo_pipe_chain(label: &'static str) -> Chain {
+    chain_with_blocks(
+        label,
+        vec![
+            input_stereo(vec![0, 1]),
+            output(ChainOutputMode::Stereo, vec![0, 1]),
+        ],
+    )
+}
+
+#[test]
+#[cfg_attr(
+    debug_assertions,
+    ignore = "deadline tests require --release for meaningful timing"
+)]
+fn pipe_stereo_32_at_48000_meets_deadline_control_no_taps() {
+    // 32 frames @ 48k — period 666 µs, the buffer size the user
+    // reported as clean before the visualization work landed. Control:
+    // no taps registered, only the chain itself.
+    let chain = stereo_pipe_chain("issue580-control-32-48k");
+    let result = run_deadline(
+        "issue580_control_no_taps_32@48k",
+        &chain,
+        2,
+        2,
+        32,
+        48_000,
+        N_ITERATIONS,
+    );
+    result.assert_meets();
+}
+
+#[test]
+#[cfg_attr(
+    debug_assertions,
+    ignore = "deadline tests require --release for meaningful timing"
+)]
+fn pipe_stereo_32_at_48000_with_meter_taps_meets_deadline() {
+    // Issue #580 regression pin. Same chain + same buffer as the
+    // control above, but with the runtime taps the meter polling timer
+    // keeps alive for the session — 1 input ring + 2 stream rings per
+    // stream/chain — registered before measurement starts. Handles are
+    // bound to a local so `Arc::strong_count > 1` and `prune_dead_*`
+    // (not called here, but mirrored against the live behaviour) would
+    // keep them.
+    let chain = stereo_pipe_chain("issue580-with-meter-taps-32-48k");
+    let runtime = Arc::new(
+        build_chain_runtime_state(&chain, 48_000.0_f32, &[DEFAULT_ELASTIC_TARGET])
+            .expect("runtime should build for issue #580 regression test"),
+    );
+
+    // Mirror `subscribe_stream_input_tap` for stream 0 — one channel of
+    // the stereo input (channel 0).
+    let _input_handles: Vec<Arc<SpscRing<f32>>> = runtime.subscribe_input_tap(
+        /* input_index */ 0,
+        /* total_channels */ 2,
+        /* subscribed_channels */ &[0],
+        ISSUE_580_RING_CAPACITY,
+    );
+    // Mirror `subscribe_stream_tap` for stream 0 — L + R post-FX.
+    let _stream_handles: [Arc<SpscRing<f32>>; 2] =
+        runtime.subscribe_stream_tap(/* stream_index */ 0, ISSUE_580_RING_CAPACITY);
+
+    let result = measure_deadline(
+        "issue580_with_meter_taps_32@48k",
+        &runtime,
+        2,
+        2,
+        32,
+        48_000,
+        N_ITERATIONS,
+    );
+    // Pin the regression: until the fix lands, this assertion is the
+    // canary. Once green, the fix is upheld.
+    result.assert_meets();
+
+    // Keep handles alive across the measurement — drop them only here
+    // so the audio-thread dispatch sees rings whose `Arc::strong_count`
+    // is > 1 throughout, matching the live meter timer's behaviour.
+    drop(_input_handles);
+    drop(_stream_handles);
 }

--- a/crates/engine/src/audio_deadline_tests.rs
+++ b/crates/engine/src/audio_deadline_tests.rs
@@ -506,10 +506,15 @@ fn stereo_pipe_chain(label: &'static str) -> Chain {
 }
 
 #[test]
-#[cfg_attr(
-    debug_assertions,
-    ignore = "deadline tests require --release for meaningful timing"
-)]
+#[ignore = "issue #580: buffer=32 @48k has a 666 µs callback period — \
+ razor-thin under OS scheduler contention from PARALLEL test runs. The \
+ test catches a real production fragility (any preemption longer than \
+ one buffer = an audible click) but the default `cargo test` runs the \
+ full suite in parallel, which guarantees occasional false-positive \
+ overruns from unrelated test threads. To invoke this test reliably: \
+ `cargo test -p engine --release --lib audio_deadline -- --ignored \
+ --test-threads=1`. The engine-thread cost itself is well under budget \
+ (p50=0us, p99=1us) — this test pins that AND the OS-scheduler floor."]
 fn pipe_stereo_32_at_48000_meets_deadline_control_no_taps() {
     // 32 frames @ 48k — period 666 µs, the buffer size the user
     // reported as clean before the visualization work landed. Control:
@@ -528,10 +533,17 @@ fn pipe_stereo_32_at_48000_meets_deadline_control_no_taps() {
 }
 
 #[test]
-#[cfg_attr(
-    debug_assertions,
-    ignore = "deadline tests require --release for meaningful timing"
-)]
+#[ignore = "issue #580: see sibling control test. The audio-thread \
+ tap-dispatch cost itself is well under budget at buffer=32 (this test \
+ proves it offline: p50=0us, p99=0us, max=139us against 666us period). \
+ The user-reported regression — clean audio at buffer=32 before the \
+ meter work, dropouts after — is NOT a per-callback CPU cost; it is \
+ GUI-thread lock contention on `processing` via `stream_count()`, \
+ pinned by `runtime::stream_count_contention`. This test stays as a \
+ forward-looking guard-rail: any future refactor that puts real work \
+ into the per-sample tap push will fail it. Invoke with: \
+ `cargo test -p engine --release --lib audio_deadline -- --ignored \
+ --test-threads=1`."]
 fn pipe_stereo_32_at_48000_with_meter_taps_meets_deadline() {
     // Issue #580 regression pin. Same chain + same buffer as the
     // control above, but with the runtime taps the meter polling timer

--- a/crates/engine/src/audio_under_block_toggle_tests.rs
+++ b/crates/engine/src/audio_under_block_toggle_tests.rs
@@ -1,0 +1,186 @@
+//! THE RULE (issue #580 follow-up)
+//! ════════════════════════════════
+//!
+//! Toggling a block (enable / disable) must NEVER silence the audio
+//! callback. The user-facing symptom of this rule being broken is a
+//! click in the output the moment the block is toggled — exactly the
+//! artefact reported as residual on top of the #580 atomic-mirror fix.
+//!
+//! Concretely: `set_block_enabled` is the fast-path API that flips a
+//! `BlockRuntimeNode`'s `FadeState` in place (issue #522). If it
+//! holds the `processing` Mutex blocking while doing so, the audio
+//! thread's `try_lock` in `process_input_f32` (runtime.rs:102) fails
+//! for any in-flight callback — that buffer comes out silent
+//! (audible click at buffer = 32 @ 48 kHz). The fix, when this test
+//! fires red, is to make the toggle path lock-free with respect to
+//! the audio thread (atomic state transition + memory barrier; the
+//! audio thread reads the state under its existing `try_lock` of the
+//! per-input scratch and respects the transition naturally).
+//!
+//! How this test enforces the rule
+//! ───────────────────────────────
+//! - Build a runtime with a real DSP block (Core reverb / room) in
+//!   the chain. The block is the one the toggle thread flips.
+//! - Spawn a "toggle thread" that calls `set_block_enabled(..., true)`
+//!   / `(..., false)` in a tight loop — far higher rate than the
+//!   user can possibly click in the UI, to compress the contention
+//!   window into a short test.
+//! - On the test thread, drive 10k buffer=32 audio callbacks with a
+//!   constant non-zero input. After a warm-up so the elastic SPSC is
+//!   at steady state, any single silenced output buffer is conclusive
+//!   evidence that an audio callback was skipped (the try_lock failed
+//!   because the toggle was holding the lock at that instant).
+//!
+//! `#[ignore]` for the same reason as the other buffer=32 stress
+//! tests — sensitive to parallel-test scheduler load. Run serially:
+//!
+//! ```text
+//! cargo test -p engine --release --lib audio_under_block_toggle \
+//!   -- --ignored --test-threads=1
+//! ```
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use domain::ids::{BlockId, ChainId, DeviceId};
+use project::block::{
+    schema_for_block_model, AudioBlock, AudioBlockKind, CoreBlock, InputBlock, InputEntry,
+    OutputBlock, OutputEntry,
+};
+use project::chain::{Chain, ChainInputMode, ChainOutputMode};
+use project::param::ParameterSet;
+
+use super::{
+    build_chain_runtime_state, process_input_f32, process_output_f32, set_block_enabled,
+    DEFAULT_ELASTIC_TARGET,
+};
+
+const SR: f32 = 48_000.0;
+const BLOCK_ID: &str = "issue580:toggle-target";
+
+fn neutral_params(effect_type: &str, model: &str) -> ParameterSet {
+    let schema =
+        schema_for_block_model(effect_type, model).expect("schema must exist for test model");
+    ParameterSet::default()
+        .normalized_against(&schema)
+        .expect("defaults must normalize")
+}
+
+fn toggle_chain() -> Chain {
+    Chain {
+        id: ChainId("issue580-toggle-stress".into()),
+        description: Some("issue #580 block-toggle contention".into()),
+        instrument: "electric_guitar".into(),
+        enabled: true,
+        volume: 100.0,
+        blocks: vec![
+            AudioBlock {
+                id: BlockId("test:in".into()),
+                enabled: true,
+                kind: AudioBlockKind::Input(InputBlock {
+                    model: "standard".into(),
+                    entries: vec![InputEntry {
+                        device_id: DeviceId("dev".into()),
+                        mode: ChainInputMode::Mono,
+                        channels: vec![0],
+                    }],
+                }),
+            },
+            AudioBlock {
+                id: BlockId(BLOCK_ID.into()),
+                enabled: true,
+                kind: AudioBlockKind::Core(CoreBlock {
+                    effect_type: "reverb".into(),
+                    model: "room".into(),
+                    params: neutral_params("reverb", "room"),
+                }),
+            },
+            AudioBlock {
+                id: BlockId("test:out".into()),
+                enabled: true,
+                kind: AudioBlockKind::Output(OutputBlock {
+                    model: "standard".into(),
+                    entries: vec![OutputEntry {
+                        device_id: DeviceId("dev".into()),
+                        mode: ChainOutputMode::Stereo,
+                        channels: vec![0, 1],
+                    }],
+                }),
+            },
+        ],
+    }
+}
+
+#[test]
+#[ignore = "issue #580 follow-up: block-toggle contention. Sensitive to \
+ parallel-test scheduler load. Run serially: `cargo test -p engine \
+ --release --lib audio_under_block_toggle -- --ignored --test-threads=1`."]
+fn audio_callback_not_silenced_during_repeated_block_toggle() {
+    let runtime = Arc::new(
+        build_chain_runtime_state(&toggle_chain(), SR, &[DEFAULT_ELASTIC_TARGET])
+            .expect("runtime should build"),
+    );
+    let block_id = BlockId(BLOCK_ID.into());
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_toggle = Arc::clone(&stop);
+    let runtime_toggle = Arc::clone(&runtime);
+    let block_for_toggle = block_id.clone();
+
+    let toggle_thread = std::thread::spawn(move || {
+        let mut enabled = false;
+        while !stop_toggle.load(Ordering::Relaxed) {
+            // The user-visible "click on toggle" trace: every call to
+            // `set_block_enabled` is a potential contention window with
+            // the audio thread's `try_lock` on `processing`.
+            let _ = set_block_enabled(&runtime_toggle, &block_for_toggle, enabled);
+            enabled = !enabled;
+            std::thread::yield_now();
+        }
+    });
+
+    let buffer_frames = 32_usize;
+    let input_total_channels = 1_usize;
+    let output_total_channels = 2_usize;
+    let input_buf = vec![0.5_f32; buffer_frames * input_total_channels];
+    let mut output_buf = vec![0.0_f32; buffer_frames * output_total_channels];
+
+    // Warm-up so the elastic buffer + fade-in are at steady state. The
+    // measurement loop afterwards trusts that any silent output buffer
+    // is the direct consequence of an audio-thread try_lock failure.
+    for _ in 0..256 {
+        process_input_f32(&runtime, 0, &input_buf, input_total_channels);
+        process_output_f32(&runtime, 0, &mut output_buf, output_total_channels);
+    }
+
+    let iterations = 10_000_usize;
+    let mut silenced = 0_usize;
+    for _ in 0..iterations {
+        process_input_f32(&runtime, 0, &input_buf, input_total_channels);
+        process_output_f32(&runtime, 0, &mut output_buf, output_total_channels);
+        if output_buf.iter().all(|&s| s.abs() < 1e-6) {
+            silenced += 1;
+        }
+    }
+
+    stop.store(true, Ordering::Relaxed);
+    toggle_thread.join().expect("toggle thread joins cleanly");
+
+    eprintln!(
+        "[audio_under_block_toggle] {iterations} callbacks under repeated \
+         set_block_enabled storm: {silenced} silenced buffers"
+    );
+
+    assert_eq!(
+        silenced, 0,
+        "issue #580 residual: {silenced} of {iterations} audio callbacks \
+         emitted silence while `set_block_enabled` was being called \
+         repeatedly from another thread. The block-toggle fast path is \
+         still contending with the audio thread's processing.try_lock. \
+         Make the toggle path lock-free w.r.t. the audio thread — the \
+         FadeState transition can be an atomic store, the audio thread \
+         reads it under its existing per-callback try_lock and respects \
+         the transition naturally. Every silenced callback in this test \
+         is a click the user hears when toggling a block in the UI."
+    );
+}

--- a/crates/engine/src/audio_under_gui_pressure_tests.rs
+++ b/crates/engine/src/audio_under_gui_pressure_tests.rs
@@ -1,0 +1,183 @@
+//! THE RULE (issue #580 follow-up, broader scope)
+//! ═══════════════════════════════════════════════
+//!
+//! Under sustained polling from non-audio threads (GUI timer, MCP poll,
+//! observability tick), the audio thread's `process_input_f32` /
+//! `process_output_f32` callbacks **must keep producing audio every
+//! single callback**. Zero silenced buffers, zero gaps.
+//!
+//! Concretely: `process_input_f32` takes the `processing` Mutex via
+//! `try_lock` (engine/runtime.rs around line 102). When `try_lock`
+//! fails, the function returns early — no samples are pushed into the
+//! per-route SPSC, the output stage's next `pop` returns silence, and
+//! the user hears a click. The same failure mode covers any OTHER
+//! lock / allocation / syscall the audio path may grow over time.
+//!
+//! This test exercises the failure path indirectly without instrumenting
+//! production code: it drives N audio callbacks with a non-zero input
+//! signal while a parallel "GUI thread" hammers every `ChainRuntimeState`
+//! accessor we know the live GUI calls at sustained rate. After a brief
+//! warm-up (so the elastic buffer + fade-in are at steady state) any
+//! single missed `process_input_f32` will leave the SPSC route empty,
+//! and the subsequent `process_output_f32` will emit a buffer of zeros.
+//!
+//! - If zero silenced buffers: the audio callback survives sustained
+//!   GUI pressure for every accessor enumerated below. Any future click
+//!   regression is then **not** in this class — look elsewhere
+//!   (allocations on hot path, processor cost, OS scheduling).
+//! - If silenced buffers > 0: at least one accessor in `gui_thread`
+//!   below still contends with the audio thread. Identify it (binary
+//!   search by commenting accessors out, or instrument production with
+//!   a missed-callback counter) and fix at the source — never relax
+//!   this assertion.
+//!
+//! `#[ignore]` by default for the same reason as the buffer = 32
+//! deadline pair in `audio_deadline_tests.rs`: a tight loop with a
+//! background thread is sensitive to the full test suite's parallel
+//! scheduler load and would false-positive. Invoke serially:
+//!
+//! ```text
+//! cargo test -p engine --release --lib audio_under_gui_pressure \
+//!   -- --ignored --test-threads=1
+//! ```
+
+use crate::runtime::{
+    build_chain_runtime_state, process_input_f32, process_output_f32, DEFAULT_ELASTIC_TARGET,
+};
+use domain::ids::{BlockId, ChainId, DeviceId};
+use project::block::{
+    AudioBlock, AudioBlockKind, InputBlock, InputEntry, OutputBlock, OutputEntry,
+};
+use project::chain::{Chain, ChainInputMode, ChainOutputMode};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+fn chain() -> Chain {
+    Chain {
+        id: ChainId("issue580-stress".into()),
+        description: Some("issue #580 broader pressure test".into()),
+        instrument: "electric_guitar".into(),
+        enabled: true,
+        volume: 100.0,
+        blocks: vec![
+            AudioBlock {
+                id: BlockId("input:0".into()),
+                enabled: true,
+                kind: AudioBlockKind::Input(InputBlock {
+                    model: "standard".into(),
+                    entries: vec![InputEntry {
+                        device_id: DeviceId("dev".into()),
+                        mode: ChainInputMode::Stereo,
+                        channels: vec![0, 1],
+                    }],
+                }),
+            },
+            AudioBlock {
+                id: BlockId("output:0".into()),
+                enabled: true,
+                kind: AudioBlockKind::Output(OutputBlock {
+                    model: "standard".into(),
+                    entries: vec![OutputEntry {
+                        device_id: DeviceId("dev".into()),
+                        mode: ChainOutputMode::Stereo,
+                        channels: vec![0, 1],
+                    }],
+                }),
+            },
+        ],
+    }
+}
+
+#[test]
+#[ignore = "issue #580 follow-up: stress test sensitive to parallel \
+ scheduler load — run with `cargo test -p engine --release --lib \
+ audio_under_gui_pressure -- --ignored --test-threads=1`. Pins the \
+ broader invariant that NO ChainRuntimeState accessor called from a \
+ non-audio thread at sustained rate may silence an audio callback."]
+fn audio_callback_not_silenced_under_sustained_gui_polling() {
+    let runtime = Arc::new(
+        build_chain_runtime_state(&chain(), 48_000.0_f32, &[DEFAULT_ELASTIC_TARGET])
+            .expect("runtime should build"),
+    );
+
+    // Spawn the "GUI thread" — hammer every ChainRuntimeState accessor
+    // the live GUI calls at sustained rate. New accessor surfaces should
+    // be added here as they ship. The yield_now keeps the loop tight
+    // without monopolising one core.
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_gui = Arc::clone(&stop);
+    let runtime_gui = Arc::clone(&runtime);
+    let gui_thread = std::thread::spawn(move || {
+        while !stop_gui.load(Ordering::Relaxed) {
+            // Issue #580: this was the contended path pre-fix.
+            let _ = runtime_gui.stream_count();
+            // Cheap atomic reads — included so any future change that
+            // accidentally swaps an atomic for a locked structure is
+            // caught.
+            let _ = runtime_gui.is_output_muted();
+            let _ = runtime_gui.volume_pct();
+            std::thread::yield_now();
+        }
+    });
+
+    let buffer_frames = 32_usize;
+    let input_total_channels = 2_usize;
+    let output_total_channels = 2_usize;
+    let input_buf = vec![0.5_f32; buffer_frames * input_total_channels];
+    let mut output_buf = vec![0.0_f32; buffer_frames * output_total_channels];
+
+    // Warm-up: drive enough callbacks for the fade-in ramp and elastic
+    // pre-fill to settle. The route SPSC is then in steady state — any
+    // subsequent silenced input callback shows up as zero output.
+    for _ in 0..256 {
+        process_input_f32(&runtime, 0, &input_buf, input_total_channels);
+        process_output_f32(&runtime, 0, &mut output_buf, output_total_channels);
+    }
+
+    // Measure: count callbacks where the output is fully silent. Under
+    // the test scenario (constant non-zero input, no fade-in remaining,
+    // route SPSC primed) the only way a buffer comes out silent is if
+    // `process_input_f32` returned early and the SPSC pop found nothing.
+    let iterations = 10_000_usize;
+    let mut silenced_buffers = 0_usize;
+    let started = Instant::now();
+    for _ in 0..iterations {
+        process_input_f32(&runtime, 0, &input_buf, input_total_channels);
+        process_output_f32(&runtime, 0, &mut output_buf, output_total_channels);
+        if output_buf.iter().all(|&s| s.abs() < 1e-6) {
+            silenced_buffers += 1;
+        }
+    }
+    let elapsed = started.elapsed();
+
+    stop.store(true, Ordering::Relaxed);
+    gui_thread.join().expect("gui thread should join cleanly");
+
+    eprintln!(
+        "[audio_under_gui_pressure] {iterations} callbacks under sustained \
+         GUI polling: {silenced_buffers} silenced buffers in {elapsed:?}"
+    );
+
+    assert_eq!(
+        silenced_buffers, 0,
+        "issue #580 broader rule: {silenced_buffers} of {iterations} audio \
+         callbacks emitted a silent buffer while a parallel thread polled \
+         ChainRuntimeState accessors at sustained rate. Some accessor in \
+         the GUI thread above still contends with the audio path's \
+         try_lock — find which one and mirror its value into an atomic / \
+         ArcSwap updated at the rare write sites in runtime_graph.rs. \
+         Never relax this assertion: every silenced buffer is an audible \
+         click in production."
+    );
+
+    // Sanity bound on test duration — if the GUI thread starved the
+    // audio thread for many seconds we want a louder signal than the
+    // assert above. 10k callbacks at buffer=32 @ 48k = ~6.67 s of
+    // audio; allow 10× slack for the real wall clock of a busy CI box.
+    assert!(
+        elapsed < Duration::from_secs(70),
+        "test took {elapsed:?} — likely starvation/deadlock between the \
+         audio loop and the GUI poller; investigate the lock graph"
+    );
+}

--- a/crates/engine/src/block_enabled_fast_path_tests.rs
+++ b/crates/engine/src/block_enabled_fast_path_tests.rs
@@ -23,8 +23,8 @@ use project::chain::{Chain, ChainInputMode, ChainOutputMode};
 use project::param::ParameterSet;
 
 use super::{
-    build_chain_runtime_state, set_block_enabled, ChainRuntimeState, FadeState,
-    DEFAULT_ELASTIC_TARGET,
+    build_chain_runtime_state, process_input_f32, process_output_f32, set_block_enabled,
+    ChainRuntimeState, FadeState, DEFAULT_ELASTIC_TARGET,
 };
 
 const SR: f32 = 48_000.0;
@@ -95,6 +95,22 @@ fn build_runtime() -> Arc<ChainRuntimeState> {
     )
 }
 
+/// Drive one input + output callback. Issue #580 follow-up:
+/// `set_block_enabled` now queues the toggle on a lock-free
+/// `ArrayQueue` and the audio thread drains + applies it inside its
+/// own `processing` `try_lock` guard. So these tests must run at
+/// least one callback after the toggle to observe the resulting
+/// `fade_state` mutation / `error_queue` entry.
+fn drive_one_callback(runtime: &Arc<ChainRuntimeState>) {
+    let input_total_channels = 1_usize; // mono input per `test_chain`
+    let output_total_channels = 2_usize; // stereo output per `test_chain`
+    let frames = 32_usize;
+    let input_buf = vec![0.0_f32; frames * input_total_channels];
+    let mut output_buf = vec![0.0_f32; frames * output_total_channels];
+    process_input_f32(runtime, 0, &input_buf, input_total_channels);
+    process_output_f32(runtime, 0, &mut output_buf, output_total_channels);
+}
+
 fn block_fade_state(runtime: &ChainRuntimeState, block: &BlockId) -> Option<FadeState> {
     let processing = runtime.processing.lock().expect("lock processing");
     for input_state in processing.input_states.iter() {
@@ -118,7 +134,8 @@ fn set_block_enabled_false_transitions_to_fading_out_without_rebuild() {
         "block must start active or fading in, got {before:?}"
     );
 
-    set_block_enabled(&runtime, &block, false).expect("fast-path must succeed");
+    set_block_enabled(&runtime, &block, false).expect("queueing must succeed");
+    drive_one_callback(&runtime); // drain pending_block_toggles
 
     let after = block_fade_state(&runtime, &block).expect("block stays in runtime after disable");
     assert!(
@@ -132,8 +149,9 @@ fn set_block_enabled_true_after_disable_transitions_back_to_fading_in() {
     let runtime = build_runtime();
     let block = BlockId(BLOCK_ID.into());
 
-    set_block_enabled(&runtime, &block, false).expect("disable succeeds");
-    set_block_enabled(&runtime, &block, true).expect("re-enable succeeds");
+    set_block_enabled(&runtime, &block, false).expect("queue disable");
+    set_block_enabled(&runtime, &block, true).expect("queue re-enable");
+    drive_one_callback(&runtime); // drain both queued toggles
 
     let after = block_fade_state(&runtime, &block).expect("block stays in runtime");
     assert!(
@@ -143,13 +161,30 @@ fn set_block_enabled_true_after_disable_transitions_back_to_fading_in() {
 }
 
 #[test]
-fn set_block_enabled_unknown_block_returns_err_without_mutation() {
+fn set_block_enabled_unknown_block_posts_error_to_error_queue() {
+    // Issue #580 follow-up: `set_block_enabled` now returns Ok if the
+    // toggle was queued successfully — the per-block lookup (and its
+    // "not found" diagnosis) happens on the audio thread, which posts
+    // the failure to the runtime's `error_queue` for the GUI to drain
+    // via `poll_errors`. Pin the new contract.
     let runtime = build_runtime();
     let missing = BlockId("does:not:exist".into());
 
     let result = set_block_enabled(&runtime, &missing, false);
     assert!(
-        result.is_err(),
-        "missing block must yield Err, got {result:?}"
+        result.is_ok(),
+        "queueing must succeed even for an unknown block id, got {result:?}"
+    );
+
+    drive_one_callback(&runtime); // audio thread drains + diagnoses
+
+    let errors = runtime.poll_errors();
+    let saw_not_found = errors
+        .iter()
+        .any(|e| e.block_id == missing && e.message.contains("not found"));
+    assert!(
+        saw_not_found,
+        "audio thread must post a 'not found' BlockError for the missing \
+         block id, got {errors:?}"
     );
 }

--- a/crates/engine/src/runtime.rs
+++ b/crates/engine/src/runtime.rs
@@ -743,6 +743,10 @@ mod rig_spillover;
 mod audio_deadline;
 
 #[cfg(test)]
+#[path = "stream_count_contention_tests.rs"]
+mod stream_count_contention;
+
+#[cfg(test)]
 #[path = "audio_signal_integrity_tests.rs"]
 mod audio_signal_integrity;
 

--- a/crates/engine/src/runtime.rs
+++ b/crates/engine/src/runtime.rs
@@ -747,6 +747,10 @@ mod audio_deadline;
 mod stream_count_contention;
 
 #[cfg(test)]
+#[path = "audio_under_gui_pressure_tests.rs"]
+mod audio_under_gui_pressure;
+
+#[cfg(test)]
 #[path = "audio_signal_integrity_tests.rs"]
 mod audio_signal_integrity;
 

--- a/crates/engine/src/runtime.rs
+++ b/crates/engine/src/runtime.rs
@@ -104,6 +104,15 @@ pub fn process_input_f32(
         Err(_) => return,
     };
 
+    // Issue #580 follow-up: drain queued block-toggle requests inside
+    // the same lock we already hold. The GUI thread's
+    // `set_block_enabled` is now lock-free (push to ArrayQueue) so it
+    // never contends with this `try_lock` — the click the user heard
+    // on every UI block on/off is gone. Cheap: the queue is empty in
+    // steady state, a `pop` is two atomic ops, and a non-empty drain
+    // does one in-place walk over `input_states.blocks` per toggle.
+    crate::runtime_block_toggle::drain_pending_block_toggles(runtime, &mut processing_guard);
+
     // If a latency probe is armed, replace the first portion of this
     // callback's input with a short sine beep and record the injection
     // time. Only the primary input (index 0) probes so we measure the
@@ -753,6 +762,10 @@ mod audio_under_gui_pressure;
 #[cfg(test)]
 #[path = "audio_alloc_invariant_tests.rs"]
 mod audio_alloc_invariant;
+
+#[cfg(test)]
+#[path = "audio_under_block_toggle_tests.rs"]
+mod audio_under_block_toggle;
 
 #[cfg(test)]
 #[path = "audio_signal_integrity_tests.rs"]

--- a/crates/engine/src/runtime.rs
+++ b/crates/engine/src/runtime.rs
@@ -751,6 +751,10 @@ mod stream_count_contention;
 mod audio_under_gui_pressure;
 
 #[cfg(test)]
+#[path = "audio_alloc_invariant_tests.rs"]
+mod audio_alloc_invariant;
+
+#[cfg(test)]
 #[path = "audio_signal_integrity_tests.rs"]
 mod audio_signal_integrity;
 

--- a/crates/engine/src/runtime_block_toggle.rs
+++ b/crates/engine/src/runtime_block_toggle.rs
@@ -13,31 +13,100 @@
 //! Extracted as its own module to keep `runtime_graph.rs` within the
 //! 600-LOC file cap (it was already at the limit). Re-exported through
 //! `runtime.rs` so callers keep using the `engine::runtime::*` path.
+//!
+//! Issue #580 follow-up: queue the toggle instead of taking
+//! `processing.lock()`
+//! ─────────────────────────────────────────────────────────────────
+//!
+//! The original implementation took `processing.lock()` BLOCKING on the
+//! GUI thread and walked `input_states.blocks` in place. While that
+//! looked cheap (a single in-place mutation), the audio thread's
+//! `process_input_f32` acquires the same Mutex via `try_lock` and
+//! returns early — emitting a silent buffer — whenever the try_lock
+//! fails. With the OS preempting the GUI thread mid-toggle, that
+//! produced an audible click on every UI block on/off at buffer = 32
+//! (`audio_under_block_toggle_tests` reported 315 / 10 000 silenced
+//! buffers under stress).
+//!
+//! The fix moves the mutation to the audio thread's own callback:
+//!   - `set_block_enabled` (GUI) pushes `(BlockId, enabled)` to a
+//!     lock-free `ArrayQueue` on the runtime. No `processing.lock()`,
+//!     no contention with the audio thread.
+//!   - `drain_pending_block_toggles` runs inside the audio thread's
+//!     existing `try_lock`'d section in `process_input_f32`. It walks
+//!     `input_states.blocks` and applies each queued toggle in place,
+//!     transitioning `fade_state` so the existing click-safe crossfade
+//!     handles the audible change.
+//!
+//! Failure modes that used to return `Err` synchronously now post to
+//! the runtime's `error_queue` (the existing audio-side error channel
+//! the UI already drains via `poll_errors`). The two existing failure
+//! shapes are preserved:
+//!   - re-enabling a block whose live node is a `RuntimeProcessor::Bypass`
+//!     (needs a full rebuild — message starts with "needs full rebuild").
+//!   - the block id is not present in any input runtime of the chain
+//!     (caller bug — message starts with "not found").
+//! The only synchronous error that survives is "the toggle queue is
+//! full", which in practice means the audio thread has stalled and the
+//! GUI is faster than the drain — a louder bug than a dropped toggle.
 
 use anyhow::{anyhow, Result};
 
 use domain::ids::BlockId;
 
 use crate::runtime::FADE_IN_FRAMES;
-use crate::runtime_state::{lock_recover, ChainRuntimeState, FadeState, RuntimeProcessor};
+use crate::runtime_state::{
+    BlockError, ChainProcessingState, ChainRuntimeState, FadeState, RuntimeProcessor,
+};
 
-/// Toggle the `enabled` flag of a block in a live chain runtime. Walks
-/// every per-input `ChainProcessingState` of `runtime`, finds the
-/// matching `BlockRuntimeNode` by id, and flips its `fade_state` so the
-/// audio thread crossfades on the next callback. No chain re-resolve,
-/// no processor rebuild, no CPAL queries.
+/// Queue a per-block enabled flip for the audio thread to apply on its
+/// next callback. Returns `Err` only if the queue is full (the audio
+/// thread is not draining — a stall louder than a dropped toggle).
 ///
-/// Returns `Err` when:
-/// - the block id is not found in any input runtime (caller can fall
-///   back to a full `upsert_chain`); or
-/// - re-enabling a block whose live node is a `RuntimeProcessor::Bypass`
-///   (it has no real processor to fade in — needs a full rebuild).
+/// The actual mutation runs on the audio thread inside
+/// [`drain_pending_block_toggles`]. Per-block failures (Bypass needing
+/// rebuild, block id not found) are posted to the runtime's
+/// `error_queue` for the GUI to drain via `poll_errors`.
 pub fn set_block_enabled(
     runtime: &ChainRuntimeState,
     block_id: &BlockId,
     enabled: bool,
 ) -> Result<()> {
-    let mut processing = lock_recover(&runtime.processing, "chain runtime");
+    runtime
+        .pending_block_toggles
+        .push((block_id.clone(), enabled))
+        .map_err(|_| anyhow!("block-toggle queue full — audio thread stalled?"))
+}
+
+/// Drain every queued toggle and apply it in place. Called by the audio
+/// thread from `process_input_f32`, inside the `processing` try_lock
+/// guard — so the GUI thread's `set_block_enabled` never needs to take
+/// the lock at all.
+///
+/// Returns the number of toggles applied (for tests / instrumentation).
+pub(crate) fn drain_pending_block_toggles(
+    runtime: &ChainRuntimeState,
+    processing: &mut ChainProcessingState,
+) -> usize {
+    let mut applied = 0;
+    while let Some((block_id, enabled)) = runtime.pending_block_toggles.pop() {
+        apply_block_toggle(processing, &block_id, enabled, runtime);
+        applied += 1;
+    }
+    applied
+}
+
+/// In-place mutation that flips `fade_state` for every node matching
+/// `block_id` across every per-input runtime of the chain. Mirrors the
+/// pre-#580 inline implementation but never takes the `processing`
+/// lock itself (the audio-thread caller already holds it via
+/// `process_input_f32`'s try_lock guard).
+fn apply_block_toggle(
+    processing: &mut ChainProcessingState,
+    block_id: &BlockId,
+    enabled: bool,
+    runtime: &ChainRuntimeState,
+) {
     let mut touched = 0usize;
     for input_state in processing.input_states.iter_mut() {
         for node in input_state.blocks.iter_mut() {
@@ -45,10 +114,14 @@ pub fn set_block_enabled(
                 continue;
             }
             if enabled && matches!(node.processor, RuntimeProcessor::Bypass) {
-                return Err(anyhow!(
-                    "block '{}' has no live processor — needs full rebuild to re-enable",
-                    block_id.0
-                ));
+                let _ = runtime.error_queue.push(BlockError {
+                    block_id: block_id.clone(),
+                    message: format!(
+                        "block '{}' has no live processor — needs full rebuild to re-enable",
+                        block_id.0
+                    ),
+                });
+                continue;
             }
             let was_enabled = node.block_snapshot.enabled;
             if was_enabled != enabled {
@@ -67,10 +140,12 @@ pub fn set_block_enabled(
         }
     }
     if touched == 0 {
-        return Err(anyhow!(
-            "block '{}' not found in any input runtime of the chain",
-            block_id.0
-        ));
+        let _ = runtime.error_queue.push(BlockError {
+            block_id: block_id.clone(),
+            message: format!(
+                "block '{}' not found in any input runtime of the chain",
+                block_id.0
+            ),
+        });
     }
-    Ok(())
 }

--- a/crates/engine/src/runtime_graph.rs
+++ b/crates/engine/src/runtime_graph.rs
@@ -362,6 +362,12 @@ fn assemble_chain_runtime_state(
         .map(|_| InputCallbackScratch::default())
         .collect();
 
+    // Issue #580: lock-free mirror of `input_states.len()` for the meter
+    // polling timer to read at 30 Hz without contending with the audio
+    // thread's `processing` try_lock. Captured before the Vec moves into
+    // the Mutex.
+    let initial_stream_count = input_states.len();
+
     Ok(ChainRuntimeState {
         processing: Mutex::new(ChainProcessingState {
             input_states,
@@ -383,6 +389,7 @@ fn assemble_chain_runtime_state(
         // de unity isolado (probe runtimes de latência) sobrescrevem com
         // `set_volume_pct(100.0)` depois.
         volume_pct_bits: std::sync::atomic::AtomicU32::new(chain.volume.to_bits()),
+        stream_count: std::sync::atomic::AtomicUsize::new(initial_stream_count),
     })
 }
 
@@ -644,6 +651,16 @@ fn update_chain_runtime_state_impl(
     {
         let mut processing = lock_recover(&runtime.processing, "chain runtime");
         processing.input_states = new_input_states;
+        // Issue #580: keep the lock-free `stream_count` mirror in sync
+        // with the new Vec length. Updated INSIDE the same critical
+        // section that swaps the Vec so any concurrent reader sees a
+        // consistent (new Vec length, new count) pair after the lock
+        // releases. Relaxed ordering — the value is purely advisory for
+        // the meter timer's subscription loop.
+        runtime.stream_count.store(
+            processing.input_states.len(),
+            std::sync::atomic::Ordering::Relaxed,
+        );
 
         // Rebuild input_to_segments mapping from current segments
         let max_input_idx = segments

--- a/crates/engine/src/runtime_graph.rs
+++ b/crates/engine/src/runtime_graph.rs
@@ -390,6 +390,11 @@ fn assemble_chain_runtime_state(
         // `set_volume_pct(100.0)` depois.
         volume_pct_bits: std::sync::atomic::AtomicU32::new(chain.volume.to_bits()),
         stream_count: std::sync::atomic::AtomicUsize::new(initial_stream_count),
+        // Issue #580 follow-up: GUI block-toggle is queued and drained
+        // on the audio thread inside its own `processing` lock,
+        // removing the GUI/audio Mutex contention that caused an
+        // audible click on every block on/off at small buffer sizes.
+        pending_block_toggles: ArrayQueue::new(64),
     })
 }
 

--- a/crates/engine/src/runtime_state.rs
+++ b/crates/engine/src/runtime_state.rs
@@ -312,6 +312,21 @@ pub struct ChainRuntimeState {
     /// seeing the old count just defers an extra subscription to the
     /// next tick. No synchronisation with audio-thread state needed.
     pub(crate) stream_count: AtomicUsize,
+    /// Lock-free producer/consumer queue for pending block-toggle
+    /// requests (issue #580 follow-up). The GUI's
+    /// `Command::ToggleBlockEnabled` handler calls `set_block_enabled`,
+    /// which pushes `(block_id, enabled)` here without taking any lock.
+    /// The audio thread drains and applies the toggle inside its
+    /// `process_input_f32` `try_lock`'d section (one cheap walk over
+    /// `input_states.blocks`, in place). Result: the GUI thread NEVER
+    /// holds `processing`, so the audio thread's `try_lock` never fails
+    /// because of a user toggle — the click the user heard on every
+    /// block on/off is gone. Capacity 64 is far above the user's
+    /// per-frame click rate (the audio drain runs at hundreds of Hz),
+    /// so a queue overflow in practice would mean the audio thread has
+    /// stalled — which is a louder bug than a dropped toggle. The
+    /// `set_block_enabled` API still surfaces such overflows as `Err`.
+    pub(crate) pending_block_toggles: ArrayQueue<(BlockId, bool)>,
 }
 
 impl ChainRuntimeState {

--- a/crates/engine/src/runtime_state.rs
+++ b/crates/engine/src/runtime_state.rs
@@ -25,7 +25,7 @@
 //!     modules.
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicU8, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicU8, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use arc_swap::ArcSwap;
@@ -299,6 +299,19 @@ pub struct ChainRuntimeState {
     /// f32 armazenado como u32 bits (Relaxed ordering é suficiente — não há
     /// sincronização com outras escritas).
     pub(crate) volume_pct_bits: AtomicU32,
+    /// Lock-free mirror of `processing.input_states.len()` (issue #580).
+    /// The meter polling timer calls `stream_count` at 30 Hz on the GUI
+    /// thread — reading it through the `processing` Mutex contends with
+    /// the audio thread's `process_input_f32 → try_lock`, and a failed
+    /// try_lock there means the callback emits silence (audible click at
+    /// small buffer sizes). `input_states.len()` only changes on runtime
+    /// build / rebuild in `runtime_graph`, so a single `AtomicUsize`
+    /// updated at those two sites is sufficient — readers never block
+    /// the audio thread. Relaxed ordering: the value is purely
+    /// informational for the GUI's subscription loop; a reader briefly
+    /// seeing the old count just defers an extra subscription to the
+    /// next tick. No synchronisation with audio-thread state needed.
+    pub(crate) stream_count: AtomicUsize,
 }
 
 impl ChainRuntimeState {
@@ -453,11 +466,14 @@ impl ChainRuntimeState {
     /// How many streams this chain currently runs (one per
     /// `InputProcessingState`). Used by the UI to know how many
     /// per-stream taps to subscribe.
+    ///
+    /// Reads a lock-free atomic mirror updated by `runtime_graph` on
+    /// build / rebuild (issue #580). Never blocks — the meter polling
+    /// timer calls this at 30 Hz on the GUI thread, and any lock taken
+    /// here contends with the audio thread's `try_lock` on
+    /// `processing`, silencing callbacks at small buffer sizes.
     pub fn stream_count(&self) -> usize {
-        self.processing
-            .lock()
-            .map(|p| p.input_states.len())
-            .unwrap_or(0)
+        self.stream_count.load(Ordering::Relaxed)
     }
 
     /// For a given LOCAL stream index in this runtime

--- a/crates/engine/src/stream_count_contention_tests.rs
+++ b/crates/engine/src/stream_count_contention_tests.rs
@@ -1,42 +1,78 @@
-//! Issue #580: `ChainRuntimeState::stream_count` must not block on the
-//! `processing` Mutex.
+//! THE RULE (issue #580, pinned forever)
+//! ═══════════════════════════════════════
+//!
+//! Any method on `ChainRuntimeState` that is callable from a non-audio
+//! thread at sustained rate (GUI timer, MCP poll, observability tick)
+//! **MUST NOT acquire `processing` (or any other Mutex shared with the
+//! audio thread)**, not even with `try_lock`. Use a lock-free atomic
+//! mirror updated at the rare write sites in `runtime_graph.rs`
+//! (`build_chain_runtime_state` + the rebuild step that swaps
+//! `input_states`) instead.
+//!
+//! If a new accessor needs a value that lives behind the Mutex, mirror
+//! it into an atomic (or `ArcSwap`) at the write sites — do not push
+//! the cost onto the read path. CLAUDE.md invariant #8 ("zero lock on
+//! the audio thread") covers this in spirit: a Mutex the audio thread
+//! `try_lock`s is still a synchronisation point, and *every* contention
+//! window the read side opens is a callback the audio thread skips.
 //!
 //! Why this is load-bearing
 //! ────────────────────────
 //! The audio thread enters `process_input_f32` and calls
 //! `runtime.processing.try_lock()` (engine/runtime.rs around line 102).
-//! If the lock is held, the callback returns early — **no samples are
-//! pushed to any output route for that buffer**. The Latency-probe
-//! comment in `process_input_f32` already documents this as a tolerable
-//! event "during a config rebuild in flight" — i.e. very rare.
+//! When the lock is held by another thread, the call returns Err and the
+//! callback **emits no samples for that buffer**. The latency-probe
+//! comment in `process_input_f32` documents that as tolerable "during a
+//! config rebuild in flight" — i.e. a write event that fires once per
+//! preset switch / block add-remove / rig-nav. Any *read* accessor that
+//! takes the same lock at high rate breaks the rare-event assumption,
+//! producing audible clicks at small buffer sizes.
 //!
-//! `ChainRuntimeState::stream_count` taking a *blocking* `.lock()` on the
-//! same Mutex breaks that "rare event" assumption. The meter polling
-//! timer (`adapter-gui/src/meter_wiring.rs::start_meter_polling`, wired
-//! from `desktop_app.rs:353`) calls it **once per chain at 30 Hz** —
-//! steady state, for the life of the session, regardless of whether any
-//! visualisation window is open.
+//! The symptom is buffer-size dependent: at buffer = 32 frames @ 48 kHz
+//! (callback period ≈ 666 µs), even a single OS preemption that holds
+//! the GUI thread mid-`lock()` blows the window — the missed input
+//! callback is felt at output because the elastic SPSC ring between the
+//! two stages only buffers `buffer_size` samples of upstream headroom.
+//! At buffer = 256 (≈ 5.3 ms) the window is 8× larger AND the ring
+//! holds 8× more headroom, so misses are absorbed silently. Offline
+//! single-threaded deadline tests **cannot reproduce this** — they need
+//! the contention between threads that only this kind of test
+//! simulates.
 //!
-//! Whenever the GUI thread is holding `processing` to read its length,
-//! the audio thread's `try_lock` fails and the callback emits silence.
-//! At buffer = 32 frames @ 48 kHz (callback period ≈ 666 µs), any
-//! OS-level preemption holding the GUI mid-lock blows the window. At
-//! buffer = 256 (≈ 5.3 ms), the window is 8× larger and the elastic
-//! output buffer absorbs the dropouts — which is exactly the regression
-//! reported in #580 ("had to raise the buffer from 32 to 256 to get
-//! clean audio after the per-stream meters landed").
+//! Case study — the regression this test pins
+//! ──────────────────────────────────────────
+//! Pre-fix, `ChainRuntimeState::stream_count()` was implemented as
+//! `processing.lock().map(|p| p.input_states.len())` (runtime_state.rs).
+//! The meter polling timer
+//! `adapter-gui/src/meter_wiring.rs::start_meter_polling` (wired from
+//! `desktop_app.rs:353`) calls `controller.stream_count(&chain.id)` at
+//! 30 Hz from app startup, **per chain, regardless of any visualisation
+//! window being open**. Two chains = 60 blocking lock acquisitions per
+//! second on the GUI thread, sustained for the life of the session.
+//! Users hit dropouts at buffer = 32 that disappeared at buffer = 256
+//! — exact 8× ratio matching the window/headroom analysis above.
 //!
-//! `input_states.len()` only changes on runtime build / rebuild
-//! (`runtime_graph::build_chain_runtime_state` and the rebuild path in
-//! the same file). Both are infrequent. So `stream_count` does not need
-//! the lock at all — it can read an `AtomicUsize` mirror updated at
-//! those two sites.
+//! Fix: `stream_count` reads an `AtomicUsize` mirror updated by
+//! `build_chain_runtime_state` and the rebuild path in
+//! `runtime_graph.rs` (both rare). The accessor is lock-free.
 //!
-//! This test holds the `processing` Mutex on the test thread (simulating
-//! the audio thread mid-callback) and asserts that another thread can
-//! call `stream_count()` without blocking. The current implementation
-//! fails this — the call blocks forever and the channel timeout fires.
-//! After the fix lands, it passes immediately.
+//! How this test enforces the rule
+//! ───────────────────────────────
+//! The test thread holds `runtime.processing` for the duration of the
+//! check (standing in for the audio thread mid-callback). A second
+//! thread calls `stream_count()` and tries to deliver its result back
+//! through a channel; the test thread expects the result inside a tight
+//! timeout. If `stream_count()` ever tries to acquire the same Mutex
+//! (whether `.lock()` blocking OR `.try_lock()` followed by a fallback
+//! that depends on the lock being free), the channel never receives and
+//! the timeout fires with the error message below — pointing the next
+//! contributor directly at the rule.
+//!
+//! This test fires red on the regression pattern, regardless of which
+//! specific accessor introduced it. If a future change adds another
+//! GUI-callable read on `ChainRuntimeState` that takes `processing`,
+//! adapt this test to cover the new accessor too (one-test-per-pattern
+//! is fine; do not delete the existing one to "save lines").
 
 use crate::runtime::{build_chain_runtime_state, DEFAULT_ELASTIC_TARGET};
 use domain::ids::{BlockId, ChainId, DeviceId};
@@ -117,12 +153,19 @@ fn stream_count_does_not_block_on_processing_lock() {
     let received = rx.recv_timeout(Duration::from_millis(200));
     assert!(
         received.is_ok(),
-        "issue #580: stream_count() blocked on the processing Mutex. \
-         The meter polling timer calls it at 30 Hz on the GUI thread; \
-         while it holds the lock the audio thread's process_input_f32 \
-         try_lock fails and the callback emits silence. stream_count() \
-         must read a lock-free atomic mirror so it never contends with \
-         the audio callback."
+        "THE RULE (issue #580): a non-audio-thread accessor on \
+         ChainRuntimeState — `stream_count` here, but the rule applies \
+         to every GUI / MCP / observability poll — must NOT acquire the \
+         `processing` Mutex, not even with try_lock. The audio thread \
+         takes that Mutex via try_lock in process_input_f32 and skips \
+         the entire callback (emitting silence) whenever the try_lock \
+         fails. At 30 Hz from the meter polling timer the GUI thread \
+         opens enough contention windows that buffer=32 @48k cannot \
+         stay glitch-free, while buffer=256 hides it via elastic-buffer \
+         headroom. Fix: mirror the needed value into an AtomicUsize / \
+         ArcSwap updated at the rare write sites in runtime_graph.rs \
+         (build + rebuild). See the module docstring for the full \
+         pattern."
     );
 
     let count = received.unwrap();

--- a/crates/engine/src/stream_count_contention_tests.rs
+++ b/crates/engine/src/stream_count_contention_tests.rs
@@ -1,0 +1,133 @@
+//! Issue #580: `ChainRuntimeState::stream_count` must not block on the
+//! `processing` Mutex.
+//!
+//! Why this is load-bearing
+//! ────────────────────────
+//! The audio thread enters `process_input_f32` and calls
+//! `runtime.processing.try_lock()` (engine/runtime.rs around line 102).
+//! If the lock is held, the callback returns early — **no samples are
+//! pushed to any output route for that buffer**. The Latency-probe
+//! comment in `process_input_f32` already documents this as a tolerable
+//! event "during a config rebuild in flight" — i.e. very rare.
+//!
+//! `ChainRuntimeState::stream_count` taking a *blocking* `.lock()` on the
+//! same Mutex breaks that "rare event" assumption. The meter polling
+//! timer (`adapter-gui/src/meter_wiring.rs::start_meter_polling`, wired
+//! from `desktop_app.rs:353`) calls it **once per chain at 30 Hz** —
+//! steady state, for the life of the session, regardless of whether any
+//! visualisation window is open.
+//!
+//! Whenever the GUI thread is holding `processing` to read its length,
+//! the audio thread's `try_lock` fails and the callback emits silence.
+//! At buffer = 32 frames @ 48 kHz (callback period ≈ 666 µs), any
+//! OS-level preemption holding the GUI mid-lock blows the window. At
+//! buffer = 256 (≈ 5.3 ms), the window is 8× larger and the elastic
+//! output buffer absorbs the dropouts — which is exactly the regression
+//! reported in #580 ("had to raise the buffer from 32 to 256 to get
+//! clean audio after the per-stream meters landed").
+//!
+//! `input_states.len()` only changes on runtime build / rebuild
+//! (`runtime_graph::build_chain_runtime_state` and the rebuild path in
+//! the same file). Both are infrequent. So `stream_count` does not need
+//! the lock at all — it can read an `AtomicUsize` mirror updated at
+//! those two sites.
+//!
+//! This test holds the `processing` Mutex on the test thread (simulating
+//! the audio thread mid-callback) and asserts that another thread can
+//! call `stream_count()` without blocking. The current implementation
+//! fails this — the call blocks forever and the channel timeout fires.
+//! After the fix lands, it passes immediately.
+
+use crate::runtime::{build_chain_runtime_state, DEFAULT_ELASTIC_TARGET};
+use domain::ids::{BlockId, ChainId, DeviceId};
+use project::block::{
+    AudioBlock, AudioBlockKind, InputBlock, InputEntry, OutputBlock, OutputEntry,
+};
+use project::chain::{Chain, ChainInputMode, ChainOutputMode};
+use std::sync::mpsc;
+use std::sync::Arc;
+use std::time::Duration;
+
+fn input_stereo(channels: Vec<usize>) -> AudioBlock {
+    AudioBlock {
+        id: BlockId("input:0".into()),
+        enabled: true,
+        kind: AudioBlockKind::Input(InputBlock {
+            model: "standard".into(),
+            entries: vec![InputEntry {
+                device_id: DeviceId("dev".into()),
+                mode: ChainInputMode::Stereo,
+                channels,
+            }],
+        }),
+    }
+}
+
+fn output_stereo(channels: Vec<usize>) -> AudioBlock {
+    AudioBlock {
+        id: BlockId("output:0".into()),
+        enabled: true,
+        kind: AudioBlockKind::Output(OutputBlock {
+            model: "standard".into(),
+            entries: vec![OutputEntry {
+                device_id: DeviceId("dev".into()),
+                mode: ChainOutputMode::Stereo,
+                channels,
+            }],
+        }),
+    }
+}
+
+fn chain() -> Chain {
+    Chain {
+        id: ChainId("issue580-contention".into()),
+        description: Some("issue #580 stream_count contention test".into()),
+        instrument: "electric_guitar".into(),
+        enabled: true,
+        volume: 100.0,
+        blocks: vec![input_stereo(vec![0, 1]), output_stereo(vec![0, 1])],
+    }
+}
+
+#[test]
+fn stream_count_does_not_block_on_processing_lock() {
+    let runtime = Arc::new(
+        build_chain_runtime_state(&chain(), 48_000.0_f32, &[DEFAULT_ELASTIC_TARGET])
+            .expect("runtime should build"),
+    );
+
+    // Simulate the audio thread mid-callback: hold `processing`.
+    let _guard = runtime
+        .processing
+        .lock()
+        .expect("processing lock should be held cleanly for the test");
+
+    // Now call `stream_count()` from another thread. If it takes the
+    // same Mutex (current behaviour, pre-fix), it blocks forever and
+    // the channel `recv_timeout` returns `Err`. After the fix lands —
+    // reading an `AtomicUsize` mirror updated by build / rebuild — it
+    // returns immediately.
+    let runtime_clone = Arc::clone(&runtime);
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let count = runtime_clone.stream_count();
+        let _ = tx.send(count);
+    });
+
+    let received = rx.recv_timeout(Duration::from_millis(200));
+    assert!(
+        received.is_ok(),
+        "issue #580: stream_count() blocked on the processing Mutex. \
+         The meter polling timer calls it at 30 Hz on the GUI thread; \
+         while it holds the lock the audio thread's process_input_f32 \
+         try_lock fails and the callback emits silence. stream_count() \
+         must read a lock-free atomic mirror so it never contends with \
+         the audio callback."
+    );
+
+    let count = received.unwrap();
+    assert_eq!(
+        count, 1,
+        "single-stream stereo chain should report exactly 1 stream"
+    );
+}


### PR DESCRIPTION
## Summary

- Root-cause and fix the user-reported regression in #580: clean audio at device buffer = 32 frames @ 48 kHz before the per-stream meters landed, dropouts after — only mitigated by raising the buffer to 256. Both contributing causes were the SAME class: a non-audio thread held the same `processing` Mutex the audio thread takes via `try_lock` in `process_input_f32`, the OS preempted it mid-hold, the audio thread's try_lock failed, the callback emitted silence (audible click).
- **Fix 1** — `ChainRuntimeState::stream_count` was a blocking `processing.lock()`. The meter polling timer calls it at 30 Hz per chain. Replaced with `AtomicUsize::load(Relaxed)`, updated by `build_chain_runtime_state` + the rebuild step that swaps `input_states` (both rare).
- **Fix 2** — `set_block_enabled` was a blocking `processing.lock()` walk over `input_states.blocks`. User-reported residual: an audible click on every UI block on/off. Replaced with a lock-free `ArrayQueue<(BlockId, bool)>` on the runtime; the audio thread drains and applies queued toggles inside the `try_lock` guard it already holds for its own DSP. Per-toggle precondition failures move from synchronous `Err` to the existing `error_queue` channel — which means the GUI's "fall back to upsert_chain on Err" path is lost for the Bypass case. If that turns out to be load-bearing for a real recovery flow, follow-up needs to surface the async error to the application command handler.

## Tests

Five regression-pin tests live in `crates/engine/src/`. The contention test (Fix 1) runs in the default suite. The four stress / invariant tests are `#[ignore]` because they are sensitive to parallel test-suite scheduler load; each one documents in its docstring how to invoke serially.

- `stream_count_contention_tests.rs` — holds `processing` on the test thread and asserts another thread can call `stream_count()` without blocking. Pins THE RULE (issue #580): no non-audio-thread accessor on `ChainRuntimeState` may take a Mutex shared with the audio thread.
- `audio_under_gui_pressure_tests.rs` — 10 000 buffer = 32 callbacks while a parallel thread polls every `ChainRuntimeState` accessor the live GUI calls at sustained rate; asserts zero silenced output buffers. Broader rule pin, catches any future accessor that re-introduces blocking-lock behaviour.
- `audio_alloc_invariant_tests.rs` — installs a counting `#[global_allocator]` (gated `#[cfg(test)]`, production binaries keep the System allocator) and asserts the engine framework allocates 0 times across 1 000 buffer = 32 callbacks. Pins CLAUDE.md invariant #8.
- `audio_under_block_toggle_tests.rs` — 10 000 buffer = 32 callbacks while a parallel thread spams `set_block_enabled`. Was the red test for Fix 2: 315 / 10 000 silenced buffers pre-fix, 0 / 10 000 post-fix.
- `audio_deadline_tests.rs` (existing file) gains the buffer = 32 @ 48 k pair (control + with meter-style taps registered) as forward-looking guard-rails for engine-thread CPU at the tightest realistic buffer.

## Test plan

- [ ] `cargo test -p engine --release --lib` is green (532 passed, 16 ignored, 0 failed on this branch).
- [ ] `cargo test -p engine --release --lib stream_count_contention -- --test-threads=1` — green (pinned: lock-free `stream_count`).
- [ ] `cargo test -p engine --release --lib audio_under_gui_pressure -- --ignored --test-threads=1` — green (broader rule).
- [ ] `cargo test -p engine --release --lib audio_alloc_invariant -- --ignored --test-threads=1` — green (zero allocs on the audio thread).
- [ ] `cargo test -p engine --release --lib audio_under_block_toggle -- --ignored --test-threads=1` — green (lock-free block toggle).
- [ ] `cargo test -p engine --release --lib audio_deadline -- --ignored --test-threads=1` — green (buffer = 32 @ 48 k engine CPU floor).
- [ ] On the user's Mac: load the Nirvana preset on the "guitarra setlist" chain at buffer = 32, confirm clean audio; toggle the chain enabled / blocks enabled in the UI, confirm no audible click on either operation.
- [ ] Chain-toggle resume (`pause_chain` → re-enable through `upsert_chain` rebuild) still takes the lock during its rebuild step. If a click is audible specifically when re-enabling a paused chain, that needs a follow-up issue (already on the table — same regression CLASS, different code path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)