### PR TITLE
fix(gui): show chosen external DI loop file in the selector and keep it selectable

### DIFF
--- a/crates/adapter-gui/src/chain_row_wiring.rs
+++ b/crates/adapter-gui/src/chain_row_wiring.rs
@@ -19,7 +19,6 @@ use slint::{ComponentHandle, Timer, VecModel};
 
 use anyhow::Result;
 use application::command::Command;
-use application::di_loader::DiLoopSource;
 use application::dispatcher::CommandDispatcher;
 use domain::ids::ChainId;
 use infra_cpal::{AudioDeviceDescriptor, ProjectRuntimeController};
@@ -504,22 +503,35 @@ pub(crate) fn wire(window: &AppWindow, ctx: ChainRowCtx) {
         let project_session = project_session.clone();
         let toast_timer = toast_timer.clone();
         window.on_di_loop_source_selected(move |index, source_str| {
-            let Some(window) = weak_window.upgrade() else { return; };
+            let Some(window) = weak_window.upgrade() else {
+                return;
+            };
             let session_borrow = project_session.borrow();
             let Some(session) = session_borrow.as_ref() else {
-                set_status_error(&window, &toast_timer, &rust_i18n::t!("error-no-project-loaded"));
+                set_status_error(
+                    &window,
+                    &toast_timer,
+                    &rust_i18n::t!("error-no-project-loaded"),
+                );
                 return;
             };
             let chain_id = {
                 let proj = session.project.borrow();
-                let Some(chain) = proj.chains.get(index as usize) else { return; };
+                let Some(chain) = proj.chains.get(index as usize) else {
+                    return;
+                };
                 chain.id.clone()
             };
-            // Build bundled_ids from the chain's di_loop_sources model so the
-            // parse function can validate the selection. A Bundled source is
-            // one that isn't the sentinel; File sources come via the separate
-            // choose-file callback.
-            let source = DiLoopSource::Bundled(source_str.to_string());
+            // Bundled id → Bundled source; the file label of an already-loaded
+            // File (#661) → no-op (dispatcher already holds it). Sentinel is
+            // routed to choose-file by the ComboBox, never here.
+            let bundled_ids = crate::di_loop_ui_sources::bundled_di_loop_ids();
+            let bundled_refs: Vec<&str> = bundled_ids.iter().map(|s| s.as_str()).collect();
+            let Some(source) =
+                crate::di_loop_ui_sources::parse_di_loop_source(&source_str, &bundled_refs)
+            else {
+                return;
+            };
             let cmds = crate::di_loop_wiring::di_loop_commands(
                 chain_id,
                 crate::di_loop_wiring::DiLoopIntent::SelectSource { source },
@@ -546,10 +558,14 @@ pub(crate) fn wire(window: &AppWindow, ctx: ChainRowCtx) {
         let project_runtime = project_runtime.clone();
         window.on_di_loop_play(move |index| {
             let session_borrow = project_session.borrow();
-            let Some(session) = session_borrow.as_ref() else { return; };
+            let Some(session) = session_borrow.as_ref() else {
+                return;
+            };
             let chain_id = {
                 let proj = session.project.borrow();
-                let Some(chain) = proj.chains.get(index as usize) else { return; };
+                let Some(chain) = proj.chains.get(index as usize) else {
+                    return;
+                };
                 chain.id.clone()
             };
             crate::di_loop_wiring::play_chain_di_loop(
@@ -568,10 +584,14 @@ pub(crate) fn wire(window: &AppWindow, ctx: ChainRowCtx) {
         let project_runtime = project_runtime.clone();
         window.on_di_loop_stop(move |index| {
             let session_borrow = project_session.borrow();
-            let Some(session) = session_borrow.as_ref() else { return; };
+            let Some(session) = session_borrow.as_ref() else {
+                return;
+            };
             let chain_id = {
                 let proj = session.project.borrow();
-                let Some(chain) = proj.chains.get(index as usize) else { return; };
+                let Some(chain) = proj.chains.get(index as usize) else {
+                    return;
+                };
                 chain.id.clone()
             };
             crate::di_loop_wiring::stop_chain_di_loop(

--- a/crates/adapter-gui/src/di_loop_ui_sources.rs
+++ b/crates/adapter-gui/src/di_loop_ui_sources.rs
@@ -15,6 +15,8 @@
 //! Both functions are pure (no I/O, no Slint). Tested in
 //! `tests/issue_614_di_loop_ui_sources.rs`.
 
+use std::path::Path;
+
 use application::di_loader::DiLoopSource;
 
 /// The last entry in the ComboBox — signals "open the file picker".
@@ -62,20 +64,52 @@ pub fn build_di_loop_sources(bundled_ids: &[&str]) -> Vec<String> {
     result
 }
 
+/// Display label for a user-chosen [`DiLoopSource::File`] in the ComboBox —
+/// the file name with extension (e.g. `/x/ambience.wav` → `ambience.wav`),
+/// falling back to the full path string when there is no file name (#661).
+pub fn di_loop_file_label(path: &Path) -> String {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .map_or_else(|| path.to_string_lossy().into_owned(), |n| n.to_string())
+}
+
+/// Build the ComboBox source list including the currently loaded source.
+///
+/// Bundled ids first; then, when `loaded` is a [`DiLoopSource::File`], its
+/// [`di_loop_file_label`] (so the chosen file is visible and selectable);
+/// then [`CHOOSE_FILE_SENTINEL`] last. A `Bundled`/`None` `loaded` adds no
+/// extra entry (issue #661).
+pub fn build_di_loop_sources_with_loaded(
+    bundled_ids: &[&str],
+    loaded: Option<&DiLoopSource>,
+) -> Vec<String> {
+    let mut result: Vec<String> = bundled_ids.iter().map(|id| id.to_string()).collect();
+    if let Some(DiLoopSource::File(path)) = loaded {
+        let label = di_loop_file_label(path);
+        if !result.iter().any(|s| *s == label) {
+            result.push(label);
+        }
+    }
+    result.push(CHOOSE_FILE_SENTINEL.to_string());
+    result
+}
+
 /// Index of the currently selected `source` within the ComboBox `sources`
 /// list, or `-1` when it has no row to highlight (issue #661).
 ///
-/// A [`DiLoopSource::Bundled`] maps to the position of its id; an id not in
-/// the list (or a [`DiLoopSource::File`], which is never a bundled entry)
-/// yields `-1`. The `-1` sentinel matches Slint's `ComboBox.current-index`
-/// "nothing selected" convention.
+/// A [`DiLoopSource::Bundled`] maps to the position of its id; a
+/// [`DiLoopSource::File`] maps to the position of its [`di_loop_file_label`]
+/// (present only when the list was built via
+/// [`build_di_loop_sources_with_loaded`]). Anything not in the list yields
+/// `-1`, matching Slint's `ComboBox.current-index` "nothing selected" value.
 pub fn di_loop_selected_index(sources: &[String], source: &DiLoopSource) -> i32 {
-    let DiLoopSource::Bundled(id) = source else {
-        return -1;
+    let needle = match source {
+        DiLoopSource::Bundled(id) => id.clone(),
+        DiLoopSource::File(path) => di_loop_file_label(path),
     };
     sources
         .iter()
-        .position(|s| s == id)
+        .position(|s| *s == needle)
         .map_or(-1, |pos| pos as i32)
 }
 

--- a/crates/adapter-gui/src/meter_wiring.rs
+++ b/crates/adapter-gui/src/meter_wiring.rs
@@ -394,6 +394,11 @@ pub fn start_meter_polling(
     let last_signature: std::rc::Rc<
         std::cell::RefCell<std::collections::HashMap<domain::ids::ChainId, u64>>,
     > = std::rc::Rc::new(std::cell::RefCell::new(std::collections::HashMap::new()));
+    // #661: bundled DI loop ids are static for the session (the di-loops
+    // directory is scanned once on project load by `replace_project_chains`);
+    // cache them here so the per-tick source-list refresh never hits the
+    // filesystem.
+    let bundled_di_loop_ids = crate::di_loop_ui_sources::bundled_di_loop_ids();
     let timer = slint::Timer::default();
     timer.start(TimerMode::Repeated, TICK, move || {
         let session_borrow = project_session.borrow();
@@ -498,23 +503,44 @@ pub fn start_meter_polling(
             // reflects the engine's current armed/disarmed state.
             let di_playing_now = controller.chain_has_di_loop(&cid);
             let di_changed = row.di_loop_playing != di_playing_now;
-            // #661: re-derive the loaded source's row index from the
-            // dispatcher so the popup ComboBox highlights the active source
-            // when reopened (the popup is re-instantiated on each show).
-            let di_selected_now = match session.dispatcher.di_loop_source_for_chain(&cid) {
-                Some(source) => {
-                    let sources: Vec<String> =
-                        row.di_loop_sources.iter().map(|s| s.to_string()).collect();
-                    crate::di_loop_ui_sources::di_loop_selected_index(&sources, &source)
-                }
-                None => -1,
-            };
+            // #661: re-derive the loaded source from the dispatcher so the
+            // popup ComboBox (a) lists a user-chosen File as a labelled entry
+            // and (b) highlights the active source when reopened (the popup is
+            // re-instantiated on each show).
+            let loaded_source = session.dispatcher.di_loop_source_for_chain(&cid);
+            let bundled_refs: Vec<&str> = bundled_di_loop_ids.iter().map(|s| s.as_str()).collect();
+            let desired_sources = crate::di_loop_ui_sources::build_di_loop_sources_with_loaded(
+                &bundled_refs,
+                loaded_source.as_ref(),
+            );
+            let di_selected_now = loaded_source.as_ref().map_or(-1, |s| {
+                crate::di_loop_ui_sources::di_loop_selected_index(&desired_sources, s)
+            });
             let di_selected_changed = row.di_loop_selected_index != di_selected_now;
-            if aggregate_changed || stream_meters_changed || di_changed || di_selected_changed {
+            let di_sources_changed = {
+                let current: Vec<String> =
+                    row.di_loop_sources.iter().map(|s| s.to_string()).collect();
+                current != desired_sources
+            };
+            if aggregate_changed
+                || stream_meters_changed
+                || di_changed
+                || di_selected_changed
+                || di_sources_changed
+            {
                 row.meter_in_dbfs = in_db;
                 row.meter_out_dbfs = out_db;
                 if di_changed {
                     row.di_loop_playing = di_playing_now;
+                }
+                if di_sources_changed {
+                    row.di_loop_sources =
+                        slint::ModelRc::from(std::rc::Rc::new(slint::VecModel::from(
+                            desired_sources
+                                .into_iter()
+                                .map(slint::SharedString::from)
+                                .collect::<Vec<_>>(),
+                        )));
                 }
                 if di_selected_changed {
                     row.di_loop_selected_index = di_selected_now;

--- a/crates/adapter-gui/tests/issue_661_di_loop_file_source.rs
+++ b/crates/adapter-gui/tests/issue_661_di_loop_file_source.rs
@@ -1,0 +1,64 @@
+//! Issue #661 (follow-up) — RED-FIRST tests for representing a user-chosen
+//! `DiLoopSource::File` in the chain-tile ComboBox.
+//!
+//! A File source was previously unrepresentable in the source list, so after
+//! "Choose file…" the ComboBox kept showing the sentinel and `selected_index`
+//! was -1 (nothing highlighted). These helpers give the loaded File a labelled
+//! entry so the popup shows the chosen file and it can be (re)selected.
+
+use std::path::PathBuf;
+
+use application::di_loader::DiLoopSource;
+
+use adapter_gui::di_loop_ui_sources::{
+    build_di_loop_sources_with_loaded, di_loop_file_label, di_loop_selected_index,
+    CHOOSE_FILE_SENTINEL,
+};
+
+#[test]
+fn file_label_is_the_file_name_with_extension() {
+    let label = di_loop_file_label(&PathBuf::from("/Users/me/Desktop/ambience take.wav"));
+    assert_eq!(label, "ambience take.wav");
+}
+
+#[test]
+fn sources_with_loaded_file_inserts_label_before_sentinel() {
+    let loaded = DiLoopSource::File(PathBuf::from("/x/my_loop.wav"));
+    let sources = build_di_loop_sources_with_loaded(&["dry_1", "dry_2"], Some(&loaded));
+
+    assert_eq!(sources.len(), 4, "2 bundled + file label + sentinel");
+    assert_eq!(sources[0], "dry_1");
+    assert_eq!(sources[1], "dry_2");
+    assert_eq!(sources[2], "my_loop.wav");
+    assert_eq!(sources[3], CHOOSE_FILE_SENTINEL);
+}
+
+#[test]
+fn sources_with_no_file_loaded_is_just_bundled_plus_sentinel() {
+    let sources = build_di_loop_sources_with_loaded(&["dry_1"], None);
+    assert_eq!(
+        sources,
+        vec!["dry_1".to_string(), CHOOSE_FILE_SENTINEL.to_string()]
+    );
+}
+
+#[test]
+fn sources_with_bundled_loaded_does_not_add_a_file_label() {
+    let loaded = DiLoopSource::Bundled("dry_1".to_string());
+    let sources = build_di_loop_sources_with_loaded(&["dry_1"], Some(&loaded));
+    assert_eq!(
+        sources,
+        vec!["dry_1".to_string(), CHOOSE_FILE_SENTINEL.to_string()]
+    );
+}
+
+#[test]
+fn selected_index_points_at_the_loaded_file_label() {
+    let loaded = DiLoopSource::File(PathBuf::from("/x/my_loop.wav"));
+    let sources = build_di_loop_sources_with_loaded(&["dry_1", "dry_2"], Some(&loaded));
+    let idx = di_loop_selected_index(&sources, &loaded);
+    assert_eq!(
+        idx, 2,
+        "the file label sits at index 2 (after the 2 bundled ids)"
+    );
+}

--- a/crates/adapter-gui/tests/issue_661_di_loop_selected_index.rs
+++ b/crates/adapter-gui/tests/issue_661_di_loop_selected_index.rs
@@ -40,5 +40,8 @@ fn selected_index_file_source_returns_minus_one() {
         &sources,
         &DiLoopSource::File(std::path::PathBuf::from("/tmp/whatever.wav")),
     );
-    assert_eq!(idx, -1, "a File source is not represented in the bundled list");
+    assert_eq!(
+        idx, -1,
+        "a File source is not represented in the bundled list"
+    );
 }


### PR DESCRIPTION
Follow-up to #661 / #662. After "Choose file…" loads an external WAV (`DiLoopSource::File`), the chain-tile ComboBox kept showing the "Choose file…" sentinel — the chosen file was neither displayed as selected nor re-selectable, so the user couldn't tell it loaded and couldn't comfortably play it.

## Root cause

A `File` source has no entry in the ComboBox model (only bundled ids + sentinel), so `current-index` resolved to -1 and the selector showed nothing meaningful.

## Changes

- **adapter-gui (`di_loop_ui_sources`)**: `di_loop_file_label` + `build_di_loop_sources_with_loaded` insert the loaded File's name before the sentinel; `di_loop_selected_index` now maps a `File` to its label's position.
- **meter_wiring**: rebuild the per-chain source list from the dispatcher's loaded source each tick (bundled ids cached once) so a chosen File appears labelled + highlighted; selection index synced alongside `di_loop_playing`.
- **chain_row_wiring**: resolve the picked entry via `parse_di_loop_source` — re-selecting a file label is a no-op instead of a bogus `Bundled(label)` lookup.

Play itself was never File-specific (the runtime path is source-agnostic); making the file visible + selected restores a coherent, playable state.

## Tests (TDD red-first)

- `issue_661_di_loop_file_source.rs` (5) — file label, source-list-with-loaded (File/None/Bundled), File → index.
- No regression: `issue_614_*di_loop*` + `issue_661_di_loop_selected_index` green.

Closes #665

🤖 Generated with [Claude Code](https://claude.com/claude-code)
