### PR TITLE
ci(#677): cache the quality-gate baseline build

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -54,6 +54,20 @@ jobs:
         with:
           shared-key: pr-quality
 
+      # #677: the gate measures the base (develop) from scratch every PR
+      # (`--force-full`). Without a cache for the separate `baseline/` checkout
+      # its `target/` is built clean each run — ~half the gate's wall-clock for
+      # a deterministic-per-SHA result. Cache the baseline workspace keyed by its
+      # own Cargo.lock (develop's at the base SHA), so consecutive PRs against the
+      # same develop reuse a warm baseline build. The full fix (feeding stored
+      # base metrics so the base is not re-measured at all) needs a
+      # `--baseline-metrics` feature in xgodev/quality-gate.
+      - name: Cache cargo (baseline build)
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: pr-quality-baseline
+          workspaces: baseline
+
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@v2
         with:


### PR DESCRIPTION
Closes #677.

## Problem
The PR gate runs `qg --force-full`, which measures the base (`develop`) from scratch on every PR — build + test + coverage. The `Swatinem/rust-cache` step caches only the PR workspace (`.`); the separate `baseline/` checkout has no `target/` cache, so develop is recompiled clean every run. That is ~half the gate wall-clock, repeated for a result that is deterministic per develop SHA.

## Change
Add a second `Swatinem/rust-cache@v2` step scoped to the `baseline` workspace (own `shared-key: pr-quality-baseline`). It keys on `baseline/Cargo.lock` (develop's lockfile at the base SHA), so consecutive PRs against the same develop reuse a warm baseline build instead of recompiling it clean.

Workflow-only change — no Rust diff, so no gate metric can regress.

## Not in scope (needs upstream)
The complete "persist the result, don't re-measure the base" fix requires a `--baseline-metrics <json>` feature in `xgodev/quality-gate`: run the gate on every `develop` push, store the metrics JSON keyed by SHA, and feed it to the PR gate so only the PR is measured. The current gate CLI (`--base` / `--baseline-dir` / `--refresh-baseline`) has no way to consume stored base metrics. Tracked in #677.

🤖 Generated with [Claude Code](https://claude.com/claude-code)