### PR TITLE
fix(#580): restore rebuild fallback when re-enabling a born-disabled block

### DIFF
--- a/crates/engine/src/block_enabled_fast_path_tests.rs
+++ b/crates/engine/src/block_enabled_fast_path_tests.rs
@@ -161,6 +161,46 @@ fn set_block_enabled_true_after_disable_transitions_back_to_fading_in() {
 }
 
 #[test]
+fn re_enabling_a_born_disabled_block_declines_fast_path_for_rebuild() {
+    // Issue #580 follow-up (user repro): blocks in `input-1` saved as
+    // `enabled: false` are built as a `Bypass` node with NO live processor.
+    // The queued fast path can't fade in a DSP that doesn't exist. Before
+    // #580 `set_block_enabled` returned `Err` synchronously for this case
+    // and the controller fell back to a full rebuild (which builds the real
+    // processor). #580 made the call always-`Ok` (just enqueue), dropping
+    // that fallback — the audio thread only spammed
+    //   "block '...' has no live processor — needs full rebuild to re-enable"
+    // to the error queue and the block never came back. Pin the restored
+    // contract: re-enabling a born-disabled (bypass) block DECLINES
+    // synchronously so the caller rebuilds, and posts NO async error.
+    let mut chain = test_chain();
+    for b in chain.blocks.iter_mut() {
+        if b.id == BlockId(BLOCK_ID.into()) {
+            b.enabled = false;
+        }
+    }
+    let runtime = Arc::new(
+        build_chain_runtime_state(&chain, SR, &[DEFAULT_ELASTIC_TARGET])
+            .expect("runtime must build for test chain"),
+    );
+    let block = BlockId(BLOCK_ID.into());
+
+    let result = set_block_enabled(&runtime, &block, true);
+    assert!(
+        result.is_err(),
+        "re-enabling a born-disabled (bypass) block must decline the fast \
+         path so the caller falls back to a full rebuild, got {result:?}"
+    );
+
+    drive_one_callback(&runtime); // nothing was queued → nothing to drain
+    let errors = runtime.poll_errors();
+    assert!(
+        errors.is_empty(),
+        "declining synchronously must not also post an async error, got {errors:?}"
+    );
+}
+
+#[test]
 fn set_block_enabled_unknown_block_posts_error_to_error_queue() {
     // Issue #580 follow-up: `set_block_enabled` now returns Ok if the
     // toggle was queued successfully — the per-block lookup (and its

--- a/crates/engine/src/runtime_block_toggle.rs
+++ b/crates/engine/src/runtime_block_toggle.rs
@@ -72,6 +72,20 @@ pub fn set_block_enabled(
     block_id: &BlockId,
     enabled: bool,
 ) -> Result<()> {
+    // A block whose live node is a `Bypass` (built while disabled, or
+    // build-faulted) has no DSP to fade in. Queueing a re-enable would only
+    // post "has no live processor" from the audio thread and leave the
+    // block dead. Decline synchronously — wait-free read of the bypass
+    // mirror, no `processing` lock — so the caller falls back to a full
+    // rebuild that builds the real processor (issue #580 regression).
+    // Disabling (`enabled == false`) never needs a processor, so it always
+    // queues on the lock-free fast path.
+    if enabled && runtime.bypass_block_ids.load().contains(block_id) {
+        return Err(anyhow!(
+            "block '{}' has no live processor — needs full rebuild to re-enable",
+            block_id.0
+        ));
+    }
     runtime
         .pending_block_toggles
         .push((block_id.clone(), enabled))

--- a/crates/engine/src/runtime_graph.rs
+++ b/crates/engine/src/runtime_graph.rs
@@ -33,7 +33,7 @@
 //!     so the existing `engine::runtime::*` paths used by infra-cpal /
 //!     adapter-console keep working unchanged.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::AtomicU64;
 use std::sync::{Arc, Mutex};
 
@@ -55,7 +55,7 @@ use crate::runtime_endpoints::{effective_inputs, effective_outputs};
 use crate::runtime_segments::{split_chain_into_segments, ChainSegment};
 use crate::runtime_state::{
     lock_recover, BlockRuntimeNode, ChainProcessingState, InputCallbackScratch,
-    InputProcessingState, OutgoingTail, OutputRoutingState, SPILLOVER_FRAMES,
+    InputProcessingState, OutgoingTail, OutputRoutingState, RuntimeProcessor, SPILLOVER_FRAMES,
 };
 
 /// Bounded capacity for the per-chain SPSC error queue. Audio-thread
@@ -367,6 +367,11 @@ fn assemble_chain_runtime_state(
     // thread's `processing` try_lock. Captured before the Vec moves into
     // the Mutex.
     let initial_stream_count = input_states.len();
+    // Issue #580 follow-up: capture the set of bypass (no live processor)
+    // nodes so the GUI block-toggle fast path can decline re-enabling them
+    // and fall back to a rebuild. Computed before `input_states` moves into
+    // the Mutex, mirroring `initial_stream_count`.
+    let initial_bypass_block_ids = collect_bypass_block_ids(&input_states);
 
     Ok(ChainRuntimeState {
         processing: Mutex::new(ChainProcessingState {
@@ -395,7 +400,25 @@ fn assemble_chain_runtime_state(
         // removing the GUI/audio Mutex contention that caused an
         // audible click on every block on/off at small buffer sizes.
         pending_block_toggles: ArrayQueue::new(64),
+        bypass_block_ids: ArcSwap::from_pointee(initial_bypass_block_ids),
     })
+}
+
+/// Collect the ids of every block whose live node is a
+/// `RuntimeProcessor::Bypass` (built while disabled, or build-faulted).
+/// These nodes have no real DSP, so re-enabling them needs a full rebuild
+/// rather than the in-place fade fast path. See `ChainRuntimeState::
+/// bypass_block_ids`.
+fn collect_bypass_block_ids(input_states: &[InputProcessingState]) -> HashSet<BlockId> {
+    let mut ids = HashSet::new();
+    for input_state in input_states {
+        for node in &input_state.blocks {
+            if matches!(node.processor, RuntimeProcessor::Bypass) {
+                ids.insert(node.block_id.clone());
+            }
+        }
+    }
+    ids
 }
 
 /// Build effective input entries from chain's InputBlock entries, plus Insert return entries.
@@ -666,6 +689,13 @@ fn update_chain_runtime_state_impl(
             processing.input_states.len(),
             std::sync::atomic::Ordering::Relaxed,
         );
+        // Issue #580 follow-up: refresh the lock-free bypass mirror from the
+        // new nodes so re-enabling a (still) born-disabled block keeps
+        // declining the fast path. Swapped inside the same critical section
+        // as the Vec so a reader never sees a stale (nodes, bypass-set) pair.
+        runtime
+            .bypass_block_ids
+            .store(Arc::new(collect_bypass_block_ids(&processing.input_states)));
 
         // Rebuild input_to_segments mapping from current segments
         let max_input_idx = segments

--- a/crates/engine/src/runtime_state.rs
+++ b/crates/engine/src/runtime_state.rs
@@ -24,7 +24,7 @@
 //!     used only from `runtime.rs`, `stream_tap.rs`, and the test
 //!     modules.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicU8, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -327,6 +327,22 @@ pub struct ChainRuntimeState {
     /// stalled — which is a louder bug than a dropped toggle. The
     /// `set_block_enabled` API still surfaces such overflows as `Err`.
     pub(crate) pending_block_toggles: ArrayQueue<(BlockId, bool)>,
+    /// Lock-free mirror of the block ids whose live node is a
+    /// `RuntimeProcessor::Bypass` — blocks built while disabled (or whose
+    /// build faulted) carry no real DSP. Re-enabling such a block CANNOT
+    /// be served by the queued in-place fade fast path (there is no
+    /// processor to fade in), so `set_block_enabled` declines synchronously
+    /// and the caller falls back to a full `upsert_chain` rebuild.
+    ///
+    /// Issue #580 regression: once the fast path started *queueing* every
+    /// toggle and always returning `Ok`, the synchronous decline that used
+    /// to trigger that rebuild was lost — re-enabling a born-disabled block
+    /// only spammed "has no live processor" to `error_queue` and the block
+    /// never came back. This mirror restores the decline without taking the
+    /// `processing` lock on the GUI thread (`ArcSwap::load` is wait-free).
+    /// Swapped at the same build/rebuild sites that update `stream_count`,
+    /// so it always reflects the current set of live nodes.
+    pub(crate) bypass_block_ids: ArcSwap<HashSet<BlockId>>,
 }
 
 impl ChainRuntimeState {


### PR DESCRIPTION
## Problem (user repro)

Toggling blocks in `input-1` spammed:

```
ERROR adapter_gui::helpers] Erro de plugin: block 'rig:input-1:block:…' has no live processor — needs full rebuild to re-enable
```

and the block never came back on.

## Root cause

A block whose live node is a `RuntimeProcessor::Bypass` — built while `enabled: false`, **or** whose build faulted (e.g. a plugin/NAM/IR that failed to load) — carries no real DSP. Before #580, `set_block_enabled` returned `Err` synchronously for such a node and `sync_block_toggle` fell back to a full `upsert_chain` rebuild (which builds the real processor).

The #580 lock-free block-toggle queue made `set_block_enabled` always return `Ok` (just enqueue). That dropped the synchronous decline that used to trigger the rebuild — the audio thread only posted "has no live processor" to `error_queue` and the block stayed dead.

## Fix

Restore the synchronous decline **without** re-introducing GUI/audio lock contention:

- New wait-free mirror `ChainRuntimeState::bypass_block_ids: ArcSwap<HashSet<BlockId>>`, populated at the same build/rebuild sites as `stream_count` (issue #580 pattern).
- `set_block_enabled` reads it wait-free (`ArcSwap::load`) and returns `Err` when re-enabling a bypass block, so the controller falls back to a full rebuild that builds (or retries) the real processor.
- Disabling, and re-enabling a *runtime-disabled* block (which keeps its processor), still take the lock-free queue fast path.
- **Audio thread unchanged** — no new lock/alloc on the callback.

## Tests

- New red→green: `re_enabling_a_born_disabled_block_declines_fast_path_for_rebuild` pins the restored contract (synchronous decline, no async error).
- Existing `set_block_enabled_true_after_disable_transitions_back_to_fading_in` still passes → the common lock-free fast path is intact.
- `cargo test -p engine --lib`: 529 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)