### PR TITLE
fix(#591): footswitch opens compact view + MIDI-activity selection markers (follow-up to #598)

### DIFF
--- a/crates/adapter-gui/src/chain_rig_nav_wiring.rs
+++ b/crates/adapter-gui/src/chain_rig_nav_wiring.rs
@@ -165,10 +165,18 @@ pub(crate) fn apply_events_to_ui(window: &AppWindow, ctx: &ChainRigNavCtx, event
         }
     }
 
+    // #591: a footswitch `toggle_compact_view` → SetCompactViewEnabled emits
+    // this. The compact view is a per-chain window opened via the same
+    // callback the expand button uses — open it for the active chain.
+    let open_compact_view = events
+        .iter()
+        .any(|e| matches!(e, Event::CompactViewEnabledChanged { enabled: true }));
+
     let session_borrow = ctx.project_session.borrow();
     let Some(session) = session_borrow.as_ref() else {
         return;
     };
+    let mut compact_open_idx: Option<i32> = None;
 
     // Re-sync the live runtime for each chain a command touched (once).
     let mut synced: Vec<ChainId> = Vec::new();
@@ -197,6 +205,13 @@ pub(crate) fn apply_events_to_ui(window: &AppWindow, ctx: &ChainRigNavCtx, event
         let sel_arc = session.dispatcher.selection_state();
         let sel = sel_arc.read().expect("selection state poisoned");
         crate::selection_highlight::sync_selection_markers(window, &proj, &sel);
+        if open_compact_view {
+            compact_open_idx = sel
+                .active_chain
+                .as_deref()
+                .and_then(|id| proj.chains.iter().position(|c| c.id.0 == id))
+                .map(|i| i as i32);
+        }
     }
     sync_project_dirty(
         window,
@@ -205,6 +220,14 @@ pub(crate) fn apply_events_to_ui(window: &AppWindow, ctx: &ChainRigNavCtx, event
         &ctx.project_dirty,
         ctx.auto_save,
     );
+
+    // #591: open the active chain's compact view AFTER dropping the session
+    // borrow — the callback re-borrows `project_session`, so invoking it
+    // while still borrowed would panic.
+    drop(session_borrow);
+    if let Some(idx) = compact_open_idx {
+        window.invoke_open_compact_chain_view(idx);
+    }
 }
 
 pub(crate) fn wire(window: &AppWindow, ctx: ChainRigNavCtx) {

--- a/crates/adapter-gui/src/compact_chain_callbacks.rs
+++ b/crates/adapter-gui/src/compact_chain_callbacks.rs
@@ -87,6 +87,17 @@ pub(crate) fn wire(window: &AppWindow, ctx: CompactChainCallbacksCtx) {
             return;
         };
         let ci = chain_index as usize;
+        // #591: if this chain's compact view is already open, focus it
+        // rather than stacking a second window — a footswitch
+        // (`toggle_compact_view`) can re-trigger this for the active chain.
+        if let Some((open_ci, weak)) = &*open_compact_window.borrow() {
+            if *open_ci == ci {
+                if let Some(existing) = weak.upgrade() {
+                    let _ = existing.show();
+                    return;
+                }
+            }
+        }
         let compact_win = match CompactChainViewWindow::new() {
             Ok(w) => w,
             Err(e) => {

--- a/crates/adapter-gui/src/midi_adapter_wiring.rs
+++ b/crates/adapter-gui/src/midi_adapter_wiring.rs
@@ -19,7 +19,7 @@ use std::sync::{Arc, RwLock};
 
 use anyhow::Result;
 use application::SelectionState;
-use slint::{Timer, Weak};
+use slint::{ComponentHandle, Timer, Weak};
 
 use crate::chain_rig_nav_wiring::{apply_events_to_ui, ChainRigNavCtx};
 use crate::cli::MidiMapArg;
@@ -60,6 +60,11 @@ pub(crate) fn wire(window: Weak<AppWindow>, ctx: ChainRigNavCtx, arg: MidiMapArg
 
     let timer = Timer::default();
     let daemon_selection_for_timer = Arc::clone(&daemon_selection);
+    // #591: the chain/block selection markers are MIDI-activity feedback —
+    // shown only when a MIDI command arrives and hidden again after 10s of
+    // no further MIDI. This one-shot timer is re-armed on every MIDI command.
+    let markers_hide_timer: std::rc::Rc<std::cell::RefCell<Option<Timer>>> =
+        std::rc::Rc::new(std::cell::RefCell::new(None));
     timer.start(
         slint::TimerMode::Repeated,
         std::time::Duration::from_millis(16),
@@ -95,6 +100,22 @@ pub(crate) fn wire(window: Weak<AppWindow>, ctx: ChainRigNavCtx, arg: MidiMapArg
                 return;
             }
             if let Some(window) = window.upgrade() {
+                // #591: a MIDI command arrived — light the selection markers
+                // and (re)arm the 10s hide timer so they fade out after the
+                // last footswitch stimulus.
+                window.set_midi_selection_active(true);
+                let weak_for_hide = window.as_weak();
+                let hide = Timer::default();
+                hide.start(
+                    slint::TimerMode::SingleShot,
+                    std::time::Duration::from_secs(10),
+                    move || {
+                        if let Some(w) = weak_for_hide.upgrade() {
+                            w.set_midi_selection_active(false);
+                        }
+                    },
+                );
+                *markers_hide_timer.borrow_mut() = Some(hide);
                 apply_events_to_ui(&window, &ctx, &events);
             }
         },

--- a/crates/adapter-gui/ui/app-window.slint
+++ b/crates/adapter-gui/ui/app-window.slint
@@ -65,6 +65,9 @@ export component AppWindow inherits Window {
     in property <int> selected-chain-block-chain-index;
     in property <int> selected-chain-block-index;
     in property <int> selected-chain-block-neighbor-index: -1;
+    // #591: true while a MIDI command is recent (last 10s) — gates the
+    // chain/block selection markers so they only show on footswitch activity.
+    in property <bool> midi-selection-active: false;
     in property <[BlockTypePickerItem]> block-type-options;
     in property <[BlockModelPickerItem]> block-model-options;
     in property <[BlockModelPickerItem]> filtered-block-model-options;
@@ -370,6 +373,7 @@ export component AppWindow inherits Window {
         selected-chain-block-chain-index: root.selected-chain-block-chain-index;
         selected-chain-block-index: root.selected-chain-block-index;
         selected-chain-block-neighbor-index: root.selected-chain-block-neighbor-index;
+        midi-selection-active: root.midi-selection-active;
         block-type-options: root.block-type-options;
         block-model-options: root.block-model-options;
         filtered-block-model-options: root.filtered-block-model-options;
@@ -596,6 +600,7 @@ export component AppWindow inherits Window {
         selected-chain-block-chain-index: root.selected-chain-block-chain-index;
         selected-chain-block-index: root.selected-chain-block-index;
         selected-chain-block-neighbor-index: root.selected-chain-block-neighbor-index;
+        midi-selection-active: root.midi-selection-active;
         block-type-options: root.block-type-options;
         block-model-options: root.block-model-options;
         filtered-block-model-options: root.filtered-block-model-options;

--- a/crates/adapter-gui/ui/components/block_chip.slint
+++ b/crates/adapter-gui/ui/components/block_chip.slint
@@ -13,6 +13,9 @@ export component BlockChip inherits Rectangle {
     // #591: the block the footswitch's block-toggle (neighbor) would act
     // on — marked lighter than the active block so the user sees the pair.
     in property <bool> neighbor: false;
+    // #591: gates the selected/neighbor markers — they only show while a
+    // MIDI command is recent (last 10s), then fade out.
+    in property <bool> markers-visible: false;
     in property <bool> dragging: false;
     // True while ANY block in the same chain row is being dragged. Drives
     // the type-label fade so the floating ghost has a clear path across
@@ -37,34 +40,23 @@ export component BlockChip inherits Rectangle {
 
     width: 100px;
     height: 100px;
-    background: root.selected ? #f0a02014 : transparent;
-    // #591: mark the active block (strong) and the neighbor the block
-    // footswitch toggle acts on (light). The chain row already outlines
-    // the active chain; this shows the selected block within it.
-    // `pulse` adds a brief stronger emphasis when the selection MOVES to
-    // this chip (footswitch block step), fading back after a moment.
-    property <bool> pulse: false;
-    border-width: root.selected ? (root.pulse ? 3px : 2px) : root.neighbor ? 1px : 0px;
-    border-color: root.selected
-        ? (root.pulse ? #ffc14d : #f0a020)
-        : root.neighbor ? #f0a0207a : transparent;
+    // #591: the active-block (strong) and neighbor (light) markers only
+    // show while a MIDI command is recent (`markers-visible`), then fade
+    // out after 10s. Lit when the block is enabled, dimmer when disabled.
+    background: (root.markers-visible && root.selected) ? #f0a02014 : transparent;
+    border-width: root.markers-visible
+        ? (root.selected ? 2px : root.neighbor ? 1px : 0px)
+        : 0px;
+    border-color: root.markers-visible
+        ? (root.selected
+            ? (root.block.enabled ? #f0a020 : #f0a02066)
+            : root.neighbor
+                ? (root.block.enabled ? #f0a0207a : #f0a02040)
+                : transparent)
+        : transparent;
     border-radius: 6px;
-    animate border-width { duration: 1500ms; easing: ease-out; }
-    animate border-color { duration: 1500ms; easing: ease-out; }
-    changed selected => {
-        if (root.selected) {
-            root.pulse = true;
-            chip-pulse-timer.running = true;
-        }
-    }
-    chip-pulse-timer := Timer {
-        interval: 1700ms;
-        running: false;
-        triggered => {
-            root.pulse = false;
-            self.running = false;
-        }
-    }
+    animate border-width { duration: 350ms; easing: ease-out; }
+    animate border-color { duration: 350ms; easing: ease-out; }
 
     // Type label on top — fades out while a drag is happening anywhere in
     // this chain row so it doesn't obscure the floating ghost or the chips

--- a/crates/adapter-gui/ui/desktop_main.slint
+++ b/crates/adapter-gui/ui/desktop_main.slint
@@ -43,6 +43,7 @@ export component DesktopMain inherits Rectangle {
     in property <int> selected-chain-block-chain-index;
     in property <int> selected-chain-block-index;
     in property <int> selected-chain-block-neighbor-index: -1;
+    in property <bool> midi-selection-active: false;
     in property <[BlockTypePickerItem]> block-type-options;
     in property <[BlockModelPickerItem]> block-model-options;
     in property <[BlockModelPickerItem]> filtered-block-model-options;
@@ -297,6 +298,7 @@ export component DesktopMain inherits Rectangle {
             selected-chain-block-chain-index: root.selected-chain-block-chain-index;
             selected-chain-block-index: root.selected-chain-block-index;
             selected-chain-block-neighbor-index: root.selected-chain-block-neighbor-index;
+            midi-selection-active: root.midi-selection-active;
             block-type-options: root.block-type-options;
             block-model-options: root.block-model-options;
             filtered-block-model-options: root.filtered-block-model-options;

--- a/crates/adapter-gui/ui/pages/chain_row.slint
+++ b/crates/adapter-gui/ui/pages/chain_row.slint
@@ -25,6 +25,9 @@ export component ChainRow inherits Rectangle {
     in property <int> selected-block-index;
     // #591: UI index of the block the footswitch block-toggle acts on.
     in property <int> selected-block-neighbor-index: -1;
+    // #591: gates the selection markers — they only show while a MIDI
+    // command is recent (last 10s).
+    in property <bool> midi-selection-active: false;
     in property <bool> fullscreen: false;
     callback toggle-chain-enabled(int);
     callback chain-volume-changed(int, int);
@@ -78,36 +81,16 @@ export component ChainRow inherits Rectangle {
 
     background: transparent;
     border-radius: 6px;
-    // #591: highlight the row when this chain is the active selection
-    // (set by tapping the chain, by selecting one of its blocks, or by
-    // MIDI prev/next). This is the chain the footswitch toggles.
+    // #591: outline the row when this chain is the active selection AND a
+    // MIDI command is recent (last 10s). The marker is MIDI-activity
+    // feedback — it appears on a footswitch command and fades out after
+    // 10s of no stimulus (`midi-selection-active` flips false). Lit when
+    // the chain is enabled, dimmer when disabled.
     property <bool> chain-selected: root.selected-block-chain-index == root.chain-index;
-    // #591: transient emphasis when the selection MOVES to this chain —
-    // a strong border that fades back to the subtle persistent marker
-    // after a moment, so a footswitch step is visible without leaving
-    // permanent clutter. `pulse` is raised on the rising edge of
-    // `chain-selected` and cleared by the one-shot timer below.
-    property <bool> pulse: false;
-    border-width: root.chain-selected ? (root.pulse ? 3px : 1px) : 0px;
-    border-color: root.chain-selected
-        ? (root.pulse ? #ffc14d : #f0a02066)
-        : transparent;
-    animate border-width { duration: 1600ms; easing: ease-out; }
-    animate border-color { duration: 1600ms; easing: ease-out; }
-    changed chain-selected => {
-        if (root.chain-selected) {
-            root.pulse = true;
-            pulse-timer.running = true;
-        }
-    }
-    pulse-timer := Timer {
-        interval: 1800ms;
-        running: false;
-        triggered => {
-            root.pulse = false;
-            self.running = false;
-        }
-    }
+    border-width: (root.chain-selected && root.midi-selection-active) ? 2px : 0px;
+    border-color: root.chain.enabled ? #f0a020 : #f0a02055;
+    animate border-width { duration: 350ms; easing: ease-out; }
+    animate border-color { duration: 350ms; easing: ease-out; }
     // 74 + n*108 used to land the IN/OUT meters at y = root.height - 22,
     // which collided with the block grid (bottom at y = 62 + n*108).
     // Add 32px of breathing room so the meters sit clearly below the
@@ -415,6 +398,7 @@ export component ChainRow inherits Rectangle {
                 ? false
                 : root.selected-block-chain-index == root.chain-index && root.selected-block-index == block-index;
             neighbor: root.selected-block-chain-index == root.chain-index && root.selected-block-neighbor-index == block-index;
+            markers-visible: root.midi-selection-active;
             dragging: root.dragging-chain-index == root.chain-index && root.dragging-block-index == block-index;
             chain-dragging: root.dragging-chain-index == root.chain-index && root.dragging-block-index >= 0;
             clicked => { root.select-chain-block(root.chain-index, block-index); }

--- a/crates/adapter-gui/ui/pages/project_chains.slint
+++ b/crates/adapter-gui/ui/pages/project_chains.slint
@@ -17,6 +17,7 @@ export component ProjectChainsPage inherits Rectangle {
     in property <int> selected-chain-block-chain-index;
     in property <int> selected-chain-block-index;
     in property <int> selected-chain-block-neighbor-index: -1;
+    in property <bool> midi-selection-active: false;
     in property <[BlockTypePickerItem]> block-type-options;
     in property <[BlockModelPickerItem]> block-model-options;
     in property <[BlockModelPickerItem]> filtered-block-model-options;
@@ -241,6 +242,7 @@ export component ProjectChainsPage inherits Rectangle {
                 selected-block-chain-index: root.selected-chain-block-chain-index;
                 selected-block-index: root.selected-chain-block-index;
                 selected-block-neighbor-index: root.selected-chain-block-neighbor-index;
+                midi-selection-active: root.midi-selection-active;
                 toggle-chain-enabled(index) => { root.toggle-chain-enabled(index); }
                 chain-volume-changed(index, v) => { root.chain-volume-changed(index, v); }
                 remove-chain(index) => { root.remove-chain(index); }

--- a/crates/adapter-gui/ui/touch_main.slint
+++ b/crates/adapter-gui/ui/touch_main.slint
@@ -42,6 +42,7 @@ export component TouchMain inherits Rectangle {
     in property <int> selected-chain-block-chain-index;
     in property <int> selected-chain-block-index;
     in property <int> selected-chain-block-neighbor-index: -1;
+    in property <bool> midi-selection-active: false;
     in property <[BlockTypePickerItem]> block-type-options;
     in property <[BlockModelPickerItem]> block-model-options;
     in property <[BlockModelPickerItem]> filtered-block-model-options;
@@ -301,6 +302,7 @@ export component TouchMain inherits Rectangle {
             selected-chain-block-chain-index: root.selected-chain-block-chain-index;
             selected-chain-block-index: root.selected-chain-block-index;
             selected-chain-block-neighbor-index: root.selected-chain-block-neighbor-index;
+            midi-selection-active: root.midi-selection-active;
             block-type-options: root.block-type-options;
             block-model-options: root.block-model-options;
             filtered-block-model-options: root.filtered-block-model-options;

--- a/crates/application/src/event.rs
+++ b/crates/application/src/event.rs
@@ -201,6 +201,14 @@ pub enum Event {
         enabled: bool,
     },
 
+    /// #591: the compact view was toggled (MIDI slot `toggle_compact_view`
+    /// → `SetCompactViewEnabled`). The adapter opens/closes the per-chain
+    /// compact window for the active chain; without this event the MIDI
+    /// drain had nothing to act on and the footswitch did nothing.
+    CompactViewEnabledChanged {
+        enabled: bool,
+    },
+
     // ── Project-level events ──────────────────────────────────────────────────
     /// A project was loaded from disk.
     ProjectLoaded,
@@ -327,6 +335,7 @@ impl Event {
             | Event::ChainPresetDeleted { .. }
             | Event::TunerEnabledChanged { .. }
             | Event::SpectrumEnabledChanged { .. }
+            | Event::CompactViewEnabledChanged { .. }
             | Event::ProjectClosed
             // #513 / #493: MIDI device / mapping / learn events live at the
             // system or project root, not a single chain.

--- a/crates/application/src/local_dispatcher.rs
+++ b/crates/application/src/local_dispatcher.rs
@@ -303,7 +303,10 @@ impl CommandDispatcher for LocalDispatcher {
                     .write()
                     .expect("selection state poisoned")
                     .compact_view_enabled = enabled;
-                Ok(vec![])
+                // #591: emit so the adapter can open/close the compact view
+                // for the active chain — the MIDI footswitch path drains
+                // events and had nothing to act on before.
+                Ok(vec![Event::CompactViewEnabledChanged { enabled }])
             }
             Command::ToggleActiveBlockNeighborEnabled => {
                 self.handle_toggle_active_block_neighbor_enabled()

--- a/crates/application/src/local_dispatcher_tests.rs
+++ b/crates/application/src/local_dispatcher_tests.rs
@@ -1423,6 +1423,28 @@ fn select_active_chain_non_existent_returns_err() {
     assert!(result.is_err(), "expected Err for missing chain, got Ok");
 }
 
+#[test]
+fn set_compact_view_enabled_emits_event_so_the_gui_can_react() {
+    // #591: a footswitch bound to `toggle_compact_view` dispatches
+    // SetCompactViewEnabled. The handler only flipped a SelectionState
+    // snapshot and returned no events, so the MIDI drain had nothing to
+    // act on and the compact view never opened ("isso não faz nada").
+    let project = make_project_two_chains();
+    let dispatcher = LocalDispatcher::new(Rc::clone(&project));
+
+    let events = dispatcher
+        .dispatch(Command::SetCompactViewEnabled { enabled: true })
+        .expect("dispatch ok");
+
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            Event::CompactViewEnabledChanged { enabled: true }
+        )),
+        "expected CompactViewEnabledChanged{{true}}, got {events:?}"
+    );
+}
+
 // ── AddChain tests ────────────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
Follow-up to #598 (already merged). Two further #591 fixes:

## 1. `toggle_compact_view` footswitch was a dead command
`SetCompactViewEnabled` only flipped a `SelectionState` bool that nothing rendered and emitted no event, so the footswitch did nothing. Now it emits `Event::CompactViewEnabledChanged`; the MIDI drain opens the per-chain compact window for the **active chain** via the same callback the expand button uses, guarded so a re-trigger focuses the existing window instead of stacking a second one.

## 2. Selection markers are MIDI-activity feedback (user request)
The chain/block outlines now:
- appear **only when a MIDI command arrives**,
- **fade out after 10s** of no further MIDI stimulus,
- are **lit when the chain/block is enabled, dimmer when disabled**.

Replaced the earlier per-row/chip 1.6s pulse with a global `midi-selection-active` gate (set by the MIDI drain + a re-armed 10s one-shot timer). GUI clicks no longer flash the markers — they are MIDI feedback.

## Tests
- `set_compact_view_enabled_emits_event_so_the_gui_can_react` (dispatcher, red-first).
- `cargo test -p adapter-gui --lib` green (443); clean Slint build after merging current develop.

## Validate (in your main folder)
```
git fetch && git checkout bugfix/issue-591 && git pull
```
1. Idle (no MIDI) → no outlines on chains/blocks.
2. Press any footswitch (MIDI) → active chain + block (active & neighbor) outlines light up.
3. Wait ~10s with no MIDI → outlines fade away.
4. Enabled = bright outline; disabled = dim.
5. Bank-1 C (`toggle_compact_view`) → opens the active chain's compact view (re-press focuses it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)