### PR TITLE
fix(#599): plugin catalog honors paths.plugins_path, not only plugins_root

### DIFF
--- a/crates/plugin-loader/src/config.rs
+++ b/crates/plugin-loader/src/config.rs
@@ -2,42 +2,58 @@
 //!
 //! Order of precedence:
 //!   1. `OPENRIG_PLUGINS_ROOT` environment variable.
-//!   2. `plugins_root:` field in `config.yaml` (relative paths resolve
-//!      against the config file's directory; absolute paths pass through).
-//!   3. Last-resort default `<config dir>/plugins` — picks up whatever
+//!   2. `paths.plugins_path:` in `config.yaml` — the canonical location
+//!      written by the Settings -> Paths screen (#513).
+//!   3. Legacy top-level `plugins_root:` in `config.yaml` (#287), kept for
+//!      back-compat with configs that predate the Settings -> Paths screen.
+//!   4. Last-resort default `<config dir>/plugins` — picks up whatever
 //!      `plugins/` directory ships next to the config in the current
 //!      install layout. The cross-platform layout (.app bundle / .deb /
 //!      .msi) all place a `plugins/` directory next to the deployed
 //!      `config.yaml`, so this works without per-OS hardcoding.
 //!
-//! Issue: #287
+//! For (2) and (3): relative paths resolve against the config file's
+//! directory; absolute paths pass through unchanged.
+//!
+//! Issues: #287, #513, #599
 
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
-/// Subset of `config.yaml` the plugin loader cares about. Other fields
-/// (e.g. legacy `paths`) round-trip via `serde(flatten)` on the engine's
-/// own config struct, not here.
+/// The `paths:` section of `config.yaml`, narrowed to the one field the
+/// plugin loader reads. Mirrors the canonical owner in `infra-filesystem`'s
+/// `AssetPaths` (a layering-safe read-only view — the loader must not depend
+/// on `infra-filesystem`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct PluginPathsSection {
+    /// Directory containing every plugin package
+    /// (`<plugins_path>/<backend>/<id>/manifest.yaml`). Written by the
+    /// Settings -> Paths screen (#513).
+    #[serde(default)]
+    pub plugins_path: Option<PathBuf>,
+}
+
+/// Subset of `config.yaml` the plugin loader cares about.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct PluginPathsConfig {
-    /// Directory containing every bundled plugin package
-    /// (`<plugins_root>/<backend>/<id>/manifest.yaml`). Resolved relative
-    /// to the config file's directory when loaded via
-    /// [`plugins_root_from_config`]; absolute paths pass through.
+    /// Canonical plugins directory, under `paths.plugins_path` (#513).
+    #[serde(default)]
+    pub paths: PluginPathsSection,
+    /// Legacy top-level `plugins_root` (#287). Kept for back-compat with
+    /// configs written before the Settings -> Paths screen existed.
     #[serde(default)]
     pub plugins_root: Option<PathBuf>,
 }
 
 /// Resolve the plugin packages directory to use at runtime.
 ///
