### PR TITLE
fix(#690): persist non-float block param edits into the rig preset base

### DIFF
--- a/crates/adapter-gui/src/issue_690_nam_gate_persistence_tests.rs
+++ b/crates/adapter-gui/src/issue_690_nam_gate_persistence_tests.rs
@@ -1,0 +1,220 @@
+//! Issue #690 — red-first repro: the user toggles the noise gate on a
+//! NAM block in the block editor, saves the project, reopens it, and the
+//! gate is back to its previous state. The contract under test is the
+//! same as the rest of the persistence matrix: **what was dispatched and
+//! saved must survive a `save_project_session` ↔ `load_project_session`
+//! round-trip** — including for NAM-backed blocks, whose params are
+//! seeded from the plugin manifest (#675) and must NOT be re-seeded over
+//! the user's saved values on load.
+
+use crate::project_ops::{create_new_project_session, load_project_session, save_project_session};
+use crate::state::ProjectSession;
+use application::block_factory::{build_default_block, resolve_effect_type_for_model};
+use application::chain_factory::{build_default_chain, DefaultChainParams, EndpointSpec};
+use application::command::Command;
+use application::dispatcher::CommandDispatcher;
+use domain::ids::{BlockId, ChainId};
+use project::block::AudioBlockKind;
+use project::param::ParameterSet;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+fn fixture_plugins_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../application/tests/fixtures/plugins")
+}
+
+struct Sandbox {
+    _tmp: TempDir,
+    path: PathBuf,
+    cfg: PathBuf,
+}
+
+impl Sandbox {
+    fn new() -> Self {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("project.yaml");
+        let cfg = tmp.path().join("config.yaml");
+        // The load path resolves NAM packages through the configured
+        // plugins root — point it at the same fixture tree the registry
+        // is initialised from.
+        std::fs::write(
+            &cfg,
+            format!("plugins_root: {}\n", fixture_plugins_root().display()),
+        )
+        .expect("write config with plugins_root");
+        Self {
+            _tmp: tmp,
+            path,
+            cfg,
+        }
+    }
+
+    fn new_session(&self) -> ProjectSession {
+        let mut session = create_new_project_session(&self.cfg);
+        session.project_path = Some(self.path.clone());
+        session.config_path = Some(self.cfg.clone());
+        session
+    }
+
+    fn save(&self, session: &ProjectSession) {
+        save_project_session(session, &self.path).expect("save");
+    }
+
+    fn reload(&self) -> ProjectSession {
+        load_project_session(&self.path, &self.cfg).expect("reload")
+    }
+}
+
+fn add_chain(session: &ProjectSession) -> ChainId {
+    let chain = build_default_chain(DefaultChainParams {
+        project: &session.project.borrow(),
+        instrument: "electric_guitar",
+        description: Some("X".into()),
+        input: EndpointSpec {
+            device_id: Some("dev"),
+            channels: vec![0],
+        },
+        output: EndpointSpec {
+            device_id: Some("test-out"),
+            channels: vec![0, 1],
+        },
+    });
+    session
+        .dispatcher
+        .dispatch(Command::SaveChain { chain })
+        .expect("SaveChain");
+    session.project.borrow().chains[0].id.clone()
+}
+
+/// Insert the fixture NAM grid pedal the same way the GUI block editor
+/// does: a default block built from the manifest, via InsertPrebuiltBlock.
+fn insert_nam_block(session: &ProjectSession, chain: &ChainId, id: &str) -> BlockId {
+    static INIT: std::sync::Once = std::sync::Once::new();
+    INIT.call_once(|| plugin_loader::registry::init_many(&[fixture_plugins_root()]));
+    let effect_type =
+        resolve_effect_type_for_model("nam_ts9_grid").expect("effect type for the grid pedal");
+    let block = build_default_block(BlockId(id.into()), &effect_type, "nam_ts9_grid")
+        .expect("default NAM block");
+    let position = session
+        .project
+        .borrow()
+        .chains
+        .iter()
+        .find(|c| c.id == *chain)
+        .map(|c| c.blocks.len() - 1)
+        .expect("chain present");
+    session
+        .dispatcher
+        .dispatch(Command::InsertPrebuiltBlock {
+            chain: chain.clone(),
+            block,
+            position,
+        })
+        .expect("InsertPrebuiltBlock");
+    BlockId(id.into())
+}
+
+fn block_params(session: &ProjectSession, block: &BlockId) -> ParameterSet {
+    session
+        .project
+        .borrow()
+        .chains
+        .iter()
+        .flat_map(|c| c.blocks.iter())
+        .find(|b| b.id == *block)
+        .map(|b| match &b.kind {
+            AudioBlockKind::Nam(nam) => nam.params.clone(),
+            AudioBlockKind::Core(core) => core.params.clone(),
+            other => panic!("expected a NAM-backed block, got {}", other.label()),
+        })
+        .expect("block present after reload")
+}
+
+#[test]
+fn nam_noise_gate_toggle_survives_save_and_reload() {
+    let s = Sandbox::new();
+    let session = s.new_session();
+    let chain_id = add_chain(&session);
+    let block = insert_nam_block(&session, &chain_id, "nam1");
+
+    // Sanity: the fixture manifest seeds the gate ON (#675).
+    let seeded = block_params(&session, &block);
+    assert_eq!(
+        seeded.get_bool("noise_gate.enabled"),
+        Some(true),
+        "fixture must seed the gate enabled — repro precondition"
+    );
+
+    // First save+reload turns the chain into a rig-projected one
+    // (`rig:input-N`) — the user's project is always in this state by
+    // the time they edit an existing block.
+    s.save(&session);
+    let session = s.reload();
+    let chain_id = session.project.borrow().chains[0].id.clone();
+    assert!(
+        chain_id.0.starts_with("rig:"),
+        "after a save+reload the chain must be rig-projected — repro precondition"
+    );
+
+    // The user flips the gate in the block editor.
+    session
+        .dispatcher
+        .dispatch(Command::SetBlockParameterBool {
+            chain: chain_id.clone(),
+            block: block.clone(),
+            path: "noise_gate.enabled".into(),
+            value: false,
+        })
+        .expect("SetBlockParameterBool");
+    s.save(&session);
+
+    let reloaded = s.reload();
+    let params = block_params(&reloaded, &block);
+    assert_eq!(
+        params.get_bool("noise_gate.enabled"),
+        Some(false),
+        "BUG #690: the noise-gate toggle on a NAM block must survive \
+         save + reload — it reverted to the pre-save state"
+    );
+}
+
+#[test]
+fn nam_noise_gate_threshold_survives_save_and_reload() {
+    let s = Sandbox::new();
+    let session = s.new_session();
+    let chain_id = add_chain(&session);
+    let block = insert_nam_block(&session, &chain_id, "nam1");
+
+    // Sanity: the fixture capture seeds threshold_db = -55 (#675).
+    let seeded = block_params(&session, &block);
+    assert_eq!(
+        seeded.get_f32("noise_gate.threshold_db"),
+        Some(-55.0),
+        "fixture must seed the threshold — repro precondition"
+    );
+
+    // Same rig-projected state as the toggle repro.
+    s.save(&session);
+    let session = s.reload();
+    let chain_id = session.project.borrow().chains[0].id.clone();
+
+    session
+        .dispatcher
+        .dispatch(Command::SetBlockParameterNumber {
+            chain: chain_id.clone(),
+            block: block.clone(),
+            path: "noise_gate.threshold_db".into(),
+            value: -23.5,
+        })
+        .expect("SetBlockParameterNumber");
+    s.save(&session);
+
+    let reloaded = s.reload();
+    let params = block_params(&reloaded, &block);
+    assert_eq!(
+        params.get_f32("noise_gate.threshold_db"),
+        Some(-23.5),
+        "BUG #690: the noise-gate threshold on a NAM block must survive \
+         save + reload — it reverted to the manifest-seeded value"
+    );
+}

