### PR TITLE
fix(#581): audio device row — ComboBox clicks no longer deselect; Apply now persists across restarts

### DIFF
--- a/crates/adapter-gui/tests/issue_581_audio_row_toggle_does_not_block_combobox.rs
+++ b/crates/adapter-gui/tests/issue_581_audio_row_toggle_does_not_block_combobox.rs
@@ -1,0 +1,96 @@
+//! Issue #581 — In Settings → System → Audio, clicking the Hz / Buffer /
+//! Bits ComboBox of a selected device deselects the device instead of
+//! opening the dropdown.
+//!
+//! Root cause (in `section_system_audio.slint`): the toggle `TouchArea`
+//! is the last sibling inside `AudioDeviceRow` (top of the Slint
+//! z-order) with a hard-coded `width: 300px`. The selected-state
+//! controls are positioned relative to the right edge — the sample-rate
+//! ComboBox at `x: parent.width - 394px`. Whenever the row is narrower
+//! than ~694px the ComboBox lives inside the TouchArea bounding box and
+//! the toggle wins the hit test, firing `toggled(!device.selected)`.
+//!
+//! The Rust backend (`update_device_sample_rate` in
+//! `crates/adapter-gui/src/audio_devices.rs`) is correct and already
+//! preserves `selected`. The bug is purely in the Slint layout, so this
+//! test is a static invariant on the `.slint` source: the `TouchArea`
+//! width must be conditional on `root.device.selected` so it can shrink
+//! to leave room for the controls when the row is expanded. A literal
+//! `width: 300px;` (or any other fixed width) is forbidden.
+
+use std::fs;
+use std::path::PathBuf;
+
+fn slint_source() -> String {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let path = manifest_dir
+        .join("ui")
+        .join("pages")
+        .join("settings")
+        .join("section_system_audio.slint");
+    fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()))
+}
+
+/// Extract the `TouchArea { ... }` block that lives inside
+/// `component AudioDeviceRow inherits Rectangle { ... }`. We scan for
+/// the literal `TouchArea {` and return the brace-matched body.
+fn toggle_touch_area_body(source: &str) -> String {
+    let component_marker = "component AudioDeviceRow inherits Rectangle {";
+    let component_start = source
+        .find(component_marker)
+        .expect("component AudioDeviceRow not found in section_system_audio.slint");
+
+    let after_component = &source[component_start..];
+    let touch_area_marker = "TouchArea {";
+    let touch_area_rel = after_component
+        .find(touch_area_marker)
+        .expect("TouchArea not found inside AudioDeviceRow");
+    let body_start = component_start + touch_area_rel + touch_area_marker.len();
+
+    let bytes = source.as_bytes();
+    let mut depth = 1i32;
+    let mut i = body_start;
+    while i < bytes.len() && depth > 0 {
+        match bytes[i] {
+            b'{' => depth += 1,
+            b'}' => depth -= 1,
+            _ => {}
+        }
+        if depth == 0 {
+            return source[body_start..i].to_string();
+        }
+        i += 1;
+    }
+    panic!("unterminated TouchArea block in AudioDeviceRow");
+}
+
+/// Extract the value bound to `width:` inside the given block. Returns
+/// the substring up to (but not including) the terminating `;`.
+fn width_expression(block: &str) -> String {
+    let marker = "width:";
+    let start = block
+        .find(marker)
+        .expect("TouchArea has no `width:` binding");
+    let after_marker = &block[start + marker.len()..];
+    let end = after_marker
+        .find(';')
+        .expect("`width:` binding is missing a terminating `;`");
+    after_marker[..end].trim().to_string()
+}
+
+#[test]
+fn issue_581_toggle_touch_area_width_is_conditional_on_selected() {
+    let source = slint_source();
+    let body = toggle_touch_area_body(&source);
+    let width = width_expression(&body);
+
+    assert!(
+        width.contains("root.device.selected"),
+        "AudioDeviceRow's toggle TouchArea has `width: {width};` — a width that does NOT \
+         depend on `root.device.selected` will cover the Hz/Buffer/Bits ComboBoxes when the \
+         row expands (sample-rate ComboBox starts at `x: parent.width - 394px`), stealing \
+         their clicks and deselecting the device. Make the width conditional, e.g. \
+         `width: root.device.selected ? parent.width - 424px : parent.width;`."
+    );
+}

