### PR TITLE
fix(#608): hide model select/search picker for generic NAM/IR loader blocks

### DIFF
--- a/crates/adapter-gui/src/project_view.rs
+++ b/crates/adapter-gui/src/project_view.rs
@@ -29,6 +29,7 @@ pub(crate) fn block_type_picker_items(instrument: &str) -> Vec<BlockTypePickerIt
             subtitle: "".into(),
             icon_kind: item.icon_kind.into(),
             use_panel_editor: item.use_panel_editor,
+            uses_model_catalog: block_core::effect_type_uses_model_catalog(item.effect_type),
             accent_color: crate::ui_state::accent_color_for_icon_kind(item.icon_kind),
             icon_source: slint::Image::default(),
         })
@@ -44,6 +45,7 @@ pub(crate) fn block_type_picker_items(instrument: &str) -> Vec<BlockTypePickerIt
         subtitle: "".into(),
         icon_kind: "input".into(),
         use_panel_editor: false,
+        uses_model_catalog: false,
         accent_color: crate::ui_state::accent_color_for_icon_kind("routing"),
         icon_source: slint::Image::default(),
     });
@@ -53,6 +55,7 @@ pub(crate) fn block_type_picker_items(instrument: &str) -> Vec<BlockTypePickerIt
         subtitle: "".into(),
         icon_kind: "output".into(),
         use_panel_editor: false,
+        uses_model_catalog: false,
         accent_color: crate::ui_state::accent_color_for_icon_kind("routing"),
         icon_source: slint::Image::default(),
     });
@@ -62,6 +65,7 @@ pub(crate) fn block_type_picker_items(instrument: &str) -> Vec<BlockTypePickerIt
         subtitle: "".into(),
         icon_kind: "insert".into(),
         use_panel_editor: false,
+        uses_model_catalog: false,
         accent_color: crate::ui_state::accent_color_for_icon_kind("insert"),
         icon_source: slint::Image::default(),
     });

