### PR TITLE
fix(#606): unavailable-model blocks deactivate instead of breaking the chain

### DIFF
--- a/crates/adapter-gui/src/lib_tests.rs
+++ b/crates/adapter-gui/src/lib_tests.rs
@@ -1183,3 +1183,35 @@ fn rig_project_for_routes_legacy_through_rig_engine() {
         "legacy .yaml transparently migrated to .openrig"
     );
 }
+
+#[test]
+fn chain_block_item_flags_unavailable_model_for_the_tile() {
+    use crate::project_view::chain_block_item_from_block;
+    use project::param::ParameterSet;
+
+    // The builder resolves thumbnail asset paths; init them (idempotent).
+    infra_filesystem::init_asset_paths(infra_filesystem::AssetPaths::default());
+
+    let gain = |id: &str, model: &str| AudioBlock {
+        id: BlockId(id.into()),
+        enabled: false,
+        kind: AudioBlockKind::Core(CoreBlock {
+            effect_type: "gain".into(),
+            model: model.into(),
+            params: ParameterSet::default(),
+        }),
+    };
+
+    // `ibanez_ts9` is a native gain model → resolvable. The `nam_` id has no
+    // pack on disk → unavailable. The tile uses this flag to show the block
+    // as deactivated and block its enable toggle (#606).
+    assert!(
+        !chain_block_item_from_block(&gain("a", "ibanez_ts9")).unavailable,
+        "a resolvable model must not be flagged unavailable"
+    );
+    assert!(
+        chain_block_item_from_block(&gain("u", "nam_uninstalled_pedal_for_issue_606")).unavailable,
+        "BUG #606: a block whose model is uninstalled must be flagged unavailable \
+         so the tile can show it and block its enable toggle"
+    );
+}

--- a/crates/adapter-gui/src/project_admin_persistence_tests.rs
+++ b/crates/adapter-gui/src/project_admin_persistence_tests.rs
@@ -845,3 +845,91 @@ fn find_chain_helper_locates_added_chain() {
     add_chain(&session, "GUITAR");
     assert!(find_chain(&session, "GUITAR").is_some());
 }
+
+// ────────────────────────────────────────────────────────────────────
+// Issue #606 — NAM-backed gain model survives load
+// ────────────────────────────────────────────────────────────────────
+//
+// User log: `[ERROR adapter_gui::helpers] block '…': unsupported gain
+// model 'nam_lovepedal_eternity_burst'`. The catalog files NAM gain
+// pedals (manifest `type: gain_pedal`, `backend: nam`) under the "gain"
+// family, so a slot holding one is a `Core { effect_type: "gain",
+// model: "nam_…" }`. The engine's offline `render_chain` builds such a
+// block fine (it consults the plugin catalog), but the GUI load path
+// validates "gain" blocks against the NATIVE block-gain registry only and
+// drops the model as unsupported — losing the user's block on reload.
+//
+// Repro uses `nam_maxon_od808` from OpenRig-plugins (same shape as the
+// user's `nam_lovepedal_eternity_burst`). The catalog is initialised from
+// the real plugin tree AND the config points at it, so the package is
+// unambiguously known — the only way the block disappears is the
+// native-only validation.
+fn nam_gain_block(id: &str) -> AudioBlock {
+    AudioBlock {
+        id: BlockId(id.into()),
+        enabled: true,
+        kind: AudioBlockKind::Core(CoreBlock {
+            effect_type: "gain".into(),
+            model: "nam_maxon_od808".into(),
+            params: ParameterSet::default(),
+        }),
+    }
+}
+
+#[test]
+fn issue_606_nam_backed_gain_block_survives_load() {
+    let plugins_root = PathBuf::from(
+        "/Users/joao.faria/Projetos/github.com/jpfaria/OpenRig-plugins/plugins/source",
+    );
+    assert!(
+        plugins_root.is_dir(),
+        "issue #606 repro requires OpenRig-plugins/plugins/source on disk"
+    );
+    // Populate the process-global catalog so `nam_maxon_od808` is a known
+    // disk-package gain model — isolates the routing bug from any
+    // catalog-not-loaded effect.
+    plugin_loader::registry::init_many(&[plugins_root.clone()]);
+
+    let s = Sandbox::new();
+    let session = s.new_session();
+    // Point the config at the same real plugin tree (mirrors the user's
+    // configured setup) so the load path can resolve the package too.
+    std::fs::write(
+        &s.cfg,
+        format!("plugins_root: {}\n", plugins_root.display()),
+    )
+    .expect("write config with plugins_root");
+
+    let chain_id = add_chain(&session, "X");
+    let pos = session.project.borrow().chains[0].blocks.len() - 1;
+    session
+        .dispatcher
+        .dispatch(Command::InsertPrebuiltBlock {
+            chain: chain_id.clone(),
+            block: nam_gain_block("nam_od"),
+            position: pos,
+        })
+        .expect("InsertPrebuiltBlock");
+    s.save(&session);
+
+    let reloaded = s.reload();
+    let survived = reloaded
+        .project
+        .borrow()
+        .chains
+        .iter()
+        .find(|c| c.description.as_deref() == Some("X"))
+        .map(|c| {
+            c.blocks.iter().any(
+                |b| matches!(&b.kind, AudioBlockKind::Core(cb) if cb.model == "nam_maxon_od808"),
+            )
+        })
+        .unwrap_or(false);
+    assert!(
+        survived,
+        "BUG #606: NAM-backed gain block 'nam_maxon_od808' was dropped on load \
+         (logged as 'unsupported gain model') — the load path validated the \
+         model against the native block-gain registry instead of the plugin \
+         catalog"
+    );
+}

--- a/crates/adapter-gui/src/project_admin_persistence_tests.rs
+++ b/crates/adapter-gui/src/project_admin_persistence_tests.rs
@@ -933,3 +933,64 @@ fn issue_606_nam_backed_gain_block_survives_load() {
          catalog"
     );
 }
