### PR TITLE
fix(#607): Settings path overrides survive whole-config re-save

### DIFF
--- a/crates/adapter-gui/src/desktop_app.rs
+++ b/crates/adapter-gui/src/desktop_app.rs
@@ -510,8 +510,12 @@ pub fn run_desktop_app(
         last_dispatched_name.clone(),
     );
     // --- System / Paths section (#513) ---
-    crate::settings::paths::install(&window, project_session.clone());
-    crate::settings::paths::install_secondary(&project_settings_window, project_session.clone());
+    crate::settings::paths::install(&window, project_session.clone(), app_config.clone());
+    crate::settings::paths::install_secondary(
+        &project_settings_window,
+        project_session.clone(),
+        app_config.clone(),
+    );
     crate::settings::paths::seed_initial(&window);
     crate::settings::paths::seed_initial_secondary(&project_settings_window);
     // Seed the initial project-name and project-path-display from the session.

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -64,6 +64,12 @@ mod select_chain_block_callback;
 mod select_chain_callback;
 mod selection_highlight;
 pub(crate) mod settings;
+/// #607: pure path-override helpers (persist + mirror into the in-memory
+/// `AppConfig`) exposed at the crate root for integration tests, without
+/// widening the whole `settings` module to `pub`.
+pub use settings::paths::{
+    apply_evaluations_override, apply_plugins_override, apply_presets_override,
+};
 pub mod spectrum_close;
 mod spectrum_session;
 mod spectrum_wiring;

--- a/crates/adapter-gui/src/settings/paths.rs
+++ b/crates/adapter-gui/src/settings/paths.rs
@@ -12,6 +12,14 @@
 //! When no project session is loaded the dispatch is skipped (mirrors
 //! `midi_devices::install`): persistence still happens so the choice
 //! survives even before a project is opened.
+//!
+//! #607: each Choose…/Reset also mirrors the override into the shared
+//! in-memory `AppConfig`, not only `config.yaml`. Lifecycle events
+//! (project-open / register-recent) re-persist the whole in-memory
+//! snapshot via `save_app_config(&app_config.borrow())`; without the
+//! mirror, that whole-config save would clobber a just-picked override
+//! back to its startup value (the user-visible bug: evaluations folder
+//! reverting to default after reopening the project).
 
 use std::cell::RefCell;
 use std::path::PathBuf;
@@ -23,7 +31,7 @@ use slint::ComponentHandle;
 use application::command::Command;
 use application::dispatcher::CommandDispatcher;
 use application::event::Event;
-use infra_filesystem::FilesystemStorage;
+use infra_filesystem::{AppConfig, FilesystemStorage};
 
 use crate::state::ProjectSession;
 use crate::{AppWindow, ProjectSettingsWindow};
@@ -36,14 +44,45 @@ fn pick_folder_dialog() -> Option<PathBuf> {
     FileDialog::new().pick_folder()
 }
 
+/// #607: Apply a **presets** path override — persist it into `config.yaml`
+/// AND mirror it into the shared in-memory `AppConfig`. The mirror is the
+/// fix: lifecycle events (project-open / register-recent) re-persist the
+/// whole in-memory snapshot via `save_app_config(&app_config.borrow())`; if
+/// the picker only wrote to disk, that whole-config save would clobber the
+/// user's pick back to its startup value. Keeping the snapshot in lockstep
+/// makes the override the single source of truth.
+pub fn apply_presets_override(config: &mut AppConfig, path: Option<PathBuf>) -> anyhow::Result<()> {
+    FilesystemStorage::save_presets_path(path.clone())?;
+    config.paths.presets_path = path;
+    Ok(())
+}
+
+/// #607: same persist + in-memory mirror for the **plugins** override.
+pub fn apply_plugins_override(config: &mut AppConfig, path: Option<PathBuf>) -> anyhow::Result<()> {
+    FilesystemStorage::save_plugins_path(path.clone())?;
+    config.paths.plugins_path = path;
+    Ok(())
+}
+
+/// #607: same persist + in-memory mirror for the **evaluations** override.
+pub fn apply_evaluations_override(
+    config: &mut AppConfig,
+    path: Option<PathBuf>,
+) -> anyhow::Result<()> {
+    FilesystemStorage::save_evaluations_path(path.clone())?;
+    config.paths.evaluations_path = path;
+    Ok(())
+}
+
 /// Persist the new presets-path override into `config.yaml` and, when
 /// a project session is loaded, dispatch `Command::SetPresetsPath` so
 /// the event fans out on the bus.
 fn apply_presets_path(
     project_session: &Rc<RefCell<Option<ProjectSession>>>,
+    app_config: &Rc<RefCell<AppConfig>>,
     path: Option<PathBuf>,
 ) {
-    if let Err(e) = FilesystemStorage::save_presets_path(path.clone()) {
+    if let Err(e) = apply_presets_override(&mut app_config.borrow_mut(), path.clone()) {
         log::warn!("[paths] failed to persist presets-path into config.yaml: {e}");
         return;
     }
@@ -62,9 +101,10 @@ fn apply_presets_path(
 /// Same as [`apply_presets_path`] but for the plugins override.
 fn apply_plugins_path(
     project_session: &Rc<RefCell<Option<ProjectSession>>>,
+    app_config: &Rc<RefCell<AppConfig>>,
     path: Option<PathBuf>,
 ) {
-    if let Err(e) = FilesystemStorage::save_plugins_path(path.clone()) {
+    if let Err(e) = apply_plugins_override(&mut app_config.borrow_mut(), path.clone()) {
         log::warn!("[paths] failed to persist plugins-path into config.yaml: {e}");
         return;
     }
@@ -83,9 +123,10 @@ fn apply_plugins_path(
 /// #582: same persist+dispatch pattern for the evaluations directory.
 fn apply_evaluations_path(
     project_session: &Rc<RefCell<Option<ProjectSession>>>,
+    app_config: &Rc<RefCell<AppConfig>>,
     path: Option<PathBuf>,
 ) {
-    if let Err(e) = FilesystemStorage::save_evaluations_path(path.clone()) {
+    if let Err(e) = apply_evaluations_override(&mut app_config.borrow_mut(), path.clone()) {
         log::warn!("[paths] failed to persist evaluations-path into config.yaml: {e}");
         return;
     }
@@ -161,15 +202,20 @@ fn run_reload_plugin_catalog(project_session: &Rc<RefCell<Option<ProjectSession>
 /// Each Choose… opens the native folder dialog, persists into
 /// `config.yaml`, and updates the Slint property so the UI reflects
 /// the new value immediately. Each Reset clears the override.
-pub fn install(win: &AppWindow, project_session: Rc<RefCell<Option<ProjectSession>>>) {
+pub fn install(
+    win: &AppWindow,
+    project_session: Rc<RefCell<Option<ProjectSession>>>,
+    app_config: Rc<RefCell<AppConfig>>,
+) {
     // ── presets / Choose ────────────────────────────────────────────
     let win_weak = win.as_weak();
     let session = project_session.clone();
+    let config = app_config.clone();
     win.on_pick_presets_path(move || {
         let Some(path) = pick_folder_dialog() else {
             return;
         };
-        apply_presets_path(&session, Some(path.clone()));
+        apply_presets_path(&session, &config, Some(path.clone()));
         if let Some(w) = win_weak.upgrade() {
             w.set_presets_path(path.to_string_lossy().into_owned().into());
         }
@@ -178,8 +224,9 @@ pub fn install(win: &AppWindow, project_session: Rc<RefCell<Option<ProjectSessio
     // ── presets / Reset ─────────────────────────────────────────────
     let win_weak = win.as_weak();
     let session = project_session.clone();
+    let config = app_config.clone();
     win.on_reset_presets_path(move || {
-        apply_presets_path(&session, None);
+        apply_presets_path(&session, &config, None);
         if let Some(w) = win_weak.upgrade() {
             w.set_presets_path(slint::SharedString::default());
         }
@@ -188,11 +235,12 @@ pub fn install(win: &AppWindow, project_session: Rc<RefCell<Option<ProjectSessio
     // ── plugins / Choose ────────────────────────────────────────────
     let win_weak = win.as_weak();
     let session = project_session.clone();
+    let config = app_config.clone();
     win.on_pick_plugins_path(move || {
         let Some(path) = pick_folder_dialog() else {
             return;
         };
-        apply_plugins_path(&session, Some(path.clone()));
+        apply_plugins_path(&session, &config, Some(path.clone()));
         if let Some(w) = win_weak.upgrade() {
             w.set_plugins_path(path.to_string_lossy().into_owned().into());
         }
@@ -201,8 +249,9 @@ pub fn install(win: &AppWindow, project_session: Rc<RefCell<Option<ProjectSessio
     // ── plugins / Reset ─────────────────────────────────────────────
     let win_weak = win.as_weak();
     let session = project_session.clone();
+    let config = app_config.clone();
     win.on_reset_plugins_path(move || {
-        apply_plugins_path(&session, None);
+        apply_plugins_path(&session, &config, None);
         if let Some(w) = win_weak.upgrade() {
             w.set_plugins_path(slint::SharedString::default());
         }
@@ -211,11 +260,12 @@ pub fn install(win: &AppWindow, project_session: Rc<RefCell<Option<ProjectSessio
     // ── evaluations / Choose (#582) ─────────────────────────────────
     let win_weak = win.as_weak();
     let session = project_session.clone();
+    let config = app_config.clone();
     win.on_pick_evaluations_path(move || {
         let Some(path) = pick_folder_dialog() else {
             return;
         };
-        apply_evaluations_path(&session, Some(path.clone()));
+        apply_evaluations_path(&session, &config, Some(path.clone()));
         if let Some(w) = win_weak.upgrade() {
             w.set_evaluations_path(path.to_string_lossy().into_owned().into());
         }
@@ -224,8 +274,9 @@ pub fn install(win: &AppWindow, project_session: Rc<RefCell<Option<ProjectSessio
     // ── evaluations / Reset (#582) ──────────────────────────────────
     let win_weak = win.as_weak();
     let session = project_session.clone();
+    let config = app_config.clone();
     win.on_reset_evaluations_path(move || {
-        apply_evaluations_path(&session, None);
+        apply_evaluations_path(&session, &config, None);
         if let Some(w) = win_weak.upgrade() {
             w.set_evaluations_path(slint::SharedString::default());
         }
@@ -249,14 +300,16 @@ pub fn install(win: &AppWindow, project_session: Rc<RefCell<Option<ProjectSessio
 pub fn install_secondary(
     win: &ProjectSettingsWindow,
     project_session: Rc<RefCell<Option<ProjectSession>>>,
+    app_config: Rc<RefCell<AppConfig>>,
 ) {
     let win_weak = win.as_weak();
     let session = project_session.clone();
+    let config = app_config.clone();
     win.on_pick_presets_path(move || {
         let Some(path) = pick_folder_dialog() else {
             return;
         };
-        apply_presets_path(&session, Some(path.clone()));
+        apply_presets_path(&session, &config, Some(path.clone()));
         if let Some(w) = win_weak.upgrade() {
             w.set_presets_path(path.to_string_lossy().into_owned().into());
         }
@@ -264,8 +317,9 @@ pub fn install_secondary(
 
     let win_weak = win.as_weak();
     let session = project_session.clone();
+    let config = app_config.clone();
     win.on_reset_presets_path(move || {
-        apply_presets_path(&session, None);
+        apply_presets_path(&session, &config, None);
         if let Some(w) = win_weak.upgrade() {
             w.set_presets_path(slint::SharedString::default());
         }
@@ -273,11 +327,12 @@ pub fn install_secondary(
 
     let win_weak = win.as_weak();
     let session = project_session.clone();
+    let config = app_config.clone();
     win.on_pick_plugins_path(move || {
         let Some(path) = pick_folder_dialog() else {
             return;
         };
-        apply_plugins_path(&session, Some(path.clone()));
+        apply_plugins_path(&session, &config, Some(path.clone()));
         if let Some(w) = win_weak.upgrade() {
             w.set_plugins_path(path.to_string_lossy().into_owned().into());
         }
@@ -285,8 +340,9 @@ pub fn install_secondary(
 
     let win_weak = win.as_weak();
     let session = project_session.clone();
+    let config = app_config.clone();
     win.on_reset_plugins_path(move || {
-        apply_plugins_path(&session, None);
+        apply_plugins_path(&session, &config, None);
         if let Some(w) = win_weak.upgrade() {
             w.set_plugins_path(slint::SharedString::default());
         }
@@ -295,11 +351,12 @@ pub fn install_secondary(
     // ── evaluations (#582) — secondary window ───────────────────────
     let win_weak = win.as_weak();
     let session = project_session.clone();
+    let config = app_config.clone();
     win.on_pick_evaluations_path(move || {
         let Some(path) = pick_folder_dialog() else {
             return;
         };
-        apply_evaluations_path(&session, Some(path.clone()));
+        apply_evaluations_path(&session, &config, Some(path.clone()));
         if let Some(w) = win_weak.upgrade() {
             w.set_evaluations_path(path.to_string_lossy().into_owned().into());
         }
@@ -307,8 +364,9 @@ pub fn install_secondary(
 
     let win_weak = win.as_weak();
     let session = project_session.clone();
+    let config = app_config.clone();
     win.on_reset_evaluations_path(move || {
-        apply_evaluations_path(&session, None);
+        apply_evaluations_path(&session, &config, None);
         if let Some(w) = win_weak.upgrade() {
             w.set_evaluations_path(slint::SharedString::default());
         }

--- a/crates/adapter-gui/tests/issue_607_path_override_survives_whole_config_resave.rs
+++ b/crates/adapter-gui/tests/issue_607_path_override_survives_whole_config_resave.rs
@@ -1,0 +1,120 @@
+//! Issue #607 — a path override picked in Settings → Caminhos must survive a
+//! subsequent **whole-config** re-save of the in-memory `AppConfig` snapshot
+//! (which happens on every project-open / register-recent).
+//!
+//! User reproduction:
+//!   1. Settings → CAMINHOS → ESCOLHER... for "Pasta de avaliações".
+//!   2. Open / switch project (any lifecycle event that re-persists the
+//!      in-memory app config via `save_app_config(&app_config.borrow())`).
+//!   3. `config.yaml` `paths.evaluations_path` is back to `null` — the pick
+//!      is lost. `presets_path` / `plugins_path` only appear to survive
+//!      because they were loaded into the in-memory snapshot at a prior
+//!      startup; one set in the current session would be clobbered the same.
+//!
+//! Root cause: the Settings pickers persist straight to disk
+//! (`save_*_path`) but never update the shared in-memory `AppConfig`. The
+//! next whole-config save writes the stale snapshot, reverting the override.
+//!
+//! Fix contract: applying an override must update the in-memory `AppConfig`
+//! in lockstep with the disk write, so a later whole-config save carries the
+//! user's pick. This test exercises that seam (`apply_evaluations_override`)
+//! and is RED today (the function does not exist).
+
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use adapter_gui::{apply_evaluations_override, apply_plugins_override, apply_presets_override};
+use infra_filesystem::FilesystemStorage;
+
+/// HOME is process-global; serialize tests that swap it.
+static HOME_LOCK: Mutex<()> = Mutex::new(());
+
+fn with_temp_home<F: FnOnce(&PathBuf)>(label: &str, f: F) {
+    let _g = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let tmp =
+        std::env::temp_dir().join(format!("openrig-607-{label}-{}-{now}", std::process::id()));
+    std::fs::create_dir_all(&tmp).expect("mkdir tempdir");
+    let prev = std::env::var_os("HOME");
+    std::env::set_var("HOME", &tmp);
+    let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(&tmp)));
+    if let Some(prev) = prev {
+        std::env::set_var("HOME", prev);
+    } else {
+        std::env::remove_var("HOME");
+    }
+    let _ = std::fs::remove_dir_all(&tmp);
+    if let Err(p) = res {
+        std::panic::resume_unwind(p);
+    }
+}
+
+#[test]
+fn issue_607_evaluations_override_survives_whole_config_resave() {
+    with_temp_home("eval-clobber", |_| {
+        // App startup: the in-memory snapshot is loaded from config.yaml.
+        // Fresh HOME → no override yet.
+        let mut in_memory = FilesystemStorage::load_app_config().expect("initial load");
+        assert_eq!(
+            in_memory.paths.evaluations_path, None,
+            "fresh config must start with no evaluations override"
+        );
+
+        // User picks the evaluations folder. The picker must both persist to
+        // disk AND keep the in-memory snapshot in sync.
+        let picked = PathBuf::from("/tmp/openrig-607-picked-evaluations");
+        apply_evaluations_override(&mut in_memory, Some(picked.clone()))
+            .expect("apply_evaluations_override must persist");
+
+        // The in-memory snapshot now carries the pick (so a later whole-config
+        // save cannot clobber it).
+        assert_eq!(
+            in_memory.paths.evaluations_path,
+            Some(picked.clone()),
+            "the in-memory AppConfig must reflect the picked override"
+        );
+
+        // Lifecycle event (open project / register recent) re-persists the
+        // whole in-memory snapshot.
+        FilesystemStorage::save_app_config(&in_memory).expect("whole-config re-save");
+
+        // The pick must still be there after the round-trip.
+        let reloaded = FilesystemStorage::load_app_config().expect("reload");
+        assert_eq!(
+            reloaded.paths.evaluations_path,
+            Some(picked),
+            "REGRESSION #607: a whole-config re-save clobbered the user's \
+             evaluations pick back to null"
+        );
+    });
+}
+
+#[test]
+fn issue_607_all_three_overrides_survive_whole_config_resave() {
+    with_temp_home("all-three", |_| {
+        let mut in_memory = FilesystemStorage::load_app_config().expect("initial load");
+
+        let presets = PathBuf::from("/tmp/openrig-607-presets");
+        let plugins = PathBuf::from("/tmp/openrig-607-plugins");
+        let evals = PathBuf::from("/tmp/openrig-607-evals");
+
+        apply_presets_override(&mut in_memory, Some(presets.clone())).expect("presets");
+        apply_plugins_override(&mut in_memory, Some(plugins.clone())).expect("plugins");
+        apply_evaluations_override(&mut in_memory, Some(evals.clone())).expect("evals");
+
+        // Whole-config re-save of the (now-synced) snapshot must keep all three.
+        FilesystemStorage::save_app_config(&in_memory).expect("whole-config re-save");
+
+        let reloaded = FilesystemStorage::load_app_config().expect("reload");
+        assert_eq!(reloaded.paths.presets_path, Some(presets), "presets clobbered");
+        assert_eq!(reloaded.paths.plugins_path, Some(plugins), "plugins clobbered");
+        assert_eq!(
+            reloaded.paths.evaluations_path,
+            Some(evals),
+            "evaluations clobbered"
+        );
+    });
+}


### PR DESCRIPTION
Closes #607.

## Problem
Set the **evaluations folder** in Settings → Caminhos, exit the project, reopen → it reverts to **(PADRÃO)**. On disk `config.yaml` shows `paths.evaluations_path: null` even though `presets_path`/`plugins_path` persisted.

## Root cause
The Settings pickers persisted a picked folder straight to `config.yaml` (`FilesystemStorage::save_*_path`) but **never updated the shared in-memory `AppConfig`** held by the GUI. Lifecycle events (project-open / register-recent) re-persist that whole in-memory snapshot via `save_app_config(&app_config.borrow())`; with a stale snapshot, the just-picked override was **clobbered back to its startup value**.

`presets_path`/`plugins_path` only appeared to survive because they were loaded into the snapshot at a prior startup — one set in the current session would be clobbered the same way. The **load** path was already correct (#599 honors `plugins_path`); this is a save/clobber bug, not a load bug.

## Fix
Introduce `apply_{presets,plugins,evaluations}_override` — persist to `config.yaml` **AND** mirror the value into the in-memory `AppConfig` in lockstep, so the override is the single source of truth and any later whole-config save carries it. `install`/`install_secondary` thread the shared `app_config` and route through these helpers.

## Tests (RED-first — adapter-gui integration, temp HOME)
- `issue_607_evaluations_override_survives_whole_config_resave`
- `issue_607_all_three_overrides_survive_whole_config_resave`

`cargo test -p adapter-gui` + `cargo test --workspace --lib`: 0 failed. Build: 0 code warnings.