### PR TITLE
fix(#617): uniformly partition IR convolution so 64-frame buffers don't xrun

### DIFF
--- a/crates/engine/src/elastic_prime.rs
+++ b/crates/engine/src/elastic_prime.rs
@@ -11,9 +11,21 @@
 //! These are pure helpers so the policy is testable in isolation from the
 //! runtime assembly.
 
-use ir::PARTITION_SIZE;
 use project::block::AudioBlockKind;
 use project::chain::Chain;
+
+/// Output elastic-buffer cushion (frames) primed for IR/convolution chains
+/// on a cold start.
+///
+/// Historically this equalled the convolver's partition size: the old
+/// convolver ran its whole per-partition FFT as one burst every
+/// `ir::PARTITION_SIZE` samples, and the cushion had to cover that spike.
+/// Issue #617 made the convolver spread that work evenly across callbacks
+/// (`ir::PARTITION_SIZE` dropped to 64), removing the spike at the source.
+/// The cushion is now decoupled from the partition size and kept at the
+/// proven #592 magnitude purely to absorb generic first-callback producer
+/// warmup jitter at small device buffers — not the (now eliminated) spike.
+pub(crate) const IR_COLD_START_CUSHION_FRAMES: usize = 512;
 
 /// Whether `chain` has an enabled convolution (IR / cab) block — the only
 /// block kind whose per-partition FFT spike warrants the cushion.
@@ -37,7 +49,7 @@ pub(crate) fn chain_has_convolution(chain: &Chain) -> bool {
 /// partition of headroom; everyone else keeps the device-derived `base`.
 pub(crate) fn elastic_capacity_target(base: usize, has_convolution: bool) -> usize {
     if has_convolution {
-        base.max(PARTITION_SIZE)
+        base.max(IR_COLD_START_CUSHION_FRAMES)
     } else {
         base
     }

--- a/crates/engine/src/elastic_prime_tests.rs
+++ b/crates/engine/src/elastic_prime_tests.rs
@@ -1,6 +1,9 @@
 //! Unit tests for the issue #592 convolution-cushion policy helpers.
 
-use super::{chain_has_convolution, elastic_capacity_target, elastic_prime_frames};
+use super::{
+    chain_has_convolution, elastic_capacity_target, elastic_prime_frames,
+    IR_COLD_START_CUSHION_FRAMES,
+};
 
 use domain::ids::{BlockId, ChainId, DeviceId};
 use project::block::{
@@ -98,10 +101,11 @@ fn nam_amp_is_not_convolution() {
 }
 
 #[test]
-fn capacity_floors_at_partition_for_convolution() {
-    // buffer 64 → base 128 < partition 512 ⇒ floored up.
-    assert_eq!(elastic_capacity_target(128, true), ir::PARTITION_SIZE);
-    // A base already above the partition is kept.
+fn capacity_floors_at_cold_start_cushion_for_convolution() {
+    // buffer 64 → base 128 < cushion 512 ⇒ floored up to the cold-start
+    // cushion (decoupled from the convolver partition size in #617).
+    assert_eq!(elastic_capacity_target(128, true), IR_COLD_START_CUSHION_FRAMES);
+    // A base already above the cushion is kept.
     assert_eq!(elastic_capacity_target(2048, true), 2048);
     // Non-convolution keeps the lean base unchanged.
     assert_eq!(elastic_capacity_target(128, false), 128);

--- a/crates/engine/src/issue_592_elastic_prime_tests.rs
+++ b/crates/engine/src/issue_592_elastic_prime_tests.rs
@@ -5,9 +5,13 @@
 //! of underrunning ("xiado"/distortion until a warm rebuild).
 //!
 //! Root cause (confirmed in code): the IR convolver
-//! (`ir::FftBlockConvolver`) runs a full FFT inline every
-//! `ir::PARTITION_SIZE` (512) samples, so at buffer 64 one callback in
-//! eight is far heavier than the rest. The elastic buffer that decouples
+//! (`ir::FftBlockConvolver`) ran a full FFT inline every
+//! `ir::PARTITION_SIZE` samples, so at buffer 64 one callback in
+//! eight was far heavier than the rest. (Issue #617 later eliminated that
+//! spike at the source by shrinking the partition to 64 so the work is
+//! uniform per callback; this cold-start cushion is now decoupled — see
+//! `IR_COLD_START_CUSHION_FRAMES` — and kept for producer warmup jitter.)
+//! The elastic buffer that decouples
 //! the DSP producer from the output consumer starts EMPTY
 //! (`ElasticBuffer::new` → len 0) and its `target_level` was dead code —
 //! there was no jitter cushion. Cold-start (slow first callbacks) drains

--- a/crates/ir/src/lib.rs
+++ b/crates/ir/src/lib.rs
@@ -240,15 +240,31 @@ struct FftBlockConvolver {
     state: Option<PartitionedState>,
 }
 
-/// Minimum partition size. Keeps the number of partitions low for
-/// real-time performance. With MAX_IR_SAMPLES=8192 and PARTITION_SIZE=512,
-/// we get at most 16 partitions — very manageable.
+/// Convolution partition size, in samples.
 ///
-/// Exposed because the engine's output elastic buffer must carry at least
-/// this many frames of jitter cushion for an IR chain: the convolver runs
-/// one full FFT inline per partition, so at small device buffers that
-/// periodic spike would otherwise underrun the output (issue #592).
-pub const PARTITION_SIZE: usize = 512;
+/// This is the granularity at which the convolver runs its inline FFT +
+/// frequency-delay-line multiply-accumulate: that work happens once per
+/// `PARTITION_SIZE` input samples. It MUST stay at or below the smallest
+/// real-time device buffer we support (64) so the work is spread evenly
+/// across callbacks. When `PARTITION_SIZE` is larger than the device
+/// buffer the whole convolution burst lands inside a single callback —
+/// a periodic spike that overruns small buffers and crackles/clips
+/// (issue #617; the symptom that 128-frame buffers masked because their
+/// larger per-callback budget could absorb the burst). Keeping it at 64
+/// makes each 64-frame callback do exactly one partition's worth of work
+/// (uniform cost, no spike) and also bounds the convolver's added latency
+/// to one partition (~1.3 ms at 48 kHz) instead of ~10.7 ms.
+///
+/// Trade-off (per the audio invariant hierarchy: stability > CPU): more
+/// partitions for a long IR (up to 128 for MAX_IR_SAMPLES=8192) raise the
+/// *average* per-callback cost, but it stays tiny in absolute terms and,
+/// crucially, uniform — no callback misses its deadline.
+///
+/// Still exposed because the engine's output elastic buffer floors its
+/// jitter cushion at one partition for IR chains (issue #592). With the
+/// per-partition spike removed at the source, that cushion is now only a
+/// warmup belt-and-suspenders rather than the primary defence.
+pub const PARTITION_SIZE: usize = 64;
 
 impl FftBlockConvolver {
     fn new(ir: Vec<f32>) -> Result<Self> {
@@ -317,6 +333,16 @@ impl FftBlockConvolver {
                 state.accum[i] += state.fdl[fdl_off + i] * state.ir_partitions[ir_off + i];
             }
         }
+
+        // The DC (bin 0) and Nyquist (last bin) components of a real signal's
+        // spectrum are purely real. Multiplying and accumulating per-partition
+        // spectra leaves tiny imaginary residues there from f32 round-off,
+        // which `realfft`'s strict inverse rejects ("imaginary parts of first
+        // and last values were non-zero"). They are mathematically zero, so
+        // clamp them — this is round-off cleanup, not a signal change.
+        let nyquist = spectrum_len - 1;
+        state.accum[0].im = 0.0;
+        state.accum[nyquist].im = 0.0;
 
         // Inverse FFT
         state

--- a/crates/ir/tests/issue_617_uniform_block_cost.rs
+++ b/crates/ir/tests/issue_617_uniform_block_cost.rs
@@ -1,0 +1,134 @@
+//! Issue #617 — the cabinet IR convolver must spread its work evenly across
+//! real-time callbacks, with NO periodic per-partition spike that overruns
+//! small device buffers.
+//!
+//! Root cause: the convolver ran one full FFT + a multiply-accumulate over
+//! ALL IR partitions INLINE every `PARTITION_SIZE` input samples. With
+//! `PARTITION_SIZE` (512) far larger than a small device buffer (64), that
+//! burst landed inside a single 64-frame callback, which then did ~all the
+//! convolution work at once — a spike ~tens of times the cost of its
+//! neighbour callbacks. On slower hardware (or any tight 64-frame budget)
+//! that one callback misses its deadline → xrun → audible "clipping". At
+//! buffer 128 the per-callback budget is large enough to absorb the same
+//! burst, which is why raising the buffer hid the symptom.
+//!
+//! These tests pin two properties of the fix:
+//!   1. `cost_per_callback_is_uniform_at_buffer_64` — no block costs wildly
+//!      more than the median (the spike is gone). RED before the fix.
+//!   2. `convolution_stays_linear_and_correct` — the fix is output-equivalent
+//!      (partitioned convolution is exact for any partition size), so the
+//!      sound is unchanged (invariant #9, numeric determinism).
+
+use std::time::Instant;
+
+use block_core::MonoProcessor;
+use ir::MonoIrProcessor;
+
+const SR: f32 = 48_000.0;
+
+/// A realistic, deterministic cabinet-length IR (near MAX_IR_SAMPLES) so the
+/// convolver uses many partitions — that is what makes the per-partition
+/// burst heavy enough to overrun a 64-frame callback.
+fn cabinet_ir(len: usize) -> Vec<f32> {
+    (0..len)
+        .map(|n| {
+            let t = n as f32 / SR;
+            let env = (-t * 25.0).exp();
+            let body = (2.0 * std::f32::consts::PI * 1500.0 * t).sin()
+                + 0.5 * (2.0 * std::f32::consts::PI * 3200.0 * t).sin();
+            env * body
+        })
+        .collect()
+}
+
+fn di_signal(frames: usize) -> Vec<f32> {
+    (0..frames)
+        .map(|n| 0.2 * (2.0 * std::f32::consts::PI * 220.0 * n as f32 / SR).sin())
+        .collect()
+}
+
+#[test]
+fn cost_per_callback_is_uniform_at_buffer_64() {
+    let mut ir = MonoIrProcessor::new(cabinet_ir(8192));
+    let block = 64usize;
+    let signal = di_signal(block * 3000);
+
+    // Warm up state allocation / caches so the measurement reflects steady
+    // state, not the first-build transient.
+    let mut warm = signal[..block].to_vec();
+    for _ in 0..64 {
+        ir.process_block(&mut warm);
+    }
+
+    let mut times_ns: Vec<u64> = Vec::with_capacity(signal.len() / block);
+    let mut buf = vec![0.0f32; block];
+    for chunk in signal.chunks_exact(block) {
+        buf.copy_from_slice(chunk);
+        let t0 = Instant::now();
+        ir.process_block(&mut buf);
+        times_ns.push(t0.elapsed().as_nanos() as u64);
+    }
+
+    times_ns.sort_unstable();
+    let median = times_ns[times_ns.len() / 2].max(1) as f64;
+    // 99th percentile filters the rare OS scheduling hiccup but is still well
+    // inside the burst band of the broken convolver (every 8th block at
+    // buffer 64 was a spike ≈ 12.5% of blocks).
+    let p99 = times_ns[times_ns.len() * 99 / 100] as f64;
+    let ratio = p99 / median;
+
+    assert!(
+        ratio < 4.0,
+        "IR per-callback cost is bursty (issue #617): p99 block = {p99:.0}ns is {ratio:.1}x the \
+         median {median:.0}ns. A periodic per-partition FFT spike (PARTITION_SIZE >> device buffer) \
+         concentrates the convolution into one callback and overruns small buffers."
+    );
+}
+
+#[test]
+fn convolution_stays_linear_and_correct() {
+    let taps = cabinet_ir(2048);
+    let probe_len = 8192usize;
+
+    // Effective impulse response of the block (includes its internal
+    // latency): feed a unit impulse followed by silence.
+    let mut sys_a = MonoIrProcessor::new(taps.clone());
+    let mut h = vec![0.0f32; probe_len];
+    h[0] = 1.0;
+    sys_a.process_block(&mut h);
+
+    // Arbitrary deterministic DI burst.
+    let x: Vec<f32> = (0..512)
+        .map(|n| (((n * 37) % 101) as f32 / 50.0 - 1.0) * 0.3)
+        .collect();
+
+    // The block applied to x.
+    let mut sys_b = MonoIrProcessor::new(taps);
+    let mut y = vec![0.0f32; probe_len];
+    y[..x.len()].copy_from_slice(&x);
+    sys_b.process_block(&mut y);
+
+    // For any correct LTI convolver, y == conv(x, h) regardless of the
+    // internal partition scheme. This proves the fix does not alter the sound.
+    let mut y_ref = vec![0.0f32; probe_len];
+    for (n, slot) in y_ref.iter_mut().enumerate() {
+        let mut acc = 0.0f32;
+        let kmax = n.min(x.len() - 1);
+        for k in 0..=kmax {
+            acc += x[k] * h[n - k];
+        }
+        *slot = acc;
+    }
+
+    let peak = y_ref.iter().fold(0.0f32, |a, &b| a.max(b.abs())).max(1e-6);
+    let max_err = y
+        .iter()
+        .zip(&y_ref)
+        .fold(0.0f32, |a, (&yi, &ri)| a.max((yi - ri).abs()));
+    assert!(
+        max_err < 1e-3 * peak,
+        "partitioned convolution is not a correct linear convolution: max_err={max_err:.2e}, \
+         peak={peak:.2e} (relative {:.2e})",
+        max_err / peak
+    );
+}

--- a/docs/blocks-catalog.md
+++ b/docs/blocks-catalog.md
@@ -50,7 +50,7 @@ Mass-import LV2 (issue #379, 2026-05-04): adicionou ~246 plugins LV2 ao catálog
 
 - **Native** — DSP em Rust, mais rápido
 - **NAM** — Neural Amp Modeler
-- **IR** — Impulse Response (cabs, corpos)
+- **IR** — Impulse Response (cabs, corpos). Uniformly-partitioned FFT convolution (`crates/ir`); partition size = 64 so per-callback cost is uniform with no periodic FFT spike — safe at 64-frame device buffers, ~1.3 ms added latency (#617).
 - **LV2** — Plugins externos open-source
 
 ## Instrumentos suportados

--- a/docs/superpowers/specs/2026-03-30-elastic-buffer-design.md
+++ b/docs/superpowers/specs/2026-03-30-elastic-buffer-design.md
@@ -138,3 +138,27 @@ Non-convolution chains are untouched (no extra latency). The cushion costs
 one partition (~10.7 ms @ 48 kHz) of added output latency on IR chains at
 small buffers — the deliberate "more buffer when using IR" trade, ranked
 below stream stability in the trade-off hierarchy.
+
+## Addendum — spike eliminated at the source (issue #617)
+
+The #592 cushion above treated the symptom: it gave the output buffer
+enough slack to ride out the convolver's periodic per-partition FFT burst.
+But the burst itself — running the whole partition's FFT + frequency-delay-
+line multiply-accumulate **inline** every `ir::PARTITION_SIZE` samples —
+still overran the *steady-state* 64-frame budget on tight/slow setups (the
+cushion only helps the cold start; once primed it is consumed and a
+recurring spike larger than the per-callback budget still underruns).
+
+#617 removes the burst at the source by shrinking `ir::PARTITION_SIZE` from
+512 to **64** (≤ the smallest supported device buffer). Each 64-frame
+callback now does exactly one partition's worth of work — the cost is
+**uniform across callbacks, with no spike** — and the convolver's added
+latency drops from ~10.7 ms to ~1.3 ms. The average per-callback cost rises
+(up to 128 partitions for an 8192-sample IR) but stays tiny in absolute
+terms; per the trade-off hierarchy (stability > CPU) this is the right call.
+
+Consequently the cold-start cushion is now **decoupled** from the partition
+size: `engine::elastic_prime::IR_COLD_START_CUSHION_FRAMES` (512) replaces
+the `ir::PARTITION_SIZE` floor, kept at the proven #592 magnitude solely to
+absorb generic first-callback producer warmup jitter — no longer the
+(now-eliminated) spike.


### PR DESCRIPTION
Closes #617. Stacked on `bugfix/issue-612` (where the IR/NAM code lives), so this PR targets `bugfix/issue-612` for a clean one-commit diff.

## Problem
With the cabinet IR (`block_ir`) enabled, audio crackles/clips at a 64-frame device buffer; raising the buffer to 128 hides it. User-validated: specific to the CAB block.

## Root cause
`crates/ir`'s uniformly-partitioned FFT convolver ran the whole per-partition FFT + frequency-delay-line multiply-accumulate **inline once every `PARTITION_SIZE` (512) samples**. With the partition far larger than a 64-frame buffer, that burst lands inside a single callback — a periodic spike measured at **~35× the median block cost** — overrunning the real-time deadline (invariant #7 → xrun). Buffer 128 only widened the per-callback budget enough to absorb the same burst. #592's elastic cushion covered only the cold start, not the steady-state recurring spike.

## Fix
- **`ir::PARTITION_SIZE` 512 → 64** (≤ smallest supported device buffer): each callback now does exactly one partition's work — uniform cost, no spike. Partitioned convolution is exact for any partition size, so output is **bit-equivalent**; added latency drops **~10.7 ms → ~1.3 ms**. Mean per-callback cost rises (up to 128 partitions for an 8192-sample IR) but stays tiny and uniform — per the trade-off hierarchy (stability > CPU).
- **Clamp the DC/Nyquist imaginary round-off** before the inverse real FFT: with the smaller FFT the per-partition round-off crossed `realfft`'s strict zero check and **panicked the audio thread**. Those bins are mathematically real (round-off cleanup, not a signal change).
- **Decouple the #592 cold-start cushion** from the partition size (`engine::IR_COLD_START_CUSHION_FRAMES = 512`) so removing the spike doesn't shrink the warmup cushion.

## Tests (TDD red-first)
- `cost_per_callback_is_uniform_at_buffer_64` — RED before (p99 ≈ 35× median block at buffer 64), GREEN after (uniform).
- `convolution_stays_linear_and_correct` — proves the output is unchanged (invariant #9, numeric determinism): for any LTI convolver `y == conv(x, impulse_response)`.
- Full `ir` (35) + `engine` (543 lib + integration) suites green; `cargo test --workspace --lib` green; zero warnings.

## Invariants
- #2 latency: improved (~10.7 ms → ~1.3 ms on IR chains).
- #3 stability / #6 jitter: the periodic spike is eliminated.
- #7 CPU: average rises but stays tiny and **uniform** (no deadline miss); correct trade per the hierarchy.
- #9 determinism: output bit-equivalent (correctness test).

## ⚠️ On-device validation needed
The actual xrun reproduces only on the target hardware — this dev Mac has ~20× headroom even at the spike with the small fixture IR. Please validate at buffer 64 with a real cabinet IR on the target machine.