--- a/crates/adapter-gui/tests/issue_581_save_audio_settings_persists_to_openrig.rs
+++ b/crates/adapter-gui/tests/issue_581_save_audio_settings_persists_to_openrig.rs
@@ -1,0 +1,155 @@
+//! Issue #581 (additional scope) — Settings → System → Audio:
+//! clicking **Aplicar** mutates the in-memory session, but the choice
+//! is lost on restart, so the user re-picks the device every cold
+//! start.
+//!
+//! Root cause: `Command::SaveAudioSettings`
+//! (`crates/application/src/local_dispatcher_project.rs`) writes the
+//! new `device_settings` into the in-memory `Project` and emits
+//! `Event::AudioSettingsSaved`, but never touches durable storage.
+//! Today the durable side is bolted onto the GUI caller
+//! (`crates/adapter-gui/src/settings/audio.rs` calls
+//! `FilesystemStorage::save_gui_audio_settings(...)` before dispatching),
+//! which means any other transport (MCP, gRPC) dispatching the same
+//! command silently loses the user's pick — a violation of the
+//! Command-bus parity LAW: every transport must hit the same persistence
+//! the GUI does. Persistence belongs INSIDE the handler.
+//!
+//! This test reproduces the broken contract end-to-end: dispatch
+//! `SaveAudioSettings` against a fresh dispatcher and then reload the
+//! per-machine `config.yaml` from disk — exactly what
+//! `load_project_session` does on the next launch. RED today, GREEN
+//! once the handler persists.
+
+use std::cell::RefCell;
+use std::path::PathBuf;
+use std::rc::Rc;
+use std::sync::Mutex;
+
+use application::command::Command;
+use application::dispatcher::CommandDispatcher;
+use application::local_dispatcher::LocalDispatcher;
+use domain::ids::DeviceId;
+use infra_filesystem::FilesystemStorage;
+use project::device::DeviceSettings;
+use project::project::Project;
+
+/// `$HOME` is process-global; serialise tests that swap it.
+static HOME_LOCK: Mutex<()> = Mutex::new(());
+
+fn empty_project_rc() -> Rc<RefCell<Project>> {
+    Rc::new(RefCell::new(Project {
+        name: Some("issue-581-fixture".to_string()),
+        device_settings: vec![],
+        chains: vec![],
+        midi: None,
+    }))
+}
+
+fn picked_device() -> DeviceSettings {
+    DeviceSettings {
+        device_id: DeviceId("picked-device".to_string()),
+        sample_rate: 88200,
+        buffer_size_frames: 128,
+        bit_depth: 24,
+        #[cfg(target_os = "linux")]
+        realtime: true,
+        #[cfg(target_os = "linux")]
+        rt_priority: 70,
+        #[cfg(target_os = "linux")]
+        nperiods: 3,
+    }
+}
+
+/// Run `f` with `$HOME` redirected at a fresh tempdir so the FS write
+/// stays out of the developer's real `~/Library/Application Support/`
+/// — mirrors `tests/issue_540_set_paths_persists.rs::with_temp_home`.
+fn with_temp_home<F: FnOnce(&PathBuf)>(label: &str, f: F) {
+    let _g = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let tmp =
+        std::env::temp_dir().join(format!("openrig-581-{label}-{}-{now}", std::process::id()));
+    std::fs::create_dir_all(&tmp).expect("mkdir tempdir");
+    let prev = std::env::var_os("HOME");
+    std::env::set_var("HOME", &tmp);
+    let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(&tmp)));
+    if let Some(prev) = prev {
+        std::env::set_var("HOME", prev);
+    } else {
+        std::env::remove_var("HOME");
+    }
+    let _ = std::fs::remove_dir_all(&tmp);
+    if let Err(p) = res {
+        std::panic::resume_unwind(p);
+    }
+}
+
+#[test]
+fn issue_581_save_audio_settings_persists_into_config_yaml() {
+    with_temp_home("save-audio", |_| {
+        let project = empty_project_rc();
+        let dispatcher = LocalDispatcher::new(Rc::clone(&project));
+
+        // The single action under test: user clicks **Aplicar** with a
+        // picked device + non-default sample rate / buffer / bit depth.
+        // The GUI dispatches exactly one command — no side helper is
+        // invoked on the caller, so persistence MUST live inside the
+        // handler for MCP and gRPC clients to behave the same way.
+        let picked = picked_device();
+        dispatcher
+            .dispatch(Command::SaveAudioSettings {
+                device_settings: vec![picked.clone()],
+            })
+            .expect("SaveAudioSettings dispatch");
+
+        // Simulate the next cold start: re-read the per-machine
+        // `config.yaml` from disk fresh — this is what
+        // `load_project_session` does in `adapter-gui/src/project_ops.rs`
+        // before populating `project.device_settings`.
+        let config =
+            FilesystemStorage::load_app_config().expect("load_app_config from fresh HOME");
+
+        // The picked device must round-trip into the durable config so
+        // `project_ops::build_device_settings_from_gui` can rebuild it
+        // on the next launch.
+        let persisted_device_ids: Vec<&str> = config
+            .input_devices
+            .iter()
+            .chain(config.output_devices.iter())
+            .map(|d| d.device_id.as_str())
+            .collect();
+        assert!(
+            persisted_device_ids.contains(&picked.device_id.0.as_str()),
+            "REGRESSION: Command::SaveAudioSettings did not persist `{}` into config.yaml — \
+             the user's audio device pick survives in memory only and is lost on the next \
+             app start. Persist inside the handler so MCP and gRPC clients dispatching the \
+             same command get persistence too. Persisted ids: {:?}",
+            picked.device_id.0,
+            persisted_device_ids,
+        );
+
+        // And the picked sample-rate / buffer / bit-depth must round-trip too —
+        // otherwise the device row would come back selected with default values.
+        let persisted = config
+            .input_devices
+            .iter()
+            .chain(config.output_devices.iter())
+            .find(|d| d.device_id == picked.device_id.0)
+            .expect("picked device id present in config.yaml after dispatch");
+        assert_eq!(
+            persisted.sample_rate, picked.sample_rate,
+            "sample_rate must round-trip through config.yaml"
+        );
+        assert_eq!(
+            persisted.buffer_size_frames, picked.buffer_size_frames,
+            "buffer_size_frames must round-trip through config.yaml"
+        );
+        assert_eq!(
+            persisted.bit_depth, picked.bit_depth,
+            "bit_depth must round-trip through config.yaml"
+        );
+    });
+}

