### PR TITLE
fix(#647): WINDOWS_EXPORT_ALL_SYMBOLS so MSVC produces nam_wrapper.lib (fixes LNK1181)

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -33,6 +33,12 @@ add_library(nam_wrapper SHARED
   ${AUDIO_DSP_TOOLS_SOURCES}
 )
 
+# On MSVC a SHARED lib exports nothing without __declspec(dllexport), so no
+# import library (nam_wrapper.lib) is produced and the Rust link fails with
+# LNK1181. Export all symbols on Windows so cmake generates the import lib
+# (#647). No-op on GCC/Clang, which export all symbols by default.
+set_target_properties(nam_wrapper PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
 target_include_directories(nam_wrapper PUBLIC
   ${CMAKE_SOURCE_DIR}
 )


### PR DESCRIPTION
Closes #647.

After the MSVC compile-flag fixes (#643/#645), Windows now compiles but fails at the Rust link: `LINK : fatal error LNK1181: cannot open input file 'nam_wrapper.lib'`.

**Root cause:** `nam_wrapper` is a SHARED lib whose `extern "C"` functions have no `__declspec(dllexport)`. On MSVC a DLL with no exported symbols produces no import library, so `-l dylib=nam_wrapper` finds nothing. GCC/Clang export all symbols by default → Linux/macOS were fine.

**Fix:** `set_target_properties(nam_wrapper PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)` — cmake auto-generates the import lib on Windows. No-op on Linux/macOS (verified `cargo build -p nam` clean on macOS).

Last in the #612 Windows-build regression series (cmake wrapper never validated on Windows MSVC since Windows isn't built in PR CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)