### PR TITLE
fix(#542): user plugins root overrides bundled on id collision

### DIFF
--- a/crates/plugin-loader/src/registry.rs
+++ b/crates/plugin-loader/src/registry.rs
@@ -168,8 +168,20 @@ pub fn reload(plugins_roots: &[std::path::PathBuf]) -> ReloadStats {
     let natives = NATIVES.lock().expect("NATIVES poisoned").clone();
     let native_count = natives.len();
     let mut loaded = natives;
-    let mut seen_ids: std::collections::HashSet<String> =
+    // Natives always win — their runtime fn pointers are compiled in and
+    // have no manifest on disk to override them.
+    let native_ids: std::collections::HashSet<String> =
         loaded.iter().map(|e| e.manifest.id.clone()).collect();
+    // Among disk roots, a LATER root overrides an EARLIER one on id
+    // collision (issue #542): `init_many(&[bundled_root, user_root])`
+    // passes the read-only bundled tree first and the user's writable
+    // `plugins_path` second, so the user's copy must win. Otherwise a
+    // bundled IR cab shipped with an uncalibrated `output_gain_db: 0.0`
+    // shadows the user's calibrated copy → the convolver runs raw →
+    // ~+18 dB hot → "estourado". Maps each disk id to its slot so a
+    // later root replaces in place (keeping registration order stable).
+    let mut disk_slot: std::collections::HashMap<String, usize> =
+        std::collections::HashMap::new();
     for root in plugins_roots {
         if !root.is_dir() {
             continue;
@@ -179,12 +191,14 @@ pub fn reload(plugins_roots: &[std::path::PathBuf]) -> ReloadStats {
                 for result in results {
                     match result {
                         Ok(package) => {
-                            // De-dup by manifest id: when the same
-                            // package appears in both the bundled and
-                            // user roots, the first occurrence wins
-                            // (bundled has priority since it's earlier
-                            // in the list).
-                            if seen_ids.insert(package.manifest.id.clone()) {
+                            let id = package.manifest.id.clone();
+                            if native_ids.contains(&id) {
+                                // A native with this id already won.
+                            } else if let Some(&slot) = disk_slot.get(&id) {
+                                // Later root overrides the earlier one.
+                                loaded[slot] = package;
+                            } else {
+                                disk_slot.insert(id, loaded.len());
                                 loaded.push(package);
                             }
                         }

--- a/crates/plugin-loader/tests/registry_user_overrides_bundled.rs
+++ b/crates/plugin-loader/tests/registry_user_overrides_bundled.rs
@@ -1,0 +1,86 @@
+//! Issue #542 (reopened) — red-first guard for the OpenRig-side root cause
+//! of "CAB/IR estourando o som".
+//!
+//! The installed app registers plugins with
+//! `registry::init_many(&[bundled_root, user_root])` (adapter-gui
+//! `desktop_app.rs`). The bundled copy inside `OpenRig.app/Contents/
+//! Resources/plugins` ships IR manifests with `output_gain_db: 0.0`
+//! (uncalibrated), while the user's `plugins_path` points at a calibrated
+//! copy (e.g. `-18.3` for `ir_marshall_4x12_v30/ev_mix_b`). With
+//! `output_gain_db: 0.0` the runtime `wrap_with_output_gain_db` is a no-op
+//! → the IR convolution runs raw → ~+18 dB hot → the limiter is slammed
+//! and the user hears "estourado".
+//!
+//! The user's plugins_path IS calibrated, yet it still clips — because the
+//! bundled (uncalibrated) entry, registered FIRST, shadows it. The fix is
+//! a registry-precedence contract: when the same `model_id` exists in more
+//! than one root, the LATER root (the user's) must win over the earlier
+//! (bundled) one. This test pins that contract.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use plugin_loader::manifest::Backend;
+
+fn write_ir_plugin(root: &Path, model_id: &str, output_gain_db: f64) {
+    let plugin_dir = root.join("ir").join("test_cab");
+    fs::create_dir_all(&plugin_dir).expect("create plugin dir");
+    // The capture references a wav; create an (empty) placeholder so disk
+    // discovery does not skip the package over a missing file.
+    fs::write(plugin_dir.join("imp.wav"), b"").expect("write placeholder wav");
+    let manifest = format!(
+        "manifest_version: 1\n\
+         id: {model_id}\n\
+         display_name: Test Cab\n\
+         brand: test\n\
+         type: cab\n\
+         backend: ir\n\
+         parameters:\n\
+         - name: capture\n  \
+           display_name: Capture\n  \
+           values:\n  \
+           - main\n\
+         captures:\n\
+         - values:\n    \
+             capture: main\n  \
+           file: imp.wav\n  \
+           output_gain_db: {output_gain_db}\n"
+    );
+    fs::write(plugin_dir.join("manifest.yaml"), manifest).expect("write manifest");
+}
+
+fn capture_output_gain_db(model_id: &str) -> Option<f32> {
+    let pkg = plugin_loader::registry::find(model_id)?;
+    match &pkg.manifest.backend {
+        Backend::Ir { captures, .. } => captures.first().and_then(|c| c.output_gain_db),
+        _ => None,
+    }
+}
+
+#[test]
+fn user_plugins_root_overrides_bundled_on_model_id_collision() {
+    // Unique temp scratch (no rand available; fixed name, cleaned first).
+    let base = std::env::temp_dir().join("openrig_issue542_precedence");
+    let _ = fs::remove_dir_all(&base);
+    let bundled: PathBuf = base.join("bundled");
+    let user: PathBuf = base.join("user");
+
+    // Same model_id in both roots; bundled is UNCALIBRATED (0.0), user is
+    // CALIBRATED (-18.3) — exactly the installed-app topology.
+    write_ir_plugin(&bundled, "ir_test_cab", 0.0);
+    write_ir_plugin(&user, "ir_test_cab", -18.3);
+
+    // Exact order used by the live app: bundled first, user second.
+    plugin_loader::registry::init_many(&[bundled, user]);
+
+    let resolved = capture_output_gain_db("ir_test_cab")
+        .expect("ir_test_cab must be discoverable from the registry");
+
+    assert!(
+        (resolved - (-18.3)).abs() < 1e-3,
+        "REGRESSION (#542): user plugins_path is calibrated (-18.3 dB) but the registry \
+         resolved output_gain_db = {resolved:.4}. The bundled (uncalibrated, 0.0 dB) copy \
+         is shadowing the user's calibrated plugin. With 0.0 dB the IR runs raw → +18 dB → \
+         'estourado'. The user's plugins root must take precedence over the bundled one."
+    );
+}


### PR DESCRIPTION
## Problem

"CAB/IR estourando o som" on every IR/WAV cab (native cabs were fine).

The installed app registers plugins with `registry::init_many(&[bundled_root, user_root])` (`adapter-gui/desktop_app.rs`):
- `bundled_root` = the copy shipped inside `OpenRig.app/Contents/Resources/plugins`
- `user_root` = the user's `plugins_path` from `config.yaml`

The bundled tree ships **134/135 IR manifests with `output_gain_db: 0.0`** (uncalibrated). On a manifest-id collision the dedup in `registry::reload()` kept the **first** occurrence, so the bundled (0.0) entry **shadowed the user's calibrated copy** (e.g. `ir_marshall_4x12_v30/ev_mix_b` = −18.31 dB in the repo).

With `output_gain_db: 0.0`, `wrap_with_output_gain_db` is a no-op → the IR convolver runs raw (~+18 dB spectral peak) → the brickwall limiter is slammed → "estourado". Native cabs don't go through the package registry, which is why they were unaffected. The user's `plugins_path` was already calibrated and it still clipped — because the bundle shadowed it.

## Fix

Among disk roots a **later** root overrides an **earlier** one on id collision; natives still always win. Covers cold load and the #561 hot-reload path (both go through `reload()`).

- `crates/plugin-loader/src/registry.rs` — `reload()` dedup is now last-disk-root-wins
- `crates/plugin-loader/tests/registry_user_overrides_bundled.rs` — red-first guard (RED: resolved 0.0 → GREEN: −18.3)

## Out of scope

The bundle shipping `output_gain_db: 0.0` is an OpenRig-plugins / pack-step concern, not touched here.

## Verification

- red test: RED → GREEN
- `cargo test -p plugin-loader`: 64 passed
- `cargo test -p engine --test issue_542_od_chain_clips`: 2 passed
- `cargo build -p plugin-loader`: clean, zero warnings

Closes #542

🤖 Generated with [Claude Code](https://claude.com/claude-code)