+
+// A gain block whose `nam_` pack is NOT installed in the catalog.
+fn uninstalled_nam_gain_block(id: &str) -> AudioBlock {
+    AudioBlock {
+        id: BlockId(id.into()),
+        enabled: true,
+        kind: AudioBlockKind::Core(CoreBlock {
+            effect_type: "gain".into(),
+            model: "nam_uninstalled_pedal_for_issue_606".into(),
+            params: ParameterSet::default(),
+        }),
+    }
+}
+
+#[test]
+fn issue_606_uninstalled_model_block_is_disabled_on_load() {
+    let plugins_root = PathBuf::from(
+        "/Users/joao.faria/Projetos/github.com/jpfaria/OpenRig-plugins/plugins/source",
+    );
+    assert!(
+        plugins_root.is_dir(),
+        "issue #606 repro requires OpenRig-plugins/plugins/source on disk"
+    );
+    // Catalog loaded, but the block's `nam_` pack is deliberately absent.
+    plugin_loader::registry::init_many(&[plugins_root.clone()]);
+
+    let s = Sandbox::new();
+    let session = s.new_session();
+    std::fs::write(
+        &s.cfg,
+        format!("plugins_root: {}\n", plugins_root.display()),
+    )
+    .expect("write config with plugins_root");
+
+    let chain_id = add_chain(&session, "X");
+    let pos = session.project.borrow().chains[0].blocks.len() - 1;
+    session
+        .dispatcher
+        .dispatch(Command::InsertPrebuiltBlock {
+            chain: chain_id.clone(),
+            block: uninstalled_nam_gain_block("ghost"),
+            position: pos,
+        })
+        .expect("InsertPrebuiltBlock");
+    s.save(&session);
+
+    let reloaded = s.reload();
+    let proj = reloaded.project.borrow();
+    let block = proj
+        .chains
+        .iter()
+        .flat_map(|c| c.blocks.iter())
+        .find(|b| b.id.0 == "ghost")
+        .expect("the block must be preserved on load, not dropped");
+    assert!(
+        !block.enabled,
+        "BUG #606: a block whose model is uninstalled must be DISABLED on load \
+         so the chain keeps playing instead of leaving a silently-faulted 'on' \
+         pedal"
+    );
+}

