### PR TITLE
fix(#622): recalc block-editor window size when a plugin is picked

### DIFF
--- a/crates/adapter-gui/src/block_model_search_wiring.rs
+++ b/crates/adapter-gui/src/block_model_search_wiring.rs
@@ -86,6 +86,11 @@ pub(crate) fn wire(
             if let Some(win) = weak_block_editor_window.upgrade() {
                 win.set_block_drawer_selected_model_index(idx);
                 win.invoke_choose_block_model(idx);
+                // Picking a plugin must resize the window to fit the new
+                // model's params — the same recalc the parameter-update path
+                // runs. Without it, a plugin with more params overflows a
+                // window left at the previous size (issue #622).
+                crate::block_editor_window_lifecycle::apply_panel_dimensions(&win);
             }
         });
     }

--- a/crates/adapter-gui/tests/issue_622_model_pick_resizes_window.rs
+++ b/crates/adapter-gui/tests/issue_622_model_pick_resizes_window.rs
@@ -1,0 +1,36 @@
+//! Issue #622: choosing a plugin/model in the block editor must recalculate
+//! the editor window size, exactly like the parameter-update path does.
+//!
+//! The picker funnels every model choice through
+//! `block_model_search_wiring`'s `on_choose_block_model_by_id` handler. That
+//! handler rebuilt the parameter list but never resized the window, so a
+//! plugin with more parameters than the previous one overflowed a window
+//! left at the old size (the user had to see a too-small window / cut-off
+//! params). The fix mirrors the update path: call `apply_panel_dimensions`
+//! after the model is applied.
+//!
+//! UI rendering is hard to assert without an `AppWindow`, so this follows
+//! the crate's source-presence convention (see `no_native_dialogs.rs`): it
+//! flips GREEN the moment the recalc is wired in and RED again on regression.
+
+use std::path::PathBuf;
+
+fn read_src(relative: &str) -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("src")
+        .join(relative);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+#[test]
+fn choosing_a_model_by_id_recalculates_block_editor_window_size() {
+    let src = read_src("block_model_search_wiring.rs");
+    assert!(
+        src.contains("apply_panel_dimensions"),
+        "issue #622: block_model_search_wiring must recalculate the block \
+         editor window size after a model pick (call `apply_panel_dimensions`, \
+         the same recalc the parameter-update path runs). Without it, picking \
+         a plugin with more params leaves the window at the previous size and \
+         the new params don't fit."
+    );
+}


### PR DESCRIPTION
Re #622. Follow-up to #624/#629 — the actual root cause.

## Root cause
The parameter-update path already resizes the block-editor window (`apply_panel_dimensions`), but the model **picker** did not. The block editor's `on_choose_block_model_by_id` handler (`block_model_search_wiring`) rebuilt the parameter list yet never recalculated the window size — so selecting a plugin with more params than the previous one left the window at the old size, and the new params didn't fit. (My earlier sizing-formula changes in #624/#629 never addressed this missing trigger — that's why the symptom persisted.)

## Fix
After applying the picked model, call `apply_panel_dimensions` on the block editor window — mirroring the update path the user confirmed already works. It runs after the param models are rebuilt, so the window sizes to the new plugin's param count regardless of which `on_choose_block_model` handler is active.

## Test
`choosing_a_model_by_id_recalculates_block_editor_window_size` — source-presence pin (the crate's convention for AppWindow-coupled wiring, see `no_native_dialogs.rs`): RED before (no `apply_panel_dimensions` call in `block_model_search_wiring`), GREEN after. adapter-gui builds clean.

Diff is just the trigger fix; the sizing-formula work landed via #629.