### PR TITLE
fix(#596): persist audio input/output device split in config.yaml

### DIFF
--- a/crates/adapter-gui/src/audio_devices.rs
+++ b/crates/adapter-gui/src/audio_devices.rs
@@ -402,3 +402,7 @@ fn parse_positive_u32(value: &str, field: &str) -> Result<u32> {
         .parse::<u32>()
         .map_err(|_| anyhow!("'{}' inválido: '{}'", field, value))
 }
+
+#[cfg(test)]
+#[path = "audio_devices_tests.rs"]
+mod tests;

--- a/crates/adapter-gui/src/audio_devices_tests.rs
+++ b/crates/adapter-gui/src/audio_devices_tests.rs
@@ -1,0 +1,60 @@
+//! Regression: audio interface selection resets to empty on reopen.
+//!
+//! Audio device selection is a SYSTEM concept (ADR 0003) persisted in the
+//! per-machine `config.yaml`. On boot the device rows must repopulate their
+//! `selected` flag from that global config — independent of the loaded
+//! project, which does not (and per the design must not) own the selection.
+//! The boot wiring used to feed `build_project_device_rows` an empty slice,
+//! so nothing was ever pre-selected and every reopen looked "empty".
+
+use super::*;
+use infra_filesystem::GuiAudioDeviceSettings;
+
+fn gui_dev(id: &str, name: &str, sample_rate: u32, buffer: u32, depth: u32) -> GuiAudioDeviceSettings {
+    GuiAudioDeviceSettings {
+        device_id: id.into(),
+        name: name.into(),
+        sample_rate,
+        buffer_size_frames: buffer,
+        bit_depth: depth,
+        #[cfg(target_os = "linux")]
+        realtime: true,
+        #[cfg(target_os = "linux")]
+        rt_priority: 70,
+        #[cfg(target_os = "linux")]
+        nperiods: 3,
+    }
+}
+
+fn descriptor(id: &str, name: &str) -> AudioDeviceDescriptor {
+    AudioDeviceDescriptor {
+        id: id.into(),
+        name: name.into(),
+        channels: 2,
+    }
+}
+
+#[test]
+fn boot_preselects_devices_persisted_in_global_config() {
+    // Persisted per-machine config from a previous session (config.yaml).
+    let saved_inputs = vec![gui_dev("mic", "Mic", 48_000, 64, 24)];
+    let saved_outputs = vec![gui_dev("speaker", "Speaker", 48_000, 64, 32)];
+
+    // Live devices enumerated at boot — same ids as what was saved.
+    let live_inputs = vec![descriptor("mic", "Mic")];
+    let live_outputs = vec![descriptor("speaker", "Speaker")];
+
+    // Boot must derive the pre-fill from the GLOBAL config, not the project.
+    let device_settings =
+        crate::project_ops::build_device_settings_from_gui(&saved_inputs, &saved_outputs);
+    let rows = build_project_device_rows(&live_inputs, &live_outputs, &device_settings);
+
+    assert!(
+        rows.iter().any(|r| r.device_id.as_str() == "mic" && r.selected),
+        "input device persisted in global config must stay selected on reopen"
+    );
+    assert!(
+        rows.iter().any(|r| r.device_id.as_str() == "speaker" && r.selected),
+        "output device persisted in global config must stay selected on reopen"
+    );
+}

--- a/crates/adapter-gui/src/desktop_app_init.rs
+++ b/crates/adapter-gui/src/desktop_app_init.rs
@@ -76,10 +76,18 @@ pub(crate) fn populate_initial_window_state(
     window.set_wizard_step(if settings.is_complete() { 1 } else { 0 });
     window.set_status_message("".into());
 
+    // Audio device selection is a SYSTEM concept (ADR 0003): repopulate the
+    // `selected` flags from the persisted per-machine config, not the project
+    // (which does not own the selection). Passing `&[]` here is what made the
+    // selection look empty on every reopen.
+    let persisted_device_settings = crate::project_ops::build_device_settings_from_gui(
+        &settings.input_devices,
+        &settings.output_devices,
+    );
     let project_devices = Rc::new(VecModel::from(build_project_device_rows(
         &*input_chain_devices.borrow(),
         &*output_chain_devices.borrow(),
-        &[],
+        &persisted_device_settings,
     )));
     window.set_input_devices(ModelRc::from(input_devices.clone()));
     window.set_output_devices(ModelRc::from(output_devices.clone()));

--- a/crates/adapter-gui/src/settings/audio.rs
+++ b/crates/adapter-gui/src/settings/audio.rs
@@ -75,6 +75,38 @@ fn project_device_settings_from_rows(
         .collect()
 }
 
+/// Project mode exposes a single flat device list (it has one picker, not the
+/// separate input/output pickers of GUI mode). Classify each selected device by
+/// membership in the live input/output descriptor lists so the global config
+/// still records the correct per-direction ids — the same physical interface
+/// enumerates with a different id per direction. A device exposed in both
+/// directions (shared id) is recorded in both; an id that matches neither
+/// (stale/disconnected) is kept as an input so the selection is never silently
+/// dropped.
+fn split_device_settings_by_direction(
+    selected: &[DeviceSettings],
+    input_descriptors: &[AudioDeviceDescriptor],
+    output_descriptors: &[AudioDeviceDescriptor],
+) -> (Vec<DeviceSettings>, Vec<DeviceSettings>) {
+    let mut inputs = Vec::new();
+    let mut outputs = Vec::new();
+    for device in selected {
+        let is_input = input_descriptors
+            .iter()
+            .any(|d| d.id == device.device_id.0);
+        let is_output = output_descriptors
+            .iter()
+            .any(|d| d.id == device.device_id.0);
+        if is_output {
+            outputs.push(device.clone());
+        }
+        if is_input || !is_output {
+            inputs.push(device.clone());
+        }
+    }
+    (inputs, outputs)
+}
+
 pub(crate) fn wire(
     window: &AppWindow,
     project_settings_window: &ProjectSettingsWindow,
@@ -160,8 +192,16 @@ pub(crate) fn wire(
                                 {
                                     log::warn!("apply_device_settings failed: {e}");
                                 }
+                                // GUI mode carries a proper input/output split
+                                // (two separate device models), so persist each
+                                // direction's ids into its own config field.
                                 let _ = session.dispatcher.dispatch(Command::SaveAudioSettings {
-                                    device_settings: new_device_settings,
+                                    input_devices: project_device_settings_from_rows(
+                                        settings.input_devices.clone(),
+                                    ),
+                                    output_devices: project_device_settings_from_rows(
+                                        settings.output_devices.clone(),
+                                    ),
                                 });
                                 if let Err(e) = sync_project_runtime(&project_runtime, session) {
                                     set_status_error(&window, &toast_timer, &e.to_string());
@@ -183,16 +223,10 @@ pub(crate) fn wire(
                                 return;
                             }
                         };
-                    // Persist device settings to per-machine config
-                    let gui_settings = GuiSystemSettings {
-                        input_devices: project_device_settings.clone(),
-                        output_devices: project_device_settings.clone(),
-                        language: current_language(),
-                        midi_devices: vec![],
-                    };
-                    if let Err(e) = FilesystemStorage::save_gui_audio_settings(&gui_settings) {
-                        log::warn!("failed to persist gui audio settings: {e}");
-                    }
+                    // config.yaml persistence is owned by the dispatcher's
+                    // SaveAudioSettings handler below (#581 parity) — it writes
+                    // the per-direction split. No direct save_gui_audio_settings
+                    // here: that collapsed input==output and corrupted re-match.
                     let mut session_borrow = project_session.borrow_mut();
                     let Some(session) = session_borrow.as_mut() else {
                         set_status_error(
@@ -207,8 +241,15 @@ pub(crate) fn wire(
                     if let Err(e) = infra_cpal::apply_device_settings(&new_device_settings) {
                         log::warn!("apply_device_settings failed: {e}");
                     }
+                    let (input_device_settings, output_device_settings) =
+                        split_device_settings_by_direction(
+                            &new_device_settings,
+                            &input_chain_devices.borrow(),
+                            &output_chain_devices.borrow(),
+                        );
                     if let Err(e) = session.dispatcher.dispatch(Command::SaveAudioSettings {
-                        device_settings: new_device_settings,
+                        input_devices: input_device_settings,
+                        output_devices: output_device_settings,
                     }) {
                         set_status_error(&window, &toast_timer, &e.to_string());
                         return;
@@ -302,15 +343,10 @@ pub(crate) fn wire(
                     }
                 }
                 AudioSettingsMode::Project => {
-                    let gui_settings = GuiSystemSettings {
-                        input_devices: project_device_settings.clone(),
-                        output_devices: project_device_settings.clone(),
-                        language: current_language(),
-                        midi_devices: vec![],
-                    };
-                    if let Err(e) = FilesystemStorage::save_gui_audio_settings(&gui_settings) {
-                        log::warn!("failed to persist gui audio settings: {e}");
-                    }
+                    // config.yaml persistence is owned by the dispatcher's
+                    // SaveAudioSettings handler below (#581 parity) — it writes
+                    // the per-direction split. No direct save_gui_audio_settings
+                    // here: that collapsed input==output and corrupted re-match.
                     let mut session_borrow = project_session.borrow_mut();
                     let Some(session) = session_borrow.as_mut() else {
                         settings_window.set_status_message(
@@ -323,8 +359,15 @@ pub(crate) fn wire(
                     if let Err(e) = infra_cpal::apply_device_settings(&new_device_settings) {
                         log::warn!("apply_device_settings failed: {e}");
                     }
+                    let (input_device_settings, output_device_settings) =
+                        split_device_settings_by_direction(
+                            &new_device_settings,
+                            &input_chain_devices.borrow(),
+                            &output_chain_devices.borrow(),
+                        );
                     if let Err(e) = session.dispatcher.dispatch(Command::SaveAudioSettings {
-                        device_settings: new_device_settings,
+                        input_devices: input_device_settings,
+                        output_devices: output_device_settings,
                     }) {
                         settings_window.set_status_message(e.to_string().into());
                         return;

--- a/crates/adapter-gui/tests/issue_581_save_audio_settings_persists_to_openrig.rs
+++ b/crates/adapter-gui/tests/issue_581_save_audio_settings_persists_to_openrig.rs
@@ -101,7 +101,8 @@ fn issue_581_save_audio_settings_persists_into_config_yaml() {
         let picked = picked_device();
         dispatcher
             .dispatch(Command::SaveAudioSettings {
-                device_settings: vec![picked.clone()],
+                input_devices: vec![picked.clone()],
+                output_devices: vec![],
             })
             .expect("SaveAudioSettings dispatch");
 

--- a/crates/application/src/command.rs
+++ b/crates/application/src/command.rs
@@ -263,7 +263,15 @@ pub enum Command {
     /// `DeviceSettings` before dispatching. The dispatcher replaces the
     /// project's `device_settings` with the provided list.
     SaveAudioSettings {
-        device_settings: Vec<project::device::DeviceSettings>,
+        /// Devices selected as inputs. Persisted into `config.input_devices`.
+        input_devices: Vec<project::device::DeviceSettings>,
+        /// Devices selected as outputs. Persisted into `config.output_devices`.
+        ///
+        /// Kept separate from `input_devices` because the same physical
+        /// interface enumerates with a different `device_id` per direction
+        /// (CoreAudio/WASAPI); collapsing both into one flat list corrupts the
+        /// saved selection and breaks re-match on reopen (#581 follow-up).
+        output_devices: Vec<project::device::DeviceSettings>,
     },
 
     /// #513: persist the per-machine MIDI device selection (config.yaml).

--- a/crates/application/src/local_dispatcher_project.rs
+++ b/crates/application/src/local_dispatcher_project.rs
@@ -60,40 +60,56 @@ impl LocalDispatcher {
                 Ok(vec![Event::ProjectMutated])
             }
 
-            Command::SaveAudioSettings { device_settings } => {
-                self.project.borrow_mut().device_settings = device_settings.clone();
+            Command::SaveAudioSettings {
+                input_devices,
+                output_devices,
+            } => {
+                // The in-memory project carries a single flat selection (the
+                // deduplicated union of both directions); per-direction ids
+                // live only in `config.yaml`.
+                let mut flat = input_devices.clone();
+                for dev in &output_devices {
+                    if !flat.iter().any(|d| d.device_id == dev.device_id) {
+                        flat.push(dev.clone());
+                    }
+                }
+                self.project.borrow_mut().device_settings = flat;
 
-                // #581: persist the pick into the per-machine
-                // `config.yaml` so it survives restarts and so every
-                // transport (GUI, MCP, gRPC) dispatching this command
-                // gets the same durable effect — per the Command-bus
-                // parity LAW. Touch only `input_devices` /
-                // `output_devices`, preserving the rest of `AppConfig`
-                // (language, midi_devices, paths, recent_projects).
-                let gui_devices: Vec<GuiAudioDeviceSettings> = device_settings
-                    .iter()
-                    .map(|s| GuiAudioDeviceSettings {
-                        device_id: s.device_id.0.clone(),
-                        // `name` is for UI display; `DeviceSettings`
-                        // does not carry it. The GUI rebuilds the
-                        // human name from the live cpal descriptor
-                        // (`build_project_device_rows`), so an empty
-                        // string here is safe.
-                        name: String::new(),
-                        sample_rate: s.sample_rate,
-                        buffer_size_frames: s.buffer_size_frames,
-                        bit_depth: s.bit_depth,
-                        #[cfg(target_os = "linux")]
-                        realtime: s.realtime,
-                        #[cfg(target_os = "linux")]
-                        rt_priority: s.rt_priority,
-                        #[cfg(target_os = "linux")]
-                        nperiods: s.nperiods,
-                    })
-                    .collect();
+                // #581: persist the pick into the per-machine `config.yaml`
+                // so it survives restarts and so every transport (GUI, MCP,
+                // gRPC) dispatching this command gets the same durable effect
+                // — per the Command-bus parity LAW. Input and output are
+                // persisted SEPARATELY: the same physical interface
+                // enumerates with a different `device_id` per direction
+                // (CoreAudio/WASAPI), so collapsing them corrupts re-match on
+                // reopen. Touch only `input_devices` / `output_devices`,
+                // preserving the rest of `AppConfig` (language, midi_devices,
+                // paths, recent_projects).
+                let to_gui = |list: &[project::device::DeviceSettings]| {
+                    list.iter()
+                        .map(|s| GuiAudioDeviceSettings {
+                            device_id: s.device_id.0.clone(),
+                            // `name` is for UI display; `DeviceSettings`
+                            // does not carry it. The GUI rebuilds the human
+                            // name from the live cpal descriptor
+                            // (`build_project_device_rows`), so an empty
+                            // string here is safe.
+                            name: String::new(),
+                            sample_rate: s.sample_rate,
+                            buffer_size_frames: s.buffer_size_frames,
+                            bit_depth: s.bit_depth,
+                            #[cfg(target_os = "linux")]
+                            realtime: s.realtime,
+                            #[cfg(target_os = "linux")]
+                            rt_priority: s.rt_priority,
+                            #[cfg(target_os = "linux")]
+                            nperiods: s.nperiods,
+                        })
+                        .collect::<Vec<GuiAudioDeviceSettings>>()
+                };
                 let mut config = FilesystemStorage::load_app_config().unwrap_or_default();
-                config.input_devices = gui_devices.clone();
-                config.output_devices = gui_devices;
+                config.input_devices = to_gui(&input_devices);
+                config.output_devices = to_gui(&output_devices);
                 FilesystemStorage::save_app_config(&config)
                     .map_err(|e| anyhow!("failed to persist audio settings: {e}"))?;
 

--- a/crates/application/src/local_dispatcher_tests.rs
+++ b/crates/application/src/local_dispatcher_tests.rs
@@ -2471,7 +2471,8 @@ fn save_audio_settings_writes_device_settings_and_emits_event() {
 
         let settings = vec![make_device_settings("dev_a"), make_device_settings("dev_b")];
         let result = dispatcher.dispatch(Command::SaveAudioSettings {
-            device_settings: settings.clone(),
+            input_devices: settings.clone(),
+            output_devices: vec![],
         });
 
         assert!(result.is_ok(), "dispatch returned Err: {:?}", result);
@@ -2502,7 +2503,8 @@ fn save_audio_settings_replaces_previous_settings() {
         let dispatcher = LocalDispatcher::new(Rc::clone(&project));
 
         let result = dispatcher.dispatch(Command::SaveAudioSettings {
-            device_settings: vec![make_device_settings("new_dev")],
+            input_devices: vec![make_device_settings("new_dev")],
+            output_devices: vec![],
         });
 
         assert!(result.is_ok());
@@ -2524,11 +2526,50 @@ fn save_audio_settings_empty_clears_settings() {
         let dispatcher = LocalDispatcher::new(Rc::clone(&project));
 
         let result = dispatcher.dispatch(Command::SaveAudioSettings {
-            device_settings: vec![],
+            input_devices: vec![],
+            output_devices: vec![],
         });
 
         assert!(result.is_ok());
         assert!(project.borrow().device_settings.is_empty());
+    });
+}
+
+// Regression: the same physical interface enumerates with a DIFFERENT id per
+// direction (e.g. CoreAudio input `dev:1` vs output `dev:2`). The command must
+// carry the input/output split so the handler persists each list into its own
+// `config.yaml` field — collapsing both into one flat list corrupts the saved
+// selection and the device fails to re-match on reopen (#581 follow-up).
+#[test]
+fn save_audio_settings_persists_input_and_output_separately() {
+    crate::local_dispatcher_paths_tests::with_tmp_home("save-audio-split", || {
+        let project = Rc::new(RefCell::new(Project {
+            name: None,
+            device_settings: vec![],
+            chains: vec![],
+            midi: None,
+        }));
+        let dispatcher = LocalDispatcher::new(Rc::clone(&project));
+
+        let result = dispatcher.dispatch(Command::SaveAudioSettings {
+            input_devices: vec![make_device_settings("dev:in")],
+            output_devices: vec![make_device_settings("dev:out")],
+        });
+        assert!(result.is_ok(), "dispatch returned Err: {:?}", result);
+
+        let config = infra_filesystem::FilesystemStorage::load_app_config().unwrap();
+        let in_ids: Vec<&str> = config
+            .input_devices
+            .iter()
+            .map(|d| d.device_id.as_str())
+            .collect();
+        let out_ids: Vec<&str> = config
+            .output_devices
+            .iter()
+            .map(|d| d.device_id.as_str())
+            .collect();
+        assert_eq!(in_ids, vec!["dev:in"], "input devices must persist input ids only");
+        assert_eq!(out_ids, vec!["dev:out"], "output devices must persist output ids only");
     });
 }
 

--- a/docs/midi.md
+++ b/docs/midi.md
@@ -278,7 +278,7 @@ below is bindable.
 | 27 | `CreateProject` | Create a new project | `{ project: object }` |
 | 28 ★ | `SetChainVolume` | Set chain volume (% — knob via `scale`, or fixed `value`) | `{ chain: id, value: num }` |
 | 29 | `UpdateProjectName` | Rename the project | `{ name: text }` |
-| 30 | `SaveAudioSettings` | Save audio device settings | `{ device_settings: [object] }` |
+| 30 | `SaveAudioSettings` | Save audio device settings (input/output persisted separately into per-machine `config.yaml`) | `{ input_devices: [object], output_devices: [object] }` |
 | 31 ★ | `ApplyRigNav` | Preset/scene: step (footswitch) or jump (fixed) | `{ chain: id, kind: <see below> }` |
 | 32 ★ | `SelectChainBlock` | Select a block by index (dispatcher-owned; MIDI/MCP/GUI) | `{ chain: id, block_index: uint }` |
 | 33 | `RenameRigPreset` | Rename the chain's active preset | `{ chain: id, name: text }` |


### PR DESCRIPTION
Closes #596.

## Problem
Audio interface selection (input/output) was lost on reopen — "volta vazio".

## Root causes (proven from a real `config.yaml` + live CoreAudio enumeration)
1. **Boot seeded the device rows with an empty list** (`build_project_device_rows(.., .., &[])`), so nothing was pre-selected on launch regardless of what was persisted.
2. **`Command::SaveAudioSettings` carried a flat `Vec<DeviceSettings>`** (no direction); the handler wrote it into BOTH `config.input_devices` and `config.output_devices`. The same physical interface enumerates with a different `device_id` per direction (e.g. TEYUN Q26 `…:1` in / `…:2` out), so collapsing the split corrupted re-match on reopen. Follow-up to #581.

## Fix
- `Command::SaveAudioSettings { input_devices, output_devices }` — carry the split through the bus (preserves #581 MCP/gRPC parity; MCP schema is derived).
- Handler persists each list into its own `config.yaml` field; `project.device_settings` = dedup union for in-memory consumers.
- Boot seeds rows from the persisted global config.
- GUI mode passes the split it already has; Project mode (single picker) classifies the flat selection by live input/output descriptor membership.
- Dropped the redundant GUI-side `save_gui_audio_settings` clobber calls (dispatcher now owns durable persistence — ADR 0003: device selection is system-level).

## Tests (TDD red-first)
- `save_audio_settings_persists_input_and_output_separately` (handler split) — witnessed RED (`left: ["dev:in"]` vs `right: ["dev:out"]`) → GREEN.
- `boot_preselects_devices_persisted_in_global_config` (boot pre-fill) — RED → GREEN.
- Existing `SaveAudioSettings` + `issue_581` tests updated to the new shape; full `application`/`adapter-gui`/`adapter-mcp` suites green, workspace builds clean.

## Migration note
Existing `config.yaml` files corrupted by the old clobber (input == output) self-heal on the first save after this change.