--- a/crates/adapter-gui/ui/components/block_panel_header.slint
+++ b/crates/adapter-gui/ui/components/block_panel_header.slint
@@ -9,6 +9,9 @@ export component BlockPanelHeader inherits Rectangle {
     in property <string> block-type-label;
     in property <length> badge-width;
     in property <bool> edit-mode;
+    // Issue #608: false for generic NAM/IR file-loader blocks → hide the
+    // catalog model select/search picker (they load a file, not a model).
+    in property <bool> show-model-picker: true;
     in property <[BlockModelPickerItem]> filtered-models;
     in property <BlockModelPickerItem> selected-model;
     in-out property <string> search-text;
@@ -48,8 +51,10 @@ export component BlockPanelHeader inherits Rectangle {
         letter-spacing: 1.5px;
     }
 
-    // Model selector with embedded search (fills middle)
-    ModelSelectWithSearch {
+    // Model selector with embedded search (fills middle). Hidden for the
+    // generic NAM/IR file-loader blocks (#608) — they have no catalog
+    // model to pick; the loaded model name is shown as a static label.
+    if root.show-model-picker : ModelSelectWithSearch {
         x: 100px;
         y: (parent.height - 40px) / 2;
         width: parent.width - 100px - root.badge-width - (root.edit-mode ? 80px : 48px);
@@ -58,6 +63,20 @@ export component BlockPanelHeader inherits Rectangle {
         search-text <=> root.search-text;
         select(model-id) => { root.choose-model-by-id(model-id); }
         search-text-changed(text) => { root.search-model(text); }
+    }
+
+    if !root.show-model-picker : Text {
+        x: 100px;
+        y: 0;
+        width: parent.width - 100px - root.badge-width - (root.edit-mode ? 80px : 48px);
+        height: parent.height;
+        text: root.selected-model.display_name;
+        color: #f1f4f8;
+        font-size: 13px;
+        font-weight: 700;
+        vertical-alignment: center;
+        horizontal-alignment: left;
+        overflow: elide;
     }
 
     // Type badge

--- a/crates/adapter-gui/ui/models.slint
+++ b/crates/adapter-gui/ui/models.slint
@@ -124,6 +124,11 @@ export struct BlockTypePickerItem {
     subtitle: string,
     icon_kind: string,
     use_panel_editor: bool,
+    // Issue #608: false for the generic NAM/IR file-loader blocks, which
+    // have no catalog model to choose — the Block Editor hides the model
+    // select/search picker for them. Computed in Rust via
+    // `block_core::effect_type_uses_model_catalog`.
+    uses_model_catalog: bool,
     accent_color: color,
     icon_source: image,
 }

--- a/crates/adapter-gui/ui/pages/block_panel_editor.slint
+++ b/crates/adapter-gui/ui/pages/block_panel_editor.slint
@@ -162,6 +162,12 @@ export component BlockPanelEditor inherits Rectangle {
         block-type-label: root.block-type-label;
         badge-width: root.badge-width;
         edit-mode: root.block-drawer-edit-mode;
+        // #608: hide the catalog picker for generic NAM/IR file-loaders;
+        // the decision is computed in Rust and carried on the type item.
+        show-model-picker: root.block-drawer-selected-type-index >= 0
+            && root.block-drawer-selected-type-index < root.block-type-options.length
+            ? root.block-type-options[root.block-drawer-selected-type-index].uses_model_catalog
+            : true;
         filtered-models: root.filtered-block-model-options;
         selected-model: root.block-drawer-selected-model-index >= 0
             && root.block-drawer-selected-model-index < root.block-model-options.length

--- a/crates/block-core/src/effect_type_caps.rs
+++ b/crates/block-core/src/effect_type_caps.rs
@@ -1,0 +1,23 @@
+//! Capability predicates keyed on a block's `effect_type`.
+//!
+//! Pure domain logic (no UI, no state) so the rules are testable in
+//! isolation and consumed identically by every transport.
+
+use crate::constants::{EFFECT_TYPE_IR, EFFECT_TYPE_NAM};
+
+/// Whether a block of `effect_type` selects its model from the plugin
+/// **catalog** (`true`) or loads a **file** the user picks (`false`).
+///
+/// The generic NAM (`nam`) and IR (`ir`) loader blocks load a `.nam` /
+/// `.wav` file directly — they have no catalog model to choose, so the
+/// Block Editor hides the model select/search picker for them (issue
+/// #608). Every other effect_type — including NAM-backed gain/amp/preamp
+/// pedals and cab IRs, which live under their natural effect_type and pick
+/// a capture from the catalog — keeps the picker.
+pub fn effect_type_uses_model_catalog(effect_type: &str) -> bool {
+    !matches!(effect_type, EFFECT_TYPE_NAM | EFFECT_TYPE_IR)
+}
+
+#[cfg(test)]
+#[path = "effect_type_caps_tests.rs"]
+mod tests;

--- a/crates/block-core/src/effect_type_caps_tests.rs
+++ b/crates/block-core/src/effect_type_caps_tests.rs
@@ -1,0 +1,38 @@
+use super::*;
+use crate::constants::{
+    EFFECT_TYPE_AMP, EFFECT_TYPE_CAB, EFFECT_TYPE_DELAY, EFFECT_TYPE_DYNAMICS, EFFECT_TYPE_FILTER,
+    EFFECT_TYPE_GAIN, EFFECT_TYPE_MODULATION, EFFECT_TYPE_PREAMP, EFFECT_TYPE_REVERB,
+};
+
+#[test]
+fn file_loader_effect_types_do_not_use_catalog() {
+    assert!(!effect_type_uses_model_catalog(EFFECT_TYPE_NAM));
+    assert!(!effect_type_uses_model_catalog(EFFECT_TYPE_IR));
+}
+
+#[test]
+fn every_other_effect_type_uses_catalog() {
+    for et in [
+        EFFECT_TYPE_GAIN,
+        EFFECT_TYPE_AMP,
+        EFFECT_TYPE_PREAMP,
+        EFFECT_TYPE_CAB,
+        EFFECT_TYPE_REVERB,
+        EFFECT_TYPE_DELAY,
+        EFFECT_TYPE_DYNAMICS,
+        EFFECT_TYPE_FILTER,
+        EFFECT_TYPE_MODULATION,
+    ] {
+        assert!(
+            effect_type_uses_model_catalog(et),
+            "effect_type `{et}` should keep the catalog picker"
+        );
+    }
+}
+
+#[test]
+fn unknown_effect_type_defaults_to_catalog() {
+    // A not-yet-known effect_type keeps the picker (only nam/ir are file
+    // loaders); fail-open is the safe default for an unrecognised type.
+    assert!(effect_type_uses_model_catalog("totally_new_type"));
+}

--- a/crates/block-core/src/lib.rs
+++ b/crates/block-core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod audio_types;
 pub mod brand_visual;
 pub mod constants;
 pub mod dsp;
+pub mod effect_type_caps;
 pub mod param;
 pub mod traits;
 pub mod visual;
@@ -32,6 +33,7 @@ pub use constants::{
     INST_ACOUSTIC_GUITAR, INST_BASS, INST_DRUMS, INST_ELECTRIC_GUITAR, INST_GENERIC, INST_KEYS,
     INST_VOICE,
 };
+pub use effect_type_caps::effect_type_uses_model_catalog;
 pub use dsp::{
     calculate_coefficient, capitalize_first, db_to_lin, lin_to_db, BiquadFilter, BiquadKind,
     EnvelopeFollower, OnePoleHighPass, OnePoleLowPass, BIQUAD_COEFF_RAMP_FRAMES,

--- a/crates/block-core/tests/issue_608_model_picker.rs
+++ b/crates/block-core/tests/issue_608_model_picker.rs
@@ -1,0 +1,43 @@
+//! Issue #608 — the Block Editor must NOT show the catalog model
+//! select/search picker for the generic NAM (`nam`) and IR (`ir`) loader
+//! blocks: their "model" is a file the user loads, not a catalog entry.
+//!
+//! The picker visibility is derived from a pure domain predicate keyed on
+//! the effect_type. nam/ir are file-loaders (no catalog) → no picker;
+//! every other effect_type selects its model from the catalog → picker.
+
+use block_core::{
+    effect_type_uses_model_catalog, EFFECT_TYPE_AMP, EFFECT_TYPE_CAB, EFFECT_TYPE_GAIN,
+    EFFECT_TYPE_IR, EFFECT_TYPE_NAM, EFFECT_TYPE_PREAMP, EFFECT_TYPE_REVERB,
+};
+
+#[test]
+fn nam_and_ir_loaders_do_not_use_the_model_catalog() {
+    assert!(
+        !effect_type_uses_model_catalog(EFFECT_TYPE_NAM),
+        "generic NAM loader selects a file, not a catalog model — no picker"
+    );
+    assert!(
+        !effect_type_uses_model_catalog(EFFECT_TYPE_IR),
+        "generic IR loader selects a file, not a catalog model — no picker"
+    );
+}
+
+#[test]
+fn catalog_backed_effect_types_use_the_model_catalog() {
+    // NAM-backed pedals/amps live under their natural effect_type (gain /
+    // amp / preamp) and DO pick a capture from the catalog; cab IRs (effect
+    // type `cab`) likewise pick a catalog capture. All keep the picker.
+    for et in [
+        EFFECT_TYPE_GAIN,
+        EFFECT_TYPE_AMP,
+        EFFECT_TYPE_PREAMP,
+        EFFECT_TYPE_CAB,
+        EFFECT_TYPE_REVERB,
+    ] {
+        assert!(
+            effect_type_uses_model_catalog(et),
+            "effect_type `{et}` selects its model from the catalog — keep the picker"
+        );
+    }
+}

--- a/docs/screens.md
+++ b/docs/screens.md
@@ -5,7 +5,7 @@ Pedalboard virtual: usuário monta cadeia de efeitos visualmente, ajusta parâme
 - **Launcher** — criar/abrir projetos
 - **Project Setup** — pede o nome ao criar novo projeto
 - **Chains** — visualização da cadeia de blocos, drag/reorder. Tapping a chain row's header selects it (outlined) as the active chain — the one a MIDI footswitch bound to `toggle_active_chain_enabled` acts on (#591). A block whose model is not installed (an uninstalled NAM/IR/LV2 pack, or one unsupported on this platform) loads **disabled** and is shown dimmed with an amber tint, distinct from a manually-switched-off block; the chain keeps playing without it and its enable toggle stays inert until the pack is installed and the catalog reloads (#606).
-- **Block Editor** — edita parâmetros de um bloco
+- **Block Editor** — edita parâmetros de um bloco. The header's model select/search picker is shown only for catalog-backed block types; the generic NAM (`nam`) and IR (`ir`) file-loader blocks have no catalog model to choose, so their header shows the loaded model name as a static label instead of the picker (#608).
 - **Compact Chain View** — power switches e troca rápida de modelo
 - **Settings** — unified configuration screen, reached from the top bar. Two scope headers:
   - *System* (persists to `config.yaml`, stays on the machine when you move the `.openrig`):


### PR DESCRIPTION
## Problem

The Block Editor showed the catalog **model select dropdown** (with a "BUSCAR MODELOS…" search) for the generic **NAM** (`nam`) and **IR** (`ir`) file-loader blocks. Those blocks load a `.nam`/`.wav` file the user picks — they have no catalog model to choose, so the picker is meaningless there.

## Fix

- New pure domain predicate `block_core::effect_type_uses_model_catalog(effect_type)` — `false` for `nam`/`ir`, `true` for every other effect_type (incl. NAM-backed gain/amp/preamp pedals and cab IRs, which live under their natural effect_type and pick a catalog capture).
- The decision is computed in **Rust** and carried to the UI on `BlockTypePickerItem.uses_model_catalog` — no effect_type rule in Slint (SSOT in block-core).
- `BlockPanelHeader` hides `ModelSelectWithSearch` when `show-model-picker` is false and shows the loaded model name as a static label instead.

## Tests
- `block-core`: `effect_type_caps` unit tests + `issue_608_model_picker` integration test (nam/ir → no catalog; gain/amp/preamp/cab/reverb/… → catalog; unknown → fail-open to catalog).
- `adapter-gui` builds clean (Slint codegen + Rust).

Docs: `docs/screens.md` Block Editor note.

Refs #608 (left open pending visual validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)