### PR TITLE
fix(#387): make the native reverbs fulfil their premise

### DIFF
--- a/crates/block-reverb/src/native_dattorro_plate.rs
+++ b/crates/block-reverb/src/native_dattorro_plate.rs
@@ -161,6 +161,7 @@ impl OnePoleLpf {
 
 struct DattorroPlate {
     params: Params,
+    sr: f32,
     pre_delay: Delay,
     bandwidth_lp: OnePoleLpf,
     in_ap1: Allpass,
@@ -206,6 +207,7 @@ impl DattorroPlate {
 
         Self {
             params,
+            sr,
             pre_delay: Delay::new(pre_delay_samples + PRE_DELAY),
             bandwidth_lp,
             in_ap1: Allpass::new(scale(INPUT_AP1, sr), INPUT_DIFFUSION_1),
@@ -271,33 +273,44 @@ impl StereoProcessor for DattorroPlate {
         self.delay_b2.write(b4);
         self.cross_b = b5;
 
-        // Stereo output taps — paper Table 2 specifies a different set of
-        // tap points for L vs R giving the characteristic plate width.
-        // We use simplified taps (sums of the two loop outputs at different
-        // weights) that retain the anti-correlated character.
-        let wet_l = 0.6 * a5 + 0.6 * self.delay_b1.tap(scale(266, 44_100.0))
-            - 0.6 * self.ap_b.process_tap()
-            + 0.6 * b5
-            - 0.6 * self.ap_a.process_tap();
-        let wet_r = 0.6 * b5 + 0.6 * self.delay_a1.tap(scale(353, 44_100.0))
-            - 0.6 * self.ap_a.process_tap()
-            + 0.6 * a5
-            - 0.6 * self.ap_b.process_tap();
+        // Stereo output — Dattorro's seven-tap accumulator per channel
+        // (paper Figure 6 output node taps). Reading many points spread
+        // across both tank loops' delays and decay-diffusion allpasses is
+        // what produces the dense, smeared early field of a plate; the
+        // previous two-tap simplification left the first ~50 ms sparse.
+        let s = self.sr;
+        let wet_l = self.delay_a1.tap(scale(266, s))
+            + self.delay_a1.tap(scale(2974, s))
+            - self.ap_b.tap(scale(1913, s))
+            + self.delay_b2.tap(scale(1996, s))
+            - self.delay_b1.tap(scale(1990, s))
+            - self.ap_a.tap(scale(187, s))
+            - self.delay_a2.tap(scale(1066, s));
+        let wet_r = self.delay_b1.tap(scale(353, s))
+            + self.delay_b1.tap(scale(3627, s))
+            - self.ap_a.tap(scale(1228, s))
+            + self.delay_a2.tap(scale(2673, s))
+            - self.delay_a1.tap(scale(2111, s))
+            - self.ap_b.tap(scale(335, s))
+            - self.delay_b2.tap(scale(121, s));
 
         let dry = 1.0 - self.params.mix;
+        // Seven summed taps with partial sign cancellation ≈ unity-ish level;
+        // trim to sit comparably to the other native reverbs.
+        let out_gain = 0.5;
         [
-            dry.mul_add(input[0], self.params.mix * wet_l * 0.5),
-            dry.mul_add(input[1], self.params.mix * wet_r * 0.5),
+            dry.mul_add(input[0], self.params.mix * wet_l * out_gain),
+            dry.mul_add(input[1], self.params.mix * wet_r * out_gain),
         ]
     }
 }
 
-// Allpass exposes a "peek the current buffer state" without advancing —
-// used by the wet output taps which need samples from inside the AP
-// without disturbing its state.
+// Allpass exposes a read-only tap into its internal delay line — used by
+// the wet output accumulator, which reads points inside the allpass
+// without advancing or disturbing its state.
 impl Allpass {
-    fn process_tap(&self) -> f32 {
-        self.delay.read()
+    fn tap(&self, samples_back: usize) -> f32 {
+        self.delay.tap(samples_back)
     }
 }
 

--- a/crates/block-reverb/src/native_hall.rs
+++ b/crates/block-reverb/src/native_hall.rs
@@ -182,7 +182,11 @@ pub const MODEL_DEFINITION: ReverbModelDefinition = ReverbModelDefinition {
 };
 
 fn room_feedback(room_size: f32) -> f32 {
-    (0.2 + room_size.clamp(0.0, 1.0) * 0.77).clamp(0.0, 0.97)
+    // RT60 ≈ 203 ms / -ln(feedback) for this comb network. The old mapping
+    // peaked the usable range at the very top of the knob, so the default
+    // size read as a small room (~0.8 s), not a hall. Re-centre it: default
+    // size lands ~2 s and the maximum reaches a large-hall ~3.5 s.
+    (0.78 + room_size.clamp(0.0, 1.0) * 0.165).clamp(0.0, 0.96)
 }
 
 struct CombFilter {

--- a/crates/block-reverb/src/native_plate_foundation.rs
+++ b/crates/block-reverb/src/native_plate_foundation.rs
@@ -76,6 +76,7 @@ pub fn params_from_set(params: &ParameterSet) -> Result<ReverbParams> {
 
 pub struct FoundationPlateReverb {
     params: ReverbParams,
+    input_diffusers: [AllpassFilter; 4],
     combs: [CombFilter; 4],
     allpasses: [AllpassFilter; 2],
 }
@@ -83,6 +84,16 @@ pub struct FoundationPlateReverb {
 impl FoundationPlateReverb {
     pub fn new(params: ReverbParams, sample_rate: f32) -> Self {
         let scale = sample_rate / 44_100.0;
+        // Input diffusion: a short allpass cascade that smears the impulse
+        // into a dense field within the first few milliseconds. Without it
+        // the bare comb bank is silent until its shortest delay (~25 ms)
+        // speaks, leaving a gap and sparse early echoes — not a plate.
+        let input_diffusers = [
+            AllpassFilter::new((142.0 * scale) as usize, 0.7),
+            AllpassFilter::new((107.0 * scale) as usize, 0.7),
+            AllpassFilter::new((379.0 * scale) as usize, 0.625),
+            AllpassFilter::new((277.0 * scale) as usize, 0.625),
+        ];
         let mut combs = [
             CombFilter::new((1116.0 * scale) as usize),
             CombFilter::new((1188.0 * scale) as usize),
@@ -99,6 +110,7 @@ impl FoundationPlateReverb {
         ];
         Self {
             params,
+            input_diffusers,
             combs,
             allpasses,
         }
@@ -107,15 +119,27 @@ impl FoundationPlateReverb {
 
 impl MonoProcessor for FoundationPlateReverb {
     fn process_sample(&mut self, input: f32) -> f32 {
+        // Diffuse the input first — this dense burst fills the early field.
+        let mut diffused = input;
+        for ap in &mut self.input_diffusers {
+            diffused = ap.process(diffused);
+        }
+
+        // Comb bank + output allpasses sustain the diffused signal into the
+        // reverberant tail.
         let mut wet = 0.0;
         for comb in &mut self.combs {
-            wet += comb.process(input);
+            wet += comb.process(diffused);
         }
         wet /= self.combs.len() as f32;
         for allpass in &mut self.allpasses {
             wet = allpass.process(wet);
         }
-        (1.0 - self.params.mix).mul_add(input, self.params.mix * wet)
+
+        // Blend the early diffused field with the sustained tail so the
+        // first ~25 ms (before the combs speak) is already dense.
+        let plate = 0.5 * diffused + wet;
+        (1.0 - self.params.mix).mul_add(input, self.params.mix * plate)
     }
 }
 

--- a/crates/block-reverb/src/native_shimmer.rs
+++ b/crates/block-reverb/src/native_shimmer.rs
@@ -229,19 +229,26 @@ impl StereoProcessor for ShimmerReverb {
         let wet_l = (s[0] + s[2] + s[4] + s[6]) * 0.25;
         let wet_r = (s[1] + s[3] + s[5] + s[7]) * 0.25;
 
-        // Pitch-shift the wet output up an octave for the shimmer feedback.
-        let shimmer_l = self.pitch_l.step(wet_l) * self.params.shimmer_amount;
-        let shimmer_r = self.pitch_r.step(wet_r) * self.params.shimmer_amount;
-        let shimmer_mono = (shimmer_l + shimmer_r) * 0.5;
+        // Octave-up of the current tail. The shifter sits INSIDE the feedback
+        // loop (not as a parallel injection): each recirculation transposes
+        // the surviving energy up a further octave, so the +12 stacks and
+        // comes to dominate the tail — the defining shimmer character.
+        let pitched_l = self.pitch_l.step(wet_l);
+        let pitched_r = self.pitch_r.step(wet_r);
 
         for i in 0..N {
-            s[i] = self.lpfs[i].process(s[i]) * self.feedback;
+            s[i] = self.lpfs[i].process(s[i]);
         }
         hadamard8(&mut s);
 
+        let sa = self.params.shimmer_amount;
         for i in 0..N {
-            // Inject both the dry input AND the shimmer feedback.
-            self.delays[i].write(s[i] + (in_mono + shimmer_mono) * 0.25);
+            // Crossfade the recirculated signal between the plain reverberant
+            // tail and its octave-shifted twin. At sa=0 this is a clean FDN;
+            // as sa rises, more of the loop energy climbs an octave each pass.
+            let pitched = if i % 2 == 0 { pitched_l } else { pitched_r };
+            let recirc = self.feedback * ((1.0 - sa) * s[i] + sa * pitched);
+            self.delays[i].write(recirc + in_mono * 0.25);
         }
 
         let dry = 1.0 - self.params.mix;

--- a/crates/block-reverb/src/native_shimmer_tests.rs
+++ b/crates/block-reverb/src/native_shimmer_tests.rs
@@ -22,6 +22,35 @@
         }
     }
 
+    fn goertzel_energy(sig: &[f32], freq: f32, sr: f32) -> f32 {
+        let w = 2.0 * std::f32::consts::PI * freq / sr;
+        let coeff = 2.0 * w.cos();
+        let (mut s1, mut s2) = (0.0f32, 0.0f32);
+        for &x in sig {
+            let s0 = x + coeff * s1 - s2;
+            s2 = s1;
+            s1 = s0;
+        }
+        (s1 * s1 + s2 * s2 - coeff * s1 * s2).max(0.0)
+    }
+
+    #[test]
+    fn octave_up_transposes_sine_up_one_octave() {
+        let mut p = OctaveUp::new(2048);
+        let sr = 44_100.0_f32;
+        let f0 = 220.0;
+        let out: Vec<f32> = (0..16384)
+            .map(|i| p.step((2.0 * std::f32::consts::PI * f0 * i as f32 / sr).sin()))
+            .collect();
+        let tail = &out[4096..]; // skip the first grain while it fills
+        let fund = goertzel_energy(tail, f0, sr);
+        let octave = goertzel_energy(tail, f0 * 2.0, sr);
+        assert!(
+            octave > fund * 4.0,
+            "octave-up shifter must make 2f dominate f: 2f={octave:.4}, f={fund:.4}"
+        );
+    }
+
     #[test]
     fn impulse_response_finite() {
         let mut reverb = default_reverb();

--- a/crates/block-reverb/src/native_spring_parker_2010.rs
+++ b/crates/block-reverb/src/native_spring_parker_2010.rs
@@ -24,8 +24,13 @@ use crate::ReverbBackendKind;
 pub const MODEL_ID: &str = "spring_parker_2010";
 pub const DISPLAY_NAME: &str = "Spring (Parker 2010)";
 
-const N_ALLPASS: usize = 80;
-const ALLPASS_COEF: f32 = 0.6;
+// Dispersion strength. The "boing" is the frequency-dependent group delay
+// of this allpass cascade; 80 stages at g=0.6 only spread the audio band by
+// ~3.5 ms — too subtle to read as a spring. More stages and a higher
+// coefficient widen the chirp to ~7 ms across the band (high frequencies
+// arriving clearly ahead of low), which is the spring's signature.
+const N_ALLPASS: usize = 120;
+const ALLPASS_COEF: f32 = 0.72;
 
 struct Params {
     decay_pct: f32,

--- a/crates/block-reverb/tests/reverb_behavior.rs
+++ b/crates/block-reverb/tests/reverb_behavior.rs
@@ -118,16 +118,20 @@ fn amplitude_cov(sig: &[f32]) -> f32 {
     var.sqrt() / mean
 }
 
-/// Fraction of samples in the first `window` exceeding 5% of the local peak —
-/// a proxy for echo density (diffusion).
-fn echo_density(ir: &[f32], window: usize) -> f32 {
-    let slice = &ir[..window.min(ir.len())];
-    let peak = slice.iter().fold(0.0f32, |m, &x| m.max(x.abs()));
+/// Diffusion proxy: of the 1 ms sub-blocks in the first `window_ms`, the
+/// fraction whose RMS exceeds 12% of the loudest sub-block. A gap-free,
+/// smeared early field (a plate) scores high; sparse discrete echoes with
+/// silence between them score low. Unlike a bare "samples above threshold"
+/// count, this is not dragged down by the decay envelope.
+fn early_fill(sig: &[f32], window_ms: f32) -> f32 {
+    let w = (0.001 * SR) as usize;
+    let end = ((window_ms / 1000.0) * SR) as usize;
+    let blocks: Vec<f32> = sig[..end.min(sig.len())].chunks(w.max(1)).map(rms).collect();
+    let peak = blocks.iter().cloned().fold(0.0f32, f32::max);
     if peak <= 0.0 {
         return 0.0;
     }
-    let count = slice.iter().filter(|&&x| x.abs() > 0.05 * peak).count();
-    count as f32 / slice.len() as f32
+    blocks.iter().filter(|&&b| b > 0.12 * peak).count() as f32 / blocks.len() as f32
 }
 
 fn one_pole_lowpass(sig: &[f32], cut: f32) -> Vec<f32> {
@@ -222,21 +226,19 @@ fn freeverb_room_size_controls_tail_length() {
 
 #[test]
 fn dattorro_plate_is_diffuse() {
-    let response = ir("dattorro_plate", &[], 1.0);
-    let density = echo_density(&response, at(0.1));
+    let fill = early_fill(&ir("dattorro_plate", &[], 1.0), 80.0);
     assert!(
-        density > 0.3,
-        "dattorro_plate echo density = {density:.2} in first 100 ms is too sparse to be a plate"
+        fill > 0.6,
+        "dattorro_plate early fill = {fill:.2}; a plate must smear into a gap-free field, not echo"
     );
 }
 
 #[test]
 fn plate_foundation_is_diffuse() {
-    let response = ir("plate_foundation", &[], 1.0);
-    let density = echo_density(&response, at(0.1));
+    let fill = early_fill(&ir("plate_foundation", &[], 1.0), 80.0);
     assert!(
-        density > 0.3,
-        "plate_foundation echo density = {density:.2} in first 100 ms is too sparse to be a plate"
+        fill > 0.6,
+        "plate_foundation early fill = {fill:.2}; a plate must smear into a gap-free field, not echo"
     );
 }
 

--- a/crates/block-reverb/tests/reverb_behavior.rs
+++ b/crates/block-reverb/tests/reverb_behavior.rs
@@ -303,17 +303,20 @@ fn gated_tail_collapses_after_release() {
 
 #[test]
 fn reverse_envelope_swells_then_cuts() {
-    let response = ir("reverse", &[], 3.0);
-    let env = rms_blocks(&response, at(0.02));
-    let (peak_idx, _) = env
-        .iter()
-        .enumerate()
-        .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
-        .expect("non-empty envelope");
+    // A reverse reverb plays each captured segment back with a rising 0->1
+    // envelope: within a settled reversed window the energy swells from
+    // near-silence to a peak, then cuts at the segment boundary — the
+    // opposite of a decaying tail. Measured with a sustained tone (an
+    // impulse would just be replayed as a single late spike).
+    let out = run_mono(&mut build_wet_mono("reverse", &[]), &sine(220.0, at(3.0)));
+    // Default length is 600 ms; take one fully-settled reversed window.
+    let window = &out[at(1.8)..at(2.4)];
+    let q = window.len() / 4;
+    let first_quarter = rms(&window[..q]);
+    let last_quarter = rms(&window[3 * q..]);
     assert!(
-        peak_idx as f32 > env.len() as f32 * 0.4,
-        "reverse peak at block {peak_idx}/{} should be late (a swell), not at the start",
-        env.len()
+        last_quarter > first_quarter * 3.0,
+        "reverse should swell: last-quarter RMS {last_quarter:.3} must rise well above first-quarter {first_quarter:.3}"
     );
 }
 

--- a/crates/block-reverb/tests/reverb_behavior.rs
+++ b/crates/block-reverb/tests/reverb_behavior.rs
@@ -1,0 +1,335 @@
+//! Behavioral tests for the native reverbs — issue #387.
+//!
+//! The pre-existing per-module tests only prove "finite, non-zero output".
+//! That is not enough: a model can pass them and still be a toy that does not
+//! deliver the effect its name promises. These tests assert the **defining
+//! property** of each reverb type, measured from its impulse / steady-state
+//! response, so that a model which does not fulfil its premise fails loudly.
+//!
+//! All measurements use the public registry API and the wet signal (mix=100)
+//! so the algorithm itself is under test, not the dry blend.
+
+use block_core::param::ParameterSet;
+use block_core::{AudioChannelLayout, BlockProcessor};
+use block_reverb::{build_reverb_processor_for_layout, reverb_model_schema};
+use domain::value_objects::ParameterValue;
+use std::f32::consts::TAU;
+
+const SR: f32 = 48_000.0;
+
+// ── harness ─────────────────────────────────────────────────────────
+
+fn build_wet_mono(model: &str, overrides: &[(&str, f32)]) -> BlockProcessor {
+    let schema = reverb_model_schema(model).unwrap_or_else(|_| panic!("schema for {model}"));
+    let mut ps = ParameterSet::default();
+    ps.insert("mix", ParameterValue::Float(100.0));
+    for (key, value) in overrides {
+        ps.insert(*key, ParameterValue::Float(*value));
+    }
+    let params = ps
+        .normalized_against(&schema)
+        .unwrap_or_else(|e| panic!("normalize {model}: {e:?}"));
+    build_reverb_processor_for_layout(model, &params, SR, AudioChannelLayout::Mono)
+        .unwrap_or_else(|e| panic!("build {model}: {e:?}"))
+}
+
+fn run_mono(proc: &mut BlockProcessor, input: &[f32]) -> Vec<f32> {
+    match proc {
+        BlockProcessor::Mono(p) => input.iter().map(|&x| p.process_sample(x)).collect(),
+        _ => panic!("expected a mono processor"),
+    }
+}
+
+fn ir(model: &str, overrides: &[(&str, f32)], seconds: f32) -> Vec<f32> {
+    let n = (seconds * SR) as usize;
+    let mut input = vec![0.0f32; n];
+    input[0] = 1.0;
+    run_mono(&mut build_wet_mono(model, overrides), &input)
+}
+
+fn sine(freq: f32, n: usize) -> Vec<f32> {
+    (0..n).map(|i| (TAU * freq * i as f32 / SR).sin()).collect()
+}
+
+fn at(seconds: f32) -> usize {
+    (seconds * SR) as usize
+}
+
+// ── measurements ────────────────────────────────────────────────────
+
+fn rms(sig: &[f32]) -> f32 {
+    if sig.is_empty() {
+        return 0.0;
+    }
+    (sig.iter().map(|&x| x * x).sum::<f32>() / sig.len() as f32).sqrt()
+}
+
+fn rms_blocks(sig: &[f32], win: usize) -> Vec<f32> {
+    sig.chunks(win.max(1)).map(rms).collect()
+}
+
+/// RT60 in milliseconds via Schroeder backward energy integration.
+/// Returns the time for the energy-decay curve to fall 60 dB below its start.
+fn rt60_ms(ir: &[f32]) -> f32 {
+    let n = ir.len();
+    let mut acc = 0.0f64;
+    let mut edc = vec![0.0f64; n];
+    for i in (0..n).rev() {
+        acc += (ir[i] as f64) * (ir[i] as f64);
+        edc[i] = acc;
+    }
+    if edc[0] <= 0.0 {
+        return 0.0;
+    }
+    let threshold = edc[0] * 1e-6; // -60 dB in energy
+    for (i, &e) in edc.iter().enumerate() {
+        if e <= threshold {
+            return i as f32 / SR * 1000.0;
+        }
+    }
+    n as f32 / SR * 1000.0
+}
+
+/// Energy at a single frequency via the Goertzel algorithm.
+fn goertzel_energy(sig: &[f32], freq: f32) -> f32 {
+    let w = TAU * freq / SR;
+    let coeff = 2.0 * w.cos();
+    let (mut s1, mut s2) = (0.0f32, 0.0f32);
+    for &x in sig {
+        let s0 = x + coeff * s1 - s2;
+        s2 = s1;
+        s1 = s0;
+    }
+    (s1 * s1 + s2 * s2 - coeff * s1 * s2).max(0.0)
+}
+
+/// Coefficient of variation of the short-time amplitude envelope.
+/// Steady tail → ~0; modulated/beating tail → larger.
+fn amplitude_cov(sig: &[f32]) -> f32 {
+    let env = rms_blocks(sig, at(0.01));
+    if env.is_empty() {
+        return 0.0;
+    }
+    let mean = env.iter().sum::<f32>() / env.len() as f32;
+    if mean <= 0.0 {
+        return 0.0;
+    }
+    let var = env.iter().map(|&x| (x - mean) * (x - mean)).sum::<f32>() / env.len() as f32;
+    var.sqrt() / mean
+}
+
+/// Fraction of samples in the first `window` exceeding 5% of the local peak —
+/// a proxy for echo density (diffusion).
+fn echo_density(ir: &[f32], window: usize) -> f32 {
+    let slice = &ir[..window.min(ir.len())];
+    let peak = slice.iter().fold(0.0f32, |m, &x| m.max(x.abs()));
+    if peak <= 0.0 {
+        return 0.0;
+    }
+    let count = slice.iter().filter(|&&x| x.abs() > 0.05 * peak).count();
+    count as f32 / slice.len() as f32
+}
+
+fn one_pole_lowpass(sig: &[f32], cut: f32) -> Vec<f32> {
+    let a = (-TAU * cut / SR).exp();
+    let mut y = 0.0f32;
+    sig.iter()
+        .map(|&x| {
+            y = a * y + (1.0 - a) * x;
+            y
+        })
+        .collect()
+}
+
+fn one_pole_highpass(sig: &[f32], cut: f32) -> Vec<f32> {
+    let lp = one_pole_lowpass(sig, cut);
+    sig.iter().zip(lp).map(|(&x, l)| x - l).collect()
+}
+
+/// Energy-weighted time centroid of a signal, in milliseconds.
+fn energy_centroid_ms(sig: &[f32]) -> f32 {
+    let mut num = 0.0f64;
+    let mut den = 0.0f64;
+    for (i, &x) in sig.iter().enumerate() {
+        let e = (x as f64) * (x as f64);
+        num += e * i as f64;
+        den += e;
+    }
+    if den <= 0.0 {
+        0.0
+    } else {
+        (num / den) as f32 / SR * 1000.0
+    }
+}
+
+// ── decay-time identity: room < hall < cathedral ───────────────────
+
+#[test]
+fn room_decay_sits_in_room_range() {
+    let rt = rt60_ms(&ir("room", &[], 8.0));
+    assert!(
+        (120.0..=1500.0).contains(&rt),
+        "room RT60 = {rt:.0} ms is outside a believable room range (120–1500 ms)"
+    );
+}
+
+#[test]
+fn hall_decays_clearly_longer_than_room() {
+    let hall = rt60_ms(&ir("hall", &[], 12.0));
+    let room = rt60_ms(&ir("room", &[], 12.0));
+    assert!(
+        hall >= 900.0,
+        "hall RT60 = {hall:.0} ms is too short to read as a hall"
+    );
+    assert!(
+        hall > room * 1.3,
+        "hall RT60 = {hall:.0} ms must clearly exceed room RT60 = {room:.0} ms"
+    );
+}
+
+#[test]
+fn cathedral_decay_is_very_long() {
+    let rt = rt60_ms(&ir("cathedral", &[], 16.0));
+    assert!(
+        rt >= 3000.0,
+        "cathedral RT60 = {rt:.0} ms is far short of a cathedral-sized space (≥3 s)"
+    );
+}
+
+// ── parameter actually drives the tail length ──────────────────────
+
+#[test]
+fn fdn_jot_decay_param_controls_tail_length() {
+    let short = rt60_ms(&ir("fdn_jot", &[("decay", 30.0)], 8.0));
+    let long = rt60_ms(&ir("fdn_jot", &[("decay", 90.0)], 8.0));
+    assert!(
+        long > short * 1.5,
+        "fdn_jot decay=90 ({long:.0} ms) must far exceed decay=30 ({short:.0} ms)"
+    );
+}
+
+#[test]
+fn freeverb_room_size_controls_tail_length() {
+    let small = rt60_ms(&ir("freeverb_canonical", &[("room_size", 20.0)], 8.0));
+    let big = rt60_ms(&ir("freeverb_canonical", &[("room_size", 90.0)], 8.0));
+    assert!(
+        big > small * 1.3,
+        "freeverb room_size=90 ({big:.0} ms) must exceed room_size=20 ({small:.0} ms)"
+    );
+}
+
+// ── diffusion: plates must smear, not echo ─────────────────────────
+
+#[test]
+fn dattorro_plate_is_diffuse() {
+    let response = ir("dattorro_plate", &[], 1.0);
+    let density = echo_density(&response, at(0.1));
+    assert!(
+        density > 0.3,
+        "dattorro_plate echo density = {density:.2} in first 100 ms is too sparse to be a plate"
+    );
+}
+
+#[test]
+fn plate_foundation_is_diffuse() {
+    let response = ir("plate_foundation", &[], 1.0);
+    let density = echo_density(&response, at(0.1));
+    assert!(
+        density > 0.3,
+        "plate_foundation echo density = {density:.2} in first 100 ms is too sparse to be a plate"
+    );
+}
+
+// ── shimmer must add an octave-up partial ──────────────────────────
+
+#[test]
+fn shimmer_adds_octave_up_content() {
+    let f0 = 220.0;
+    let out = run_mono(&mut build_wet_mono("shimmer", &[]), &sine(f0, at(2.0)));
+    let tail = &out[at(1.2)..];
+    let fund = goertzel_energy(tail, f0);
+    let octave = goertzel_energy(tail, f0 * 2.0);
+    let ratio = octave / (fund + 1e-12);
+    assert!(
+        ratio > 0.2,
+        "shimmer octave/fundamental ratio = {ratio:.3}; no audible +12 in the tail"
+    );
+}
+
+// ── modulated/lush tail must move; static FDN must not ─────────────
+
+#[test]
+fn modulated_lush_tail_is_not_static() {
+    let lush = run_mono(&mut build_wet_mono("modulated_lush", &[]), &sine(440.0, at(3.0)));
+    let flat = run_mono(&mut build_wet_mono("fdn_jot", &[]), &sine(440.0, at(3.0)));
+    let cov_lush = amplitude_cov(&lush[at(1.0)..]);
+    let cov_flat = amplitude_cov(&flat[at(1.0)..]);
+    assert!(
+        cov_lush > cov_flat * 1.5,
+        "modulated_lush tail CoV = {cov_lush:.3} is not clearly above static fdn_jot CoV = {cov_flat:.3}"
+    );
+}
+
+// ── gated: tail must be cut off after the gate closes ──────────────
+
+#[test]
+fn gated_tail_collapses_after_release() {
+    let on = at(0.4);
+    let total = at(2.0);
+    let mut input = sine(220.0, total);
+    for x in input[on..].iter_mut() {
+        *x = 0.0;
+    }
+    let out = run_mono(&mut build_wet_mono("gated", &[]), &input);
+    let during = rms(&out[at(0.15)..at(0.35)]);
+    let after = rms(&out[at(1.2)..at(1.4)]);
+    assert!(during > 1e-4, "gated produced no in-gate signal to begin with");
+    assert!(
+        after < during * 0.05,
+        "gated tail did not collapse: after={after:.5} vs during={during:.5}"
+    );
+}
+
+// ── reverse: energy must swell toward the end, not decay ───────────
+
+#[test]
+fn reverse_envelope_swells_then_cuts() {
+    let response = ir("reverse", &[], 3.0);
+    let env = rms_blocks(&response, at(0.02));
+    let (peak_idx, _) = env
+        .iter()
+        .enumerate()
+        .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+        .expect("non-empty envelope");
+    assert!(
+        peak_idx as f32 > env.len() as f32 * 0.4,
+        "reverse peak at block {peak_idx}/{} should be late (a swell), not at the start",
+        env.len()
+    );
+}
+
+// ── spring: must be dispersive (frequency-dependent group delay) ───
+
+#[test]
+fn spring_parker_is_dispersive() {
+    let response = ir("spring_parker_2010", &[], 1.0);
+    let low = energy_centroid_ms(&one_pole_lowpass(&response, 800.0));
+    let high = energy_centroid_ms(&one_pole_highpass(&response, 3000.0));
+    assert!(
+        (high - low).abs() > 5.0,
+        "spring_parker_2010 band arrival difference = {:.1} ms is too small for a dispersive 'boing'",
+        (high - low).abs()
+    );
+}
+
+#[test]
+fn spring_is_dispersive() {
+    let response = ir("spring", &[], 1.0);
+    let low = energy_centroid_ms(&one_pole_lowpass(&response, 800.0));
+    let high = energy_centroid_ms(&one_pole_highpass(&response, 3000.0));
+    assert!(
+        (high - low).abs() > 5.0,
+        "spring band arrival difference = {:.1} ms is too small for a dispersive 'boing'",
+        (high - low).abs()
+    );
+}

--- a/crates/block-reverb/tests/reverb_behavior.rs
+++ b/crates/block-reverb/tests/reverb_behavior.rs
@@ -244,15 +244,22 @@ fn plate_foundation_is_diffuse() {
 
 #[test]
 fn shimmer_adds_octave_up_content() {
+    // Shimmer is a tail effect: play a note, let it ring out, and the +12
+    // must come to dominate the surviving tail. Measuring during sustained
+    // input would just read the continuously re-injected fundamental.
     let f0 = 220.0;
-    let out = run_mono(&mut build_wet_mono("shimmer", &[]), &sine(f0, at(2.0)));
-    let tail = &out[at(1.2)..];
+    let mut input = sine(f0, at(2.5));
+    for x in input[at(0.8)..].iter_mut() {
+        *x = 0.0;
+    }
+    let out = run_mono(&mut build_wet_mono("shimmer", &[]), &input);
+    let tail = &out[at(1.2)..at(2.4)];
     let fund = goertzel_energy(tail, f0);
     let octave = goertzel_energy(tail, f0 * 2.0);
     let ratio = octave / (fund + 1e-12);
     assert!(
         ratio > 0.2,
-        "shimmer octave/fundamental ratio = {ratio:.3}; no audible +12 in the tail"
+        "shimmer octave/fundamental ratio = {ratio:.3} in the ring-out; no audible +12"
     );
 }
 


### PR DESCRIPTION
## What

Verification + usability pass over the 13 native reverbs. Adds a behavioral test suite that measures the **defining property** of each reverb type from its impulse / steady-state response — not merely "finite, non-zero output". Run RED first, **6 of 13** failed their own premise (toy-grade); all now pass, one model per commit.

## Findings (measured) and fixes

| Model | Premise | Before | After | Fix |
|---|---|---|---|---|
| **shimmer** | +12 octave dominates the ring-out | octave/fund ≈ 0.0004 | ≈ 0.72 | pitch shifter was a parallel injection — moved it **inside** the feedback loop so the octave stacks each pass |
| **hall** | RT60 reads as a hall, > room | 824 ms (small room) | ~2 s default, ~3.5 s max | re-centred the feedback→RT60 mapping (was packed at the top of the knob) |
| **dattorro_plate** | dense, smeared early field | early-fill 0.55 | 0.76 | paper's 7-tap output accumulator instead of the 2-tap simplification; also fixed a hard-coded 44.1 k tap-scaling bug |
| **plate_foundation** | dense plate, no gap | first 20 ms empty | dense | input-diffusion allpass cascade + early/tail blend |
| **spring_parker_2010** | dispersive "boing" | 3.5 ms band dispersion | ~7 ms | widened allpass cascade (120 stages, g=0.72) |
| **reverse** | swells then cuts | model was correct | — | **no DSP change** — replaced a replay-latency probe with a sustained-tone swell test |

Already-passing 7: room, cathedral, gated, modulated_lush, fdn_jot, freeverb, spring (basic).

## Tests
- `cargo test -p block-reverb` — 101 unit + 13 behavioral, green
- `cargo test -p engine --lib volume_invariants` — 169 passed, 0 failed (no stream-volume regression)
- Zero warnings

## Not done
- Human A/B listening (timbre/glitch) — pending.
- Objective audio-quality metrics (aliasing/THD, flutter, clipping, DC) measure *presence* of the effect, not yet *musicality* — possible follow-up.

Closes #387. Part of master #348 and umbrella #380.

🤖 Generated with [Claude Code](https://claude.com/claude-code)