### PR TITLE
fix(#643): #612 cross-platform release regressions — Windows cmake flags + macOS Resources mkdir

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -51,9 +51,10 @@ target_compile_definitions(nam_wrapper PRIVATE
   EIGEN_DONT_VECTORIZE
 )
 
-if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-  target_compile_options(nam_wrapper PRIVATE -Wall -Wextra -Wpedantic -Wno-unused-parameter)
-else()
+# GCC/Clang warning flags only — MSVC's cl rejects -Wextra/-Wpedantic
+# (error D8021), which broke the Windows release build (#643). MSVC needs
+# none here (cmake-rs already passes -W0).
+if (NOT MSVC)
   target_compile_options(nam_wrapper PRIVATE -Wall -Wextra -Wpedantic -Wno-unused-parameter)
 endif()
 

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -48,6 +48,7 @@ rm -rf "$APP" dist/dmg_contents dist/OpenRig-*.dmg
 
 mkdir -p "$APP/Contents/MacOS"
 mkdir -p "$APP/Contents/Frameworks"
+mkdir -p "$APP/Contents/Resources"
 
 echo "==> Creating universal binary with lipo..."
 lipo -create \


### PR DESCRIPTION
Closes #643.

The Windows x64 release build fails compiling the NAM wrapper: `cl : command line error D8021: invalid numeric argument '/Wextra'`. `cpp/CMakeLists.txt` applied `-Wall -Wextra -Wpedantic -Wno-unused-parameter` unconditionally (the `if(Darwin)/else` branches were identical), and MSVC's `cl` rejects `-Wextra`.

**Fix:** guard the GCC/Clang flags behind `if(NOT MSVC)`. Linux/macOS keep them (behaviour identical — `NOT MSVC` is true there); MSVC uses the cmake-rs default `-W0`.

A #612 regression (the cmake-built official-core wrapper) that only surfaced at **release** because Windows isn't built in PR CI (`windows-x64` is `skipping` on PRs). Verifiable only in the release Windows job; Linux/macOS unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)