### PR TITLE
feat(ir): user-adjustable Output Level (dB) knob, seeded from capture audit

### DIFF
--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -21,6 +21,7 @@ pub mod local_dispatcher;
 mod local_dispatcher_block_edit;
 mod local_dispatcher_block_lifecycle;
 mod local_dispatcher_block_param;
+mod local_dispatcher_ir_reseed;
 mod local_dispatcher_chain_crud;
 mod local_dispatcher_di_loop;
 mod local_dispatcher_chain_io;

--- a/crates/application/src/local_dispatcher_block_param.rs
+++ b/crates/application/src/local_dispatcher_block_param.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 use crate::command::Command;
 use crate::event::Event;
 use crate::local_dispatcher::LocalDispatcher;
+use crate::local_dispatcher_ir_reseed::reseed_ir_output_db;
 
 impl LocalDispatcher {
     /// Block-parameter commands: set/select a single parameter on a block.
@@ -18,7 +19,9 @@ impl LocalDispatcher {
                 value,
             } => {
                 self.with_block(&chain, &block, |b| {
-                    project::block::param_writer::set_parameter_number(b, &path, value)
+                    project::block::param_writer::set_parameter_number(b, &path, value)?;
+                    reseed_ir_output_db(b, &path);
+                    Ok(())
                 })?;
                 Ok(vec![Event::BlockParameterChanged { chain, block, path }])
             }
@@ -40,7 +43,9 @@ impl LocalDispatcher {
                 value,
             } => {
                 self.with_block(&chain, &block, |b| {
-                    project::block::param_writer::set_parameter_text(b, &path, &value)
+                    project::block::param_writer::set_parameter_text(b, &path, &value)?;
+                    reseed_ir_output_db(b, &path);
+                    Ok(())
                 })?;
                 Ok(vec![Event::BlockParameterChanged { chain, block, path }])
             }
@@ -52,7 +57,9 @@ impl LocalDispatcher {
                 index: _,
             } => {
                 self.with_block(&chain, &block, |b| {
-                    project::block::param_writer::set_parameter_option(b, &path, &value)
+                    project::block::param_writer::set_parameter_option(b, &path, &value)?;
+                    reseed_ir_output_db(b, &path);
+                    Ok(())
                 })?;
                 Ok(vec![Event::BlockParameterChanged { chain, block, path }])
             }

--- a/crates/application/src/local_dispatcher_ir_reseed.rs
+++ b/crates/application/src/local_dispatcher_ir_reseed.rs
@@ -1,0 +1,72 @@
+//! Issue #655: re-seed the IR `output_db` knob when the user changes a
+//! capture axis.
+//!
+//! The IR Output Level knob is an *absolute* dB value (mirroring NAM):
+//! its default mirrors the selected capture's audit baseline. When the
+//! user picks a different mic/position the resolved capture changes, so
+//! the knob must re-seed to the new capture's baseline — otherwise the
+//! previously selected capture's offset would be applied to the new IR,
+//! changing its loudness (volume invariant #10).
+
+use plugin_loader::manifest::{Backend, GridCapture, GridParameter};
+use project::block::AudioBlock;
+use project::param::ParameterSet;
+
+/// The `output_db` (absolute dB) the IR knob should re-seed to after a
+/// capture-axis change: the newly selected capture's audit baseline, with
+/// the manifest-level value as fallback. Returns `None` when the changed
+/// param is `output_db` itself (the user is dragging the knob — never
+/// clobber that) or when no capture/audit resolves; callers then leave the
+/// knob untouched.
+pub(crate) fn reseed_output_db_for_capture_change(
+    parameters: &[GridParameter],
+    captures: &[GridCapture],
+    manifest_output_gain_db: Option<f32>,
+    params: &ParameterSet,
+    changed_path: &str,
+) -> Option<f32> {
+    if changed_path == "output_db" {
+        return None;
+    }
+    let capture = plugin_loader::dispatch::resolve_capture(parameters, captures, params)?;
+    capture.output_gain_db.or(manifest_output_gain_db)
+}
+
+/// Apply [`reseed_output_db_for_capture_change`] to a block in place. No-op
+/// for non-IR blocks or when the pure resolver declines. The capture is
+/// resolved against the block's *current* params (the axis write already
+/// happened), so the new selection is reflected.
+pub(crate) fn reseed_ir_output_db(block: &mut AudioBlock, changed_path: &str) {
+    let new_output_db = {
+        let Some(model) = block.model_ref() else {
+            return;
+        };
+        if model.effect_type != block_core::EFFECT_TYPE_IR {
+            return;
+        }
+        let Some(pkg) = plugin_loader::registry::find(&model.model) else {
+            return;
+        };
+        let Backend::Ir {
+            parameters,
+            captures,
+        } = &pkg.manifest.backend
+        else {
+            return;
+        };
+        reseed_output_db_for_capture_change(
+            parameters,
+            captures,
+            pkg.manifest.output_gain_db,
+            &model.params,
+            changed_path,
+        )
+    };
+    if let Some(db) = new_output_db {
+        let _ = project::block::param_writer::set_parameter_number(block, "output_db", db as f64);
+    }
+}
+
+#[cfg(test)]
+#[path = "local_dispatcher_ir_reseed_tests.rs"]
+mod tests;

--- a/crates/application/src/local_dispatcher_ir_reseed_tests.rs
+++ b/crates/application/src/local_dispatcher_ir_reseed_tests.rs
@@ -1,0 +1,87 @@
+//! Unit tests for the pure IR `output_db` re-seed resolver (#655).
+
+use super::reseed_output_db_for_capture_change;
+use domain::value_objects::ParameterValue as DomainValue;
+use plugin_loader::manifest::{GridCapture, GridParameter, ParameterValue};
+use project::param::ParameterSet;
+
+fn position_axis() -> Vec<GridParameter> {
+    vec![GridParameter {
+        name: "position".into(),
+        display_name: None,
+        values: vec![
+            ParameterValue::Text("a".into()),
+            ParameterValue::Text("b".into()),
+        ],
+    }]
+}
+
+fn captures_a_minus20_b_minus10() -> Vec<GridCapture> {
+    vec![
+        GridCapture {
+            values: [("position".to_string(), ParameterValue::Text("a".into()))]
+                .into_iter()
+                .collect(),
+            file: "a.wav".into(),
+            output_gain_db: Some(-20.0),
+        },
+        GridCapture {
+            values: [("position".to_string(), ParameterValue::Text("b".into()))]
+                .into_iter()
+                .collect(),
+            file: "b.wav".into(),
+            output_gain_db: Some(-10.0),
+        },
+    ]
+}
+
+fn params_with_position(value: &str) -> ParameterSet {
+    let mut params = ParameterSet::default();
+    params.insert("position", DomainValue::String(value.to_string()));
+    params
+}
+
+#[test]
+fn axis_change_reseeds_to_newly_selected_capture_audit() {
+    // User switched position to "b" (audit -10 dB) → knob re-seeds to -10.
+    let result = reseed_output_db_for_capture_change(
+        &position_axis(),
+        &captures_a_minus20_b_minus10(),
+        None,
+        &params_with_position("b"),
+        "position",
+    );
+    assert_eq!(result, Some(-10.0));
+}
+
+#[test]
+fn dragging_output_db_itself_never_reseeds() {
+    // The user is dragging the Output knob — must NOT clobber their value.
+    let result = reseed_output_db_for_capture_change(
+        &position_axis(),
+        &captures_a_minus20_b_minus10(),
+        None,
+        &params_with_position("b"),
+        "output_db",
+    );
+    assert_eq!(result, None);
+}
+
+#[test]
+fn capture_without_audit_falls_back_to_manifest_level() {
+    let captures = vec![GridCapture {
+        values: [("position".to_string(), ParameterValue::Text("a".into()))]
+            .into_iter()
+            .collect(),
+        file: "a.wav".into(),
+        output_gain_db: None,
+    }];
+    let result = reseed_output_db_for_capture_change(
+        &position_axis(),
+        &captures,
+        Some(-4.5),
+        &params_with_position("a"),
+        "position",
+    );
+    assert_eq!(result, Some(-4.5));
+}

--- a/crates/ir/src/from_package.rs
+++ b/crates/ir/src/from_package.rs
@@ -69,21 +69,40 @@ pub fn build_from_package(
             package.manifest.id
         ),
     };