--- a/crates/adapter-gui/src/project_ops.rs
+++ b/crates/adapter-gui/src/project_ops.rs
@@ -543,5 +543,9 @@ mod chain_rename_persistence_tests;
 mod scene_param_persistence_tests;
 
 #[cfg(test)]
+#[path = "issue_690_nam_gate_persistence_tests.rs"]
+mod issue_690_nam_gate_persistence_tests;
+
+#[cfg(test)]
 #[path = "chain_reorder_refresh_tests.rs"]
 mod chain_reorder_refresh_tests;

--- a/crates/project/src/rig_methods.rs
+++ b/crates/project/src/rig_methods.rs
@@ -17,7 +17,10 @@ impl RigProject {
     /// template; a float param / bypass that differs from the template is
     /// stored as that scene's override (and the key auto-marked as a
     /// scene-param so `apply_scene` applies it). A value back at the
-    /// template clears the override. No-op if input/preset is unknown.
+    /// template clears the override. Non-float params (Bool/Int/String)
+    /// cannot live in the f32 scene diff — they are written into the
+    /// preset base itself, shared by every scene (issue #690). No-op if
+    /// input/preset is unknown.
     pub fn write_back_processing_blocks(
         &mut self,
         input: &str,
@@ -44,6 +47,7 @@ impl RigProject {
 
         let mut set_param: Vec<(String, f32)> = Vec::new();
         let mut clear_param: Vec<String> = Vec::new();
+        let mut set_base_param: Vec<(String, String, ParameterValue)> = Vec::new();
         let mut set_bypass: Vec<(String, bool)> = Vec::new();
         let mut clear_bypass: Vec<String> = Vec::new();
 
@@ -64,15 +68,44 @@ impl RigProject {
             };
             if let Some((ep, bp)) = pair {
                 for (pid, val) in &ep.values {
-                    if let ParameterValue::Float(v) = val {
-                        let key = format!("{bid}.{pid}");
-                        if bp.get_f32(pid) != Some(*v) {
-                            set_param.push((key, *v));
-                        } else {
-                            clear_param.push(key);
+                    match val {
+                        ParameterValue::Float(v) => {
+                            let key = format!("{bid}.{pid}");
+                            if bp.get_f32(pid) != Some(*v) {
+                                set_param.push((key, *v));
+                            } else {
+                                clear_param.push(key);
+                            }
+                        }
+                        // Scenes can only carry f32 overrides (Helix
+                        // snapshot rule), so a Bool/Int/String/enum edit
+                        // is preset-level: write it into the base
+                        // template, shared by every scene. Issue #690 —
+                        // the NAM noise-gate toggle was silently dropped
+                        // here and reverted on save+reload.
+                        other => {
+                            if bp.get(pid) != Some(other) {
+                                set_base_param.push((bid.clone(), pid.clone(), other.clone()));
+                            }
                         }
                     }
                 }
+            }
+        }
+
+        for (bid, pid, val) in set_base_param {
+            let params =
+                preset
+                    .blocks
+                    .iter_mut()
+                    .find(|b| b.id.0 == bid)
+                    .and_then(|b| match &mut b.kind {
+                        AudioBlockKind::Core(c) => Some(&mut c.params),
+                        AudioBlockKind::Nam(n) => Some(&mut n.params),
+                        _ => None,
+                    });
+            if let Some(params) = params {
+                params.insert(pid, val);
             }
         }
 
@@ -251,12 +284,11 @@ impl RigProject {
         // per-scene diff, so the swapped model was never written into the
         // preset base and reverted on reload. Model identity excludes params,
         // so genuine param/bypass edits still take the diff-only path below.
-        let same_structure = preset.blocks.len() == blocks.len()
-            && preset
-                .blocks
-                .iter()
-                .zip(blocks)
-                .all(|(a, b)| a.id == b.id && a.kind.model_identity() == b.kind.model_identity());
+        let same_structure =
+            preset.blocks.len() == blocks.len()
+                && preset.blocks.iter().zip(blocks).all(|(a, b)| {
+                    a.id == b.id && a.kind.model_identity() == b.kind.model_identity()
+                });
         if same_structure {
             return false;
         }

--- a/crates/project/src/rig_scene_tests.rs
+++ b/crates/project/src/rig_scene_tests.rs
@@ -322,6 +322,59 @@ fn scene_params_remain_independent_across_scenes() {
     assert_eq!(s2_val, Some(95.0), "scene 2 keeps its own override");
 }
 
+/// Issue #690 — red-first: the user enables the noise gate on a NAM
+/// block (a **Bool** param), saves, reopens, and it reverts. The f32
+/// scene-diff cannot carry a bool, so the capture path silently dropped
+/// every non-float param edit. The toggle must survive the
+/// `write_back_processing_blocks` → `apply_scene` round-trip.
+#[test]
+fn write_back_persists_bool_param_edit_issue_690() {
+    use crate::block::{AudioBlock, AudioBlockKind, NamBlock};
+    use crate::param::ParameterSet;
+    use domain::ids::BlockId;
+    use domain::value_objects::ParameterValue;
+
+    let block_id = "nam:1".to_string();
+    let mut base_params = ParameterSet::default();
+    base_params.insert("noise_gate.enabled", ParameterValue::Bool(false));
+    base_params.insert("noise_gate.threshold_db", ParameterValue::Float(-50.0));
+    let base_block = AudioBlock {
+        id: BlockId(block_id.clone()),
+        enabled: true,
+        kind: AudioBlockKind::Nam(NamBlock {
+            model: "nam_ts9".into(),
+            params: base_params,
+        }),
+    };
+    let mut p = project_with(vec![("input-1", input(&[(1, "p")], 1))], &["p"]);
+    p.presets.get_mut("p").unwrap().blocks = vec![base_block.clone()];
+
+    // The user flips the gate ON; the projected chain feeds the edit back.
+    let mut edited = base_block.clone();
+    if let AudioBlockKind::Nam(ref mut nam) = edited.kind {
+        nam.params
+            .insert("noise_gate.enabled", ParameterValue::Bool(true));
+    }
+    p.write_back_processing_blocks("input-1", vec![edited]);
+
+    let preset = p.presets.get("p").expect("preset present");
+    let projected = preset.apply_scene(1);
+    let gate = projected
+        .iter()
+        .find(|b| b.id.0 == block_id)
+        .and_then(|b| match &b.kind {
+            AudioBlockKind::Nam(nam) => nam.params.get_bool("noise_gate.enabled"),
+            _ => None,
+        });
+    assert_eq!(
+        gate,
+        Some(true),
+        "BUG #690: a Bool param edit must survive capture + re-projection \
+         (preset blocks={:?})",
+        preset.blocks
+    );
+}
+
 #[test]
 fn write_back_chain_volume_is_per_active_scene_only() {
     let mut p = project_with(vec![("input-1", input(&[(1, "p")], 1))], &["p"]);

--- a/docs/projects/project-openrig-format.md
+++ b/docs/projects/project-openrig-format.md
@@ -66,6 +66,17 @@ project:
 | `presets.<name>` | `RigPreset` | `blocks: Vec<AudioBlock>` — processing only |
 | `midi.bindings[]` | `RigProjectMidi.bindings` | optional, ADR 0003 / #499. `Source`/`Scale`/`Binding` data types live in `crates/project/src/midi.rs`. When present, replaces the system fallback (`midi-bindings.yaml`) at resolve time; the controller (`input:`) always comes from the system `midi-profile.yaml`. Absent → resolver falls back to system file → shipped default. |
 
+### Edit capture: scene diff vs preset base (#690)
+
+`write_back_processing_blocks` (run by `Command::CaptureRigEdits` and the
+save path) captures edits made on the projected chain back into the active
+preset. **Float** param edits become the active scene's f32 override
+(Helix Snapshot rule — the key is auto-marked in `scene-params`).
+**Non-float** params (Bool/Int/String — e.g. a NAM noise-gate toggle)
+cannot live in the f32 scene diff: they are written into the preset base
+`blocks`, shared by every scene. Before #690 these edits were silently
+dropped and reverted on save+reload.
+
 ## Validation
 
 `RigProject::validate() -> Result<(), String>` is run by `parse_rig_project`


### PR DESCRIPTION
Closes #690.

## Problem

Enabling the noise gate on a NAM block, saving the project, and reopening it reverted the gate to its previous state.

## Root cause

`RigProject::write_back_processing_blocks` (the capture path run by `Command::CaptureRigEdits` and the save flow) only captured `ParameterValue::Float` diffs into the active scene's f32 override map. Bool/Int/String param edits — like `noise_gate.enabled` — were silently dropped, so the preset base kept the old value and the load re-projected it over the chain. Float knobs (e.g. `noise_gate.threshold_db`) survived via the scene diff, which is why only the on/off toggle reverted.

## Fix

Non-float param diffs are written into the preset base `blocks` — preset-level, shared by every scene, since the f32 scene diff cannot carry them by design (Helix Snapshot rule). Float capture semantics are unchanged. No audio-thread code touched — pure model/save-path logic.

## Tests (red-first)

- `write_back_persists_bool_param_edit_issue_690` (unit, `crates/project/src/rig_scene_tests.rs`): capture + `apply_scene` round-trip of a Bool edit — RED before the fix, GREEN after, unchanged.
- `nam_noise_gate_toggle_survives_save_and_reload` (e2e, `crates/adapter-gui/src/issue_690_nam_gate_persistence_tests.rs`): rig-projected chain → `SetBlockParameterBool` → save → reload — RED before, GREEN after, unchanged.
- `nam_noise_gate_threshold_survives_save_and_reload`: float sibling, documents the contrast (green before and after).

`cargo test --workspace --lib` green; user validated the fix on their machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)