### PR TITLE
fix(compact-view): refresh block list on preset switch (#667)

### DIFF
--- a/crates/adapter-gui/src/compact_chain_callbacks.rs
+++ b/crates/adapter-gui/src/compact_chain_callbacks.rs
@@ -279,9 +279,26 @@ pub(crate) fn wire(window: &AppWindow, ctx: CompactChainCallbacksCtx) {
         // dispatch path to keep in sync.
         {
             let weak_main = window.as_weak();
+            let weak_compact = compact_win.as_weak();
+            let project_session = project_session.clone();
             compact_win.on_switch_chain_preset(move |slot| {
-                if let Some(m) = weak_main.upgrade() {
-                    m.invoke_switch_chain_preset(chain_index, slot);
+                let Some(m) = weak_main.upgrade() else {
+                    return;
+                };
+                m.invoke_switch_chain_preset(chain_index, slot);
+                // #667: the switch mutates the project via the main window,
+                // but the compact view owns a separate `compact_blocks` model
+                // the main path never touches — re-project it here (same as
+                // the block-CRUD handlers do after every mutation), or the
+                // tone changes while the block list stays on the old preset.
+                let Some(cw) = weak_compact.upgrade() else {
+                    return;
+                };
+                let session_borrow = project_session.borrow();
+                if let Some(session) = session_borrow.as_ref() {
+                    let blocks =
+                        build_compact_blocks(&session.project.borrow(), chain_index as usize);
+                    cw.set_compact_blocks(ModelRc::from(Rc::new(VecModel::from(blocks))));
                 }
             });
         }

--- a/crates/adapter-gui/tests/compact_preset_switch_refreshes_blocks.rs
+++ b/crates/adapter-gui/tests/compact_preset_switch_refreshes_blocks.rs
@@ -28,8 +28,7 @@ use std::path::PathBuf;
 /// the file (which legitimately uses `set_compact_blocks`). A whole-file
 /// `contains` would therefore pass falsely.
 fn on_switch_chain_preset_closure() -> String {
-    let path =
-        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/compact_chain_callbacks.rs");
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/compact_chain_callbacks.rs");
     let src =
         std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
     let needle = "on_switch_chain_preset";

--- a/crates/adapter-gui/tests/compact_preset_switch_refreshes_blocks.rs
+++ b/crates/adapter-gui/tests/compact_preset_switch_refreshes_blocks.rs
@@ -1,0 +1,71 @@
+//! Issue #667: switching the chain preset from the **compact view** updates
+//! the audio (the project state changes, the tone changes) but leaves the
+//! compact block list showing the PREVIOUS preset's blocks.
+//!
+//! The `on_switch_chain_preset` wiring in `compact_chain_callbacks::wire`
+//! forwards to the main window via `invoke_switch_chain_preset` and stops —
+//! it never rebuilds this window's own `compact_blocks` model. The
+//! block-CRUD handlers (`compact_chain_block_handlers`,
+//! `compact_chain_param_handlers`) DO call `build_compact_blocks` +
+//! `set_compact_blocks` after every mutation, which is why insert/delete/
+//! reorder refresh the compact list but a preset switch does not.
+//!
+//! Same class as #614 ("dispatch alone is dead"): the command runs, the
+//! state changes, but the compact UI model is never re-projected.
+//!
+//! Source-presence wiring test, mirroring
+//! `compact_block_search_wiring_tests::compact_chain_callbacks_wires_on_search_block_model_to_refilter`.
+//! `compact_chain_callbacks.rs` already uses `set_compact_blocks` elsewhere
+//! (the model-search wiring), so the assertion is scoped to the
+//! `on_switch_chain_preset` closure body only — a whole-file `contains`
+//! would pass falsely.
+
+use std::path::PathBuf;
+
+/// The body of the `on_switch_chain_preset` closure: bounded from the handler
+/// registration to the next sibling header callback (`on_switch_chain_scene`),
+/// so the assertion can never bleed into the model-search wiring further down
+/// the file (which legitimately uses `set_compact_blocks`). A whole-file
+/// `contains` would therefore pass falsely.
+fn on_switch_chain_preset_closure() -> String {
+    let path =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/compact_chain_callbacks.rs");
+    let src =
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    let needle = "on_switch_chain_preset";
+    let start = src
+        .find(needle)
+        .unwrap_or_else(|| panic!("compact_chain_callbacks.rs has no `{needle}` handler"));
+    // The next header callback wired after the preset one; everything between
+    // is the preset closure (+ the #659 search-wiring line, which uses neither
+    // `build_compact_blocks` nor `set_compact_blocks`).
+    let rest = &src[start..];
+    let end = rest
+        .find("on_switch_chain_scene")
+        .unwrap_or_else(|| panic!("expected `on_switch_chain_scene` to follow the preset handler"));
+    rest[..end].to_string()
+}
+
+#[test]
+fn switching_preset_in_compact_view_rebuilds_the_compact_blocks_model() {
+    let closure = on_switch_chain_preset_closure();
+    assert!(
+        closure.contains("set_compact_blocks"),
+        "the `on_switch_chain_preset` wiring must rebuild this window's \
+         `compact_blocks` model after the preset switch (mirror the block \
+         handlers: `build_compact_blocks` + `set_compact_blocks`) — otherwise \
+         the audio changes but the compact block list stays on the previous \
+         preset (#667). Closure read:\n{closure}"
+    );
+}
+
+#[test]
+fn switching_preset_in_compact_view_reprojects_blocks_via_build_compact_blocks() {
+    let closure = on_switch_chain_preset_closure();
+    assert!(
+        closure.contains("build_compact_blocks"),
+        "the `on_switch_chain_preset` wiring must re-project the chain's blocks \
+         via `build_compact_blocks(project, chain_index)` before setting them \
+         on the compact window (#667). Closure read:\n{closure}"
+    );
+}

--- a/crates/adapter-gui/tests/issue_661_di_loop_selected_index.rs
+++ b/crates/adapter-gui/tests/issue_661_di_loop_selected_index.rs
@@ -40,5 +40,8 @@ fn selected_index_file_source_returns_minus_one() {
         &sources,
         &DiLoopSource::File(std::path::PathBuf::from("/tmp/whatever.wav")),
     );
-    assert_eq!(idx, -1, "a File source is not represented in the bundled list");
+    assert_eq!(
+        idx, -1,
+        "a File source is not represented in the bundled list"
+    );
 }


### PR DESCRIPTION
Fixes the compact view keeping the previous preset's blocks after a preset switch (audio changed, list didn't). Ref #667.

## Root cause
`compact_chain_callbacks::wire`'s `on_switch_chain_preset` only forwarded to the main window (`invoke_switch_chain_preset`) and stopped, never rebuilding this window's own `compact_blocks` model. The block-CRUD handlers already re-project via `build_compact_blocks` + `set_compact_blocks` after every mutation — preset switch was the gap. Same class as #614 ("dispatch alone is dead").

## Change
- `crates/adapter-gui/src/compact_chain_callbacks.rs` — after the switch, rebuild `compact_blocks` from the updated session inline (mirrors the block handlers).
- `crates/adapter-gui/tests/compact_preset_switch_refreshes_blocks.rs` — RED-first wiring test pinning that the preset-switch closure re-projects the compact blocks (scoped to the closure, source-presence style like the existing search-wiring test).
- `crates/adapter-gui/tests/issue_661_di_loop_selected_index.rs` — unrelated pre-existing rustfmt violation on develop, normalized to keep the gate green (surfaced while validating).

## Validation
- RED first: both wiring tests failed (closure only forwarded).
- After fix: target test green; `cargo test --workspace --lib` 261 passed / 0 failed; `cargo build -p adapter-gui` clean.
- Quality gate vs origin/develop: **passed** (fmt/lint/build/test/complexity/coverage all delta 0).

## Manual check
1. Open a chain's compact view → switch preset in the header → block list updates together with the tone.
2. Switch to a preset with a different block count → names/count match the new preset.
3. Insert/remove/reorder a block in compact → still refreshes (no regression).
4. Switch preset on the normal Chains screen → unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)