--- a/crates/adapter-gui/ui/pages/settings/section_system_audio.slint
+++ b/crates/adapter-gui/ui/pages/settings/section_system_audio.slint
@@ -156,10 +156,17 @@ component AudioDeviceRow inherits Rectangle {
         selected(value) => { root.bit-depth-selected(value); }
     }
 
+    // #581: width must shrink when the device is selected so the toggle
+    // hit region stops before the Hz/Buffer/Bits controls (the "Hz"
+    // label starts at `parent.width - 424px`). A fixed `width: 300px`
+    // overlapped the sample-rate ComboBox (`x: parent.width - 394px`)
+    // whenever the row was narrower than ~694px, stealing its clicks
+    // and deselecting the device when the user tried to open the
+    // dropdown.
     TouchArea {
         x: 0px;
         y: 0px;
-        width: 300px;
+        width: root.device.selected ? parent.width - 424px : parent.width;
         height: parent.height;
         mouse-cursor: pointer;
         clicked => { root.toggled(!root.device.selected); }

--- a/crates/application/src/local_dispatcher_paths_tests.rs
+++ b/crates/application/src/local_dispatcher_paths_tests.rs
@@ -26,7 +26,11 @@ static HOME_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 /// Run `f` with `$HOME` pointed at a fresh tempdir. Restores the
 /// previous `$HOME` (or removes it) and deletes the tempdir whether
 /// `f` panics or returns normally.
-fn with_tmp_home<F: FnOnce()>(label: &str, f: F) {
+///
+/// `pub(super)` so the sibling `local_dispatcher_tests` module can
+/// reuse it for commands that now hit `config.yaml` too (#581 made
+/// `SaveAudioSettings` persist).
+pub(super) fn with_tmp_home<F: FnOnce()>(label: &str, f: F) {
     let _g = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)

--- a/crates/application/src/local_dispatcher_project.rs
+++ b/crates/application/src/local_dispatcher_project.rs
@@ -11,6 +11,7 @@
 use std::path::PathBuf;
 
 use anyhow::{anyhow, Result};
+use infra_filesystem::{FilesystemStorage, GuiAudioDeviceSettings};
 
 use crate::command::Command;
 use crate::dispatcher::CommandDispatcher;
@@ -60,7 +61,42 @@ impl LocalDispatcher {
             }
 
             Command::SaveAudioSettings { device_settings } => {
-                self.project.borrow_mut().device_settings = device_settings;
+                self.project.borrow_mut().device_settings = device_settings.clone();
+
+                // #581: persist the pick into the per-machine
+                // `config.yaml` so it survives restarts and so every
+                // transport (GUI, MCP, gRPC) dispatching this command
+                // gets the same durable effect — per the Command-bus
+                // parity LAW. Touch only `input_devices` /
+                // `output_devices`, preserving the rest of `AppConfig`
+                // (language, midi_devices, paths, recent_projects).
+                let gui_devices: Vec<GuiAudioDeviceSettings> = device_settings
+                    .iter()
+                    .map(|s| GuiAudioDeviceSettings {
+                        device_id: s.device_id.0.clone(),
+                        // `name` is for UI display; `DeviceSettings`
+                        // does not carry it. The GUI rebuilds the
+                        // human name from the live cpal descriptor
+                        // (`build_project_device_rows`), so an empty
+                        // string here is safe.
+                        name: String::new(),
+                        sample_rate: s.sample_rate,
+                        buffer_size_frames: s.buffer_size_frames,
+                        bit_depth: s.bit_depth,
+                        #[cfg(target_os = "linux")]
+                        realtime: s.realtime,
+                        #[cfg(target_os = "linux")]
+                        rt_priority: s.rt_priority,
+                        #[cfg(target_os = "linux")]
+                        nperiods: s.nperiods,
+                    })
+                    .collect();
+                let mut config = FilesystemStorage::load_app_config().unwrap_or_default();
+                config.input_devices = gui_devices.clone();
+                config.output_devices = gui_devices;
+                FilesystemStorage::save_app_config(&config)
+                    .map_err(|e| anyhow!("failed to persist audio settings: {e}"))?;
+
                 Ok(vec![Event::AudioSettingsSaved])
             }
 

--- a/crates/application/src/local_dispatcher_tests.rs
+++ b/crates/application/src/local_dispatcher_tests.rs
@@ -2444,72 +2444,82 @@ fn make_device_settings(device_id: &str) -> project::device::DeviceSettings {
     }
 }
 
+// #581: SaveAudioSettings now persists into the per-machine
+// `config.yaml`. Each test redirects `$HOME` to a unique tempdir so the
+// FS write stays out of the developer's real `~/Library/Application
+// Support/OpenRig/`.
 #[test]
 fn save_audio_settings_writes_device_settings_and_emits_event() {
-    let project = Rc::new(RefCell::new(Project {
-        name: None,
-        device_settings: vec![],
-        chains: vec![],
-        midi: None,
-    }));
-    let dispatcher = LocalDispatcher::new(Rc::clone(&project));
+    crate::local_dispatcher_paths_tests::with_tmp_home("save-audio-emit", || {
+        let project = Rc::new(RefCell::new(Project {
+            name: None,
+            device_settings: vec![],
+            chains: vec![],
+            midi: None,
+        }));
+        let dispatcher = LocalDispatcher::new(Rc::clone(&project));
 
-    let settings = vec![make_device_settings("dev_a"), make_device_settings("dev_b")];
-    let result = dispatcher.dispatch(Command::SaveAudioSettings {
-        device_settings: settings.clone(),
+        let settings = vec![make_device_settings("dev_a"), make_device_settings("dev_b")];
+        let result = dispatcher.dispatch(Command::SaveAudioSettings {
+            device_settings: settings.clone(),
+        });
+
+        assert!(result.is_ok(), "dispatch returned Err: {:?}", result);
+        let events = result.unwrap();
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, Event::AudioSettingsSaved)),
+            "expected AudioSettingsSaved event, got {:?}",
+            events
+        );
+        let proj = project.borrow();
+        assert_eq!(proj.device_settings.len(), 2);
+        assert_eq!(proj.device_settings[0].device_id.0, "dev_a");
+        assert_eq!(proj.device_settings[1].device_id.0, "dev_b");
     });
-
-    assert!(result.is_ok(), "dispatch returned Err: {:?}", result);
-    let events = result.unwrap();
-    assert!(
-        events
-            .iter()
-            .any(|e| matches!(e, Event::AudioSettingsSaved)),
-        "expected AudioSettingsSaved event, got {:?}",
-        events
-    );
-    let proj = project.borrow();
-    assert_eq!(proj.device_settings.len(), 2);
-    assert_eq!(proj.device_settings[0].device_id.0, "dev_a");
-    assert_eq!(proj.device_settings[1].device_id.0, "dev_b");
 }
 
 #[test]
 fn save_audio_settings_replaces_previous_settings() {
-    let project = Rc::new(RefCell::new(Project {
-        name: None,
-        device_settings: vec![make_device_settings("old_dev")],
-        chains: vec![],
-        midi: None,
-    }));
-    let dispatcher = LocalDispatcher::new(Rc::clone(&project));
+    crate::local_dispatcher_paths_tests::with_tmp_home("save-audio-replace", || {
+        let project = Rc::new(RefCell::new(Project {
+            name: None,
+            device_settings: vec![make_device_settings("old_dev")],
+            chains: vec![],
+            midi: None,
+        }));
+        let dispatcher = LocalDispatcher::new(Rc::clone(&project));
 
-    let result = dispatcher.dispatch(Command::SaveAudioSettings {
-        device_settings: vec![make_device_settings("new_dev")],
+        let result = dispatcher.dispatch(Command::SaveAudioSettings {
+            device_settings: vec![make_device_settings("new_dev")],
+        });
+
+        assert!(result.is_ok());
+        let proj = project.borrow();
+        assert_eq!(proj.device_settings.len(), 1);
+        assert_eq!(proj.device_settings[0].device_id.0, "new_dev");
     });
-
-    assert!(result.is_ok());
-    let proj = project.borrow();
-    assert_eq!(proj.device_settings.len(), 1);
-    assert_eq!(proj.device_settings[0].device_id.0, "new_dev");
 }
 
 #[test]
 fn save_audio_settings_empty_clears_settings() {
-    let project = Rc::new(RefCell::new(Project {
-        name: None,
-        device_settings: vec![make_device_settings("dev_a")],
-        chains: vec![],
-        midi: None,
-    }));
-    let dispatcher = LocalDispatcher::new(Rc::clone(&project));
+    crate::local_dispatcher_paths_tests::with_tmp_home("save-audio-empty", || {
+        let project = Rc::new(RefCell::new(Project {
+            name: None,
+            device_settings: vec![make_device_settings("dev_a")],
+            chains: vec![],
+            midi: None,
+        }));
+        let dispatcher = LocalDispatcher::new(Rc::clone(&project));
 
-    let result = dispatcher.dispatch(Command::SaveAudioSettings {
-        device_settings: vec![],
+        let result = dispatcher.dispatch(Command::SaveAudioSettings {
+            device_settings: vec![],
+        });
+
+        assert!(result.is_ok());
+        assert!(project.borrow().device_settings.is_empty());
     });
-
-    assert!(result.is_ok());
-    assert!(project.borrow().device_settings.is_empty());
 }
 
 // ── SaveProject tests ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #581.

## Summary

Two bugs in **Settings → System → Audio**, both fixed on this branch:

1. **`a9bdf4db`** — Clicking the Hz / Buffer / Bits ComboBox of a selected device deselected the device instead of opening the dropdown. The toggle `TouchArea` was the last sibling in `AudioDeviceRow` (top of Slint z-order) with a fixed `width: 300px` that overlapped the right-side controls. The fix makes the width conditional on `root.device.selected` so the hit region stops before the Hz label when the row is expanded.
2. **`bfadfb30`** — Clicking **Aplicar** updated the session but the choice was lost on restart. The `Command::SaveAudioSettings` handler only mutated the in-memory `Project`; persistence was bolted onto the GUI caller, so MCP/gRPC clients dispatching the same command lost the pick (Command-bus parity LAW violation). The fix persists `input_devices` / `output_devices` into the per-machine `config.yaml` inside the handler itself, preserving every other `AppConfig` field.

## Tests

- `crates/adapter-gui/tests/issue_581_audio_row_toggle_does_not_block_combobox.rs` — static invariant on `section_system_audio.slint`: the toggle `TouchArea.width` must depend on `root.device.selected`. RED on the previous `300px` literal, GREEN after the conditional.
- `crates/adapter-gui/tests/issue_581_save_audio_settings_persists_to_openrig.rs` — round-trip test: dispatch `SaveAudioSettings`, reload `config.yaml` from a fresh tempdir, assert `device_id` + `sample_rate` + `buffer_size_frames` + `bit_depth` survived. RED on the previous handler, GREEN after the persistence.
- The 3 existing `local_dispatcher_tests::save_audio_settings_*` lib tests are now wrapped in `with_tmp_home` so they don't clobber the developer's real `~/Library/Application Support/OpenRig/config.yaml` on every `cargo test`.

## Test plan

- [ ] Settings → System → Audio → select a device → ComboBoxes appear.
- [ ] Click the **Hz** ComboBox → dropdown opens; device stays selected.
- [ ] Pick `88200`; pick a non-default **Buffer**; pick a non-default **Bits**.
- [ ] Click **Aplicar**.
- [ ] `cat ~/Library/Application\ Support/OpenRig/config.yaml` → `input_devices` / `output_devices` reflect the picks (sample_rate / buffer_size_frames / bit_depth).
- [ ] Quit the app cleanly, reopen it.
- [ ] Settings → System → Audio → the same device is still selected with the chosen Hz / Buffer / Bits.

## Out of scope

- The `.openrig` (new `RigProject` format) still does not carry `device_settings`; the per-machine `config.yaml` is the authoritative durable store, exactly as it was before this PR. Moving project-scoped audio settings into the `.openrig` is a separate ADR decision and a separate issue.