### PR TITLE
feat(gui): distinct amber badge for NAM/A2 architecture

### DIFF
--- a/crates/adapter-gui/ui/components/block_panel_header.slint
+++ b/crates/adapter-gui/ui/components/block_panel_header.slint
@@ -87,11 +87,13 @@ export component BlockPanelHeader inherits Rectangle {
         height: 22px;
         border-radius: 4px;
         background: root.type-label == "NATIVE" ? #0d2a0d
-            : root.type-label == "NAM" ? #0d1a2e
+            : root.type-label == "NAM/A2" ? #2e260d
+            : (root.type-label == "NAM" || root.type-label == "NAM/A1") ? #0d1a2e
             : #2e1a0d;
         border-width: 1px;
         border-color: root.type-label == "NATIVE" ? #1a6b1a
-            : root.type-label == "NAM" ? #1a4488
+            : root.type-label == "NAM/A2" ? #8a6a1a
+            : (root.type-label == "NAM" || root.type-label == "NAM/A1") ? #1a4488
             : #883300;
 
         Text {
@@ -100,7 +102,8 @@ export component BlockPanelHeader inherits Rectangle {
             height: parent.height;
             text: root.type-label;
             color: root.type-label == "NATIVE" ? #33bb33
-                : root.type-label == "NAM" ? #4499ff
+                : root.type-label == "NAM/A2" ? #ffcc44
+                : (root.type-label == "NAM" || root.type-label == "NAM/A1") ? #4499ff
                 : #ff8833;
             font-size: 9px;
             font-weight: 800;

--- a/crates/adapter-gui/ui/components/model_select_with_search.slint
+++ b/crates/adapter-gui/ui/components/model_select_with_search.slint
@@ -57,13 +57,15 @@ export component ModelSelectWithSearch inherits Rectangle {
         height: 22px;
         border-radius: 3px;
         background: root.selected-model.type_label == "NATIVE" ? #0d2a0d
-            : root.selected-model.type_label == "NAM" ? #0d1a2e
+            : root.selected-model.type_label == "NAM/A2" ? #2e260d
+            : (root.selected-model.type_label == "NAM" || root.selected-model.type_label == "NAM/A1") ? #0d1a2e
             : root.selected-model.type_label == "IR" ? #1a0d2e
             : root.selected-model.type_label == "LV2" ? #0d2e2a
             : #2e1a0d;
         border-width: 1px;
         border-color: root.selected-model.type_label == "NATIVE" ? #1a6b1a
-            : root.selected-model.type_label == "NAM" ? #1a4488
+            : root.selected-model.type_label == "NAM/A2" ? #8a6a1a
+            : (root.selected-model.type_label == "NAM" || root.selected-model.type_label == "NAM/A1") ? #1a4488
             : root.selected-model.type_label == "IR" ? #6b1a88
             : root.selected-model.type_label == "LV2" ? #1a886b
             : #883300;
@@ -73,7 +75,8 @@ export component ModelSelectWithSearch inherits Rectangle {
             height: parent.height;
             text: root.selected-model.type_label;
             color: root.selected-model.type_label == "NATIVE" ? #33bb33
-                : root.selected-model.type_label == "NAM" ? #4499ff
+                : root.selected-model.type_label == "NAM/A2" ? #ffcc44
+                : (root.selected-model.type_label == "NAM" || root.selected-model.type_label == "NAM/A1") ? #4499ff
                 : root.selected-model.type_label == "IR" ? #aa44ff
                 : root.selected-model.type_label == "LV2" ? #44ddaa
                 : #ff8833;
@@ -262,13 +265,15 @@ export component ModelSelectWithSearch inherits Rectangle {
                         height: 22px;
                         border-radius: 3px;
                         background: model.type_label == "NATIVE" ? #0d2a0d
-                            : model.type_label == "NAM" ? #0d1a2e
+                            : model.type_label == "NAM/A2" ? #2e260d
+                            : (model.type_label == "NAM" || model.type_label == "NAM/A1") ? #0d1a2e
                             : model.type_label == "IR" ? #1a0d2e
                             : model.type_label == "LV2" ? #0d2e2a
                             : #2e1a0d;
                         border-width: 1px;
                         border-color: model.type_label == "NATIVE" ? #1a6b1a
-                            : model.type_label == "NAM" ? #1a4488
+                            : model.type_label == "NAM/A2" ? #8a6a1a
+                            : (model.type_label == "NAM" || model.type_label == "NAM/A1") ? #1a4488
                             : model.type_label == "IR" ? #6b1a88
                             : model.type_label == "LV2" ? #1a886b
                             : #883300;
@@ -278,7 +283,8 @@ export component ModelSelectWithSearch inherits Rectangle {
                             height: parent.height;
                             text: model.type_label;
                             color: model.type_label == "NATIVE" ? #33bb33
-                                : model.type_label == "NAM" ? #4499ff
+                                : model.type_label == "NAM/A2" ? #ffcc44
+                                : (model.type_label == "NAM" || model.type_label == "NAM/A1") ? #4499ff
                                 : model.type_label == "IR" ? #aa44ff
                                 : model.type_label == "LV2" ? #44ddaa
                                 : #ff8833;

--- a/crates/adapter-gui/ui/pages/plugin_info_window.slint
+++ b/crates/adapter-gui/ui/pages/plugin_info_window.slint
@@ -95,7 +95,8 @@ export component PluginInfoPanel inherits Rectangle {
                     width: type-badge-text.preferred-width + 12px;
                     border-radius: 4px;
                     background: root.type-label == "LV2" ? #1a2a1a
-                        : root.type-label == "NAM" ? #1a1a2a
+                        : root.type-label == "NAM/A2" ? #2e260d
+                        : (root.type-label == "NAM" || root.type-label == "NAM/A1") ? #1a1a2a
                         : root.type-label == "IR" ? #2a1a1a
                         : #1e1e2a;
 
@@ -105,7 +106,8 @@ export component PluginInfoPanel inherits Rectangle {
                         font-size: 10px;
                         font-weight: 600;
                         color: root.type-label == "LV2" ? #44cc44
-                            : root.type-label == "NAM" ? #4488ff
+                            : root.type-label == "NAM/A2" ? #ffcc44
+                            : (root.type-label == "NAM" || root.type-label == "NAM/A1") ? #4488ff
                             : root.type-label == "IR" ? #ff8844
                             : #aaaacc;
                         vertical-alignment: center;

--- a/docs/blocks-catalog.md
+++ b/docs/blocks-catalog.md
@@ -54,9 +54,10 @@ Mass-import LV2 (issue #379, 2026-05-04): adicionou ~246 plugins LV2 ao catálog
   `A2` = NAM "v2" (`SlimmableContainer`, `.nam` version 0.7.0). Every NAM plugin
   is uniform (all captures share one architecture — mixed plugins are split into
   `<name>_a1` / `<name>_a2`), so the catalog renders a **NAM/A1** vs **NAM/A2**
-  badge straight from this field, without opening any `.nam`. The field is
-  optional: IR plugins and legacy NAM manifests omit it and show a plain **NAM**
-  badge.
+  badge straight from this field, without opening any `.nam`. `NAM/A2` uses a
+  distinct amber badge color (text `#ffcc44`) to set it apart from the blue
+  `NAM/A1`. The field is optional: IR plugins and legacy NAM manifests omit it
+  and show a plain **NAM** badge (blue, same as A1).
 - **IR** — Impulse Response (cabs, corpos). Uniformly-partitioned FFT convolution (`crates/ir`); partition size = 64 so per-callback cost is uniform with no periodic FFT spike — safe at 64-frame device buffers, ~1.3 ms added latency (#617).
 - **LV2** — Plugins externos open-source
 


### PR DESCRIPTION
Closes #653.

## Problem

Since #650 the per-plugin NAM architecture is surfaced as a `type_label` of `NAM/A1` or `NAM/A2`. The type-badge components still matched the exact string `== "NAM"`, so those labels fell through to the default (gray/orange) branch with no A1-vs-A2 distinction.

## Change

All four NAM badge sites now branch on the architecture:
- `NAM` / `NAM/A1` → existing per-component blue (unchanged).
- `NAM/A2` → distinct amber badge: text `#ffcc44`, bg `#2e260d`, border `#8a6a1a`.

Sites:
- `crates/adapter-gui/ui/pages/plugin_info_window.slint` (bg + text)
- `crates/adapter-gui/ui/components/block_panel_header.slint` (bg + border + text)
- `crates/adapter-gui/ui/components/model_select_with_search.slint` (selected badge + dropdown list)
- `docs/blocks-catalog.md` (documents the A2 amber badge)

Presentational only — `type_label` already carries the architecture from #650, so no Rust logic, `Command`, or `Query` is touched.

## Verification

`cargo build -p adapter-gui` green (Slint compiles).