-    // Issue #491 + #514: aplica o baseline do audit (em dB) como
-    // wrapper estático pós-convolução. IR pura é gain-passive, mas o
-    // ganho efetivo perceptual varia bastante (cab/body shapers
-    // atenuam graves diferente). Capturas IR carregam um valor por
-    // arquivo (`capture.output_gain_db`); o top-level
-    // `manifest.output_gain_db` é fallback pra plugins de baseline
-    // único.
-    let audit_db = select_audit_db(capture.output_gain_db, package.manifest.output_gain_db);
-    Ok(wrap_with_output_gain_db(processor, audit_db))
+    // Issue #491 + #514 + #655: post-convolution output gain (dB). A pure
+    // IR is gain-passive, but the perceived level varies a lot (cab/body
+    // shapers attenuate lows differently), so each capture ships an audit
+    // baseline (`capture.output_gain_db`, manifest-level as fallback).
+    // Since #655 the user-facing `output_db` knob is the absolute applied
+    // level and overrides the baseline when present; legacy presets without
+    // the param keep their audit loudness (volume invariant #10).
+    let user_output_db = params.get_f32("output_db");
+    let applied_db = resolve_output_db(
+        user_output_db,
+        capture.output_gain_db,
+        package.manifest.output_gain_db,
+    );
+    Ok(wrap_with_output_gain_db(processor, applied_db))
 }
 
 /// Choose the audit-baseline dB to apply, preferring the per-capture
 /// value over the manifest-level fallback. Issue #514.
 pub(crate) fn select_audit_db(capture_db: Option<f32>, manifest_db: Option<f32>) -> Option<f32> {
     capture_db.or(manifest_db)
+}
+
+/// Resolve the output gain (dB) the IR processor applies. Mirrors NAM's
+/// absolute-knob model (issue #655): the user `output_db` param IS the
+/// applied output level and wins when present (even `0.0`); when absent —
+/// legacy presets saved before the knob existed — it falls back to the
+/// audit baseline (per-capture, then manifest) so loudness is unchanged
+/// (volume invariant #10).
+pub(crate) fn resolve_output_db(
+    user_param_db: Option<f32>,
+    capture_audit_db: Option<f32>,
+    manifest_audit_db: Option<f32>,
+) -> Option<f32> {
+    user_param_db.or_else(|| select_audit_db(capture_audit_db, manifest_audit_db))
 }
 
 #[cfg(test)]

