### PR TITLE
fix(#588): stop runaway NAM/IR model memory — no reload on edit, mono loads once

### DIFF
--- a/crates/engine/src/offline.rs
+++ b/crates/engine/src/offline.rs
@@ -73,8 +73,17 @@ pub fn render_chain(
     if block_size == 0 {
         anyhow::bail!("block_size must be > 0");
     }
-    let (mut nodes, _output_layout) =
-        build_runtime_block_nodes(chain, AudioChannelLayout::Stereo, sample_rate, None, None)?;
+    // Offline render is fed an explicit stereo buffer whose channels may
+    // differ; do not assume mono content (issue #588), so build the full
+    // per-channel processors — byte-identical to the historical behaviour.
+    let (mut nodes, _output_layout) = build_runtime_block_nodes(
+        chain,
+        AudioChannelLayout::Stereo,
+        false,
+        sample_rate,
+        None,
+        None,
+    )?;
 
     let faulted_blocks = collect_faulted_blocks(&nodes);
 

--- a/crates/engine/src/runtime_block_builders.rs
+++ b/crates/engine/src/runtime_block_builders.rs
@@ -28,15 +28,36 @@ use crate::runtime_state::{
 
 static NEXT_BLOCK_INSTANCE_SERIAL: AtomicU64 = AtomicU64::new(1);
 
+/// Whether the signal LEAVING `node` is effectively mono (L == R), given
+/// whether the signal entering it was. Issue #588: a mono processor always
+/// emits `Stereo([s, s])`, a bypass preserves whatever flowed in, and any
+/// genuinely stereo processor (dual-mono with independent channels, true
+/// stereo, mono→stereo) may decorrelate the channels. A `Select` is treated
+/// conservatively as decorrelating (its chosen branch is opaque here).
+fn node_emits_mono_content(node: &BlockRuntimeNode, input_content_mono: bool) -> bool {
+    match &node.processor {
+        RuntimeProcessor::Audio(AudioProcessor::Mono(_)) => true,
+        RuntimeProcessor::Audio(_) => false,
+        RuntimeProcessor::Bypass => input_content_mono,
+        RuntimeProcessor::Select(_) => false,
+    }
+}
+
 pub(crate) fn build_runtime_block_nodes(
     chain: &Chain,
     input_layout: AudioChannelLayout,
+    source_is_mono: bool,
     sample_rate: f32,
     existing: Option<Vec<BlockRuntimeNode>>,
     block_indices: Option<&[usize]>,
 ) -> Result<(Vec<BlockRuntimeNode>, AudioChannelLayout)> {
     let mut blocks = Vec::new();
     let mut current_layout = input_layout;
+    // Issue #588: track whether the signal reaching the current position is
+    // still effectively mono (a mono source broadcast to identical stereo
+    // channels). Starts from the source layout and is cleared the moment a
+    // block produces genuine stereo.
+    let mut content_mono = source_is_mono;
     let mut reusable_nodes = existing
         .unwrap_or_default()
         .into_iter()
@@ -67,8 +88,9 @@ pub(crate) fn build_runtime_block_nodes(
                 }
                 blocks.push(node);
             } else {
-                blocks.push(bypass_runtime_node(block, current_layout));
+                blocks.push(bypass_runtime_node(block, current_layout, content_mono));
             }
+            content_mono = node_emits_mono_content(blocks.last().unwrap(), content_mono);
             continue;
         }
         // Input/Output/Insert blocks are routing metadata; skip them in the processing chain
@@ -87,15 +109,17 @@ pub(crate) fn build_runtime_block_nodes(
                 block,
                 select,
                 current_layout,
+                content_mono,
                 sample_rate,
                 existing_select_node,
             )?;
             current_layout = node.output_layout;
+            content_mono = node_emits_mono_content(&node, content_mono);
             blocks.push(node);
             continue;
         }
         if let Some(node) =
-            try_reuse_block_node(&mut reusable_nodes, block, current_layout, sample_rate)
+            try_reuse_block_node(&mut reusable_nodes, block, current_layout, content_mono, sample_rate)
         {
             log::info!(
                 "[engine] reuse block {:?} (id={})",
@@ -103,6 +127,7 @@ pub(crate) fn build_runtime_block_nodes(
                 block.id.0
             );
             current_layout = node.output_layout;
+            content_mono = node_emits_mono_content(&node, content_mono);
             blocks.push(node);
             continue;
         }
@@ -117,9 +142,10 @@ pub(crate) fn build_runtime_block_nodes(
                 log::info!("[engine]   {} = {:?}", path, value);
             }
         }
-        match build_block_runtime_node(chain, block, current_layout, sample_rate) {
+        match build_block_runtime_node(chain, block, current_layout, content_mono, sample_rate) {
             Ok(node) => {
                 current_layout = node.output_layout;
+                content_mono = node_emits_mono_content(&node, content_mono);
                 blocks.push(node);
             }
             Err(e) => {
@@ -134,9 +160,10 @@ pub(crate) fn build_runtime_block_nodes(
                     block.model_ref().map(|m| m.model.to_string()),
                     block.id.0
                 );
-                let mut node = bypass_runtime_node(block, current_layout);
+                let mut node = bypass_runtime_node(block, current_layout, content_mono);
                 node.faulted = true;
                 node.fault_reason = Some(reason);
+                // A faulted block is bypassed → passthrough preserves content.
                 blocks.push(node);
             }
         }
@@ -149,6 +176,7 @@ fn try_reuse_block_node(
     reusable_nodes: &mut HashMap<BlockId, BlockRuntimeNode>,
     block: &project::block::AudioBlock,
     current_layout: AudioChannelLayout,
+    content_mono: bool,
     sample_rate: f32,
 ) -> Option<BlockRuntimeNode> {
     let mut node = reusable_nodes.remove(&block.id)?;
@@ -159,6 +187,12 @@ fn try_reuse_block_node(
             node.input_layout,
             current_layout
         );
+        return None;
+    }
+    // Issue #588: the mono ↔ dual-mono decision depends on whether the
+    // incoming signal is effectively mono. If that flipped (e.g. an upstream
+    // block now produces stereo), the processor shape is wrong — rebuild.
+    if node.content_mono != content_mono {
         return None;
     }
     // Exact match — reuse as-is
@@ -249,24 +283,32 @@ fn build_block_runtime_node(
     chain: &Chain,
     block: &project::block::AudioBlock,
     input_layout: AudioChannelLayout,
+    content_mono: bool,
     sample_rate: f32,
 ) -> Result<BlockRuntimeNode> {
     Ok(match &block.kind {
-        _ if !block.enabled => bypass_runtime_node(block, input_layout),
+        _ if !block.enabled => bypass_runtime_node(block, input_layout, content_mono),
         AudioBlockKind::Nam(stage) => audio_block_runtime_node(
             block,
             input_layout,
-            build_nam_audio_processor(chain, stage, input_layout, sample_rate)?,
+            content_mono,
+            build_nam_audio_processor(chain, stage, input_layout, content_mono, sample_rate)?,
         ),
         AudioBlockKind::Core(core) => {
-            build_core_block_runtime_node(chain, block, core, input_layout, sample_rate)?
+            build_core_block_runtime_node(chain, block, core, input_layout, content_mono, sample_rate)?
         }
-        AudioBlockKind::Select(select) => {
-            build_select_runtime_node(chain, block, select, input_layout, sample_rate, None)?
-        }
+        AudioBlockKind::Select(select) => build_select_runtime_node(
+            chain,
+            block,
+            select,
+            input_layout,
+            content_mono,
+            sample_rate,
+            None,
+        )?,
         // Input/Output/Insert blocks are routing-only; they don't process audio in the block chain
         AudioBlockKind::Input(_) | AudioBlockKind::Output(_) | AudioBlockKind::Insert(_) => {
-            bypass_runtime_node(block, input_layout)
+            bypass_runtime_node(block, input_layout, content_mono)
         }
     })
 }
@@ -276,6 +318,7 @@ fn build_select_runtime_node(
     block: &project::block::AudioBlock,
     select: &SelectBlock,
     input_layout: AudioChannelLayout,
+    content_mono: bool,
     sample_rate: f32,
     existing: Option<BlockRuntimeNode>,
 ) -> Result<BlockRuntimeNode> {
@@ -303,11 +346,12 @@ fn build_select_runtime_node(
             &mut reusable_option_nodes,
             option,
             input_layout,
+            content_mono,
             sample_rate,
         ) {
             node
         } else {
-            build_block_runtime_node(chain, option, input_layout, sample_rate)?
+            build_block_runtime_node(chain, option, input_layout, content_mono, sample_rate)?
         };
         if let Some(existing_layout) = resolved_output_layout {
             if existing_layout != option_node.output_layout {
@@ -339,6 +383,7 @@ fn build_select_runtime_node(
         block_id: block.id.clone(),
         block_snapshot: block.clone(),
         input_layout,
+        content_mono,
         output_layout,
         scratch: ProcessorScratch::None,
         processor: RuntimeProcessor::Select(SelectRuntimeState {
@@ -362,12 +407,14 @@ fn build_select_runtime_node(
 pub(crate) fn bypass_runtime_node(
     block: &project::block::AudioBlock,
     input_layout: AudioChannelLayout,
+    content_mono: bool,
 ) -> BlockRuntimeNode {
     BlockRuntimeNode {
         instance_serial: next_block_instance_serial(),
         block_id: block.id.clone(),
         block_snapshot: block.clone(),
         input_layout,
+        content_mono,
         output_layout: input_layout,
         scratch: ProcessorScratch::None,
         processor: RuntimeProcessor::Bypass,
@@ -382,6 +429,7 @@ pub(crate) fn bypass_runtime_node(
 pub(crate) fn audio_block_runtime_node(
     block: &project::block::AudioBlock,
     input_layout: AudioChannelLayout,
+    content_mono: bool,
     outcome: ProcessorBuildOutcome,
 ) -> BlockRuntimeNode {
     let scratch = processor_scratch(&outcome.processor);
@@ -390,6 +438,7 @@ pub(crate) fn audio_block_runtime_node(
         block_id: block.id.clone(),
         block_snapshot: block.clone(),
         input_layout,
+        content_mono,
         output_layout: outcome.output_layout,
         scratch,
         processor: RuntimeProcessor::Audio(outcome.processor),
@@ -421,6 +470,7 @@ pub(crate) fn build_audio_processor_for_model<F>(
     effect_type: &str,
     model: &str,
     input_layout: AudioChannelLayout,
+    content_mono: bool,
     mut builder: F,
 ) -> Result<ProcessorBuildOutcome>
 where
@@ -459,6 +509,19 @@ where
             model,
         )?),
         (ModelAudioMode::DualMono, AudioChannelLayout::Mono) => {
+            AudioProcessor::Mono(expect_mono_processor(
+                builder(AudioChannelLayout::Mono)?,
+                chain,
+                effect_type,
+                model,
+            )?)
+        }
+        // Issue #588: a mono source broadcast to stereo carries identical
+        // channels (L == R). A single mono processor on that signal yields
+        // bit-identical output to two instances (`mono_mix([s, s]) == s`),
+        // at half the model footprint and CPU. Only collapse when the
+        // content reaching this block is still effectively mono.
+        (ModelAudioMode::DualMono, AudioChannelLayout::Stereo) if content_mono => {
             AudioProcessor::Mono(expect_mono_processor(
                 builder(AudioChannelLayout::Mono)?,
                 chain,
@@ -527,6 +590,7 @@ fn build_nam_audio_processor(
     chain: &Chain,
     stage: &NamBlock,
     input_layout: AudioChannelLayout,
+    content_mono: bool,
     sample_rate: f32,
 ) -> Result<ProcessorBuildOutcome> {
     build_audio_processor_for_model(
@@ -534,6 +598,7 @@ fn build_nam_audio_processor(
         block_core::EFFECT_TYPE_NAM,
         &stage.model,
         input_layout,
+        content_mono,
         |layout| build_nam_processor_via_dispatch(&stage.model, &stage.params, sample_rate, layout),
     )
 }

--- a/crates/engine/src/runtime_block_core.rs
+++ b/crates/engine/src/runtime_block_core.rs
@@ -45,6 +45,7 @@ pub(crate) fn build_core_block_runtime_node(
     block: &project::block::AudioBlock,
     core: &CoreBlock,
     input_layout: AudioChannelLayout,
+    content_mono: bool,
     sample_rate: f32,
 ) -> Result<BlockRuntimeNode> {
     let effect_type = core.effect_type.as_str();
@@ -69,99 +70,117 @@ pub(crate) fn build_core_block_runtime_node(
         EFFECT_TYPE_PREAMP => Ok(audio_block_runtime_node(
             block,
             input_layout,
+            content_mono,
             build_audio_processor_for_model(
                 chain,
                 EFFECT_TYPE_PREAMP,
                 model,
                 input_layout,
+                content_mono,
                 |layout| build_preamp_processor_for_layout(model, params, sample_rate, layout),
             )?,
         )),
         EFFECT_TYPE_AMP => Ok(audio_block_runtime_node(
             block,
             input_layout,
+            content_mono,
             build_audio_processor_for_model(
                 chain,
                 EFFECT_TYPE_AMP,
                 model,
                 input_layout,
+                content_mono,
                 |layout| build_amp_processor_for_layout(model, params, sample_rate, layout),
             )?,
         )),
         EFFECT_TYPE_FULL_RIG => Ok(audio_block_runtime_node(
             block,
             input_layout,
+            content_mono,
             build_audio_processor_for_model(
                 chain,
                 EFFECT_TYPE_FULL_RIG,
                 model,
                 input_layout,
+                content_mono,
                 |layout| build_full_rig_processor_for_layout(model, params, sample_rate, layout),
             )?,
         )),
         EFFECT_TYPE_CAB => Ok(audio_block_runtime_node(
             block,
             input_layout,
+            content_mono,
             build_audio_processor_for_model(
                 chain,
                 EFFECT_TYPE_CAB,
                 model,
                 input_layout,
+                content_mono,
                 |layout| build_cab_processor_for_layout(model, params, sample_rate, layout),
             )?,
         )),
         EFFECT_TYPE_BODY => Ok(audio_block_runtime_node(
             block,
             input_layout,
+            content_mono,
             build_audio_processor_for_model(
                 chain,
                 EFFECT_TYPE_BODY,
                 model,
                 input_layout,
+                content_mono,
                 |layout| build_body_processor_for_layout(model, params, sample_rate, layout),
             )?,
         )),
         EFFECT_TYPE_IR => Ok(audio_block_runtime_node(
             block,
             input_layout,
+            content_mono,
             build_audio_processor_for_model(
                 chain,
                 EFFECT_TYPE_IR,
                 model,
                 input_layout,
+                content_mono,
                 |layout| build_ir_processor_for_layout(model, params, sample_rate, layout),
             )?,
         )),
         EFFECT_TYPE_GAIN => Ok(audio_block_runtime_node(
             block,
             input_layout,
+            content_mono,
             build_audio_processor_for_model(
                 chain,
                 EFFECT_TYPE_GAIN,
                 model,
                 input_layout,
+                content_mono,
                 |layout| build_gain_processor_for_layout(model, params, sample_rate, layout),
             )?,
         )),
         EFFECT_TYPE_DELAY => Ok(audio_block_runtime_node(
             block,
             input_layout,
+            content_mono,
             build_audio_processor_for_model(
                 chain,
                 EFFECT_TYPE_DELAY,
                 model,
                 input_layout,
+                content_mono,
                 |layout| build_delay_processor_for_layout(model, params, sample_rate, layout),
             )?,
         )),
         EFFECT_TYPE_REVERB => Ok(audio_block_runtime_node(
             block,
             input_layout,
+            content_mono,
             build_audio_processor_for_model(
                 chain,
                 EFFECT_TYPE_REVERB,
                 model,
                 input_layout,
+                content_mono,
                 |layout| build_reverb_processor_for_layout(model, params, sample_rate, layout),
             )?,
         )),
@@ -172,6 +191,7 @@ pub(crate) fn build_core_block_runtime_node(
                 EFFECT_TYPE_UTILITY,
                 model,
                 input_layout,
+                content_mono,
                 |layout| {
                     let (bp, sh) = build_utility_processor_for_layout(
                         model,
@@ -186,60 +206,75 @@ pub(crate) fn build_core_block_runtime_node(
                 },
             )?;
             outcome.stream_handle = captured_stream;
-            Ok(audio_block_runtime_node(block, input_layout, outcome))
+            Ok(audio_block_runtime_node(
+                block,
+                input_layout,
+                content_mono,
+                outcome,
+            ))
         }
         EFFECT_TYPE_DYNAMICS => Ok(audio_block_runtime_node(
             block,
             input_layout,
+            content_mono,
             build_audio_processor_for_model(
                 chain,
                 EFFECT_TYPE_DYNAMICS,
                 model,
                 input_layout,
+                content_mono,
                 |layout| build_dynamics_processor_for_layout(model, params, sample_rate, layout),
             )?,
         )),
         EFFECT_TYPE_FILTER => Ok(audio_block_runtime_node(
             block,
             input_layout,
+            content_mono,
             build_audio_processor_for_model(
                 chain,
                 EFFECT_TYPE_FILTER,
                 model,
                 input_layout,
+                content_mono,
                 |layout| build_filter_processor_for_layout(model, params, sample_rate, layout),
             )?,
         )),
         EFFECT_TYPE_WAH => Ok(audio_block_runtime_node(
             block,
             input_layout,
+            content_mono,
             build_audio_processor_for_model(
                 chain,
                 EFFECT_TYPE_WAH,
                 model,
                 input_layout,
+                content_mono,
                 |layout| build_wah_processor_for_layout(model, params, sample_rate, layout),
             )?,
         )),
         EFFECT_TYPE_MODULATION => Ok(audio_block_runtime_node(
             block,
             input_layout,
+            content_mono,
             build_audio_processor_for_model(
                 chain,
                 EFFECT_TYPE_MODULATION,
                 model,
                 input_layout,
+                content_mono,
                 |layout| build_modulation_processor_for_layout(model, params, sample_rate, layout),
             )?,
         )),
         EFFECT_TYPE_PITCH => Ok(audio_block_runtime_node(
             block,
             input_layout,
+            content_mono,
             build_audio_processor_for_model(
                 chain,
                 EFFECT_TYPE_PITCH,
                 model,
                 input_layout,
+                content_mono,
                 |layout| build_pitch_processor_for_layout(model, params, sample_rate, layout),
             )?,
         )),
@@ -287,11 +322,13 @@ pub(crate) fn build_core_block_runtime_node(
             Ok(audio_block_runtime_node(
                 block,
                 input_layout,
+                content_mono,
                 build_audio_processor_for_model(
                     chain,
                     block_core::EFFECT_TYPE_VST3,
                     model,
                     input_layout,
+                    content_mono,
                     |layout| {
                         let p = plugin_opt
                             .take()

--- a/crates/engine/src/runtime_graph.rs
+++ b/crates/engine/src/runtime_graph.rs
@@ -499,9 +499,15 @@ fn build_input_processing_state(
         input.mode,
     );
     let had_existing = existing_blocks.is_some();
+    // Issue #588: a mono source is broadcast to identical stereo channels
+    // (`Stereo([s, s])`), so the content entering the first block is
+    // effectively mono. A DualMono/Stereo source carries independent
+    // channels and is not.
+    let source_is_mono = matches!(input_read_layout, AudioChannelLayout::Mono);
     let (blocks, _output_layout) = build_runtime_block_nodes(
         chain,
         processing_layout_channel,
+        source_is_mono,
         sample_rate,
         existing_blocks,
         block_indices,

--- a/crates/engine/src/runtime_graph.rs
+++ b/crates/engine/src/runtime_graph.rs
@@ -191,6 +191,29 @@ fn build_per_input_runtimes(
     Ok(out)
 }
 
+/// The per-input group ids a chain would produce, WITHOUT instantiating any
+/// block processor. Issue #588: the in-place `upsert_chain` fast path used to
+/// call `build_per_input_runtimes` purely to read these ids for a topology
+/// comparison — which loaded every NAM/IR model in the chain from disk on
+/// each edit, only to throw the runtime away. The grouping depends solely on
+/// the chain's input/output endpoints and segment split, never on the built
+/// processors, so it can be derived directly.
+fn input_group_ids(chain: &Chain) -> Vec<usize> {
+    let (eff_inputs, eff_input_cpal_indices, eff_split_positions) = effective_inputs(chain);
+    let eff_outputs = effective_outputs(chain);
+    let all_segments = split_chain_into_segments(
+        chain,
+        &eff_inputs,
+        &eff_input_cpal_indices,
+        &eff_split_positions,
+        &eff_outputs,
+    );
+    group_segments_by_input(chain, all_segments)
+        .into_iter()
+        .map(|(group, _segments)| group)
+        .collect()
+}
+
 /// Lookup the per-route elastic target, falling back to DEFAULT_ELASTIC_TARGET
 /// if the caller did not provide a value for this route index.
 fn target_for_route(elastic_targets: &[usize], route_idx: usize) -> usize {
@@ -838,8 +861,11 @@ impl RuntimeGraph {
         // cpal streams, so the callbacks kept the OLD Arcs and the edit
         // never reached the audio thread (slider did nothing).
         if !existing_groups.is_empty() {
-            let new_runtimes = build_per_input_runtimes(chain, sample_rate, elastic_targets)?;
-            let mut new_groups: Vec<usize> = new_runtimes.iter().map(|(g, _)| *g).collect();
+            // Issue #588: derive the new group ids WITHOUT building runtimes —
+            // building here reloaded every NAM/IR model in the chain from disk
+            // on each edit (volume, knob, toggle), only to discard them and
+            // update the existing runtime in place.
+            let mut new_groups: Vec<usize> = input_group_ids(chain);
             let mut existing_sorted = existing_groups.clone();
             new_groups.sort_unstable();
             existing_sorted.sort_unstable();

--- a/crates/engine/src/runtime_state.rs
+++ b/crates/engine/src/runtime_state.rs
@@ -166,6 +166,14 @@ pub(crate) struct BlockRuntimeNode {
     pub(crate) block_id: BlockId,
     pub(crate) block_snapshot: AudioBlock,
     pub(crate) input_layout: AudioChannelLayout,
+    /// Whether the signal reaching this block is effectively mono — i.e. a
+    /// stereo bus whose two channels carry the identical sample (a mono
+    /// source broadcast to `Stereo([s, s])`, preserved by every preceding
+    /// block). Issue #588: a `DualMono` model under effective-mono content
+    /// is built as a single mono processor instead of one per channel
+    /// (bit-identical output, half the model footprint). Part of the reuse
+    /// identity: if this flips, the block must rebuild (mono ↔ dual).
+    pub(crate) content_mono: bool,
     pub(crate) output_layout: AudioChannelLayout,
     pub(crate) scratch: ProcessorScratch,
     pub(crate) processor: RuntimeProcessor,

--- a/crates/engine/src/runtime_tests.rs
+++ b/crates/engine/src/runtime_tests.rs
@@ -882,6 +882,7 @@ fn panicking_block_node() -> BlockRuntimeNode {
             }),
         },
         input_layout: block_core::AudioChannelLayout::Mono,
+        content_mono: true,
         output_layout: block_core::AudioChannelLayout::Mono,
         scratch: ProcessorScratch::Mono(Vec::new()),
         processor: RuntimeProcessor::Audio(AudioProcessor::Mono(Box::new(PanickingProcessor))),
@@ -909,6 +910,7 @@ fn counting_block_node(
             }),
         },
         input_layout: block_core::AudioChannelLayout::Mono,
+        content_mono: true,
         output_layout: block_core::AudioChannelLayout::Mono,
         scratch: ProcessorScratch::Mono(Vec::new()),
         processor: RuntimeProcessor::Audio(AudioProcessor::Mono(Box::new(CountingProcessor {
@@ -3033,7 +3035,7 @@ fn bypass_runtime_node_has_bypass_processor() {
             params: ParameterSet::default(),
         }),
     };
-    let node = bypass_runtime_node(&block, AudioChannelLayout::Mono);
+    let node = bypass_runtime_node(&block, AudioChannelLayout::Mono, true);
     assert!(matches!(node.processor, RuntimeProcessor::Bypass));
     assert_eq!(node.block_id.0, "test:bypass");
     assert_eq!(node.input_layout, AudioChannelLayout::Mono);

--- a/crates/engine/tests/issue_588_dualmono_nam_two_instances.rs
+++ b/crates/engine/tests/issue_588_dualmono_nam_two_instances.rs
@@ -1,0 +1,117 @@
+//! Issue #588 — boundary guard for the mono-collapse optimization.
+//!
+//! The companion test `issue_588_mono_nam_single_instance` asserts that a
+//! MONO source loads a `DualMono` NAM model once. This test guards the other
+//! side of that boundary: a DualMono source carries two INDEPENDENT channels,
+//! so the model must still be instantiated per channel (two live instances).
+//! Collapsing here would silently sum/duplicate the channels and destroy the
+//! independent stereo signal — a correctness regression, not an optimization.
+//!
+//! Own integration binary so the process-global NAM counter is isolated.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Once;
+
+use block_core::param::ParameterSet;
+use domain::ids::{BlockId, ChainId, DeviceId};
+use domain::value_objects::ParameterValue;
+use project::block::{
+    AudioBlock, AudioBlockKind, InputBlock, InputEntry, NamBlock, OutputBlock, OutputEntry,
+};
+use project::chain::{Chain, ChainInputMode, ChainOutputMode};
+use project::project::Project;
+
+const SR: f32 = 48_000.0;
+
+fn fixture_plugins_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/plugins")
+}
+
+fn init_test_registry() {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        nam::register_builder();
+        ir::register_builder();
+        plugin_loader::registry::init(&fixture_plugins_root());
+    });
+}
+
+/// DualMono input (two independent channels) → NAM amp → stereo output.
+fn dualmono_source_nam_chain(id: &str) -> Chain {
+    let mut amp_params = ParameterSet::default();
+    amp_params.insert("preset", ParameterValue::String("angus".into()));
+    Chain {
+        id: ChainId(id.into()),
+        description: Some("issue-588 dual-mono source keeps two instances".into()),
+        instrument: "electric_guitar".into(),
+        enabled: true,
+        volume: 100.0,
+        blocks: vec![
+            AudioBlock {
+                id: BlockId("in".into()),
+                enabled: true,
+                kind: AudioBlockKind::Input(InputBlock {
+                    model: "standard".into(),
+                    entries: vec![InputEntry {
+                        device_id: DeviceId("dev".into()),
+                        mode: ChainInputMode::DualMono,
+                        channels: vec![0, 1],
+                    }],
+                }),
+            },
+            AudioBlock {
+                id: BlockId("amp".into()),
+                enabled: true,
+                kind: AudioBlockKind::Nam(NamBlock {
+                    model: "nam_marshall_plexi".into(),
+                    params: amp_params,
+                }),
+            },
+            AudioBlock {
+                id: BlockId("out".into()),
+                enabled: true,
+                kind: AudioBlockKind::Output(OutputBlock {
+                    model: "standard".into(),
+                    entries: vec![OutputEntry {
+                        device_id: DeviceId("dev".into()),
+                        mode: ChainOutputMode::Stereo,
+                        channels: vec![0, 1],
+                    }],
+                }),
+            },
+        ],
+    }
+}
+
+#[test]
+fn dualmono_source_keeps_independent_per_channel_nam_instances() {
+    init_test_registry();
+
+    assert!(
+        plugin_loader::registry::find("nam_marshall_plexi").is_some(),
+        "fixture plugin nam_marshall_plexi must be discoverable"
+    );
+
+    let chain = dualmono_source_nam_chain("issue-588-dualmono");
+    let mut rates = HashMap::new();
+    rates.insert(chain.id.clone(), SR);
+    let project = Project {
+        name: None,
+        device_settings: Vec::new(),
+        chains: vec![chain],
+        midi: None,
+    };
+
+    let _graph = engine::runtime_graph::build_runtime_graph(&project, &rates, &HashMap::new())
+        .expect("dual-mono-source NAM chain must build");
+
+    assert_eq!(
+        nam::live_models(),
+        2,
+        "issue #588: a DualMono source has independent L/R channels, so the \
+         NAM model must run per channel (2 instances). The mono-collapse \
+         optimization must NOT apply here — found {} instance(s).",
+        nam::live_models()
+    );
+}

--- a/crates/engine/tests/issue_588_mono_nam_single_instance.rs
+++ b/crates/engine/tests/issue_588_mono_nam_single_instance.rs
@@ -1,0 +1,126 @@
+//! Issue #588 — a MONO source must not load a mono NAM model once per
+//! stereo channel.
+//!
+//! OpenRig processes every stream as stereo internally (invariant #5): a
+//! mono input is broadcast to `Stereo([s, s])`. A mono NAM amp placed on
+//! such a chain currently gets instantiated once per channel, so the model
+//! is loaded TWICE — but for a mono source the two channels are
+//! bit-identical going into the amp, so the second instance produces
+//! identical output at double the memory and CPU. With many mono NAM/IR
+//! blocks in a rig this doubles their entire footprint.
+//!
+//! Contract: when the source feeding a mono model is mono (both stereo
+//! channels carry the same signal), exactly one model instance is loaded.
+//! The DualMono / true-stereo cases (channels differ) are out of scope for
+//! this test and legitimately need per-channel processing.
+//!
+//! This test lives in its own integration binary so the process-global NAM
+//! instance counter is not perturbed by other tests running in parallel.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Once;
+
+use block_core::param::ParameterSet;
+use domain::ids::{BlockId, ChainId, DeviceId};
+use domain::value_objects::ParameterValue;
+use project::block::{
+    AudioBlock, AudioBlockKind, InputBlock, InputEntry, NamBlock, OutputBlock, OutputEntry,
+};
+use project::chain::{Chain, ChainInputMode, ChainOutputMode};
+use project::project::Project;
+
+const SR: f32 = 48_000.0;
+
+fn fixture_plugins_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/plugins")
+}
+
+fn init_test_registry() {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        nam::register_builder();
+        ir::register_builder();
+        plugin_loader::registry::init(&fixture_plugins_root());
+    });
+}
+
+/// MONO input (single channel) → NAM amp → stereo output.
+fn mono_source_nam_chain(id: &str) -> Chain {
+    let mut amp_params = ParameterSet::default();
+    amp_params.insert("preset", ParameterValue::String("angus".into()));
+    Chain {
+        id: ChainId(id.into()),
+        description: Some("issue-588 mono source single model".into()),
+        instrument: "electric_guitar".into(),
+        enabled: true,
+        volume: 100.0,
+        blocks: vec![
+            AudioBlock {
+                id: BlockId("in".into()),
+                enabled: true,
+                kind: AudioBlockKind::Input(InputBlock {
+                    model: "standard".into(),
+                    entries: vec![InputEntry {
+                        device_id: DeviceId("dev".into()),
+                        mode: ChainInputMode::Mono,
+                        channels: vec![0],
+                    }],
+                }),
+            },
+            AudioBlock {
+                id: BlockId("amp".into()),
+                enabled: true,
+                kind: AudioBlockKind::Nam(NamBlock {
+                    model: "nam_marshall_plexi".into(),
+                    params: amp_params,
+                }),
+            },
+            AudioBlock {
+                id: BlockId("out".into()),
+                enabled: true,
+                kind: AudioBlockKind::Output(OutputBlock {
+                    model: "standard".into(),
+                    entries: vec![OutputEntry {
+                        device_id: DeviceId("dev".into()),
+                        mode: ChainOutputMode::Stereo,
+                        channels: vec![0, 1],
+                    }],
+                }),
+            },
+        ],
+    }
+}
+
+#[test]
+fn mono_source_loads_a_mono_nam_model_only_once() {
+    init_test_registry();
+
+    assert!(
+        plugin_loader::registry::find("nam_marshall_plexi").is_some(),
+        "fixture plugin nam_marshall_plexi must be discoverable"
+    );
+
+    let chain = mono_source_nam_chain("issue-588-mono");
+    let mut rates = HashMap::new();
+    rates.insert(chain.id.clone(), SR);
+    let project = Project {
+        name: None,
+        device_settings: Vec::new(),
+        chains: vec![chain],
+        midi: None,
+    };
+
+    let _graph = engine::runtime_graph::build_runtime_graph(&project, &rates, &HashMap::new())
+        .expect("mono-source NAM chain must build");
+
+    assert_eq!(
+        nam::live_models(),
+        1,
+        "issue #588: a mono source broadcast to stereo loaded the mono NAM \
+         model {} times instead of once. The two stereo channels carry the \
+         same signal, so a single mono processor must serve both — loading \
+         it per channel doubles the model footprint for identical output.",
+        nam::live_models()
+    );
+}

--- a/crates/engine/tests/issue_588_no_model_reload_on_chain_edit.rs
+++ b/crates/engine/tests/issue_588_no_model_reload_on_chain_edit.rs
@@ -1,0 +1,164 @@
+//! Issue #588 — memory: editing a LIVE chain must NOT reload the NAM
+//! model of a block that is being reused.
+//!
+//! Root cause under test: `RuntimeGraph::upsert_chain` takes an in-place
+//! fast path for an already-running chain (param / volume / toggle edit
+//! that keeps the input topology). Before deciding to take that path it
+//! calls `build_per_input_runtimes(...)` to read the new group ids for a
+//! topology comparison — and that build instantiates EVERY block in the
+//! chain, including loading each NAM/IR model from disk via the native
+//! library, only to throw the freshly-built runtime away and update the
+//! existing one in place.
+//!
+//! Consequence: every volume drag / knob turn / preset-equivalent edit on
+//! a chain that contains heavy NAM amps transiently doubles the model
+//! footprint (two full copies of every model live at once) and re-runs
+//! `CreateModelFromFile` for models that did not change. Repeated edits
+//! churn the native allocator and, if the native layer memoizes by path,
+//! grow unbounded — the observed multi-GB RSS.
+//!
+//! The contract: a chain edit that reuses a block must not reload that
+//! block's model. The model creation count must not increase when the
+//! block (and its model) is unchanged across the edit.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Once;
+
+use block_core::param::ParameterSet;
+use domain::ids::{BlockId, ChainId, DeviceId};
+use domain::value_objects::ParameterValue;
+use project::block::{
+    AudioBlock, AudioBlockKind, InputBlock, InputEntry, NamBlock, OutputBlock, OutputEntry,
+};
+use project::chain::{Chain, ChainInputMode, ChainOutputMode};
+use project::project::Project;
+
+const SR: f32 = 48_000.0;
+
+fn fixture_plugins_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/plugins")
+}
+
+fn init_test_registry() {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        nam::register_builder();
+        ir::register_builder();
+        plugin_loader::registry::init(&fixture_plugins_root());
+    });
+}
+
+/// Input → NAM amp → Output. A buildable single-input chain whose only
+/// heavy resource is the NAM model of `nam_marshall_plexi`.
+fn nam_chain(id: &str, volume: f32) -> Chain {
+    let mut amp_params = ParameterSet::default();
+    amp_params.insert("preset", ParameterValue::String("angus".into()));
+    Chain {
+        id: ChainId(id.into()),
+        description: Some("issue-588 model reload on edit".into()),
+        instrument: "electric_guitar".into(),
+        enabled: true,
+        volume,
+        blocks: vec![
+            AudioBlock {
+                id: BlockId("in".into()),
+                enabled: true,
+                kind: AudioBlockKind::Input(InputBlock {
+                    model: "standard".into(),
+                    entries: vec![InputEntry {
+                        device_id: DeviceId("dev".into()),
+                        mode: ChainInputMode::Mono,
+                        channels: vec![0],
+                    }],
+                }),
+            },
+            AudioBlock {
+                id: BlockId("amp".into()),
+                enabled: true,
+                kind: AudioBlockKind::Nam(NamBlock {
+                    model: "nam_marshall_plexi".into(),
+                    params: amp_params,
+                }),
+            },
+            AudioBlock {
+                id: BlockId("out".into()),
+                enabled: true,
+                kind: AudioBlockKind::Output(OutputBlock {
+                    model: "standard".into(),
+                    entries: vec![OutputEntry {
+                        device_id: DeviceId("dev".into()),
+                        mode: ChainOutputMode::Stereo,
+                        channels: vec![0, 1],
+                    }],
+                }),
+            },
+        ],
+    }
+}
+
+#[test]
+fn editing_a_live_chain_does_not_reload_the_reused_nam_model() {
+    init_test_registry();
+
+    assert!(
+        plugin_loader::registry::find("nam_marshall_plexi").is_some(),
+        "fixture plugin nam_marshall_plexi must be discoverable in \
+         crates/engine/tests/fixtures/plugins/"
+    );
+
+    let chain = nam_chain("issue-588", 100.0);
+    let mut rates = HashMap::new();
+    rates.insert(chain.id.clone(), SR);
+    let project = Project {
+        name: None,
+        device_settings: Vec::new(),
+        chains: vec![chain.clone()],
+        midi: None,
+    };
+
+    // Build the live graph: the NAM model is loaded exactly once here.
+    let mut graph = engine::runtime_graph::build_runtime_graph(&project, &rates, &HashMap::new())
+        .expect("graph with a NAM amp must build");
+
+    // Baseline after build. The absolute value depends on the stereo
+    // channel fan-out of a mono amp and is not the subject of this test;
+    // what matters is that an EDIT does not grow it.
+    let created_after_build = nam::models_created();
+    let live_after_build = nam::live_models();
+    assert!(
+        live_after_build >= 1,
+        "the chain's NAM amp must be resident after building the chain"
+    );
+
+    // User drags the volume slider: 100 → 150. Same call the controller
+    // makes for a live chain (topology unchanged → in-place fast path).
+    // The amp block is byte-identical across the edit, so its model MUST
+    // be reused, never reloaded.
+    let edited = nam_chain("issue-588", 150.0);
+    graph
+        .upsert_chain(&edited, SR, false, &[2048])
+        .expect("in-place volume edit must succeed");
+
+    let created_after_edit = nam::models_created();
+    let live_after_edit = nam::live_models();
+
+    assert_eq!(
+        created_after_edit - created_after_build,
+        0,
+        "issue #588: a volume edit on a live chain RELOADED the NAM model \
+         (CreateModelFromFile ran {} extra time(s)). `upsert_chain` is \
+         building a full throwaway runtime just to compare input topology, \
+         reloading every model in the chain. Derive the topology without \
+         instantiating processors so reused blocks keep their existing \
+         model.",
+        created_after_edit - created_after_build
+    );
+
+    assert_eq!(
+        live_after_edit, live_after_build,
+        "issue #588: a chain edit leaked a model — {live_after_build} resident \
+         before the edit, {live_after_edit} after. The old runtime's models \
+         must be freed once the edit swaps in the new one."
+    );
+}

--- a/crates/nam/src/lib.rs
+++ b/crates/nam/src/lib.rs
@@ -5,6 +5,7 @@ pub mod loudness_probe;
 pub mod processor;
 
 pub use from_package::{build_from_package, register_builder};
+pub use processor::{live_models, models_created};
 
 use anyhow::{bail, Result};
 use block_core::param::{ModelParameterSchema, ParameterSet};

--- a/crates/nam/src/processor.rs
+++ b/crates/nam/src/processor.rs
@@ -6,6 +6,30 @@ use block_core::param::{
 };
 use block_core::{db_to_lin, ModelAudioMode, MonoProcessor};
 use domain::value_objects::ParameterValue;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Cumulative count of NAM models loaded via `CreateModelFromFile` over the
+/// process lifetime (never decremented). Memory-observability counter
+/// (issue #588): a chain edit that reuses a block must NOT grow this — a
+/// reload of an unchanged model is wasted work and a transient 2× footprint.
+static MODELS_CREATED: AtomicUsize = AtomicUsize::new(0);
+
+/// Number of NAM models currently resident in memory (incremented on load,
+/// decremented on `Drop`). Memory-observability counter (issue #588): after
+/// any chain edit this must equal the number of NAM blocks actually in the
+/// live chain — a higher value is an orphaned model that was not freed.
+static MODELS_LIVE: AtomicUsize = AtomicUsize::new(0);
+
+/// Total NAM models loaded since process start (monotonic). See
+/// [`MODELS_CREATED`].
+pub fn models_created() -> usize {
+    MODELS_CREATED.load(Ordering::Relaxed)
+}
+
+/// NAM models currently held in memory. See [`MODELS_LIVE`].
+pub fn live_models() -> usize {
+    MODELS_LIVE.load(Ordering::Relaxed)
+}
 
 pub fn supports_model(model: &str) -> bool {
     model == GENERIC_NAM_MODEL_ID
@@ -349,6 +373,9 @@ impl Drop for NamProcessor {
         if !self.model.is_null() {
             unsafe { DeleteModel(self.model) };
             self.model = std::ptr::null_mut();
+            // Memory-observability (issue #588): mirror the increment in
+            // `new`. Only decrement for a model that was actually loaded.
+            MODELS_LIVE.fetch_sub(1, Ordering::Relaxed);
         }
     }
 }
@@ -381,6 +408,10 @@ impl NamProcessor {
         if model.is_null() {
             bail!("failed to load NAM model '{}'", model_path);
         }
+        // Memory-observability (issue #588): a model was just loaded into
+        // memory. Mirror this decrement in `Drop`.
+        MODELS_CREATED.fetch_add(1, Ordering::Relaxed);
+        MODELS_LIVE.fetch_add(1, Ordering::Relaxed);
 
         let recommended_input_db = unsafe { GetRecommendedInputDBAdjustment(model) };
         let recommended_output_db = unsafe { GetRecommendedOutputDBAdjustment(model) };


### PR DESCRIPTION
Closes #588.

OpenRig was observed using ~4GB of RAM. Two independent causes in how NAM/IR neural models are held, both fixed here (RED-first, output bit-identical).

## 1. Live-chain edits reloaded every model from disk
`RuntimeGraph::upsert_chain` took an in-place fast path for an already-running chain (volume / knob / preset edit that preserves input topology) but first called `build_per_input_runtimes(...)` **only to read the new group ids** for a topology comparison — instantiating every block and reloading each NAM/IR model via `CreateModelFromFile`, then discarding the runtime. Every edit transiently doubled the chain's model footprint and churned the native allocator (a dragged slider reloads models hundreds of times/sec).

**Fix:** derive the group ids directly from the chain endpoints (`input_group_ids`) without instantiating processors. Reused blocks keep their existing model. The in-place reuse path (cpal-callback `Arc` validity #350, click-free #580) is preserved.

## 2. A mono source loaded a DualMono model once per channel
Every stream is stereo internally (invariant #5): a mono input is broadcast to `Stereo([s, s])`. A `DualMono` model (every NAM amp, most IR/cab) under a stereo layout was built as two mono processors — so a mono guitar into an amp loaded the neural model **twice** for bit-identical output (the two channels are the same signal). Many mono blocks in a rig doubled their whole footprint.

**Fix:** track whether the signal reaching each block is effectively mono (channels identical) — true at a mono source, preserved by mono/bypass blocks, cleared the moment a block produces genuine stereo. A `DualMono` model under effective-mono content builds a single `AudioProcessor::Mono` instead of two. `mono_mix([s, s]) == s` exactly, so output is bit-identical at half the model memory + CPU. The flag is part of the block-reuse identity (an edit that decorrelates the channels rebuilds to per-channel). DualMono/Stereo sources are unaffected; offline render is conservative.

## Observability
Adds `nam::models_created()` / `nam::live_models()` counters (incremented on load, decremented on `Drop`) used by the regression tests.

## Tests (RED-first)
- `editing_a_live_chain_does_not_reload_the_reused_nam_model` — a volume edit reloads no reused model and leaks no instance.
- `mono_source_loads_a_mono_nam_model_only_once` — mono source → 1 instance.
- `dualmono_source_keeps_independent_per_channel_nam_instances` — boundary guard: DualMono source still uses 2.

## Verification
`cargo test -p engine --lib` 529 passed / 0 failed (volume + golden invariants intact); `issue_574` NAM render green; `nam --lib` 88 passed. Output bit-identical for mono content — no audio regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)