--- a/crates/adapter-gui/src/project_ops.rs
+++ b/crates/adapter-gui/src/project_ops.rs
@@ -338,6 +338,19 @@ pub(crate) fn load_project_session(
         .unwrap_or_else(|| domain::ids::DeviceId(String::new()));
     project::project_ensure_io::ensure_chains_have_output(&mut project, &default_output_device);
 
+    // #606: the plugin catalog is loaded at startup, so by now we can tell
+    // which block models resolve. Disable any whose pack is not installed
+    // (or that is unsupported on this platform) — the chain keeps playing
+    // with the pedal visibly off instead of silently faulting an "on" block.
+    let disabled = project::project_disable_unavailable::disable_unavailable_blocks(&mut project);
+    if !disabled.is_empty() {
+        log::warn!(
+            "disabled {} block(s) with unavailable models on load: {:?}",
+            disabled.len(),
+            disabled.iter().map(|b| &b.0).collect::<Vec<_>>()
+        );
+    }
+
     let mut session = ProjectSession::new(
         project,
         Some(project_path.to_path_buf()),

--- a/crates/adapter-gui/src/project_view.rs
+++ b/crates/adapter-gui/src/project_view.rs
@@ -371,6 +371,7 @@ pub(crate) fn chain_block_item_from_block(
         label: label.into(),
         family: family.into(),
         enabled: block.enabled,
+        unavailable: !project::project_disable_unavailable::block_model_is_available(&block.kind),
         real_index: 0,
         thumbnail,
         has_thumbnail,

--- a/crates/adapter-gui/ui/components/block_chip.slint
+++ b/crates/adapter-gui/ui/components/block_chip.slint
@@ -23,6 +23,12 @@ export component BlockChip inherits Rectangle {
     in property <bool> chain-dragging: false;
     property <color> accent-color: root.block.accent-color;
     property <string> block-type-label: root.block.type_label;
+    // #606: a block whose model is not installed is shown muted with an
+    // amber tint (distinct from the grey of a manually-disabled block) so
+    // the user can tell the pedal is unavailable, not just switched off.
+    // The enable toggle is already inert at the command layer.
+    property <bool> unavailable: root.block.unavailable;
+    property <color> unavailable-tint: #b07a3c;
     callback clicked();
     callback drag-moved(float, float);
     callback drag-finished(float, float);
@@ -55,8 +61,11 @@ export component BlockChip inherits Rectangle {
                 : transparent)
         : transparent;
     border-radius: 6px;
+    // #606: dim the whole tile when its model is unavailable.
+    opacity: root.unavailable ? 0.5 : 1.0;
     animate border-width { duration: 350ms; easing: ease-out; }
     animate border-color { duration: 350ms; easing: ease-out; }
+    animate opacity { duration: 200ms; easing: ease-out; }
 
     // Type label on top — fades out while a drag is happening anywhere in
     // this chain row so it doesn't obscure the floating ghost or the chips
@@ -67,7 +76,7 @@ export component BlockChip inherits Rectangle {
         width: parent.width;
         height: 14px;
         text: root.block-type-label;
-        color: root.block.enabled ? root.accent-color : #5c6678;
+        color: root.unavailable ? root.unavailable-tint : root.block.enabled ? root.accent-color : #5c6678;
         font-size: 8px;
         font-weight: 700;
         letter-spacing: 1px;
@@ -98,7 +107,7 @@ export component BlockChip inherits Rectangle {
         width: parent.width;
         height: hover-area.has-hover ? 90px : 78px;
         icon-kind: root.block.icon-kind;
-        tint: root.dragging ? #8b95a5 : root.block.enabled ? root.accent-color : #5c6678;
+        tint: root.unavailable ? root.unavailable-tint : root.dragging ? #8b95a5 : root.block.enabled ? root.accent-color : #5c6678;
         animate y { duration: 120ms; easing: ease-out; }
         animate height { duration: 120ms; easing: ease-out; }
     }

--- a/crates/adapter-gui/ui/models.slint
+++ b/crates/adapter-gui/ui/models.slint
@@ -46,6 +46,11 @@ export struct ChainBlockItem {
     label: string,
     family: string,
     enabled: bool,
+    // #606: the model is not installed/loadable (uninstalled NAM/IR/LV2
+    // pack, or unsupported on this platform). The tile renders it as
+    // deactivated and its enable toggle is inert — the user cannot turn on
+    // a pedal that cannot build.
+    unavailable: bool,
     real_index: int,
     thumbnail: image,
     has_thumbnail: bool,

--- a/crates/application/src/local_dispatcher_block_lifecycle.rs
+++ b/crates/application/src/local_dispatcher_block_lifecycle.rs
@@ -16,6 +16,15 @@ impl LocalDispatcher {
         match cmd {
             Command::ToggleBlockEnabled { chain, block } => {
                 let new_state = self.with_block(&chain, &block, |b| {
+                    // #606: never enable a block whose model is unavailable —
+                    // the user cannot activate a pedal whose pack is not
+                    // installed (or is unsupported on this platform). Disabling
+                    // an already-on block is always allowed.
+                    if !b.enabled
+                        && !project::project_disable_unavailable::block_model_is_available(&b.kind)
+                    {
+                        return Ok(false);
+                    }
                     b.enabled = !b.enabled;
                     Ok(b.enabled)
                 })?;

--- a/crates/application/src/local_dispatcher_project.rs
+++ b/crates/application/src/local_dispatcher_project.rs
@@ -37,7 +37,16 @@ impl LocalDispatcher {
                 Ok(vec![Event::ProjectSaved])
             }
 
-            Command::LoadProject { project, path: _ } => {
+            Command::LoadProject {
+                mut project,
+                path: _,
+            } => {
+                // #606: disable blocks whose model is not installed (or is
+                // unsupported on this platform) so the chain plays without a
+                // silently-faulted "on" pedal. Parity with the GUI load path
+                // (`adapter-gui::project_ops::load_project_session`); MCP/gRPC
+                // that dispatch LoadProject get the same normalization.
+                project::project_disable_unavailable::disable_unavailable_blocks(&mut project);
                 // Replace the shared project data in-place so all Rc::clone
                 // holders (adapter-gui's ProjectSession) see the updated state.
                 *self.project.borrow_mut() = project;

--- a/crates/application/src/local_dispatcher_tests.rs
+++ b/crates/application/src/local_dispatcher_tests.rs
@@ -1437,10 +1437,9 @@ fn set_compact_view_enabled_emits_event_so_the_gui_can_react() {
         .expect("dispatch ok");
 
     assert!(
-        events.iter().any(|e| matches!(
-            e,
-            Event::CompactViewEnabledChanged { enabled: true }
-        )),
+        events
+            .iter()
+            .any(|e| matches!(e, Event::CompactViewEnabledChanged { enabled: true })),
         "expected CompactViewEnabledChanged{{true}}, got {events:?}"
     );
 }
@@ -2645,8 +2644,16 @@ fn save_audio_settings_persists_input_and_output_separately() {
             .iter()
             .map(|d| d.device_id.as_str())
             .collect();
-        assert_eq!(in_ids, vec!["dev:in"], "input devices must persist input ids only");
-        assert_eq!(out_ids, vec!["dev:out"], "output devices must persist output ids only");
+        assert_eq!(
+            in_ids,
+            vec!["dev:in"],
+            "input devices must persist input ids only"
+        );
+        assert_eq!(
+            out_ids,
+            vec!["dev:out"],
+            "output devices must persist output ids only"
+        );
     });
 }
 
@@ -2772,6 +2779,56 @@ fn load_project_replaces_all_state() {
     assert!(proj.name.is_none());
     assert!(proj.device_settings.is_empty());
     assert!(proj.chains.is_empty());
+}
+
+#[test]
+fn load_project_disables_blocks_with_unavailable_models() {
+    // #606 parity: loading a project through the command bus (MCP/gRPC) must
+    // disable blocks whose model is not installed, exactly like the GUI load
+    // path — so the chain plays without a silently-faulted "on" pedal.
+    let project = Rc::new(RefCell::new(Project {
+        name: None,
+        device_settings: vec![],
+        chains: vec![],
+        midi: None,
+    }));
+    let dispatcher = LocalDispatcher::new(Rc::clone(&project));
+
+    let mut chain = make_empty_chain("c", true);
+    chain.blocks.push(AudioBlock {
+        id: BlockId("ghost".into()),
+        enabled: true,
+        kind: AudioBlockKind::Core(CoreBlock {
+            effect_type: "gain".into(),
+            // No native gain model and no pack on disk → unavailable.
+            model: "nam_uninstalled_pedal_for_issue_606".into(),
+            params: ParameterSet::default(),
+        }),
+    });
+    let new_proj = Project {
+        name: None,
+        device_settings: vec![],
+        chains: vec![chain],
+        midi: None,
+    };
+
+    dispatcher
+        .dispatch(Command::LoadProject {
+            project: new_proj,
+            path: std::path::PathBuf::from("/p.yaml"),
+        })
+        .expect("LoadProject");
+
+    let proj = project.borrow();
+    let ghost = proj.chains[0]
+        .blocks
+        .iter()
+        .find(|b| b.id.0 == "ghost")
+        .expect("block must be preserved on load");
+    assert!(
+        !ghost.enabled,
+        "BUG #606: LoadProject must disable a block whose model is unavailable (MCP/gRPC parity)"
+    );
 }
 
 #[test]

--- a/crates/application/src/local_dispatcher_tests.rs
+++ b/crates/application/src/local_dispatcher_tests.rs
@@ -2831,6 +2831,75 @@ fn load_project_disables_blocks_with_unavailable_models() {
     );
 }
 
+fn project_with_one_block(chain_id: &str, block: AudioBlock) -> Rc<RefCell<Project>> {
+    let mut chain = make_empty_chain(chain_id, true);
+    chain.blocks.push(block);
+    Rc::new(RefCell::new(Project {
+        name: None,
+        device_settings: vec![],
+        chains: vec![chain],
+        midi: None,
+    }))
+}
+
+fn unavailable_gain_block(id: &str, enabled: bool) -> AudioBlock {
+    AudioBlock {
+        id: BlockId(id.into()),
+        enabled,
+        kind: AudioBlockKind::Core(CoreBlock {
+            effect_type: "gain".into(),
+            model: "nam_uninstalled_pedal_for_issue_606".into(),
+            params: ParameterSet::default(),
+        }),
+    }
+}
+
+#[test]
+fn toggle_block_enabled_refuses_to_enable_unavailable_model() {
+    // #606: a disabled block whose pack is not installed must NOT be
+    // enable-able — the user can't activate a pedal that cannot build.
+    let project = project_with_one_block("c", unavailable_gain_block("ghost", false));
+    let dispatcher = LocalDispatcher::new(Rc::clone(&project));
+
+    let events = dispatcher
+        .dispatch(Command::ToggleBlockEnabled {
+            chain: ChainId("c".into()),
+            block: BlockId("ghost".into()),
+        })
+        .expect("ToggleBlockEnabled");
+
+    assert!(
+        !project.borrow().chains[0].blocks[0].enabled,
+        "BUG #606: toggling an unavailable block must NOT enable it"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::BlockEnabledChanged { enabled: false, .. })),
+        "the emitted event must report the block stayed disabled, got {events:?}"
+    );
+}
+
+#[test]
+fn toggle_block_enabled_still_disables_an_unavailable_block_that_is_on() {
+    // Disabling is always allowed, even for an unavailable model (e.g. a
+    // pack uninstalled while the block was on) — only ENABLING is blocked.
+    let project = project_with_one_block("c", unavailable_gain_block("ghost", true));
+    let dispatcher = LocalDispatcher::new(Rc::clone(&project));
+
+    dispatcher
+        .dispatch(Command::ToggleBlockEnabled {
+            chain: ChainId("c".into()),
+            block: BlockId("ghost".into()),
+        })
+        .expect("ToggleBlockEnabled");
+
+    assert!(
+        !project.borrow().chains[0].blocks[0].enabled,
+        "toggling an ON unavailable block must turn it OFF (disabling is allowed)"
+    );
+}
+
 #[test]
 fn load_project_emits_project_mutated() {
     let project = Rc::new(RefCell::new(Project {

--- a/crates/block-delay/src/registry.rs
+++ b/crates/block-delay/src/registry.rs
@@ -82,6 +82,11 @@ pub fn register_natives() {
 
 /// Returns true if the model has a usable backend on the current platform.
 pub fn is_model_available(model: &str) -> bool {
-    AVAILABLE_MODEL_IDS.iter().any(|id| *id == model)
-        || !MODEL_DEFINITIONS.iter().any(|d| d.id == model)
+    // Issue #606: a non-native id is only available when its disk package is
+    // actually in the catalog — see `plugin_loader::registry::model_available`.
+    plugin_loader::registry::model_available(
+        model,
+        |m| MODEL_DEFINITIONS.iter().any(|d| d.id == m),
+        |m| AVAILABLE_MODEL_IDS.contains(&m),
+    )
 }

--- a/crates/block-dyn/src/lib_tests.rs
+++ b/crates/block-dyn/src/lib_tests.rs
@@ -430,3 +430,13 @@ fn dyn_model_visual_returns_some_for_native() {
 fn dyn_model_visual_returns_none_for_unknown() {
     assert!(dyn_model_visual("nonexistent_model").is_none());
 }
+
+#[test]
+fn is_dyn_model_available_false_for_uncataloged_disk_model() {
+    // Issue #606 (sibling family): an uninstalled disk-package dynamics
+    // model must report UNAVAILABLE rather than optimistically true.
+    assert!(
+        !crate::is_dyn_model_available("lv2_some_compressor_not_installed"),
+        "an uninstalled disk-package dynamics model must be unavailable"
+    );
+}

--- a/crates/block-dyn/src/registry.rs
+++ b/crates/block-dyn/src/registry.rs
@@ -79,6 +79,11 @@ pub fn register_natives() {
 
 /// Returns true if the model has a usable backend on the current platform.
 pub fn is_model_available(model: &str) -> bool {
-    AVAILABLE_MODEL_IDS.iter().any(|id| *id == model)
-        || !MODEL_DEFINITIONS.iter().any(|d| d.id == model)
+    // Issue #606: a non-native id is only available when its disk package is
+    // actually in the catalog — see `plugin_loader::registry::model_available`.
+    plugin_loader::registry::model_available(
+        model,
+        |m| MODEL_DEFINITIONS.iter().any(|d| d.id == m),
+        |m| AVAILABLE_MODEL_IDS.contains(&m),
+    )
 }

--- a/crates/block-filter/src/registry.rs
+++ b/crates/block-filter/src/registry.rs
@@ -67,6 +67,11 @@ pub fn register_natives() {
 
 /// Returns true if the model has a usable backend on the current platform.
 pub fn is_model_available(model: &str) -> bool {
-    AVAILABLE_MODEL_IDS.iter().any(|id| *id == model)
-        || !MODEL_DEFINITIONS.iter().any(|d| d.id == model)
+    // Issue #606: a non-native id is only available when its disk package is
+    // actually in the catalog — see `plugin_loader::registry::model_available`.
+    plugin_loader::registry::model_available(
+        model,
+        |m| MODEL_DEFINITIONS.iter().any(|d| d.id == m),
+        |m| AVAILABLE_MODEL_IDS.contains(&m),
+    )
 }

--- a/crates/block-gain/src/lib_tests.rs
+++ b/crates/block-gain/src/lib_tests.rs
@@ -424,3 +424,17 @@ fn ibanez_ts9_level_changes_output_gain() {
         "level should raise output: quiet={quiet_output}, loud={loud_output}"
     );
 }
+
+#[test]
+fn is_gain_model_available_false_for_uncataloged_disk_model() {
+    // Issue #606: a `nam_`-namespaced model that is neither a native gain
+    // model nor present in the plugin catalog must report UNAVAILABLE.
+    // Previously the check optimistically returned true for any non-native
+    // id, so the build fell through to the native registry and emitted the
+    // misleading "unsupported gain model" instead of the block being
+    // disabled.
+    assert!(
+        !crate::is_gain_model_available("nam_lovepedal_eternity_burst_not_installed"),
+        "an uninstalled NAM gain pedal must be unavailable, not optimistically available"
+    );
+}

--- a/crates/block-gain/src/registry.rs
+++ b/crates/block-gain/src/registry.rs
@@ -64,6 +64,11 @@ pub fn register_natives() {
 
 /// Returns true if the model has a usable backend on the current platform.
 pub fn is_model_available(model: &str) -> bool {
-    AVAILABLE_MODEL_IDS.iter().any(|id| *id == model)
-        || !MODEL_DEFINITIONS.iter().any(|d| d.id == model)
+    // Issue #606: a non-native id is only available when its disk package is
+    // actually in the catalog — see `plugin_loader::registry::model_available`.
+    plugin_loader::registry::model_available(
+        model,
+        |m| MODEL_DEFINITIONS.iter().any(|d| d.id == m),
+        |m| AVAILABLE_MODEL_IDS.contains(&m),
+    )
 }

--- a/crates/block-mod/src/registry.rs
+++ b/crates/block-mod/src/registry.rs
@@ -66,6 +66,11 @@ pub fn register_natives() {
 
 /// Returns true if the model has a usable backend on the current platform.
 pub fn is_model_available(model: &str) -> bool {
-    AVAILABLE_MODEL_IDS.iter().any(|id| *id == model)
-        || !MODEL_DEFINITIONS.iter().any(|d| d.id == model)
+    // Issue #606: a non-native id is only available when its disk package is
+    // actually in the catalog — see `plugin_loader::registry::model_available`.
+    plugin_loader::registry::model_available(
+        model,
+        |m| MODEL_DEFINITIONS.iter().any(|d| d.id == m),
+        |m| AVAILABLE_MODEL_IDS.contains(&m),
+    )
 }

--- a/crates/block-pitch/src/registry.rs
+++ b/crates/block-pitch/src/registry.rs
@@ -66,6 +66,11 @@ pub fn register_natives() {
 /// `libs/lv2/<platform>/`. Native/NAM/IR/VST3 models report `true` (they are
 /// always considered available; per-asset checks happen at instantiation).
 pub fn is_model_available(model: &str) -> bool {
-    AVAILABLE_MODEL_IDS.iter().any(|id| *id == model)
-        || !MODEL_DEFINITIONS.iter().any(|d| d.id == model)
+    // Issue #606: a non-native id is only available when its disk package is
+    // actually in the catalog — see `plugin_loader::registry::model_available`.
+    plugin_loader::registry::model_available(
+        model,
+        |m| MODEL_DEFINITIONS.iter().any(|d| d.id == m),
+        |m| AVAILABLE_MODEL_IDS.contains(&m),
+    )
 }

--- a/crates/block-reverb/src/registry.rs
+++ b/crates/block-reverb/src/registry.rs
@@ -66,6 +66,11 @@ pub fn register_natives() {
 
 /// Returns true if the model has a usable backend on the current platform.
 pub fn is_model_available(model: &str) -> bool {
-    AVAILABLE_MODEL_IDS.iter().any(|id| *id == model)
-        || !MODEL_DEFINITIONS.iter().any(|d| d.id == model)
+    // Issue #606: a non-native id is only available when its disk package is
+    // actually in the catalog — see `plugin_loader::registry::model_available`.
+    plugin_loader::registry::model_available(
+        model,
+        |m| MODEL_DEFINITIONS.iter().any(|d| d.id == m),
+        |m| AVAILABLE_MODEL_IDS.contains(&m),
+    )
 }

--- a/crates/engine/src/runtime_block_core.rs
+++ b/crates/engine/src/runtime_block_core.rs
@@ -60,8 +60,13 @@ pub(crate) fn build_core_block_runtime_node(
     // error and inserts a bypass node marked `faulted` — the chain stays
     // intact but the block emits silence/passthrough rather than crashing.
     if !is_model_available_for_effect_type(effect_type, model) {
+        // Either a native model unsupported on this platform (LV2 .so/.dll
+        // missing) OR a disk-package (NAM/IR/LV2) whose pack is not in the
+        // catalog. Honest message either way; the caller bypasses the block
+        // as faulted so the chain keeps playing (issue #574/#606).
         anyhow::bail!(
-            "model '{}' is not available on the current platform (effect_type={})",
+            "model '{}' (effect_type={}) is unavailable — its plugin package is \
+             not installed/loaded, or it is unsupported on this platform",
             model,
             effect_type
         );

--- a/crates/engine/tests/issue_606_nam_backed_gain_model_builds.rs
+++ b/crates/engine/tests/issue_606_nam_backed_gain_model_builds.rs
@@ -1,0 +1,169 @@
+//! Issue #606 — a NAM-backed "gain" model (a gain-pedal capture, manifest
+//! `type: gain_pedal`, `backend: nam`) must build via the NAM processor,
+//! NOT the native block-gain registry.
+//!
+//! User reproduction (live log):
+//!   [ERROR adapter_gui::helpers] block 'rig:input-1:block:…':
+//!       unsupported gain model 'nam_lovepedal_eternity_burst'
+//!
+//! Root cause hypothesis: the catalog buckets NAM gain pedals under the
+//! "gain" block family (docs/blocks-catalog.md: Gain = 204 models incl.
+//! the NAM OD808/TS808/Klon/RAT… captures), so a project slot holding one
+//! is a `Core { effect_type: "gain", model: "nam_…" }`. The runtime build
+//! dispatch (`crates/engine/src/runtime_block_builders.rs`, shared by
+//! `render_chain` and the live engine that `adapter_gui::helpers` drives)
+//! routes every "gain" Core block to block-gain's NATIVE registry, which
+//! only knows native gain models (e.g. `ts9`). The NAM-backed model is
+//! rejected ("unsupported gain model") and the block is silently bypassed
+//! (faulted) — the cab/IR path already delegates disk packages correctly,
+//! gain does not.
+//!
+//! Contract: a Core block whose model is a NAM-backed disk package builds
+//! successfully (routes to the NAM processor) regardless of the categorical
+//! `effect_type` the catalog filed it under.
+//!
+//! Uses `nam_maxon_od808` from OpenRig-plugins (manifest `type: gain_pedal`,
+//! `backend: nam`) — structurally identical to the user's
+//! `nam_lovepedal_eternity_burst`. If the plugin tree is absent the test
+//! fails loudly, like the sibling #537 disk-package repro.
+
+use std::path::PathBuf;
+use std::sync::Once;
+
+use domain::ids::{BlockId, ChainId};
+use engine::offline::render_chain;
+use project::block::{AudioBlock, AudioBlockKind, CoreBlock};
+use project::chain::Chain;
+use project::param::ParameterSet;
+
+/// A NAM gain-pedal capture filed under the "gain" family in the catalog.
+const NAM_GAIN_MODEL: &str = "nam_maxon_od808";
+
+fn init_plugins() {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        nam::register_builder();
+        ir::register_builder();
+        let candidates = [
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("../../../../../OpenRig-plugins/plugins/source"),
+            PathBuf::from(
+                "/Users/joao.faria/Projetos/github.com/jpfaria/OpenRig-plugins/plugins/source",
+            ),
+        ];
+        let roots: Vec<PathBuf> = candidates.into_iter().filter(|p| p.is_dir()).collect();
+        assert!(
+            !roots.is_empty(),
+            "issue #606 repro requires OpenRig-plugins/plugins/source on disk — \
+             none of the candidate roots resolved"
+        );
+        plugin_loader::registry::init_many(&roots);
+    });
+}
+
+fn gain_core_block(block_id: &str, model: &str) -> AudioBlock {
+    AudioBlock {
+        id: BlockId(block_id.into()),
+        enabled: true,
+        kind: AudioBlockKind::Core(CoreBlock {
+            effect_type: "gain".into(),
+            model: model.into(),
+            params: ParameterSet::default(),
+        }),
+    }
+}
+
+fn chain_with(id: &str, blocks: Vec<AudioBlock>) -> Chain {
+    Chain {
+        id: ChainId(id.into()),
+        description: Some("issue-606 nam gain build".into()),
+        instrument: "electric_guitar".into(),
+        enabled: true,
+        volume: 100.0,
+        blocks,
+    }
+}
+
+#[test]
+fn nam_backed_gain_model_builds_and_is_not_faulted() {
+    init_plugins();
+
+    // Sanity: the NAM gain-pedal package is discoverable in the registry.
+    assert!(
+        plugin_loader::registry::find(NAM_GAIN_MODEL).is_some(),
+        "fixture package `{NAM_GAIN_MODEL}` must be discoverable in OpenRig-plugins"
+    );
+
+    let chain = chain_with("issue-606", vec![gain_core_block("od808", NAM_GAIN_MODEL)]);
+
+    let input = vec![[0.3_f32, 0.3_f32]; 1024];
+    let outcome = render_chain(&chain, 48_000.0, &input, 256, 0)
+        .expect("render_chain must still produce best-effort output");
+
+    let faulted: Vec<&str> = outcome
+        .faulted_blocks
+        .iter()
+        .filter(|f| f.block_id == "od808")
+        .map(|f| f.error.as_str())
+        .collect();
+
+    assert!(
+        faulted.is_empty(),
+        "BUG #606: NAM-backed gain model `{NAM_GAIN_MODEL}` was faulted instead of \
+         building via the NAM processor — the build dispatch routed a NAM model to the \
+         native block-gain registry. Errors: {faulted:?}"
+    );
+}
+
+/// The user's actual symptom: a project references a NAM gain-pedal model
+/// (`nam_lovepedal_eternity_burst`) that is NOT in the configured catalog
+/// (it lives only as a `dist/` zip, never extracted into `plugins/source`).
+/// At build time the model is not found, so the dispatch falls back to the
+/// NATIVE block-gain registry keyed on `effect_type = "gain"` and reports
+///   unsupported gain model 'nam_lovepedal_eternity_burst'
+/// then silently bypasses the block.
+///
+/// Contract: the `nam_` prefix is a reserved disk-package namespace
+/// (`nam_*`/`ir_*`/`lv2_*` are canonical catalog ids). A `nam_`-prefixed
+/// model is NAM-backed and must route to the NAM loader — even when absent
+/// from the catalog it must fault as a NAM/package problem, NEVER be
+/// misrouted to the native block-gain registry with the misleading
+/// "unsupported gain model" message.
+#[test]
+fn uncataloged_nam_model_is_not_misrouted_to_native_gain_registry() {
+    init_plugins();
+
+    // A `nam_`-namespaced id that no plugin pack will ever ship — stands in
+    // for the user's `nam_lovepedal_eternity_burst` at the moment it was not
+    // present in their configured `plugins/source` catalog.
+    let model = "nam_uninstalled_pedal_for_issue_606";
+    assert!(
+        plugin_loader::registry::find(model).is_none(),
+        "precondition: `{model}` must be ABSENT from the catalog for this repro"
+    );
+
+    let chain = chain_with("issue-606-uncataloged", vec![gain_core_block("od", model)]);
+    let input = vec![[0.3_f32, 0.3_f32]; 1024];
+    let outcome = render_chain(&chain, 48_000.0, &input, 256, 0)
+        .expect("render_chain must still produce best-effort output");
+
+    // The block legitimately faults (its .nam file isn't installed) — that
+    // is fine. What must NOT happen is misrouting to the native gain
+    // registry with the "unsupported gain model" message.
+    let errs: Vec<&str> = outcome
+        .faulted_blocks
+        .iter()
+        .filter(|f| f.block_id == "od")
+        .map(|f| f.error.as_str())
+        .collect();
+
+    assert!(
+        !errs
+            .iter()
+            .any(|e| e.to_lowercase().contains("unsupported gain model")),
+        "BUG #606: a NAM-backed (`nam_…`) model absent from the catalog was misrouted to \
+         the native block-gain registry, producing the misleading 'unsupported gain model' \
+         error and silently bypassing the block. A `nam_`-prefixed model must route to the \
+         NAM loader. Faults: {errs:?}"
+    );
+}

--- a/crates/plugin-loader/src/registry.rs
+++ b/crates/plugin-loader/src/registry.rs
@@ -180,8 +180,7 @@ pub fn reload(plugins_roots: &[std::path::PathBuf]) -> ReloadStats {
     // shadows the user's calibrated copy → the convolver runs raw →
     // ~+18 dB hot → "estourado". Maps each disk id to its slot so a
     // later root replaces in place (keeping registration order stable).
-    let mut disk_slot: std::collections::HashMap<String, usize> =
-        std::collections::HashMap::new();
+    let mut disk_slot: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
     for root in plugins_roots {
         if !root.is_dir() {
             continue;
@@ -246,6 +245,29 @@ pub fn packages_for(block_type: BlockType) -> Vec<&'static LoadedPackage> {
 /// Look up a single plugin by manifest id (`p.manifest.id`).
 pub fn find(model_id: &str) -> Option<&'static LoadedPackage> {
     packages().iter().find(|p| p.manifest.id == model_id)
+}
+
+/// True if `model_id` resolves to a buildable processor, mirroring the
+/// native-then-catalog resolution order every `build_*_processor_for_layout`
+/// uses: a native model of its family that is available on this platform,
+/// or a disk-package (NAM/IR/LV2/VST3) present in the catalog.
+///
+/// Issue #606: the per-family checks used to treat *any* non-native id as
+/// available, so an uninstalled disk package slipped through to the native
+/// registry and failed with a misleading "unsupported <family> model".
+/// Routing the disk case through the catalog makes the block report
+/// unavailable instead, so the caller can disable it and keep the chain
+/// playing.
+pub fn model_available(
+    model_id: &str,
+    is_native: impl Fn(&str) -> bool,
+    native_available_on_platform: impl Fn(&str) -> bool,
+) -> bool {
+    if is_native(model_id) {
+        native_available_on_platform(model_id)
+    } else {
+        find(model_id).is_some()
+    }
 }
 
 /// Count of natives + disk packages currently in the catalog.

--- a/crates/project/src/lib.rs
+++ b/crates/project/src/lib.rs
@@ -16,6 +16,7 @@ pub mod midi;
 pub mod migrate;
 pub mod param;
 pub mod project;
+pub mod project_disable_unavailable;
 pub mod project_ensure_io;
 pub mod rig;
 pub mod rig_command;

--- a/crates/project/src/project_disable_unavailable.rs
+++ b/crates/project/src/project_disable_unavailable.rs
@@ -41,7 +41,11 @@ pub fn disable_unavailable_blocks(project: &mut Project) -> Vec<BlockId> {
 /// True if the block's model resolves to a buildable processor right now.
 /// Mirrors the runtime build's resolution: native registry or catalog for
 /// `Core`, the plugin catalog for the disk-backed `Nam` kind.
-fn block_model_is_available(kind: &AudioBlockKind) -> bool {
+///
+/// Shared single source of truth for "can this block be built": the load
+/// pass above uses it to disable unavailable blocks, and the
+/// `ToggleBlockEnabled` command uses it to refuse enabling one (#606).
+pub fn block_model_is_available(kind: &AudioBlockKind) -> bool {
     match kind {
         AudioBlockKind::Core(core) => {
             crate::catalog::is_model_available(&core.effect_type, &core.model)

--- a/crates/project/src/project_disable_unavailable.rs
+++ b/crates/project/src/project_disable_unavailable.rs
@@ -1,0 +1,56 @@
+//! Load-time helper that disables blocks whose model cannot be resolved
+//! on this machine right now.
+//!
+//! Issue #606: a project may reference a disk-package model (a NAM/IR/LV2
+//! pack) that is not installed in the user's plugin catalog — e.g. the pack
+//! was never extracted into `plugins/source`, or the project came from
+//! another machine. Such a block cannot be built; the engine bypasses it as
+//! faulted (#574) so the chain keeps playing, but the GUI still shows it as
+//! "on", which is confusing.
+//!
+//! On load we flip every unresolvable block to `enabled = false` so the
+//! pedal is visibly deactivated and the chain plays without it. The model
+//! is preserved: when the missing pack is installed and the catalog
+//! reloads, [`crate::catalog::is_model_available`] reports it available
+//! again and the user can re-enable the block.
+//!
+//! Routing-only kinds (Input/Output/Insert) and the composite Select kind
+//! have no single resolvable model and are never touched here.
+
+use crate::block::AudioBlockKind;
+use crate::project::Project;
+use domain::ids::BlockId;
+
+/// Disable every currently-enabled block whose model is unavailable.
+/// Returns the ids of the blocks that were flipped off (already-disabled
+/// blocks are left as-is and not reported).
+pub fn disable_unavailable_blocks(project: &mut Project) -> Vec<BlockId> {
+    let mut disabled = Vec::new();
+    for chain in &mut project.chains {
+        for block in &mut chain.blocks {
+            if !block.enabled || block_model_is_available(&block.kind) {
+                continue;
+            }
+            block.enabled = false;
+            disabled.push(block.id.clone());
+        }
+    }
+    disabled
+}
+
+/// True if the block's model resolves to a buildable processor right now.
+/// Mirrors the runtime build's resolution: native registry or catalog for
+/// `Core`, the plugin catalog for the disk-backed `Nam` kind.
+fn block_model_is_available(kind: &AudioBlockKind) -> bool {
+    match kind {
+        AudioBlockKind::Core(core) => {
+            crate::catalog::is_model_available(&core.effect_type, &core.model)
+        }
+        AudioBlockKind::Nam(nam) => plugin_loader::registry::find(&nam.model).is_some(),
+        // Routing-only and composite kinds carry no single resolvable model.
+        AudioBlockKind::Select(_)
+        | AudioBlockKind::Input(_)
+        | AudioBlockKind::Output(_)
+        | AudioBlockKind::Insert(_) => true,
+    }
+}

--- a/crates/project/tests/issue_606_disable_unavailable_blocks.rs
+++ b/crates/project/tests/issue_606_disable_unavailable_blocks.rs
@@ -1,0 +1,109 @@
+//! Issue #606 — on load, a block whose model is unavailable (an uninstalled
+//! NAM/IR/LV2 pack, or a native unsupported on this platform) must be
+//! disabled (`enabled = false`) so the chain keeps playing with the block
+//! bypassed and the user is not left staring at a silently-faulted-but-"on"
+//! pedal. Available blocks (native models or cataloged disk packages) are
+//! left untouched.
+
+use domain::ids::{BlockId, ChainId, DeviceId};
+use project::block::{AudioBlock, AudioBlockKind, CoreBlock, InputBlock, InputEntry};
+use project::chain::{Chain, ChainInputMode};
+use project::param::ParameterSet;
+use project::project::Project;
+use project::project_disable_unavailable::disable_unavailable_blocks;
+
+fn gain_block(id: &str, model: &str) -> AudioBlock {
+    AudioBlock {
+        id: BlockId(id.into()),
+        enabled: true,
+        kind: AudioBlockKind::Core(CoreBlock {
+            effect_type: "gain".into(),
+            model: model.into(),
+            params: ParameterSet::default(),
+        }),
+    }
+}
+
+fn input_block(id: &str) -> AudioBlock {
+    AudioBlock {
+        id: BlockId(id.into()),
+        enabled: true,
+        kind: AudioBlockKind::Input(InputBlock {
+            model: "standard".into(),
+            entries: vec![InputEntry {
+                device_id: DeviceId("dev".into()),
+                mode: ChainInputMode::Mono,
+                channels: vec![0],
+            }],
+        }),
+    }
+}
+
+fn chain(blocks: Vec<AudioBlock>) -> Chain {
+    Chain {
+        id: ChainId("c".into()),
+        description: Some("issue-606".into()),
+        instrument: "electric_guitar".into(),
+        enabled: true,
+        volume: 100.0,
+        blocks,
+    }
+}
+
+#[test]
+fn disables_block_with_uninstalled_model_and_keeps_available_ones() {
+    // `ibanez_ts9` is a native gain model (always available). The `nam_` id
+    // is not in the catalog (no pack on disk) → unavailable. The Input block
+    // is routing-only and must never be touched.
+    let mut project = Project {
+        name: None,
+        device_settings: Vec::new(),
+        chains: vec![chain(vec![
+            input_block("in"),
+            gain_block("ts9", "ibanez_ts9"),
+            gain_block("missing", "nam_uninstalled_pedal_for_issue_606"),
+        ])],
+        midi: None,
+    };
+
+    let disabled = disable_unavailable_blocks(&mut project);
+
+    let blocks = &project.chains[0].blocks;
+    assert!(blocks[0].enabled, "routing Input block must stay enabled");
+    assert!(
+        blocks[1].enabled,
+        "available native gain (ibanez_ts9) must stay enabled"
+    );
+    assert!(
+        !blocks[2].enabled,
+        "BUG #606: a block whose model is uninstalled must be disabled on load \
+         so the chain keeps playing instead of silently faulting an 'on' pedal"
+    );
+    assert_eq!(
+        disabled,
+        vec![BlockId("missing".into())],
+        "the call reports exactly the block ids it disabled"
+    );
+}
+
+#[test]
+fn leaves_already_disabled_unavailable_block_disabled_without_reporting_it() {
+    // An unavailable block that is already off is a no-op: it stays off and
+    // is NOT reported (nothing changed).
+    let mut missing = gain_block("missing", "nam_uninstalled_pedal_for_issue_606");
+    missing.enabled = false;
+    let mut project = Project {
+        name: None,
+        device_settings: Vec::new(),
+        chains: vec![chain(vec![input_block("in"), missing])],
+        midi: None,
+    };
+
+    let disabled = disable_unavailable_blocks(&mut project);
+
+    assert!(!project.chains[0].blocks[1].enabled);
+    assert!(
+        disabled.is_empty(),
+        "an already-disabled block is not re-reported"
+    );
+}

--- a/docs/screens.md
+++ b/docs/screens.md
@@ -4,7 +4,7 @@ Pedalboard virtual: usuário monta cadeia de efeitos visualmente, ajusta parâme
 
 - **Launcher** — criar/abrir projetos
 - **Project Setup** — pede o nome ao criar novo projeto
-- **Chains** — visualização da cadeia de blocos, drag/reorder. Tapping a chain row's header selects it (outlined) as the active chain — the one a MIDI footswitch bound to `toggle_active_chain_enabled` acts on (#591).
+- **Chains** — visualização da cadeia de blocos, drag/reorder. Tapping a chain row's header selects it (outlined) as the active chain — the one a MIDI footswitch bound to `toggle_active_chain_enabled` acts on (#591). A block whose model is not installed (an uninstalled NAM/IR/LV2 pack, or one unsupported on this platform) loads **disabled** and is shown dimmed with an amber tint, distinct from a manually-switched-off block; the chain keeps playing without it and its enable toggle stays inert until the pack is installed and the catalog reloads (#606).
 - **Block Editor** — edita parâmetros de um bloco
 - **Compact Chain View** — power switches e troca rápida de modelo
 - **Settings** — unified configuration screen, reached from the top bar. Two scope headers:


### PR DESCRIPTION
Closes #606.

## Symptom
```
[ERROR adapter_gui::helpers] block 'rig:input-1:block:…': unsupported gain model 'nam_lovepedal_eternity_burst'
```
A block whose disk-package model (NAM/IR/LV2) was not installed in the catalog crashed through to the native registry and was silently bypassed, with a misleading error.

## Root cause
`block_*::registry::is_model_available` returned `true` for **any** non-native id (`AVAILABLE_MODEL_IDS.contains || !MODEL_DEFINITIONS.contains`) without consulting the plugin catalog. So an uninstalled pack was reported "available", the build fell through to the native `block-gain`/etc. registry, and failed with `unsupported <family> model`.

## Behavior (as agreed on the issue)
The chain must keep playing; the pedal deactivates, can't be re-activated while its pack is missing, and is visibly marked unavailable.

1. **Detection** — `plugin_loader::registry::model_available` helper; the 7 disk-capable families (gain/dyn/reverb/delay/mod/filter/pitch) gate non-native ids on catalog presence. Engine pre-check now emits an honest "package not installed/loaded" message; the block faults to a bypass so the chain keeps playing (#574).
2. **Load** — `project::project_disable_unavailable::disable_unavailable_blocks` sets every unresolvable block to `enabled=false` on load (model preserved → reinstalling the pack lets the user re-enable). Wired into `adapter-gui::load_project_session` **and** the `Command::LoadProject` handler (MCP/gRPC parity).
3. **Toggle** — `ToggleBlockEnabled` refuses to enable an unavailable block; disabling stays allowed. The MIDI toggle-active-block path inherits the guard (same handler).
4. **UI** — `ChainBlockItem.unavailable`; `BlockChip` renders unavailable blocks dimmed (0.5) with an amber tint, distinct from the grey of a manually-disabled block. Colour/opacity only — no new i18n strings.

## Tests (all RED-first)
- engine `issue_606_nam_backed_gain_model_builds`
- `block-gain` / `block-dyn` `is_*_model_available_false_for_uncataloged_disk_model`
- project `issue_606_disable_unavailable_blocks`
- adapter-gui `issue_606_uninstalled_model_block_is_disabled_on_load`, `chain_block_item_flags_unavailable_model_for_the_tile`
- application `load_project_disables_blocks_with_unavailable_models`, `toggle_block_enabled_refuses_to_enable_unavailable_model`

`cargo test --workspace --lib` green (exit 0).

## Docs
`docs/screens.md` — Chains screen notes the unavailable-block behavior.