--- a/crates/ir/src/from_package_tests.rs
+++ b/crates/ir/src/from_package_tests.rs
@@ -1,6 +1,6 @@
 //! Unit tests for `from_package` audit-baseline selection. Issue #514.
 
-use super::select_audit_db;
+use super::{resolve_output_db, select_audit_db};
 
 #[test]
 fn per_capture_audit_takes_precedence_over_top_level() {
@@ -25,4 +25,40 @@ fn capture_audit_used_when_top_level_missing() {
 #[test]
 fn no_audit_anywhere_returns_none() {
     assert_eq!(select_audit_db(None, None), None);
+}
+
+// --- resolve_output_db: user knob is the absolute applied level (#655) ---
+
+#[test]
+fn user_output_db_param_overrides_audit_baseline() {
+    // The user dragged the Output knob to +3 dB; that is the applied
+    // level regardless of the capture's audit baseline.
+    assert_eq!(
+        resolve_output_db(Some(3.0), Some(-22.9), Some(6.0)),
+        Some(3.0)
+    );
+}
+
+#[test]
+fn user_output_db_zero_is_respected_not_treated_as_absent() {
+    // 0 dB is a deliberate user choice (absolute), NOT "fall back to
+    // audit". Distinguishes Some(0.0) from None.
+    assert_eq!(resolve_output_db(Some(0.0), Some(-22.9), None), Some(0.0));
+}
+
+#[test]
+fn legacy_preset_without_param_falls_back_to_capture_audit() {
+    // No output_db in the preset (pre-#655) → keep the per-capture audit
+    // loudness. Volume invariant #10: existing presets must not change.
+    assert_eq!(resolve_output_db(None, Some(-22.9), Some(6.0)), Some(-22.9));
+}
+
+#[test]
+fn legacy_preset_falls_back_to_manifest_audit_when_capture_lacks_value() {
+    assert_eq!(resolve_output_db(None, None, Some(-4.5)), Some(-4.5));
+}
+
+#[test]
+fn no_param_and_no_audit_anywhere_returns_none() {
+    assert_eq!(resolve_output_db(None, None, None), None);
 }

--- a/crates/project/src/block/dispatch.rs
+++ b/crates/project/src/block/dispatch.rs
@@ -145,7 +145,32 @@ pub(crate) fn synthesize_parameters_from_manifest(
         } => {
             // Same dead-axis filter as NAM (issue #649).
             let axes = plugin_loader::grid_axes::effective_grid_axes(parameters, captures);
-            axes.iter().map(grid_parameter_to_spec).collect()
+            let mut specs: Vec<block_core::param::ParameterSpec> =
+                axes.iter().map(grid_parameter_to_spec).collect();
+            // Issue #655: user-adjustable Output Level knob (mirrors NAM).
+            // The default mirrors the engine baseline — the first capture's
+            // audit (manifest-level fallback, 0 dB if neither) — so the knob
+            // shows the real applied offset and a fresh block born at the
+            // first capture stays unchanged (volume invariant #10). The
+            // audio path resolves the offset per-capture from the raw saved
+            // params (see `ir::from_package::resolve_output_db`); this
+            // default only drives the UI and the new-block seed.
+            let default_db = captures
+                .first()
+                .and_then(|c| c.output_gain_db)
+                .or(package.manifest.output_gain_db)
+                .unwrap_or(0.0);
+            specs.push(block_core::param::float_parameter(
+                "output_db",
+                "Output",
+                None,
+                Some(default_db),
+                -24.0,
+                24.0,
+                0.1,
+                block_core::param::ParameterUnit::Decibels,
+            ));
+            specs
         }
         Backend::Lv2 {
             plugin_uri,
@@ -584,6 +609,90 @@ mod tests {
         );
     }
 
+    fn ir_package_with_capture_audit(first_audit_db: Option<f32>) -> LoadedPackage {
+        LoadedPackage {
+            root: PathBuf::from("/fake"),
+            manifest: PluginManifest {
+                manifest_version: 1,
+                id: "ir_test_body".into(),
+                display_name: "Test IR".into(),
+                author: None,
+                description: None,
+                inspired_by: None,
+                brand: None,
+                thumbnail: None,
+                photo: None,
+                screenshot: None,
+                brand_logo: None,
+                license: None,
+                homepage: None,
+                sources: None,
+                output_gain_db: None,
+                architecture: None,
+                block_type: BlockType::Cab,
+                backend: Backend::Ir {
+                    parameters: vec![GridParameter {
+                        name: "position".into(),
+                        display_name: None,
+                        values: vec![
+                            ParameterValue::Text("a".into()),
+                            ParameterValue::Text("b".into()),
+                        ],
+                    }],
+                    captures: vec![
+                        GridCapture {
+                            values: [("position".to_string(), ParameterValue::Text("a".into()))]
+                                .into_iter()
+                                .collect(),
+                            file: "a.wav".into(),
+                            output_gain_db: first_audit_db,
+                        },
+                        GridCapture {
+                            values: [("position".to_string(), ParameterValue::Text("b".into()))]
+                                .into_iter()
+                                .collect(),
+                            file: "b.wav".into(),
+                            output_gain_db: Some(-10.0),
+                        },
+                    ],
+                },
+            },
+        }
+    }
+
+    #[test]
+    fn ir_synthesized_schema_exposes_output_db_knob_in_decibels() {
+        // Issue #655: IR blocks need a user-adjustable Output Level knob
+        // (mirroring NAM) so resonant body IRs whose audit baseline cut
+        // them far down can be brought back up. It must be a dB control.
+        let pkg = ir_package_with_capture_audit(Some(-22.9));
+        let specs = synthesize_parameters_from_manifest(&pkg);
+        let output_db = specs
+            .iter()
+            .find(|s| s.path == "output_db")
+            .expect("IR schema must include `output_db` so the user can adjust output level");
+        assert_eq!(
+            output_db.unit,
+            block_core::param::ParameterUnit::Decibels,
+            "output_db must be a decibel control"
+        );
+    }
+
+    #[test]
+    fn ir_output_db_default_seeds_from_first_capture_audit() {
+        // The knob's default mirrors the engine's actual baseline so a
+        // freshly created IR block (born at the first capture) shows the
+        // real applied offset, not 0 dB. Volume invariant #10.
+        let pkg = ir_package_with_capture_audit(Some(-22.9));
+        let specs = synthesize_parameters_from_manifest(&pkg);
+        let output_db = specs.iter().find(|s| s.path == "output_db").unwrap();
+        assert_eq!(
+            output_db.default_value,
+            Some(domain::value_objects::ParameterValue::Float(-22.9)),
+            "output_db default must be the first capture's audit baseline"
+        );
+    }
+
     fn nam_package_with_emoji_labels() -> LoadedPackage {
         // Real-world Bogner Ecstasy capture grid — `display_name` and
         // every `Text` value carry a leading emoji. Reproduces the
@@ -604,16 +713,22 @@ mod tests {
             }],
             vec![
                 GridCapture {
-                    values: [("cabinet".to_string(), ParameterValue::Text("✋ 4X12".into()))]
-                        .into_iter()
-                        .collect(),
+                    values: [(
+                        "cabinet".to_string(),
+                        ParameterValue::Text("✋ 4X12".into()),
+                    )]
+                    .into_iter()
+                    .collect(),
                     file: "4x12.nam".into(),
                     output_gain_db: None,
                 },
                 GridCapture {
-                    values: [("cabinet".to_string(), ParameterValue::Text("🔥 2X12".into()))]
-                        .into_iter()
-                        .collect(),
+                    values: [(
+                        "cabinet".to_string(),
+                        ParameterValue::Text("🔥 2X12".into()),
+                    )]
+                    .into_iter()
+                    .collect(),
                     file: "2x12.nam".into(),
                     output_gain_db: None,
                 },

--- a/docs/blocks-catalog.md
+++ b/docs/blocks-catalog.md
@@ -58,7 +58,7 @@ Mass-import LV2 (issue #379, 2026-05-04): adicionou ~246 plugins LV2 ao catálog
   distinct amber badge color (text `#ffcc44`) to set it apart from the blue
   `NAM/A1`. The field is optional: IR plugins and legacy NAM manifests omit it
   and show a plain **NAM** badge (blue, same as A1).
-- **IR** — Impulse Response (cabs, corpos). Uniformly-partitioned FFT convolution (`crates/ir`); partition size = 64 so per-callback cost is uniform with no periodic FFT spike — safe at 64-frame device buffers, ~1.3 ms added latency (#617).
+- **IR** — Impulse Response (cabs, corpos). Uniformly-partitioned FFT convolution (`crates/ir`); partition size = 64 so per-callback cost is uniform with no periodic FFT spike — safe at 64-frame device buffers, ~1.3 ms added latency (#617). Exposes a user-adjustable **Output** knob (dB, −24..+24) mirroring NAM (#655): it is the absolute applied output level and defaults to the selected capture's `output_gain_db` audit baseline, re-seeding to the new capture's baseline when the user switches mic/position. Presets saved before the knob keep their audit loudness (the audio path resolves the per-capture baseline from the raw params; volume invariant #10).
 - **LV2** — Plugins externos open-source
 
 ### Native cab voicing (#620)


### PR DESCRIPTION
Closes #655.

## Problem

IR blocks applied the per-capture loudness-audit baseline (`output_gain_db`) as a hidden, fixed post-convolution gain. Resonant body IRs (acoustic/violão) get cut ~−14..−20 dB to tame a low-end resonance, so they land far too quiet with no way to bring them up.

## Change

Expose an absolute **Output** knob (dB, −24..+24) mirroring NAM. The `output_db` param IS the applied output level; its default is the selected capture's audit baseline.

- `crates/ir/src/from_package.rs` — `resolve_output_db(user, capture_audit, manifest_audit)`: the user param wins (even `0.0`); absent (legacy presets) falls back to the per-capture audit baseline. Wired into `build_from_package`.
- `crates/project/src/block/dispatch.rs` — synthesize an `output_db` `ParameterSpec` (Decibels, default = first-capture audit) for disk IR packages so the editor renders the knob.
- `crates/application/src/local_dispatcher_ir_reseed.rs` (new) + `local_dispatcher_block_param.rs` — on a capture-axis change, re-seed `output_db` to the newly selected capture's audit (never clobbers an `output_db` drag).
- `docs/blocks-catalog.md`.

## Regression safety (volume invariant #10)

The engine builds IR processors from the **raw saved params** (no normalization on the audio path), so presets saved before the knob existed keep their exact per-capture audit loudness. `loudness_audit` is untouched; no manifest re-normalization. Existing behavior is unchanged at default.

## Scope

Targets disk IR packages (the violão case with per-capture `output_gain_db`). The native `generic_ir` "load any WAV" model has no audit baseline and a separate build path — not in scope. Disk packages render the knob generically from the schema, so no `visual.rs`/`KnobLayoutEntry` change was needed.

## Verification

`cargo build --workspace` clean (zero warnings). Green: `ir`, `project`, `application`, `engine` (550/0 — **volume_invariants all pass**). New unit tests: `resolve_output_db` (5), `reseed_output_db_for_capture_change` (3), IR schema (2).