### PR TITLE
fix(#645): guard per-file -Wno-error from MSVC + add /EHsc (Windows release build)

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -58,9 +58,16 @@ if (NOT MSVC)
   target_compile_options(nam_wrapper PRIVATE -Wall -Wextra -Wpedantic -Wno-unused-parameter)
 endif()
 
-# Igual ao projeto original: esses arquivos podem gerar warnings chatos
-set_source_files_properties(${NAM_CORE_DIR}/NAM/dsp.cpp PROPERTIES COMPILE_FLAGS "-Wno-error")
-set_source_files_properties(${NAM_CORE_DIR}/NAM/conv1d.cpp PROPERTIES COMPILE_FLAGS "-Wno-error")
+# MSVC needs /EHsc for the core's C++ exceptions (otherwise C4530 + broken
+# unwinding); the per-file -Wno-error is GCC/Clang-only and MSVC's cl rejects it
+# (error D8021, #645).
+if (MSVC)
+  target_compile_options(nam_wrapper PRIVATE /EHsc)
+else()
+  # These core files can emit noisy warnings — keep them non-fatal on GCC/Clang.
+  set_source_files_properties(${NAM_CORE_DIR}/NAM/dsp.cpp PROPERTIES COMPILE_FLAGS "-Wno-error")
+  set_source_files_properties(${NAM_CORE_DIR}/NAM/conv1d.cpp PROPERTIES COMPILE_FLAGS "-Wno-error")
+endif()
 
 install(TARGETS nam_wrapper
   LIBRARY DESTINATION lib


### PR DESCRIPTION
Closes #645.

After #643/#644 guarded `-Wall/-Wextra/-Wpedantic`, the Windows MSVC build hits the next GCC-only flag: `cl : command line error D8021: invalid numeric argument '/Wno-error'` from the per-file `set_source_files_properties(... COMPILE_FLAGS "-Wno-error")` on `NAM/dsp.cpp` and `NAM/conv1d.cpp`. MSVC also warns C4530 (exceptions used without unwind semantics).

**Fix:** move the per-file `-Wno-error` under the `NOT MSVC` branch and add `/EHsc` for MSVC (the core throws C++ exceptions). These are the last GCC-isms in `cpp/CMakeLists.txt` (`-stdlib=libc++` is already Darwin-gated). Linux/macOS unchanged — verified `cargo build -p nam` clean on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)