### PR TITLE
fix(#696): validator derives the bus layout like the engine does

### DIFF
--- a/crates/application/src/validate.rs
+++ b/crates/application/src/validate.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, bail, Result};
 use block_core::AudioChannelLayout;
 use project::block::{schema_for_block_model, AudioBlock, AudioBlockKind};
-use project::chain::Chain;
+use project::chain::{processing_layout, Chain, ProcessingLayout};
 use project::device::DeviceSettings;
 use project::project::Project;
 use std::collections::{HashMap, HashSet};
@@ -93,7 +93,6 @@ pub fn validate_project(project: &Project) -> Result<()> {
             }
         }
 
-        // Use first input entry's channel count for layout determination
         let first_input = input_blocks.first().expect("validated non-empty");
         let first_input_entry = first_input.1.entries.first().ok_or_else(|| {
             anyhow!(
@@ -102,7 +101,7 @@ pub fn validate_project(project: &Project) -> Result<()> {
                 first_input.1.model
             )
         })?;
-        let input_layout = layout_from_channel_count(
+        layout_from_channel_count(
             "chain input",
             &chain.id.0,
             first_input_entry.channels.len(),
@@ -120,6 +119,22 @@ pub fn validate_project(project: &Project) -> Result<()> {
             &chain.id.0,
             first_output_entry.channels.len(),
         )?;
+
+        // The internal bus layout must mirror what the engine builds
+        // (`runtime_graph` → `project::chain::processing_layout`): a mono
+        // physical input feeding a stereo output is broadcast to
+        // `Stereo([s, s])` before the block chain (invariant #5), so the
+        // validator must not derive the bus from the input channel count
+        // alone (#696).
+        let proc_layout = processing_layout(
+            &first_input_entry.channels,
+            &first_output_entry.channels,
+            first_input_entry.mode,
+        );
+        let input_layout = match proc_layout {
+            ProcessingLayout::Mono => AudioChannelLayout::Mono,
+            ProcessingLayout::Stereo | ProcessingLayout::DualMono => AudioChannelLayout::Stereo,
+        };
 
         // Validate only audio blocks (non-I/O, non-Insert)
         let audio_blocks: Vec<&AudioBlock> = chain

--- a/crates/application/tests/issue_696_true_stereo_pitch_on_mono_input.rs
+++ b/crates/application/tests/issue_696_true_stereo_pitch_on_mono_input.rs
@@ -1,0 +1,96 @@
+//! Bug repro (#696, user log):
+//!
+//! ```text
+//! [ERROR] chain 'rig:input-3' block 'rig:input-3:block:9211ce62-...'
+//! uses pitch model 'native_pitch_shifter' with audio mode 'true_stereo'
+//! that does not accept a mono input bus
+//! ```
+//!
+//! Architecture invariant #5 (CLAUDE.md): every stream is ALWAYS stereo
+//! internally — a mono physical input is broadcast to `Stereo([s, s])`
+//! before the block chain. A model declaring `true_stereo` audio mode
+//! therefore always receives a stereo bus, no matter how many physical
+//! channels feed the chain. `validate_project` must not reject it.
+
+use domain::ids::{BlockId, ChainId, DeviceId};
+use project::block::{
+    AudioBlock, AudioBlockKind, CoreBlock, InputBlock, InputEntry, OutputBlock, OutputEntry,
+};
+use project::chain::{Chain, ChainInputMode, ChainOutputMode};
+use project::param::ParameterSet;
+use project::project::Project;
+
+use application::validate::validate_project;
+
+const CHAIN_ID: &str = "rig:input-3";
+const DEVICE: &str = "test:device";
+
+fn mono_input() -> AudioBlock {
+    AudioBlock {
+        id: BlockId("rig:input-3:in".into()),
+        enabled: true,
+        kind: AudioBlockKind::Input(InputBlock {
+            model: "standard".into(),
+            entries: vec![InputEntry {
+                device_id: DeviceId(DEVICE.into()),
+                mode: ChainInputMode::Mono,
+                channels: vec![0],
+            }],
+        }),
+    }
+}
+
+fn true_stereo_pitch_block() -> AudioBlock {
+    // The user's exact block: pitch / native_pitch_shifter, which the
+    // catalog registers with audio mode `true_stereo`.
+    AudioBlock {
+        id: BlockId("rig:input-3:block:9211ce62".into()),
+        enabled: true,
+        kind: AudioBlockKind::Core(CoreBlock {
+            effect_type: "pitch".into(),
+            model: "native_pitch_shifter".into(),
+            params: ParameterSet::default(),
+        }),
+    }
+}
+
+fn stereo_output() -> AudioBlock {
+    AudioBlock {
+        id: BlockId("rig:input-3:out".into()),
+        enabled: true,
+        kind: AudioBlockKind::Output(OutputBlock {
+            model: "standard".into(),
+            entries: vec![OutputEntry {
+                device_id: DeviceId(DEVICE.into()),
+                mode: ChainOutputMode::Stereo,
+                channels: vec![0, 1],
+            }],
+        }),
+    }
+}
+
+#[test]
+fn validate_accepts_true_stereo_pitch_on_mono_input_chain() {
+    let project = Project {
+        name: Some("test".into()),
+        device_settings: Vec::new(),
+        chains: vec![Chain {
+            id: ChainId(CHAIN_ID.into()),
+            description: None,
+            instrument: "electric_guitar".into(),
+            enabled: true,
+            volume: 100.0,
+            blocks: vec![mono_input(), true_stereo_pitch_block(), stereo_output()],
+        }],
+        midi: None,
+    };
+
+    let res = validate_project(&project);
+    assert!(
+        res.is_ok(),
+        "a mono-input chain is broadcast to a stereo internal bus \
+         (invariant #5), so a true_stereo pitch model must validate. \
+         Got error: {:?}",
+        res.err()
+    );
+}


### PR DESCRIPTION
Closes #696.

## Problem

Loading a project logged:

```
[ERROR] chain 'rig:input-3' block '...' uses pitch model 'native_pitch_shifter' with audio mode 'true_stereo' that does not accept a mono input bus
```

`validate_project` derived the internal bus layout from the first input entry's channel count alone, so a mono physical input started the chain walk on a mono bus and any `true_stereo` model was rejected — while the engine (`runtime_graph` → `project::chain::processing_layout`) broadcasts mono input + stereo output to a stereo bus (invariant #5) and runs the same chain fine.

## Fix

The validator now calls the same `processing_layout(input_channels, output_channels, input_mode)` and maps `DualMono`/`Stereo` to the stereo bus exactly like `runtime_graph` does. Mono input + mono output still validates as a mono bus, mirroring the engine. Per-entry channel-count checks (1–2 channels) are kept.

## Tests

- RED first: `crates/application/tests/issue_696_true_stereo_pitch_on_mono_input.rs` reproduces the user log verbatim, green after the fix.
- `cargo test -p application` and `cargo test -p engine` fully green; `cargo build` zero warnings.
- Quality gate vs `origin/develop`: **passed** (fmt 116→105, build 2→0, coverage +55.1pp on touched scope; lint/test/complexity same).

🤖 Generated with [Claude Code](https://claude.com/claude-code)