### PR TITLE
test(#688): zero the 8 test-code warnings + reactivate 12 ignored tests + enable Oversampler2x doctest

### DIFF
--- a/crates/block-amp/src/lib_tests.rs
+++ b/crates/block-amp/src/lib_tests.rs
@@ -258,7 +258,6 @@ fn registry_process_native_stereo_block_1024_sine_all_finite() {
 // ── non-native models: build requires external assets, skip ──────
 
 #[test]
-#[ignore]
 fn registry_build_non_native_models_ignored() {
     for model in supported_models().iter().filter(|m| !is_native(m)) {
         let params = defaults_for(model);

--- a/crates/block-body/src/lib_tests.rs
+++ b/crates/block-body/src/lib_tests.rs
@@ -7,7 +7,6 @@ use block_core::param::ParameterSet;
 use block_core::AudioChannelLayout;
 
 #[test]
-#[ignore]
 fn supported_bodies_expose_valid_schema() {
     for model in supported_models() {
         let schema = body_model_schema(model).expect("body schema should exist");
@@ -20,7 +19,6 @@ fn supported_bodies_expose_valid_schema() {
 }
 
 #[test]
-#[ignore]
 fn supported_bodies_build_for_mono_chains() {
     for model in supported_models() {
         let schema = body_model_schema(model).expect("schema should exist");
@@ -226,7 +224,6 @@ fn unknown_model_returns_error_for_asset_summary() {
 }
 
 #[test]
-#[ignore]
 fn unknown_model_returns_error_for_build() {
     let result = build_body_processor_for_layout(
         "nonexistent_body_model_xyz",

--- a/crates/block-cab/src/lib_tests.rs
+++ b/crates/block-cab/src/lib_tests.rs
@@ -6,7 +6,6 @@ use block_core::param::ParameterSet;
 use block_core::AudioChannelLayout;
 
 #[test]
-#[ignore]
 fn supported_cabs_expose_valid_schema() {
     for model in supported_models() {
         let schema = cab_model_schema(model).expect("cab schema should exist");
@@ -19,7 +18,6 @@ fn supported_cabs_expose_valid_schema() {
 }
 
 #[test]
-#[ignore]
 fn supported_cabs_build_for_mono_chains() {
     for model in supported_models() {
         let schema = cab_model_schema(model).expect("schema should exist");

--- a/crates/block-core/src/dsp/oversampling.rs
+++ b/crates/block-core/src/dsp/oversampling.rs
@@ -54,15 +54,27 @@ fn build_hbf() -> [f32; HBF_LEN] {
 
 /// 2× oversampler. Use as:
 ///
-/// ```ignore
+/// ```
+/// use block_core::dsp::oversampling::Oversampler2x;
+///
+/// // The non-linearity you want to run alias-free (any saturator/clipper).
+/// fn saturate(x: f32) -> f32 {
+///     x.tanh()
+/// }
+///
+/// let input = [0.0_f32, 0.25, -0.5, 0.75, -1.0];
+/// let mut output = Vec::with_capacity(input.len());
+///
 /// let mut os = Oversampler2x::new();
-/// for &x in input {
+/// for &x in &input {
 ///     let [a, b] = os.up(x);          // 2 samples at 2 fs
 ///     let a2 = saturate(a);            // non-linear processing
 ///     let b2 = saturate(b);
 ///     let y = os.down([a2, b2]);       // back to fs, anti-aliased
 ///     output.push(y);
 /// }
+///
+/// assert_eq!(output.len(), input.len());
 /// ```
 pub struct Oversampler2x {
     taps: [f32; HBF_LEN],

--- a/crates/block-gain/src/lib_tests.rs
+++ b/crates/block-gain/src/lib_tests.rs
@@ -187,7 +187,6 @@ fn registry_process_native_mono_signal_produces_non_nan() {
 // ── non-native models: build requires external assets, skip ──────
 
 #[test]
-#[ignore]
 fn registry_build_non_native_models_ignored() {
     for model in supported_models().iter().filter(|m| !is_native(m)) {
         let params = defaults_for(model);

--- a/crates/block-pitch/src/lib_tests.rs
+++ b/crates/block-pitch/src/lib_tests.rs
@@ -67,7 +67,6 @@ fn registry_schema_defaults_normalize_for_all_models() {
 // ── LV2 models: build requires external plugins, skip ───────────
 
 #[test]
-#[ignore]
 fn registry_build_lv2_models_ignored() {
     for model in supported_models() {
         let params = defaults_for(model);

--- a/crates/block-preamp/src/lib_tests.rs
+++ b/crates/block-preamp/src/lib_tests.rs
@@ -267,7 +267,6 @@ fn registry_process_native_stereo_block_1024_sine_all_finite() {
 // ── non-native models: build requires external assets, skip ──────
 
 #[test]
-#[ignore]
 fn registry_build_non_native_models_ignored() {
     for model in supported_models().iter().filter(|m| !is_native(m)) {
         let params = defaults_for(model);

--- a/crates/engine/src/runtime_tests.rs
+++ b/crates/engine/src/runtime_tests.rs
@@ -1957,7 +1957,7 @@ fn insert_chain() -> Chain {
 #[test]
 fn effective_inputs_includes_insert_return() {
     let chain = insert_chain();
-    let (eff_inputs, cpal_indices, split_positions) = effective_inputs(&chain);
+    let (eff_inputs, cpal_indices, _split_positions) = effective_inputs(&chain);
     // Should have: 1 regular input + 1 insert return = 2
     assert_eq!(eff_inputs.len(), 2);
     assert_eq!(cpal_indices.len(), 2);
@@ -2053,7 +2053,7 @@ fn effective_inputs_splits_mono_multichannel_entry() {
             }),
         }],
     };
-    let (eff_inputs, cpal_indices, split_positions) = effective_inputs(&chain);
+    let (eff_inputs, cpal_indices, _split_positions) = effective_inputs(&chain);
     assert_eq!(
         eff_inputs.len(),
         3,
@@ -2079,7 +2079,7 @@ fn effective_inputs_fallback_when_no_input_blocks() {
         volume: 100.0,
         blocks: vec![],
     };
-    let (eff_inputs, cpal_indices, split_positions) = effective_inputs(&chain);
+    let (eff_inputs, cpal_indices, _split_positions) = effective_inputs(&chain);
     assert_eq!(
         eff_inputs.len(),
         1,
@@ -2847,7 +2847,7 @@ fn effective_inputs_multiple_input_blocks() {
             },
         ],
     };
-    let (eff_inputs, cpal_indices, split_positions) = effective_inputs(&chain);
+    let (eff_inputs, cpal_indices, _split_positions) = effective_inputs(&chain);
     assert_eq!(eff_inputs.len(), 2);
     assert_eq!(eff_inputs[0].device_id.0, "dev1");
     assert_eq!(eff_inputs[1].device_id.0, "dev2");
@@ -2885,7 +2885,7 @@ fn effective_inputs_same_device_shares_cpal_index() {
             }),
         }],
     };
-    let (eff_inputs, cpal_indices, split_positions) = effective_inputs(&chain);
+    let (eff_inputs, cpal_indices, _split_positions) = effective_inputs(&chain);
     assert_eq!(eff_inputs.len(), 2);
     assert_eq!(
         cpal_indices[0], cpal_indices[1],

--- a/crates/infra-cpal/src/tests.rs
+++ b/crates/infra-cpal/src/tests.rs
@@ -13,7 +13,7 @@ use super::stream_config::{
 use super::stream_config::{max_supported_channels, required_channel_count};
 #[cfg(not(all(target_os = "linux", feature = "jack")))]
 use super::validation::validate_buffer_size;
-use super::{AudioDeviceDescriptor, ProjectRuntimeController};
+use super::AudioDeviceDescriptor;
 use cpal::BufferSize;
 #[cfg(not(all(target_os = "linux", feature = "jack")))]
 use cpal::{SampleFormat, SupportedBufferSize, SupportedStreamConfigRange};

--- a/crates/infra-yaml/src/lib_tests.rs
+++ b/crates/infra-yaml/src/lib_tests.rs
@@ -4,8 +4,7 @@
 //! the original 4-space indent so raw-string YAML literals stay intact.
 
 use super::{
-    load_chain_preset_file, save_chain_preset_file, serialize_project, ChainBlocksPreset,
-    YamlProjectRepository,
+    load_chain_preset_file, save_chain_preset_file, ChainBlocksPreset, YamlProjectRepository,
 };
 use domain::ids::{BlockId, ChainId, DeviceId};
 use project::block::{
@@ -18,7 +17,6 @@ use project::project::Project;
 use std::fs;
 use std::path::PathBuf;
 use tempfile::tempdir;
-use tempfile::TempDir;
 
 #[test]
 fn save_project_creates_yaml_that_roundtrips_basic_project() {

--- a/crates/infra-yaml/src/lib_tests.rs
+++ b/crates/infra-yaml/src/lib_tests.rs
@@ -566,12 +566,6 @@ fn roundtrip_pitch_block_preserves_type_and_model() {
 }
 
 #[test]
-#[ignore = "block-util crate is empty (utility blocks promoted to top-bar features in #320)"]
-fn roundtrip_utility_block_preserves_type_and_model() {
-    assert_core_roundtrip("utility", first_model(block_util::supported_models()));
-}
-
-#[test]
 fn roundtrip_ir_block_serializes_and_deserializes_yaml() {
     use domain::value_objects::ParameterValue;
     // IR normalization validates the file exists on disk, so we only test

--- a/crates/nam/src/lib_tests.rs
+++ b/crates/nam/src/lib_tests.rs
@@ -244,7 +244,6 @@ fn params_from_set_null_ir_path_returns_none() {
 // ── build_processor (requires NAM lib) ──────────────────────────
 
 #[test]
-#[ignore]
 fn build_processor_nonexistent_model_returns_error() {
     let mut ps = ParameterSet::default();
     ps.insert(
@@ -258,7 +257,6 @@ fn build_processor_nonexistent_model_returns_error() {
 // ── build_processor_for_layout stereo rejection ─────────────────
 
 #[test]
-#[ignore]
 fn build_processor_for_layout_stereo_returns_error() {
     let mut ps = ParameterSet::default();
     ps.insert(

--- a/crates/project/src/block_tests.rs
+++ b/crates/project/src/block_tests.rs
@@ -12,7 +12,6 @@ use crate::param::ParameterSet;
 use domain::ids::{BlockId, DeviceId};
 
 #[test]
-#[ignore] // cab:roland_jc_120_cab returns empty schema — needs fix
 fn project_contract_exposes_family_schemas() {
     let families = [
         ("preamp", block_preamp::supported_models()),

--- a/crates/project/src/catalog_tests.rs
+++ b/crates/project/src/catalog_tests.rs
@@ -333,13 +333,6 @@ fn model_stream_kind_non_utility_returns_empty() {
     assert_eq!(super::model_stream_kind("preamp", "american_clean"), "");
 }
 
-#[test]
-#[ignore = "block-util crate is empty (utility blocks promoted to top-bar features in #320)"]
-fn model_stream_kind_utility_returns_value() {
-    let model = block_util::supported_models()[0];
-    // Should not panic; may return empty or a stream kind string
-    let _ = super::model_stream_kind("utility", model);
-}
 
 // --- model_knob_layout tests ---
 


### PR DESCRIPTION
Closes #688.

## What
Test-hygiene pass on `develop` test code.

### Warnings (8 → 0)
- `infra-yaml/lib_tests`: drop unused `serialize_project` + `tempfile::TempDir` imports
- `infra-cpal/tests`: drop unused `ProjectRuntimeController` import
- `engine/runtime_tests`: prefix the 5 unused `split_positions` bindings with `_` (the two asserted-on occurrences left intact)

### Doctest
- `block-core/dsp/oversampling.rs`: the `Oversampler2x` usage example was fenced ```ignore (referenced undefined `saturate`/`input`/`output`). Made it self-contained → now a real runnable doctest.

### Reactivated 12 ignored tests (all green)
- `block-body` (3), `block-cab` (2), `nam` (2), `block-amp`/`gain`/`pitch`/`preamp` registry guards (4), `project` contract (1)

### Deleted 2 dead tests
- block-util utility-block tests (`project/catalog_tests`, `infra-yaml/lib_tests`) — the crate is empty since #320 (utility blocks promoted to top-bar features)

## Out of scope (left ignored by decision)
The remaining ~23 `#[ignore]`s guard real invariants but are blocked on their own issues (#287 asset registry, #350 isolation phase 2, #436 persistence, #580 buffer=32 stress) or need an environment not present locally (jackd, OpenRig-plugins repo, Linux-only i18n).

## Verification
`cargo test --workspace --no-run`: **0 warnings**. Reactivated crates: **0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)