### PR TITLE
fix(#593): keep NAM-backed gain/amp/preamp category on preset load

### DIFF
--- a/crates/application/tests/preset_nam_block_keeps_category_issue.rs
+++ b/crates/application/tests/preset_nam_block_keeps_category_issue.rs
@@ -1,0 +1,79 @@
+//! Bug repro (issue #593): a preset saved off chain "GUITARRA - DEFAULT"
+//! shows GAIN / AMP / PREAMP blocks, but loading the SAME preset onto
+//! another chain ("teyun") renders those blocks as generic purple NAM
+//! blocks. The blocks' category (effect_type) is lost on load.
+//!
+//! Root cause: `infra_yaml`'s `into_audio_block` had a blanket
+//! `if model.starts_with("nam_") => AudioBlockKind::Nam` branch (issue
+//! #552). A NAM-backed stompbox is persisted under its NATURAL block type
+//! (`type: gain`), and the live chain keeps it as `Core { effect_type:
+//! "gain" }`. Forcing it to `Nam` on load drops the category, so the GUI
+//! shows it as a generic NAM and the signal-chain role changes.
+//!
+//! This test registers a NAM-prefixed model under the `gain` block type,
+//! writes a preset that references it as `type: gain`, loads the preset
+//! file through the real parser, and asserts the block comes back as
+//! `Core { effect_type: "gain" }` — NOT `Nam`.
+
+use project::block::AudioBlockKind;
+
+use block_core::param::{ModelParameterSchema, ParameterSet};
+use block_core::{AudioChannelLayout, BlockProcessor};
+use plugin_loader::{BlockType, NativeRuntime};
+
+fn dummy_schema() -> anyhow::Result<ModelParameterSchema> {
+    anyhow::bail!("test runtime: schema never invoked during parse")
+}
+fn dummy_validate(_: &ParameterSet) -> anyhow::Result<()> {
+    Ok(())
+}
+fn dummy_build(_: &ParameterSet, _: f32, _: AudioChannelLayout) -> anyhow::Result<BlockProcessor> {
+    anyhow::bail!("test runtime: build never invoked during parse")
+}
+
+#[test]
+fn loading_preset_keeps_nam_gain_block_as_core_not_generic_nam() {
+    // Register a NAM-prefixed model as a gain pedal so the disk-package
+    // schema fallback resolves it (mirrors a real installed NAM stompbox).
+    plugin_loader::registry::register_native_simple(
+        "nam_fake_test_od",
+        "Fake Test OD",
+        None,
+        BlockType::GainPedal,
+        NativeRuntime {
+            schema: dummy_schema,
+            validate: dummy_validate,
+            build: dummy_build,
+        },
+    );
+    // Publish the registered native into the queried catalog (the live
+    // app does this at boot, after every `block-*` crate registers).
+    plugin_loader::registry::reload(&[]);
+    assert!(
+        plugin_loader::registry::find("nam_fake_test_od").is_some(),
+        "precondition: the fake NAM model must be in the catalog"
+    );
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let preset_path = tmp.path().join("od.yaml");
+    std::fs::write(
+        &preset_path,
+        "version: 1\nid: OD\nname: GUITARRA - DEFAULT\nblocks:\n  - type: gain\n    enabled: false\n    model: nam_fake_test_od\n",
+    )
+    .expect("write preset");
+
+    let preset = infra_yaml::load_chain_preset_file(&preset_path).expect("preset loads");
+    assert_eq!(preset.blocks.len(), 1, "the gain block must survive the load");
+
+    match &preset.blocks[0].kind {
+        AudioBlockKind::Core(core) => assert_eq!(
+            core.effect_type, "gain",
+            "a NAM-backed `type: gain` block must keep its gain category"
+        ),
+        AudioBlockKind::Nam(_) => panic!(
+            "REGRESSION: NAM-backed `type: gain` block was coerced to a generic \
+             Nam block, losing its gain category (the screenshot bug)"
+        ),
+        other => panic!("expected Core gain block, got {other:?}"),
+    }
+}

--- a/crates/infra-yaml/src/block_yaml.rs
+++ b/crates/infra-yaml/src/block_yaml.rs
@@ -374,36 +374,49 @@ impl AudioBlockYaml {
                 let (effect_type, enabled, model, params) = extract_core_block_fields(other);
                 let model = migrate_legacy_model_id(effect_type, model, &params);
 
-                // Issue #552: NAM captures are persisted under their natural
-                // block type ("gain" for stompbox NAMs, "amp" / "preamp" for
-                // amp NAMs) — that's how the MCP `add_block` path saves them
-                // when the user passes `kind: gain, model_id: nam_*`. The
-                // offline preset loader was treating the model as a generic
-                // gain/amp model and failing the registry lookup, dropping
-                // the block silently. Routing model ids prefixed with `nam_`
-                // to the Nam runtime here matches the live engine's
-                // behaviour and keeps the offline render faithful to what
-                // the user heard live.
-                if model.starts_with("nam_") {
-                    return Ok(AudioBlock {
+                // NAM captures are persisted under their NATURAL block type
+                // ("gain" for stompbox NAMs, "amp" / "preamp" for amp NAMs) —
+                // that's how the MCP `add_block` path saves them and how the
+                // live chain keeps them: a `Core { effect_type: "gain" }`,
+                // NOT a generic `Nam` block. Prefer that declared category so
+                // a preset loaded onto another chain keeps each block's
+                // widget and signal-chain role (otherwise GAIN/AMP/PREAMP all
+                // collapse to purple "NAM" blocks). The declared type resolves
+                // via the disk-package schema fallback whenever the plugin
+                // catalog is loaded — i.e. the GUI / live path.
+                match load_model_params(effect_type, &model, params.clone()) {
+                    Ok(resolved) => Ok(AudioBlock {
                         id: generated_id,
                         enabled,
-                        kind: AudioBlockKind::Nam(NamBlock {
-                            model: model.clone(),
-                            params: load_model_params(block_core::EFFECT_TYPE_NAM, &model, params)?,
+                        kind: AudioBlockKind::Core(CoreBlock {
+                            effect_type: effect_type.to_string(),
+                            model,
+                            params: resolved,
                         }),
-                    });
-                }
-
-                Ok(AudioBlock {
-                    id: generated_id,
-                    enabled,
-                    kind: AudioBlockKind::Core(CoreBlock {
-                        effect_type: effect_type.to_string(),
-                        model: model.clone(),
-                        params: load_model_params(effect_type, &model, params)?,
                     }),
-                })
+                    // Issue #552: an offline render with no plugin catalog
+                    // can't resolve the declared type. For NAM-prefixed models
+                    // fall back to the generic Nam runtime so the block still
+                    // survives instead of being dropped silently.
+                    Err(core_err) => {
+                        if model.starts_with("nam_") {
+                            Ok(AudioBlock {
+                                id: generated_id,
+                                enabled,
+                                kind: AudioBlockKind::Nam(NamBlock {
+                                    model: model.clone(),
+                                    params: load_model_params(
+                                        block_core::EFFECT_TYPE_NAM,
+                                        &model,
+                                        params,
+                                    )?,
+                                }),
+                            })
+                        } else {
+                            Err(core_err)
+                        }
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Closes #593.

## Problem

A preset saved off chain *GUITARRA - DEFAULT* shows its NAM-backed blocks as **GAIN / GAIN / AMP / PREAMP**. Loading the same preset onto another chain rendered all four as generic purple **NAM** blocks — the category (and thus the widget and signal-chain role) was lost.

## Root cause

`crates/infra-yaml/src/block_yaml.rs` → `into_audio_block` had a blanket `if model.starts_with("nam_") => AudioBlockKind::Nam` branch (issue #552). NAM captures are persisted under their natural block type (`type: gain` / `amp` / `preamp`) and the live chain keeps them as `Core { effect_type }`. The branch threw the declared type away and coerced every `nam_*` model into a generic `Nam` block.

## Fix

Prefer the declared category (`Core { effect_type }`), which resolves via the disk-package schema fallback whenever the plugin catalog is loaded (the GUI / live path). Fall back to the generic `Nam` runtime only when the declared type can't be resolved (offline render with no catalog) — preserving the #552 "don't drop the block" guarantee.

## Test

`crates/application/tests/preset_nam_block_keeps_category_issue.rs` — registers a `nam_`-prefixed model as a gain pedal, loads a preset referencing it as `type: gain` through the real parser, asserts `Core { effect_type: "gain" }`. Verified RED on old code (coerced to `Nam`) → GREEN with the fix. `infra-yaml` (87) and `adapter-render` (#552) suites stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)