### PR TITLE
fix(#603): restore IR & NAM generic-loader tiles in add-block picker

### DIFF
--- a/crates/block-ir/src/ir_generic_ir.rs
+++ b/crates/block-ir/src/ir_generic_ir.rs
@@ -1,0 +1,96 @@
+use anyhow::{Error, Result};
+use block_core::param::{
+    file_path_parameter, required_string, ModelParameterSchema, ParameterSet,
+};
+use block_core::{
+    AudioChannelLayout, BlockProcessor, ModelAudioMode, MonoProcessor, StereoProcessor,
+};
+use ir::{
+    build_mono_ir_processor_from_wav, build_stereo_ir_processor_from_wav, IrAsset, IrChannelData,
+};
+
+use crate::registry::IrModelDefinition;
+use crate::IrBlockBackendKind;
+
+pub const MODEL_ID: &str = "generic_ir";
+pub const DISPLAY_NAME: &str = "Impulse Response";
+
+struct DualMonoProcessor {
+    left: Box<dyn MonoProcessor>,
+    right: Box<dyn MonoProcessor>,
+}
+
+impl StereoProcessor for DualMonoProcessor {
+    fn process_frame(&mut self, input: [f32; 2]) -> [f32; 2] {
+        [
+            self.left.process_sample(input[0]),
+            self.right.process_sample(input[1]),
+        ]
+    }
+}
+
+fn schema() -> Result<ModelParameterSchema> {
+    Ok(ModelParameterSchema {
+        effect_type: "ir".to_string(),
+        model: MODEL_ID.to_string(),
+        display_name: "Impulse Response".to_string(),
+        audio_mode: ModelAudioMode::DualMono,
+        parameters: vec![file_path_parameter(
+            "file",
+            "IR File",
+            None,
+            None,
+            &["wav"],
+            false,
+        )],
+    })
+}
+
+fn validate(params: &ParameterSet) -> Result<()> {
+    let file = required_string(params, "file").map_err(Error::msg)?;
+    let _ = IrAsset::load_from_wav(&file)?;
+    Ok(())
+}
+
+fn asset_summary(params: &ParameterSet) -> Result<String> {
+    let file = required_string(params, "file").map_err(Error::msg)?;
+    Ok(format!("file='{file}'"))
+}
+
+fn build(
+    params: &ParameterSet,
+    sample_rate: f32,
+    layout: AudioChannelLayout,
+) -> Result<BlockProcessor> {
+    let file = required_string(params, "file").map_err(Error::msg)?;
+    match layout {
+        AudioChannelLayout::Mono => Ok(BlockProcessor::Mono(
+            build_mono_ir_processor_from_wav(&file, sample_rate)?,
+        )),
+        AudioChannelLayout::Stereo => {
+            let asset = IrAsset::load_from_wav(&file)?;
+            match asset.channel_data() {
+                IrChannelData::Mono(_) => Ok(BlockProcessor::Stereo(Box::new(DualMonoProcessor {
+                    left: build_mono_ir_processor_from_wav(&file, sample_rate)?,
+                    right: build_mono_ir_processor_from_wav(&file, sample_rate)?,
+                }))),
+                IrChannelData::Stereo(_, _) => Ok(BlockProcessor::Stereo(
+                    build_stereo_ir_processor_from_wav(&file, sample_rate)?,
+                )),
+            }
+        }
+    }
+}
+
+pub const MODEL_DEFINITION: IrModelDefinition = IrModelDefinition {
+    id: MODEL_ID,
+    display_name: DISPLAY_NAME,
+    brand: "",
+    backend_kind: IrBlockBackendKind::Native,
+    schema,
+    validate,
+    asset_summary,
+    build,
+    supported_instruments: block_core::ALL_INSTRUMENTS,
+    knob_layout: &[],
+};

--- a/crates/block-ir/src/lib_tests.rs
+++ b/crates/block-ir/src/lib_tests.rs
@@ -1,6 +1,17 @@
 use crate::{ir_model_schema, supported_models};
 
 #[test]
+fn supported_models_includes_generic_ir_loader() {
+    // The native generic IR loader ("Impulse Response") lets the user load
+    // a local `.wav` from disk. Regression guard for #603: it was deleted by
+    // the #287 plugin move, emptying the registry and removing the tile.
+    assert!(
+        supported_models().contains(&"generic_ir"),
+        "block-ir must register the native generic_ir loader"
+    );
+}
+
+#[test]
 fn supported_ir_models_expose_valid_schema() {
     for model in supported_models() {
         let schema = ir_model_schema(model).expect("schema should exist");

--- a/crates/block-nam/src/lib.rs
+++ b/crates/block-nam/src/lib.rs
@@ -68,3 +68,7 @@ pub fn build_nam_processor_for_layout(
 ) -> Result<BlockProcessor> {
     (registry::find_model_definition(model)?.build)(params, sample_rate, layout)
 }
+
+#[cfg(test)]
+#[path = "lib_tests.rs"]
+mod tests;

--- a/crates/block-nam/src/lib_tests.rs
+++ b/crates/block-nam/src/lib_tests.rs
@@ -1,0 +1,22 @@
+use crate::{nam_model_schema, supported_models};
+
+#[test]
+fn supported_models_includes_generic_nam_loader() {
+    // The native generic NAM loader ("Neural Amp Modeler") lets the user
+    // load a local `.nam` model from disk. Regression guard for #603: it was
+    // deleted by the #287 plugin move, emptying the registry and removing
+    // the tile.
+    assert!(
+        supported_models().contains(&"neural_amp_modeler"),
+        "block-nam must register the native neural_amp_modeler loader"
+    );
+}
+
+#[test]
+fn supported_nam_models_expose_valid_schema() {
+    for model in supported_models() {
+        let schema = nam_model_schema(model).expect("schema should exist");
+        assert_eq!(schema.effect_type, "nam");
+        assert_eq!(schema.model, *model);
+    }
+}

--- a/crates/block-nam/src/nam_generic_nam.rs
+++ b/crates/block-nam/src/nam_generic_nam.rs
@@ -1,0 +1,33 @@
+use anyhow::Result;
+use block_core::param::{ModelParameterSchema, ParameterSet};
+use block_core::{AudioChannelLayout, BlockProcessor};
+
+use crate::registry::NamModelDefinition;
+use crate::NamBlockBackendKind;
+
+const MODEL_ID: &str = nam::GENERIC_NAM_MODEL_ID;
+const DISPLAY_NAME: &str = "Neural Amp Modeler";
+
+fn schema() -> Result<ModelParameterSchema> {
+    Ok(nam::model_schema_for(
+        "nam",
+        MODEL_ID,
+        "Neural Amp Modeler",
+        true,
+    ))
+}
+
+fn build(params: &ParameterSet, sample_rate: f32, layout: AudioChannelLayout) -> Result<BlockProcessor> {
+    nam::build_processor_for_layout(params, sample_rate, layout)
+}
+
+pub const MODEL_DEFINITION: NamModelDefinition = NamModelDefinition {
+    id: MODEL_ID,
+    display_name: DISPLAY_NAME,
+    brand: "",
+    backend_kind: NamBlockBackendKind::Native,
+    schema,
+    build,
+    supported_instruments: block_core::ALL_INSTRUMENTS,
+    knob_layout: &[],
+};

--- a/crates/project/src/catalog_tests.rs
+++ b/crates/project/src/catalog_tests.rs
@@ -14,9 +14,32 @@ fn catalog_exposes_supported_types() {
     assert!(effect_types.contains(&"preamp"));
     assert!(effect_types.contains(&"delay"));
     assert!(effect_types.contains(&"wah"));
-    // `nam`, `ir`, `pitch` only appear when their native registries have
-    // entries OR when disk packages are loaded; in this test process the
-    // packages aren't discovered, so they may legitimately be absent.
+    // `pitch` only appears when its native registry has entries OR when
+    // disk packages are loaded; in this test process the packages aren't
+    // discovered, so it may legitimately be absent.
+}
+
+#[test]
+fn catalog_always_exposes_generic_ir_and_nam_loaders() {
+    // IR and NAM ship native generic file-loader models (load a local
+    // `.wav` IR / `.nam` model from disk). Unlike packaged catalog content,
+    // these loaders must appear in the add-block picker unconditionally —
+    // they do not depend on disk-package discovery. Regression guard for
+    // #603: the #287 plugin move swept up the two native loader sources,
+    // emptying `supported_models()` and dropping the tiles from the picker.
+    let effect_types = supported_block_types()
+        .into_iter()
+        .map(|entry| entry.effect_type)
+        .collect::<Vec<_>>();
+
+    assert!(
+        effect_types.contains(&"ir"),
+        "IR generic-loader tile must always be present in the add-block picker"
+    );
+    assert!(
+        effect_types.contains(&"nam"),
+        "NAM generic-loader tile must always be present in the add-block picker"
+    );
 }
 
 #[test]

--- a/docs/blocks-catalog.md
+++ b/docs/blocks-catalog.md
@@ -16,7 +16,7 @@
 | **Wah** | Wah-wah | 2 | Cry Classic (native); GxQuack (LV2) |
 | **Body** | Ressonância de corpo acústico | 114 | Martin (45), Taylor (30), Gibson (10), Yamaha (5), Guild (4), Takamine (4), Cort (4), Emerald (2), Rainsong (2), Lowden (2) + boutique (IR) |
 | **Pitch** | Pitch shift e harmonização | 22 | Pitch Shifter (native — time-domain granular, low-latency); Harmonizer, x42 Autotune (Microtonal/Scales), MDA Detune, MDA RePsycho, Pitchotto, ewham, Larynx pitch, MOD CAPS Mole/Sustainer (LV2 — 21 modelos pós-#379) |
-| **IR** / **NAM** | Loaders genéricos | 1+1 | generic_ir, generic_nam |
+| **IR** / **NAM** | Loaders genéricos | 1+1 | generic_ir, neural_amp_modeler |
 | **Input** / **Output** / **Insert** | I/O | — | standard, standard, external_loop |
 
 **Total: ~804 modelos em 16 tipos (5 backends: Native 34, NAM 215, IR 139, LV2 ~351, VST3 6).**


### PR DESCRIPTION
Closes #603.

## Problem
The IR and NAM tiles vanished from the add-block "choose type" modal on `develop`. These are **native generic file loaders** (load a local `.wav` IR / `.nam` model from disk), not packaged catalog content — they used to always be present.

## Root cause (two #287 commits)
1. `435ff6d73` deleted the two native loader sources (`crates/block-ir/src/ir_generic_ir.rs`, `crates/block-nam/src/nam_generic_nam.rs`) by mistake while moving *plugin* sources to OpenRig-plugins. `block_ir::supported_models()` / `block_nam::supported_models()` then returned empty slices.
2. `21e73ffc`'s catalog filter keeps a type only when it has native models **OR** disk packages; since `block_type_for_effect_type("ir"|"nam")` is `None`, both tiles were filtered out.

## Fix (Option A — restore the loaders)
Restored both loader sources verbatim from `435ff6d73^`. They compile unchanged against the current `block-core`/`ir`/`nam` APIs. The `block-*` `build.rs` auto-discovers `*.rs` with a `MODEL_DEFINITION` const, so the models re-register with no manual registry edit, and the catalog filter passes via its native-models branch again.

## Tests (RED-first — watched fail, then pass)
- `project::catalog_always_exposes_generic_ir_and_nam_loaders`
- `block-ir::supported_models_includes_generic_ir_loader`
- `block-nam::supported_models_includes_generic_nam_loader` (+ schema test)

`cargo test --workspace --lib`: 0 failed. `cargo build`: 0 warnings.

## Docs
`docs/blocks-catalog.md`: corrected the NAM loader id (`neural_amp_modeler`, not `generic_nam`).