### PR TITLE
fix(#591): MIDI footswitch follows the on-screen selected chain; mark chain/block + neighbor with transient pulse

### DIFF
--- a/crates/adapter-gui/src/chain_rig_nav_wiring.rs
+++ b/crates/adapter-gui/src/chain_rig_nav_wiring.rs
@@ -48,6 +48,12 @@ pub(crate) fn refresh_from_session(
 ) {
     if let Some(session) = project_session.borrow().as_ref() {
         refresh_chain_rig_nav(window, session);
+        // #591: show the active chain/block marker as soon as a project
+        // opens (every open path funnels through here).
+        let proj = session.project.borrow();
+        let sel_arc = session.dispatcher.selection_state();
+        let sel = sel_arc.read().expect("selection state poisoned");
+        crate::selection_highlight::sync_selection_markers(window, &proj, &sel);
     }
 }
 
@@ -182,6 +188,16 @@ pub(crate) fn apply_events_to_ui(window: &AppWindow, ctx: &ChainRigNavCtx, event
         &ctx.output_chain_devices.borrow(),
     );
     refresh_chain_rig_nav(window, session);
+    // #591: keep the on-screen chain/block markers in lock-step with the
+    // dispatcher-owned selection. This is the path a footswitch press
+    // drains through, so moving the active chain/block via MIDI now shows
+    // on screen (before, it changed invisibly).
+    {
+        let proj = session.project.borrow();
+        let sel_arc = session.dispatcher.selection_state();
+        let sel = sel_arc.read().expect("selection state poisoned");
+        crate::selection_highlight::sync_selection_markers(window, &proj, &sel);
+    }
     sync_project_dirty(
         window,
         session,

--- a/crates/adapter-gui/src/desktop_app_block_wiring.rs
+++ b/crates/adapter-gui/src/desktop_app_block_wiring.rs
@@ -124,6 +124,12 @@ pub(crate) fn wire_all(deps: &BlockWiringDeps<'_>) {
             auto_save: deps.auto_save,
         },
     );
+    // --- on_select_chain (#591: chain-level selection drives the footswitch's active chain) ---
+    crate::select_chain_callback::wire(
+        &deps.window,
+        deps.project_session.clone(),
+        deps.toast_timer.clone(),
+    );
     // --- Chain block CRUD callbacks (extracted to chain_block_crud_wiring) ---
     crate::chain_block_crud_wiring::wire(
         &deps.window,

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -62,6 +62,7 @@ mod recent_projects_wiring;
 mod runtime_lifecycle;
 mod select_chain_block_callback;
 mod select_chain_callback;
+mod selection_highlight;
 pub(crate) mod settings;
 pub mod spectrum_close;
 mod spectrum_session;

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -61,6 +61,7 @@ mod project_settings_wiring;
 mod recent_projects_wiring;
 mod runtime_lifecycle;
 mod select_chain_block_callback;
+mod select_chain_callback;
 pub(crate) mod settings;
 pub mod spectrum_close;
 mod spectrum_session;

--- a/crates/adapter-gui/src/project_ops.rs
+++ b/crates/adapter-gui/src/project_ops.rs
@@ -353,6 +353,24 @@ pub(crate) fn load_project_session(
     // (GUI/MIDI/MCP share one path). Same Rc the GUI renders from.
     session.dispatcher.attach_rig(std::rc::Rc::clone(&rig));
     session.rig = Some(rig);
+
+    // #591: default the active chain to the first one. A footswitch bound
+    // to `toggle_active_chain_enabled` reads `SelectionState.active_chain`;
+    // with no prior navigation that was `None` and the press was a silent
+    // no-op. Seeding it here also gives the Chains screen a chain to mark
+    // the moment a project opens.
+    let first_chain = session
+        .project
+        .borrow()
+        .chains
+        .first()
+        .map(|c| c.id.clone());
+    if let Some(first_chain) = first_chain {
+        let _ = session
+            .dispatcher
+            .dispatch(application::command::Command::SelectActiveChain { chain: first_chain });
+    }
+
     Ok(session)
 }
 

--- a/crates/adapter-gui/src/select_chain_callback.rs
+++ b/crates/adapter-gui/src/select_chain_callback.rs
@@ -51,11 +51,12 @@ pub(crate) fn wire(
             .dispatch(application::command::Command::SelectActiveChain { chain: chain_id })
         {
             Ok(_) => {
-                // Reflect the chain-level selection highlight (no specific
-                // block). The ChainRow border keys on this chain index;
-                // block index -1 means "no block highlighted".
-                window.set_selected_chain_block_chain_index(chain_index);
-                window.set_selected_chain_block_index(-1);
+                // Reflect the selection markers from the dispatcher-owned
+                // SelectionState (single source of truth, shared with MIDI).
+                let proj = session.project.borrow();
+                let sel_arc = session.dispatcher.selection_state();
+                let sel = sel_arc.read().expect("selection state poisoned");
+                crate::selection_highlight::sync_selection_markers(&window, &proj, &sel);
             }
             Err(_) => {
                 set_status_error(&window, &toast_timer, &rust_i18n::t!("error-invalid-chain"));

--- a/crates/adapter-gui/src/select_chain_callback.rs
+++ b/crates/adapter-gui/src/select_chain_callback.rs
@@ -1,0 +1,65 @@
+//! `on_select_chain` — dispatch entry for tapping a chain (not a block) on
+//! the Chains screen (issue #591).
+//!
+//! Selecting a chain makes it the footswitch's active chain: the MIDI slot
+//! `toggle_active_chain_enabled` reads `SelectionState.active_chain`, which
+//! the daemon mirrors from the dispatcher. Before this, `active_chain` only
+//! moved when a *block* was selected (or via MIDI prev/next), so a footswitch
+//! stayed frozen on the last block-selected chain regardless of what the user
+//! had in front of them.
+//!
+//! Wired once from `run_desktop_app`.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use slint::{ComponentHandle, Timer};
+
+use application::dispatcher::CommandDispatcher;
+
+use crate::helpers::set_status_error;
+use crate::state::ProjectSession;
+use crate::AppWindow;
+
+pub(crate) fn wire(
+    window: &AppWindow,
+    project_session: Rc<RefCell<Option<ProjectSession>>>,
+    toast_timer: Rc<Timer>,
+) {
+    let weak_window = window.as_weak();
+    window.on_select_chain(move |chain_index| {
+        let Some(window) = weak_window.upgrade() else {
+            return;
+        };
+        let session_borrow = project_session.borrow();
+        let Some(session) = session_borrow.as_ref() else {
+            set_status_error(&window, &toast_timer, &rust_i18n::t!("error-no-project-loaded"));
+            return;
+        };
+        let chain_id = {
+            let proj = session.project.borrow();
+            match proj.chains.get(chain_index as usize) {
+                Some(c) => c.id.clone(),
+                None => {
+                    set_status_error(&window, &toast_timer, &rust_i18n::t!("error-invalid-chain"));
+                    return;
+                }
+            }
+        };
+        match session
+            .dispatcher
+            .dispatch(application::command::Command::SelectActiveChain { chain: chain_id })
+        {
+            Ok(_) => {
+                // Reflect the chain-level selection highlight (no specific
+                // block). The ChainRow border keys on this chain index;
+                // block index -1 means "no block highlighted".
+                window.set_selected_chain_block_chain_index(chain_index);
+                window.set_selected_chain_block_index(-1);
+            }
+            Err(_) => {
+                set_status_error(&window, &toast_timer, &rust_i18n::t!("error-invalid-chain"));
+            }
+        }
+    });
+}

--- a/crates/adapter-gui/src/selection_highlight.rs
+++ b/crates/adapter-gui/src/selection_highlight.rs
@@ -12,6 +12,7 @@ use application::SelectionState;
 use project::project::Project;
 
 use crate::project_view::real_block_index_to_ui;
+use crate::AppWindow;
 
 /// `(chain_index, block_ui_index)` to highlight, or `-1` for "none".
 ///
@@ -36,6 +37,16 @@ pub(crate) fn active_highlight_indices(project: &Project, sel: &SelectionState) 
         .unwrap_or(-1);
 
     (chain_index as i32, block_ui_index)
+}
+
+/// Push the active chain/block markers onto the Chains screen from the
+/// dispatcher-owned `SelectionState`. Called on every path that can change
+/// the selection — GUI clicks, taps, and (critically) the MIDI/footswitch
+/// drain — so the screen always shows what a footswitch acts on.
+pub(crate) fn sync_selection_markers(window: &AppWindow, project: &Project, sel: &SelectionState) {
+    let (chain_index, block_ui_index) = active_highlight_indices(project, sel);
+    window.set_selected_chain_block_chain_index(chain_index);
+    window.set_selected_chain_block_index(block_ui_index);
 }
 
 #[cfg(test)]

--- a/crates/adapter-gui/src/selection_highlight.rs
+++ b/crates/adapter-gui/src/selection_highlight.rs
@@ -1,0 +1,144 @@
+//! #591: resolve which chain row + block chip the Chains screen highlights,
+//! straight from the dispatcher-owned `SelectionState` (the single source of
+//! truth the MIDI footswitch also reads).
+//!
+//! Before this, the highlight was driven by GUI-local block-click state, so
+//! moving the active chain/block via a MIDI footswitch (prev/next) changed
+//! the selection invisibly — the user could not tell which chain a
+//! `toggle_active_chain_enabled` press would act on. Driving the markers from
+//! `SelectionState` keeps screen and footswitch in lock-step.
+
+use application::SelectionState;
+use project::project::Project;
+
+use crate::project_view::real_block_index_to_ui;
+
+/// `(chain_index, block_ui_index)` to highlight, or `-1` for "none".
+///
+/// `block_ui_index` is the position in the UI block strip (Input/Output
+/// stripped), matching what `selected-chain-block-index` expects.
+pub(crate) fn active_highlight_indices(project: &Project, sel: &SelectionState) -> (i32, i32) {
+    let Some(active_chain) = sel.active_chain.as_deref() else {
+        return (-1, -1);
+    };
+    let Some(chain_index) = project.chains.iter().position(|c| c.id.0 == active_chain) else {
+        // Stale selection (chain removed) — mark nothing rather than a wrong row.
+        return (-1, -1);
+    };
+    let chain = &project.chains[chain_index];
+
+    let block_ui_index = sel
+        .active_block
+        .as_deref()
+        .and_then(|bid| chain.blocks.iter().position(|b| b.id.0 == bid))
+        .and_then(|real| real_block_index_to_ui(chain, real))
+        .map(|ui| ui as i32)
+        .unwrap_or(-1);
+
+    (chain_index as i32, block_ui_index)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use domain::ids::{BlockId, ChainId, DeviceId};
+    use project::block::{
+        AudioBlock, AudioBlockKind, CoreBlock, InputBlock, InputEntry, OutputBlock, OutputEntry,
+    };
+    use project::chain::{Chain, ChainInputMode, ChainOutputMode};
+    use project::param::ParameterSet;
+
+    fn io_block(id: &str, input: bool) -> AudioBlock {
+        AudioBlock {
+            id: BlockId(id.to_string()),
+            enabled: true,
+            kind: if input {
+                AudioBlockKind::Input(InputBlock {
+                    model: "standard".to_string(),
+                    entries: vec![InputEntry {
+                        device_id: DeviceId("d".to_string()),
+                        mode: ChainInputMode::Mono,
+                        channels: vec![0],
+                    }],
+                })
+            } else {
+                AudioBlockKind::Output(OutputBlock {
+                    model: "standard".to_string(),
+                    entries: vec![OutputEntry {
+                        device_id: DeviceId("d".to_string()),
+                        mode: ChainOutputMode::default(),
+                        channels: vec![0],
+                    }],
+                })
+            },
+        }
+    }
+
+    fn core_block(id: &str) -> AudioBlock {
+        AudioBlock {
+            id: BlockId(id.to_string()),
+            enabled: true,
+            kind: AudioBlockKind::Core(CoreBlock {
+                effect_type: "amp".to_string(),
+                model: "test".to_string(),
+                params: ParameterSet::default(),
+            }),
+        }
+    }
+
+    fn chain(id: &str) -> Chain {
+        Chain {
+            id: ChainId(id.to_string()),
+            description: None,
+            instrument: "electric_guitar".to_string(),
+            enabled: false,
+            volume: 100.0,
+            // Input, b0, b1, Output — UI strip is [b0, b1] (IO stripped).
+            blocks: vec![
+                io_block("in", true),
+                core_block("b0"),
+                core_block("b1"),
+                io_block("out", false),
+            ],
+        }
+    }
+
+    fn project() -> Project {
+        Project {
+            name: None,
+            device_settings: vec![],
+            chains: vec![chain("rig:input-1"), chain("rig:input-3")],
+            midi: None,
+        }
+    }
+
+    #[test]
+    fn no_active_chain_marks_nothing() {
+        let sel = SelectionState::default();
+        assert_eq!(active_highlight_indices(&project(), &sel), (-1, -1));
+    }
+
+    #[test]
+    fn active_chain_without_block_marks_the_row_only() {
+        let mut sel = SelectionState::default();
+        sel.active_chain = Some("rig:input-3".to_string());
+        // index 1, no block → block UI index -1
+        assert_eq!(active_highlight_indices(&project(), &sel), (1, -1));
+    }
+
+    #[test]
+    fn active_chain_and_block_marks_both_with_ui_block_index() {
+        let mut sel = SelectionState::default();
+        sel.active_chain = Some("rig:input-1".to_string());
+        sel.active_block = Some("b1".to_string());
+        // chain 0; "b1" is the 2nd core block → UI index 1 (IO stripped).
+        assert_eq!(active_highlight_indices(&project(), &sel), (0, 1));
+    }
+
+    #[test]
+    fn stale_active_chain_marks_nothing() {
+        let mut sel = SelectionState::default();
+        sel.active_chain = Some("rig:does-not-exist".to_string());
+        assert_eq!(active_highlight_indices(&project(), &sel), (-1, -1));
+    }
+}

--- a/crates/adapter-gui/src/selection_highlight.rs
+++ b/crates/adapter-gui/src/selection_highlight.rs
@@ -39,6 +39,33 @@ pub(crate) fn active_highlight_indices(project: &Project, sel: &SelectionState) 
     (chain_index as i32, block_ui_index)
 }
 
+/// UI block index of the block that `toggle_active_block_neighbor_enabled`
+/// would flip — the block immediately AFTER the active one in the chain's
+/// raw block list (wraps), mirroring the dispatcher handler exactly. `-1`
+/// when there is no active block, the chain has < 2 blocks, or the
+/// raw-next block is an Input/Output endpoint (no chip on the strip).
+pub(crate) fn active_neighbor_block_ui_index(project: &Project, sel: &SelectionState) -> i32 {
+    let Some(active_chain) = sel.active_chain.as_deref() else {
+        return -1;
+    };
+    let Some(chain) = project.chains.iter().find(|c| c.id.0 == active_chain) else {
+        return -1;
+    };
+    if chain.blocks.len() < 2 {
+        return -1;
+    }
+    let Some(active_block) = sel.active_block.as_deref() else {
+        return -1;
+    };
+    let Some(active_raw) = chain.blocks.iter().position(|b| b.id.0 == active_block) else {
+        return -1;
+    };
+    let neighbor_raw = (active_raw + 1) % chain.blocks.len();
+    real_block_index_to_ui(chain, neighbor_raw)
+        .map(|ui| ui as i32)
+        .unwrap_or(-1)
+}
+
 /// Push the active chain/block markers onto the Chains screen from the
 /// dispatcher-owned `SelectionState`. Called on every path that can change
 /// the selection — GUI clicks, taps, and (critically) the MIDI/footswitch
@@ -47,6 +74,7 @@ pub(crate) fn sync_selection_markers(window: &AppWindow, project: &Project, sel:
     let (chain_index, block_ui_index) = active_highlight_indices(project, sel);
     window.set_selected_chain_block_chain_index(chain_index);
     window.set_selected_chain_block_index(block_ui_index);
+    window.set_selected_chain_block_neighbor_index(active_neighbor_block_ui_index(project, sel));
 }
 
 #[cfg(test)]
@@ -151,5 +179,33 @@ mod tests {
         let mut sel = SelectionState::default();
         sel.active_chain = Some("rig:does-not-exist".to_string());
         assert_eq!(active_highlight_indices(&project(), &sel), (-1, -1));
+    }
+
+    // ── neighbor block (the block `toggle_active_block_neighbor_enabled` acts on) ──
+
+    #[test]
+    fn neighbor_is_the_next_ui_block() {
+        let mut sel = SelectionState::default();
+        sel.active_chain = Some("rig:input-1".to_string());
+        sel.active_block = Some("b0".to_string()); // UI 0
+        // neighbor = the block after the active one → b1 (UI 1)
+        assert_eq!(active_neighbor_block_ui_index(&project(), &sel), 1);
+    }
+
+    #[test]
+    fn neighbor_is_minus_one_when_next_block_is_io() {
+        let mut sel = SelectionState::default();
+        sel.active_chain = Some("rig:input-1".to_string());
+        sel.active_block = Some("b1".to_string()); // last audio block; raw-next is Output
+        // The toggle-neighbor command targets the raw-next block (here the
+        // Output endpoint), which has no chip on the strip → not markable.
+        assert_eq!(active_neighbor_block_ui_index(&project(), &sel), -1);
+    }
+
+    #[test]
+    fn neighbor_is_none_without_active_block() {
+        let mut sel = SelectionState::default();
+        sel.active_chain = Some("rig:input-1".to_string());
+        assert_eq!(active_neighbor_block_ui_index(&project(), &sel), -1);
     }
 }

--- a/crates/adapter-gui/ui/app-window.slint
+++ b/crates/adapter-gui/ui/app-window.slint
@@ -196,6 +196,7 @@ export component AppWindow inherits Window {
     callback toggle-chain-input-channel(int, bool);
     callback toggle-chain-output-channel(int, bool);
     callback select-chain-block(int, int);
+    callback select-chain(int);
     callback clear-chain-block();
     callback toggle-chain-block-enabled(int, int);
     callback start-block-insert(int, int);
@@ -488,6 +489,7 @@ export component AppWindow inherits Window {
         toggle-chain-input-channel(index, selected) => { root.toggle-chain-input-channel(index, selected); }
         toggle-chain-output-channel(index, selected) => { root.toggle-chain-output-channel(index, selected); }
         select-chain-block(chain-index, block-index) => { root.select-chain-block(chain-index, block-index); }
+        select-chain(chain-index) => { root.select-chain(chain-index); }
         clear-chain-block => { root.clear-chain-block(); }
         toggle-chain-block-enabled(chain-index, block-index) => { root.toggle-chain-block-enabled(chain-index, block-index); }
         start-block-insert(chain-index, before-index) => { root.start-block-insert(chain-index, before-index); }
@@ -678,6 +680,7 @@ export component AppWindow inherits Window {
         toggle-chain-input-channel(index, selected) => { root.toggle-chain-input-channel(index, selected); }
         toggle-chain-output-channel(index, selected) => { root.toggle-chain-output-channel(index, selected); }
         select-chain-block(chain-index, block-index) => { root.select-chain-block(chain-index, block-index); }
+        select-chain(chain-index) => { root.select-chain(chain-index); }
         clear-chain-block => { root.clear-chain-block(); }
         toggle-chain-block-enabled(chain-index, block-index) => { root.toggle-chain-block-enabled(chain-index, block-index); }
         start-block-insert(chain-index, before-index) => { root.start-block-insert(chain-index, before-index); }

--- a/crates/adapter-gui/ui/app-window.slint
+++ b/crates/adapter-gui/ui/app-window.slint
@@ -64,6 +64,7 @@ export component AppWindow inherits Window {
     in property <int> selected-chain-output-device-index;
     in property <int> selected-chain-block-chain-index;
     in property <int> selected-chain-block-index;
+    in property <int> selected-chain-block-neighbor-index: -1;
     in property <[BlockTypePickerItem]> block-type-options;
     in property <[BlockModelPickerItem]> block-model-options;
     in property <[BlockModelPickerItem]> filtered-block-model-options;
@@ -368,6 +369,7 @@ export component AppWindow inherits Window {
         selected-chain-output-device-index: root.selected-chain-output-device-index;
         selected-chain-block-chain-index: root.selected-chain-block-chain-index;
         selected-chain-block-index: root.selected-chain-block-index;
+        selected-chain-block-neighbor-index: root.selected-chain-block-neighbor-index;
         block-type-options: root.block-type-options;
         block-model-options: root.block-model-options;
         filtered-block-model-options: root.filtered-block-model-options;
@@ -593,6 +595,7 @@ export component AppWindow inherits Window {
         selected-chain-output-device-index: root.selected-chain-output-device-index;
         selected-chain-block-chain-index: root.selected-chain-block-chain-index;
         selected-chain-block-index: root.selected-chain-block-index;
+        selected-chain-block-neighbor-index: root.selected-chain-block-neighbor-index;
         block-type-options: root.block-type-options;
         block-model-options: root.block-model-options;
         filtered-block-model-options: root.filtered-block-model-options;

--- a/crates/adapter-gui/ui/components/block_chip.slint
+++ b/crates/adapter-gui/ui/components/block_chip.slint
@@ -41,10 +41,30 @@ export component BlockChip inherits Rectangle {
     // #591: mark the active block (strong) and the neighbor the block
     // footswitch toggle acts on (light). The chain row already outlines
     // the active chain; this shows the selected block within it.
-    border-width: root.selected ? 2px : root.neighbor ? 1px : 0px;
-    border-color: root.selected ? #f0a020 : root.neighbor ? #f0a0207a : transparent;
+    // `pulse` adds a brief stronger emphasis when the selection MOVES to
+    // this chip (footswitch block step), fading back after a moment.
+    property <bool> pulse: false;
+    border-width: root.selected ? (root.pulse ? 3px : 2px) : root.neighbor ? 1px : 0px;
+    border-color: root.selected
+        ? (root.pulse ? #ffc14d : #f0a020)
+        : root.neighbor ? #f0a0207a : transparent;
     border-radius: 6px;
-    animate border-color { duration: 220ms; easing: ease-out; }
+    animate border-width { duration: 1500ms; easing: ease-out; }
+    animate border-color { duration: 1500ms; easing: ease-out; }
+    changed selected => {
+        if (root.selected) {
+            root.pulse = true;
+            chip-pulse-timer.running = true;
+        }
+    }
+    chip-pulse-timer := Timer {
+        interval: 1700ms;
+        running: false;
+        triggered => {
+            root.pulse = false;
+            self.running = false;
+        }
+    }
 
     // Type label on top — fades out while a drag is happening anywhere in
     // this chain row so it doesn't obscure the floating ghost or the chips

--- a/crates/adapter-gui/ui/components/block_chip.slint
+++ b/crates/adapter-gui/ui/components/block_chip.slint
@@ -10,6 +10,9 @@ import { PowerSwitch } from "./power_switch.slint";
 export component BlockChip inherits Rectangle {
     in property <ChainBlockItem> block;
     in property <bool> selected: false;
+    // #591: the block the footswitch's block-toggle (neighbor) would act
+    // on — marked lighter than the active block so the user sees the pair.
+    in property <bool> neighbor: false;
     in property <bool> dragging: false;
     // True while ANY block in the same chain row is being dragged. Drives
     // the type-label fade so the floating ghost has a clear path across
@@ -34,9 +37,14 @@ export component BlockChip inherits Rectangle {
 
     width: 100px;
     height: 100px;
-    background: transparent;
-    border-width: 0px;
+    background: root.selected ? #f0a02014 : transparent;
+    // #591: mark the active block (strong) and the neighbor the block
+    // footswitch toggle acts on (light). The chain row already outlines
+    // the active chain; this shows the selected block within it.
+    border-width: root.selected ? 2px : root.neighbor ? 1px : 0px;
+    border-color: root.selected ? #f0a020 : root.neighbor ? #f0a0207a : transparent;
     border-radius: 6px;
+    animate border-color { duration: 220ms; easing: ease-out; }
 
     // Type label on top — fades out while a drag is happening anywhere in
     // this chain row so it doesn't obscure the floating ghost or the chips

--- a/crates/adapter-gui/ui/desktop_main.slint
+++ b/crates/adapter-gui/ui/desktop_main.slint
@@ -42,6 +42,7 @@ export component DesktopMain inherits Rectangle {
     in property <int> selected-chain-output-device-index;
     in property <int> selected-chain-block-chain-index;
     in property <int> selected-chain-block-index;
+    in property <int> selected-chain-block-neighbor-index: -1;
     in property <[BlockTypePickerItem]> block-type-options;
     in property <[BlockModelPickerItem]> block-model-options;
     in property <[BlockModelPickerItem]> filtered-block-model-options;
@@ -295,6 +296,7 @@ export component DesktopMain inherits Rectangle {
             rename-chain-preset(i, n) => { root.rename-chain-preset(i, n); }
             selected-chain-block-chain-index: root.selected-chain-block-chain-index;
             selected-chain-block-index: root.selected-chain-block-index;
+            selected-chain-block-neighbor-index: root.selected-chain-block-neighbor-index;
             block-type-options: root.block-type-options;
             block-model-options: root.block-model-options;
             filtered-block-model-options: root.filtered-block-model-options;

--- a/crates/adapter-gui/ui/desktop_main.slint
+++ b/crates/adapter-gui/ui/desktop_main.slint
@@ -159,6 +159,7 @@ export component DesktopMain inherits Rectangle {
     callback toggle-chain-input-channel(int, bool);
     callback toggle-chain-output-channel(int, bool);
     callback select-chain-block(int, int);
+    callback select-chain(int);
     callback clear-chain-block();
     callback toggle-chain-block-enabled(int, int);
     callback start-block-insert(int, int);
@@ -336,6 +337,7 @@ export component DesktopMain inherits Rectangle {
             probe-chain-latency(index) => { root.probe-chain-latency(index); }
             open-compact-chain-view(index) => { root.open-compact-chain-view(index); }
             select-chain-block(chain-index, block-index) => { root.select-chain-block(chain-index, block-index); }
+            select-chain(chain-index) => { root.select-chain(chain-index); }
             clear-chain-block => { root.clear-chain-block(); }
             toggle-chain-block-enabled(chain-index, block-index) => { root.toggle-chain-block-enabled(chain-index, block-index); }
             start-block-insert(chain-index, before-index) => { root.start-block-insert(chain-index, before-index); }

--- a/crates/adapter-gui/ui/pages/chain_row.slint
+++ b/crates/adapter-gui/ui/pages/chain_row.slint
@@ -82,8 +82,32 @@ export component ChainRow inherits Rectangle {
     // (set by tapping the chain, by selecting one of its blocks, or by
     // MIDI prev/next). This is the chain the footswitch toggles.
     property <bool> chain-selected: root.selected-block-chain-index == root.chain-index;
-    border-width: root.chain-selected ? 2px : 0px;
-    border-color: #f0a020;
+    // #591: transient emphasis when the selection MOVES to this chain —
+    // a strong border that fades back to the subtle persistent marker
+    // after a moment, so a footswitch step is visible without leaving
+    // permanent clutter. `pulse` is raised on the rising edge of
+    // `chain-selected` and cleared by the one-shot timer below.
+    property <bool> pulse: false;
+    border-width: root.chain-selected ? (root.pulse ? 3px : 1px) : 0px;
+    border-color: root.chain-selected
+        ? (root.pulse ? #ffc14d : #f0a02066)
+        : transparent;
+    animate border-width { duration: 1600ms; easing: ease-out; }
+    animate border-color { duration: 1600ms; easing: ease-out; }
+    changed chain-selected => {
+        if (root.chain-selected) {
+            root.pulse = true;
+            pulse-timer.running = true;
+        }
+    }
+    pulse-timer := Timer {
+        interval: 1800ms;
+        running: false;
+        triggered => {
+            root.pulse = false;
+            self.running = false;
+        }
+    }
     // 74 + n*108 used to land the IN/OUT meters at y = root.height - 22,
     // which collided with the block grid (bottom at y = 62 + n*108).
     // Add 32px of breathing room so the meters sit clearly below the

--- a/crates/adapter-gui/ui/pages/chain_row.slint
+++ b/crates/adapter-gui/ui/pages/chain_row.slint
@@ -36,6 +36,9 @@ export component ChainRow inherits Rectangle {
     callback save-chain-preset(int);
     callback probe-chain-latency(int);
     callback select-chain-block(int, int);
+    // #591: select the whole chain as the footswitch's active chain
+    // (no specific block). Fired by tapping empty header space.
+    callback select-chain(int);
     callback toggle-chain-block-enabled(int, int);
     callback start-block-insert(int, int);
     callback reorder-chain-block(int, int, int);
@@ -73,6 +76,12 @@ export component ChainRow inherits Rectangle {
 
     background: transparent;
     border-radius: 6px;
+    // #591: highlight the row when this chain is the active selection
+    // (set by tapping the chain, by selecting one of its blocks, or by
+    // MIDI prev/next). This is the chain the footswitch toggles.
+    property <bool> chain-selected: root.selected-block-chain-index == root.chain-index;
+    border-width: root.chain-selected ? 2px : 0px;
+    border-color: #f0a020;
     // 74 + n*108 used to land the IN/OUT meters at y = root.height - 22,
     // which collided with the block grid (bottom at y = 62 + n*108).
     // Add 32px of breathing room so the meters sit clearly below the
@@ -91,6 +100,18 @@ export component ChainRow inherits Rectangle {
         width: parent.width;
         height: 58px;
         background: transparent;
+
+        // #591: tapping empty header space selects the chain as the
+        // footswitch's active chain. Declared first → lowest z-order, so
+        // the PowerSwitch / title / action controls on top still get their
+        // own clicks; only the gaps fall through to this selector.
+        TouchArea {
+            x: 0px;
+            y: 0px;
+            width: parent.width;
+            height: parent.height;
+            clicked => { root.select-chain(root.chain-index); }
+        }
 
         PowerSwitch {
             x: 10px;

--- a/crates/adapter-gui/ui/pages/chain_row.slint
+++ b/crates/adapter-gui/ui/pages/chain_row.slint
@@ -23,6 +23,8 @@ export component ChainRow inherits Rectangle {
     in property <int> chain-count;
     in property <int> selected-block-chain-index;
     in property <int> selected-block-index;
+    // #591: UI index of the block the footswitch block-toggle acts on.
+    in property <int> selected-block-neighbor-index: -1;
     in property <bool> fullscreen: false;
     callback toggle-chain-enabled(int);
     callback chain-volume-changed(int, int);
@@ -388,6 +390,7 @@ export component ChainRow inherits Rectangle {
             selected: root.dragging-chain-index == root.chain-index && root.dragging-block-index == block-index
                 ? false
                 : root.selected-block-chain-index == root.chain-index && root.selected-block-index == block-index;
+            neighbor: root.selected-block-chain-index == root.chain-index && root.selected-block-neighbor-index == block-index;
             dragging: root.dragging-chain-index == root.chain-index && root.dragging-block-index == block-index;
             chain-dragging: root.dragging-chain-index == root.chain-index && root.dragging-block-index >= 0;
             clicked => { root.select-chain-block(root.chain-index, block-index); }

--- a/crates/adapter-gui/ui/pages/project_chains.slint
+++ b/crates/adapter-gui/ui/pages/project_chains.slint
@@ -16,6 +16,7 @@ export component ProjectChainsPage inherits Rectangle {
     in property <[ProjectChainItem]> project-chains;
     in property <int> selected-chain-block-chain-index;
     in property <int> selected-chain-block-index;
+    in property <int> selected-chain-block-neighbor-index: -1;
     in property <[BlockTypePickerItem]> block-type-options;
     in property <[BlockModelPickerItem]> block-model-options;
     in property <[BlockModelPickerItem]> filtered-block-model-options;
@@ -239,6 +240,7 @@ export component ProjectChainsPage inherits Rectangle {
                 fullscreen: root.fullscreen;
                 selected-block-chain-index: root.selected-chain-block-chain-index;
                 selected-block-index: root.selected-chain-block-index;
+                selected-block-neighbor-index: root.selected-chain-block-neighbor-index;
                 toggle-chain-enabled(index) => { root.toggle-chain-enabled(index); }
                 chain-volume-changed(index, v) => { root.chain-volume-changed(index, v); }
                 remove-chain(index) => { root.remove-chain(index); }

--- a/crates/adapter-gui/ui/pages/project_chains.slint
+++ b/crates/adapter-gui/ui/pages/project_chains.slint
@@ -65,6 +65,7 @@ export component ProjectChainsPage inherits Rectangle {
     callback probe-chain-latency(int);
     callback open-compact-chain-view(int);
     callback select-chain-block(int, int);
+    callback select-chain(int);
     callback clear-chain-block();
     callback toggle-chain-block-enabled(int, int);
     callback start-block-insert(int, int);
@@ -251,6 +252,7 @@ export component ProjectChainsPage inherits Rectangle {
                 probe-chain-latency(index) => { root.probe-chain-latency(index); }
                 open-compact-chain-view(index) => { root.open-compact-chain-view(index); }
                 select-chain-block(chain-index, block-index) => { root.select-chain-block(chain-index, block-index); }
+                select-chain(chain-index) => { root.select-chain(chain-index); }
                 toggle-chain-block-enabled(chain-index, block-index) => { root.toggle-chain-block-enabled(chain-index, block-index); }
                 start-block-insert(chain-index, before-index) => { root.start-block-insert(chain-index, before-index); }
                 reorder-chain-block(chain-index, from-index, before-index) => {

--- a/crates/adapter-gui/ui/touch_main.slint
+++ b/crates/adapter-gui/ui/touch_main.slint
@@ -149,6 +149,7 @@ export component TouchMain inherits Rectangle {
     callback toggle-chain-input-channel(int, bool);
     callback toggle-chain-output-channel(int, bool);
     callback select-chain-block(int, int);
+    callback select-chain(int);
     callback clear-chain-block();
     callback toggle-chain-block-enabled(int, int);
     callback start-block-insert(int, int);
@@ -338,6 +339,7 @@ export component TouchMain inherits Rectangle {
             probe-chain-latency(index) => { root.probe-chain-latency(index); }
             open-compact-chain-view(index) => { root.open-compact-chain-view(index); }
             select-chain-block(chain-index, block-index) => { root.select-chain-block(chain-index, block-index); }
+            select-chain(chain-index) => { root.select-chain(chain-index); }
             clear-chain-block => { root.clear-chain-block(); }
             toggle-chain-block-enabled(chain-index, block-index) => { root.toggle-chain-block-enabled(chain-index, block-index); }
             start-block-insert(chain-index, before-index) => { root.start-block-insert(chain-index, before-index); }

--- a/crates/adapter-gui/ui/touch_main.slint
+++ b/crates/adapter-gui/ui/touch_main.slint
@@ -41,6 +41,7 @@ export component TouchMain inherits Rectangle {
     in property <int> selected-chain-output-device-index;
     in property <int> selected-chain-block-chain-index;
     in property <int> selected-chain-block-index;
+    in property <int> selected-chain-block-neighbor-index: -1;
     in property <[BlockTypePickerItem]> block-type-options;
     in property <[BlockModelPickerItem]> block-model-options;
     in property <[BlockModelPickerItem]> filtered-block-model-options;
@@ -299,6 +300,7 @@ export component TouchMain inherits Rectangle {
             rename-chain-preset(i, n) => { root.rename-chain-preset(i, n); }
             selected-chain-block-chain-index: root.selected-chain-block-chain-index;
             selected-chain-block-index: root.selected-chain-block-index;
+            selected-chain-block-neighbor-index: root.selected-chain-block-neighbor-index;
             block-type-options: root.block-type-options;
             block-model-options: root.block-model-options;
             filtered-block-model-options: root.filtered-block-model-options;

--- a/crates/adapter-mcp/src/tools.rs
+++ b/crates/adapter-mcp/src/tools.rs
@@ -83,7 +83,9 @@ mod tests {
     /// command bus so every transport adapter (MCP/gRPC/…) inherits it.
     /// #582 bumped to 60 with `SetEvaluationsPath` — third
     /// system-paths override alongside `SetPresetsPath`/`SetPluginsPath`.
-    const COMMAND_VARIANT_COUNT: usize = 60;
+    /// #591 bumped to 61 with `SelectActiveChain` — chain-level selection
+    /// so a footswitch follows the on-screen active chain.
+    const COMMAND_VARIANT_COUNT: usize = 61;
 
     #[test]
     fn parity_guard_every_command_variant_is_a_tool() {

--- a/crates/adapter-midi/tests/issue_591_footswitch_follows_selected_chain.rs
+++ b/crates/adapter-midi/tests/issue_591_footswitch_follows_selected_chain.rs
@@ -1,0 +1,69 @@
+//! Issue #591 regression: selecting a chain on the Chains screen
+//! (`Command::SelectActiveChain`) must make the footswitch slot
+//! `toggle_active_chain_enabled` target THAT chain.
+//!
+//! The MIDI daemon mirrors `SelectionState` from the dispatcher, so the
+//! slot resolved from the live selection must follow the on-screen
+//! selection instead of a stale/frozen chain (the bug: the footswitch was
+//! frozen on `rig:input-3` regardless of what the user selected).
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use adapter_midi::slots::{slot_to_command, IncomingMessage};
+use application::command::{ChainId, Command};
+use application::dispatcher::CommandDispatcher;
+use application::local_dispatcher::LocalDispatcher;
+use project::chain::Chain;
+use project::project::Project;
+
+fn disabled_chain(id: &str) -> Chain {
+    Chain {
+        id: ChainId(id.to_string()),
+        description: None,
+        instrument: "electric_guitar".to_string(),
+        enabled: false,
+        volume: 100.0,
+        blocks: vec![],
+    }
+}
+
+#[test]
+fn footswitch_toggle_targets_the_chain_just_selected() {
+    let project = Rc::new(RefCell::new(Project {
+        name: None,
+        device_settings: vec![],
+        chains: vec![disabled_chain("rig:input-1"), disabled_chain("rig:input-3")],
+        midi: None,
+    }));
+    let dispatcher = LocalDispatcher::new(project);
+
+    // User taps chain rig:input-1 on the Chains screen.
+    dispatcher
+        .dispatch(Command::SelectActiveChain {
+            chain: ChainId("rig:input-1".to_string()),
+        })
+        .unwrap();
+
+    // The footswitch slot resolves against the live (mirrored) SelectionState.
+    let sel = dispatcher.selection_state();
+    let guard = sel.read().unwrap();
+    let cmd = slot_to_command(
+        "toggle_active_chain_enabled",
+        &IncomingMessage::ProgramChange {
+            channel: 1,
+            program: 1,
+        },
+        &guard,
+    )
+    .expect("an active chain is selected, so the slot must resolve");
+
+    match cmd {
+        Command::ToggleChainEnabled { chain } => assert_eq!(
+            chain,
+            ChainId("rig:input-1".to_string()),
+            "the footswitch must toggle the chain the user just selected, not a stale one"
+        ),
+        other => panic!("expected ToggleChainEnabled{{rig:input-1}}, got {other:?}"),
+    }
+}

--- a/crates/application/src/command.rs
+++ b/crates/application/src/command.rs
@@ -315,6 +315,14 @@ pub enum Command {
     /// Was GUI-only state; now dispatcher-owned so it is reachable.
     SelectChainBlock { chain: ChainId, block_index: usize },
 
+    /// #591: select a whole chain as the active one (no specific block).
+    /// Dispatched when the user taps a chain on the Chains screen so the
+    /// footswitch slot `toggle_active_chain_enabled` (which reads
+    /// `SelectionState.active_chain`) follows the on-screen selection.
+    /// Clears the active block — a block belongs to one chain. Errors if
+    /// the chain does not exist.
+    SelectActiveChain { chain: ChainId },
+
     /// #436: capture pending edits on the projected synthetic chains
     /// back into the rig. The GUI save path used to call
     /// `sync_synthetic_into_rig` by hand (model mutation in the UI);

--- a/crates/application/src/local_dispatcher.rs
+++ b/crates/application/src/local_dispatcher.rs
@@ -256,6 +256,8 @@ impl CommandDispatcher for LocalDispatcher {
                 Ok(vec![Event::ProjectMutated])
             }
 
+            Command::SelectActiveChain { chain } => self.handle_select_active_chain(chain),
+
             Command::SetLanguage { .. } => self.handle_set_language(cmd),
 
             Command::SetOutputMuted { .. } => self.handle_set_output_muted(cmd),

--- a/crates/application/src/local_dispatcher_selection.rs
+++ b/crates/application/src/local_dispatcher_selection.rs
@@ -55,6 +55,39 @@ impl LocalDispatcher {
         Ok(vec![Event::ProjectMutated])
     }
 
+    /// `Command::SelectActiveChain { chain }`. Sets a specific chain as
+    /// the active one (the footswitch `toggle_active_chain_enabled`
+    /// target), snapshots its `enabled` flag, and clears `active_block`
+    /// — a block belongs to one chain (issue #591). Errors when the chain
+    /// id is not in the project so a stale id never silently no-ops.
+    pub(crate) fn handle_select_active_chain(&self, chain: ChainId) -> Result<Vec<Event>> {
+        let project = self.project.borrow();
+        let Some(target) = project.chains.iter().find(|c| c.id == chain) else {
+            anyhow::bail!("SelectActiveChain: chain not found: {}", chain.0);
+        };
+        let enabled = target.enabled;
+        {
+            let mut sel = self
+                .selection_state
+                .write()
+                .expect("selection state poisoned");
+            let changed = sel.active_chain.as_deref() != Some(chain.0.as_str());
+            sel.active_chain_enabled = enabled;
+            sel.active_chain = Some(chain.0.clone());
+            if changed {
+                sel.active_block = None;
+            }
+        }
+        drop(project);
+
+        // Seed the legacy per-chain block-selection map so the existing
+        // GUI lights up the chain on screen (same path the MIDI relative
+        // nav uses).
+        self.selection.borrow_mut().entry(chain).or_insert(0);
+
+        Ok(vec![Event::ProjectMutated])
+    }
+
     /// `Command::ToggleActiveBlockNeighborEnabled`. Flips the
     /// `enabled` flag of the block immediately AFTER `active_block` in
     /// the active chain (wraps to first). No-op when no chain/block is

--- a/crates/application/src/local_dispatcher_tests.rs
+++ b/crates/application/src/local_dispatcher_tests.rs
@@ -1368,6 +1368,61 @@ fn toggle_chain_enabled_non_existent_returns_err() {
     assert!(result.is_err(), "expected Err for missing chain, got Ok");
 }
 
+// ── SelectActiveChain tests (issue #591) ───────────────────────────────────────
+
+#[test]
+fn select_active_chain_sets_active_chain_clears_block_and_snapshots_enabled() {
+    // chain_0 (enabled), chain_1 (disabled). The footswitch slot
+    // `toggle_active_chain_enabled` resolves against `active_chain`, so
+    // selecting a chain on the Chains screen must set it as the active one
+    // — otherwise the footswitch stays frozen on whatever was selected last
+    // (the #591 bug: it always targeted `rig:input-3`).
+    let project = make_project_two_chains();
+    let dispatcher = LocalDispatcher::new(Rc::clone(&project));
+
+    // Seed selection on chain_0 with a block, as if the user had drilled in.
+    {
+        let sel = dispatcher.selection_state();
+        let mut s = sel.write().unwrap();
+        s.active_chain = Some("chain_0".to_string());
+        s.active_block = Some("input:0".to_string());
+        s.active_chain_enabled = true;
+    }
+
+    let result = dispatcher.dispatch(Command::SelectActiveChain {
+        chain: ChainId("chain_1".to_string()),
+    });
+    assert!(result.is_ok(), "dispatch returned Err: {:?}", result);
+
+    let sel = dispatcher.selection_state();
+    let s = sel.read().unwrap();
+    assert_eq!(
+        s.active_chain.as_deref(),
+        Some("chain_1"),
+        "selecting a chain on screen must become the active chain the footswitch toggles"
+    );
+    assert!(
+        s.active_block.is_none(),
+        "changing the active chain must clear the stale active block (block lives in one chain)"
+    );
+    assert!(
+        !s.active_chain_enabled,
+        "active_chain_enabled must snapshot the newly-selected chain (chain_1 is disabled)"
+    );
+}
+
+#[test]
+fn select_active_chain_non_existent_returns_err() {
+    let project = make_project_two_chains();
+    let dispatcher = LocalDispatcher::new(Rc::clone(&project));
+
+    let result = dispatcher.dispatch(Command::SelectActiveChain {
+        chain: ChainId("chain_MISSING".to_string()),
+    });
+
+    assert!(result.is_err(), "expected Err for missing chain, got Ok");
+}
+
 // ── AddChain tests ────────────────────────────────────────────────────────────
 
 #[test]

--- a/docs/midi-profiles.md
+++ b/docs/midi-profiles.md
@@ -89,9 +89,13 @@ The active chain is set by **tapping a chain row** (anywhere on its
 header), by selecting one of its blocks, or by the `prev_chain` /
 `next_chain` slots; the selected chain is outlined on screen. A
 footswitch bound to `toggle_active_chain_enabled` therefore toggles
-the chain the user currently has selected (issue #591).
-Slots that need an active chain/block and there is none simply do
-nothing (a footswitch press on a not-yet-loaded project is a no-op).
+the chain the user currently has selected (issue #591). The active chain —
+and, inside it, the active block plus the neighbor block a block-toggle
+acts on — is marked on screen; moving the selection briefly pulses the new
+marker, which then settles to a subtle outline so it stays visible without
+clutter. On project open the first chain is selected by default, so a
+footswitch press has a target immediately.
+Slots that still have no active chain/block simply do nothing.
 
 ## Architecture
 

--- a/docs/midi-profiles.md
+++ b/docs/midi-profiles.md
@@ -85,6 +85,11 @@ CC slots (`chain_volume`, `block_param_numeric`).
 
 "Active chain" / "active block" come from `SelectionState` —
 synchronised with what the user has selected on the Chains screen.
+The active chain is set by **tapping a chain row** (anywhere on its
+header), by selecting one of its blocks, or by the `prev_chain` /
+`next_chain` slots; the selected chain is outlined on screen. A
+footswitch bound to `toggle_active_chain_enabled` therefore toggles
+the chain the user currently has selected (issue #591).
 Slots that need an active chain/block and there is none simply do
 nothing (a footswitch press on a not-yet-loaded project is a no-op).
 

--- a/docs/screens.md
+++ b/docs/screens.md
@@ -4,7 +4,7 @@ Pedalboard virtual: usuário monta cadeia de efeitos visualmente, ajusta parâme
 
 - **Launcher** — criar/abrir projetos
 - **Project Setup** — pede o nome ao criar novo projeto
-- **Chains** — visualização da cadeia de blocos, drag/reorder
+- **Chains** — visualização da cadeia de blocos, drag/reorder. Tapping a chain row's header selects it (outlined) as the active chain — the one a MIDI footswitch bound to `toggle_active_chain_enabled` acts on (#591).
 - **Block Editor** — edita parâmetros de um bloco
 - **Compact Chain View** — power switches e troca rápida de modelo
 - **Settings** — unified configuration screen, reached from the top bar. Two scope headers:


### PR DESCRIPTION
Closes #591.

## Bug

Pressing a footswitch bound to `toggle_active_chain_enabled` did nothing the user could see. The slot resolves against `SelectionState.active_chain`, but `active_chain` was only set when a **block** was selected or via MIDI prev/next — never by chain selection on the Chains screen — so it stayed frozen on the last block-selected chain (`rig:input-3` in the report). And the screen never marked the active chain/block at all, so navigating via footswitch changed the selection invisibly.

Confirmed on hardware: selecting `rig:input-1` on screen, the footswitch still toggled `rig:input-3`.

## Fix (4 parts)

1. **`Command::SelectActiveChain { chain }`** + handler (sets `active_chain`, snapshots `enabled`, clears `active_block`, errors on a missing chain). Auto-parity to MCP/gRPC; bumped `COMMAND_VARIANT_COUNT` 60→61. Tapping a chain row's header dispatches it.
2. **Markers driven from `SelectionState`** (`selection_highlight::sync_selection_markers`), synced on every path that changes the selection — clicks, taps, and the MIDI/footswitch drain (`apply_events_to_ui`). The selected **block** is now actually rendered (BlockChip declared `selected` but drew nothing), and the **neighbor** block that `toggle_active_block_neighbor_enabled` acts on is marked lighter.
3. **Transient pulse**: moving the selection flashes the new marker stronger and fades it back to a subtle outline over ~1.6s (Slint `Timer` element + `changed` handler — no Rust timer/threading).
4. **Default selection on load**: the first chain becomes active when a project opens, so a footswitch press has a target immediately.

## Tests

- `local_dispatcher_tests`: `SelectActiveChain` sets/clears/validates (red-first).
- `adapter-midi`: selecting a chain makes the footswitch slot target it (integration).
- `selection_highlight`: chain/block/neighbor index resolution from `SelectionState` (7 cases).
- `cargo test --workspace --lib` green; adapter-gui + adapter-midi suites green; clean build (Slint).

## Validate (in your main folder)

```
git fetch && git checkout bugfix/issue-591 && git pull
```

1. Open Chains (4 disabled chains) → first chain is outlined on load.
2. Footswitch bank-1 B (`toggle_active_chain_enabled`) → the outlined chain toggles.
3. Footswitch bank-1 prev/next chain → outline moves (pulses), then settles; B toggles the now-selected one.
4. Tap a chain row header → it becomes selected (outlined); B toggles it.
5. Block nav → active block + neighbor marked; moving pulses then settles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)