-/// `config_path` should point at the project's `config.yaml`. When
-/// `OPENRIG_PLUGINS_ROOT` is set in the environment, that wins outright.
-/// Otherwise the file's `plugins_root` field is honored. As a
-/// last-resort fallback, returns `<config_dir>/plugins` — install
-/// layouts (.app bundle, .deb, .msi) all place a `plugins/` directory
-/// next to the deployed `config.yaml`, so dev needs to override
-/// explicitly via the field or env var.
+/// `config_path` should point at the project's `config.yaml`. Precedence:
+/// `OPENRIG_PLUGINS_ROOT` env wins outright; then `paths.plugins_path`
+/// (canonical, #513); then the legacy top-level `plugins_root` (#287); then
+/// the `<config_dir>/plugins` install-layout fallback. Relative declared
+/// paths resolve against the config file's directory; absolute paths pass
+/// through.
 pub fn plugins_root_from_config(config_path: &Path) -> PathBuf {
     if let Ok(env_value) = std::env::var("OPENRIG_PLUGINS_ROOT") {
         let trimmed = env_value.trim();
@@ -51,13 +67,14 @@ pub fn plugins_root_from_config(config_path: &Path) -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("."));
     if let Ok(yaml) = std::fs::read_to_string(config_path) {
         if let Ok(parsed) = serde_yaml::from_str::<PluginPathsConfig>(&yaml) {
-            if let Some(declared) = parsed.plugins_root {
-                let candidate = if declared.is_absolute() {
+            // Canonical `paths.plugins_path` (#513) wins over the legacy
+            // top-level `plugins_root` (#287) when both are present.
+            if let Some(declared) = parsed.paths.plugins_path.or(parsed.plugins_root) {
+                return if declared.is_absolute() {
                     declared
                 } else {
                     config_dir.join(declared)
                 };
-                return candidate;
             }
         }
     }

--- a/crates/plugin-loader/src/lib.rs
+++ b/crates/plugin-loader/src/lib.rs
@@ -18,7 +18,7 @@ pub mod package_builders;
 pub mod registry;
 pub mod validate;
 
-pub use config::{plugins_root_from_config, PluginPathsConfig};
+pub use config::{plugins_root_from_config, PluginPathsConfig, PluginPathsSection};
 pub use discover::{discover, DiscoveryError, LoadedPackage};
 pub use install::{extract_bundle_if_needed, has_extracted_packages};
 pub use manifest::{Backend, BlockType, GridCapture, GridParameter, Lv2Slot, PluginManifest};

--- a/crates/plugin-loader/tests/plugins_root_resolution.rs
+++ b/crates/plugin-loader/tests/plugins_root_resolution.rs
@@ -1,0 +1,129 @@
+//! Issue #599 — red-first guard: the plugin catalog ignored the user's
+//! plugins directory, leaving IR/NAM/LV2 pickers empty.
+//!
+//! Settings -> Paths (#513) saves the plugins directory under
+//! `paths.plugins_path` in `config.yaml`. The loader's
+//! `plugins_root_from_config` (#287) only read the top-level `plugins_root`
+//! key, so the user's path was never scanned and the catalog fell back to
+//! `<config_dir>/plugins` (empty) -> zero disk packages.
+//!
+//! These tests pin the resolution contract: env override, then the
+//! canonical `paths.plugins_path`, then the legacy `plugins_root`, then the
+//! install-layout fallback.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use plugin_loader::plugins_root_from_config;
+
+/// Throwaway temp directory, removed on drop. Mirrors the helper in
+/// `src/install_tests.rs` (no `tempfile` dev-dependency in this crate).
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new(label: &str) -> Self {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let unique = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "openrig-config-{label}-{}-{unique}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&path);
+        fs::create_dir_all(&path).expect("create temp");
+        Self { path }
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+fn write_config(dir: &Path, body: &str) -> PathBuf {
+    let path = dir.join("config.yaml");
+    fs::write(&path, body).expect("write config.yaml");
+    path
+}
+
+#[test]
+fn reads_paths_plugins_path() {
+    // Real configs (Settings -> Paths, #513) store the plugins directory
+    // under `paths.plugins_path`, NOT the top-level `plugins_root`.
+    let tmp = TempDir::new("paths-plugins-path");
+    let plugins_dir = tmp.path.join("my-plugins");
+    fs::create_dir_all(&plugins_dir).expect("create plugins dir");
+    let config_path = write_config(
+        &tmp.path,
+        &format!("paths:\n  plugins_path: {}\n", plugins_dir.display()),
+    );
+
+    let resolved = plugins_root_from_config(&config_path);
+
+    assert_eq!(
+        resolved, plugins_dir,
+        "expected loader to resolve paths.plugins_path, got {resolved:?}"
+    );
+}
+
+#[test]
+fn prefers_paths_plugins_path_over_legacy_plugins_root() {
+    // Precedence: the canonical `paths.plugins_path` (#513) wins over the
+    // legacy top-level `plugins_root` (#287) when a config carries both.
+    let tmp = TempDir::new("precedence");
+    let canonical = tmp.path.join("canonical");
+    let legacy = tmp.path.join("legacy");
+    fs::create_dir_all(&canonical).expect("create canonical dir");
+    fs::create_dir_all(&legacy).expect("create legacy dir");
+    let config_path = write_config(
+        &tmp.path,
+        &format!(
+            "plugins_root: {}\npaths:\n  plugins_path: {}\n",
+            legacy.display(),
+            canonical.display()
+        ),
+    );
+
+    let resolved = plugins_root_from_config(&config_path);
+
+    assert_eq!(
+        resolved, canonical,
+        "paths.plugins_path must win over legacy plugins_root, got {resolved:?}"
+    );
+}
+
+#[test]
+fn honors_legacy_top_level_plugins_root() {
+    // Back-compat guard: older configs that only carry the top-level
+    // `plugins_root` (#287, no `paths` section) must keep working.
+    let tmp = TempDir::new("legacy-only");
+    let legacy = tmp.path.join("legacy-plugins");
+    fs::create_dir_all(&legacy).expect("create legacy dir");
+    let config_path = write_config(&tmp.path, &format!("plugins_root: {}\n", legacy.display()));
+
+    let resolved = plugins_root_from_config(&config_path);
+
+    assert_eq!(
+        resolved, legacy,
+        "legacy top-level plugins_root must still resolve, got {resolved:?}"
+    );
+}
+
+#[test]
+fn falls_back_to_config_dir_plugins() {
+    // No env, no `paths.plugins_path`, no legacy `plugins_root` -> the
+    // last-resort `<config_dir>/plugins` (install-layout default).
+    let tmp = TempDir::new("fallback");
+    let config_path = write_config(&tmp.path, "paths: {}\n");
+
+    let resolved = plugins_root_from_config(&config_path);
+
+    assert_eq!(
+        resolved,
+        tmp.path.join("plugins"),
+        "expected <config_dir>/plugins fallback, got {resolved:?}"
+    );
+}


### PR DESCRIPTION
Refs #599 (do not auto-close).

## Problem
Adding IR / NAM (and LV2) blocks was impossible — the model picker came up empty, so the block editor couldn't be prefilled. Native blocks were unaffected.

## Root cause
Two readers of `config.yaml` disagreed on the plugins-directory key:
- **Settings → Paths** (#513) saves it under `paths.plugins_path`.
- **`plugin_loader::plugins_root_from_config`** (#287) only read the top-level `plugins_root`.

They were never bridged, so the user's directory was ignored and the catalog fell back to `<config_dir>/plugins` (empty) → **0 disk packages**.

## Fix
`plugins_root_from_config` now resolves in precedence:
1. `OPENRIG_PLUGINS_ROOT` env (unchanged, wins outright)
2. `paths.plugins_path` (canonical, #513)
3. legacy top-level `plugins_root` (#287, back-compat)
4. `<config_dir>/plugins` fallback

Relative declared paths resolve against the config dir; absolute pass through.

## Tests (RED-first)
`crates/plugin-loader/tests/plugins_root_resolution.rs` — 4 integration tests pinning the contract (canonical, precedence over legacy, legacy back-compat, fallback). The first two were RED before the fix.

- `cargo test -p plugin-loader` → all pass
- `cargo check --workspace` → clean
- zero warnings on touched files

## Workaround (pre-fix)
`export OPENRIG_PLUGINS_ROOT="<plugins dir>"`