### PR TITLE
feat(#709): package-macos.sh accepts OPENRIG_PLUGINS_DIR as plugins source

### DIFF
--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -8,7 +8,7 @@
 | `scripts/flash-sd.sh` | Flasha SD card |
 | `scripts/coverage.sh` | Relatório HTML de cobertura |
 | `scripts/package-linux.sh` | Empacota Linux .tar.gz/.deb/.rpm/.AppImage (patchelf RUNPATH p/ libnam_wrapper + libseat) |
-| `scripts/package-macos.sh` | Empacota macOS (assina ad-hoc inside-out + gate de verificação) |
+| `scripts/package-macos.sh` | Empacota macOS (assina ad-hoc inside-out + gate de verificação). Plugins bundled: `OPENRIG_PLUGINS_DIR=/path/plugins/source` sobrescreve a origem (default `plugins/source`; override inexistente = erro fatal) |
 | `scripts/install-macos.sh` | Instalador one-liner via `curl` (baixa .dmg, copia pro /Applications, tira quarentena) |
 | `scripts/build-lib.sh` | Libs externas |
 

--- a/scripts/lib/plugins-bundle.sh
+++ b/scripts/lib/plugins-bundle.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Plugin-bundling helpers shared by the packaging scripts (issue #709).
+# Sourced — do not execute. Tested by scripts/tests/plugins_bundle_test.sh.
+
+# Resolve the plugins source directory. OPENRIG_PLUGINS_DIR overrides the
+# repo-root default `plugins/source`; an explicit override that is not a
+# directory is fatal (a silent empty bundle would mask the typo), while the
+# default is allowed to be absent (dev machines without the plugin tree).
+plugins_src_dir() {
+    if [ -n "${OPENRIG_PLUGINS_DIR:-}" ]; then
+        if [ ! -d "$OPENRIG_PLUGINS_DIR" ]; then
+            echo "FATAL: OPENRIG_PLUGINS_DIR='$OPENRIG_PLUGINS_DIR' is not a directory" >&2
+            return 1
+        fi
+        echo "$OPENRIG_PLUGINS_DIR"
+    else
+        echo "plugins/source"
+    fi
+}
+
+# bundle_plugins <src> <dest> [drop-pattern...]
+# Stage <src> into <dest>, then drop every plugin platform/<pattern> dir —
+# each LV2 plugin ships platform/{linux-*,macos-*,windows-*} binaries and
+# the non-target ones are dead weight in the bundle (issue #425).
+# A missing <src> is a NOTE, not an error: the app's plugin registry falls
+# back to the user-writable root when nothing is bundled.
+bundle_plugins() {
+    local src="$1" dest="$2"
+    shift 2
+    if [ ! -d "$src" ]; then
+        echo "    NOTE: $src not found — bundle ships without plugins"
+        return 0
+    fi
+    cp -r "$src" "$dest"
+    local dropped_dirs=0 pattern dir
+    for pattern in "$@"; do
+        while IFS= read -r dir; do
+            rm -rf "$dir"
+            dropped_dirs=$((dropped_dirs + 1))
+        done < <(find "$dest" -type d -path "*/platform/$pattern" 2>/dev/null)
+    done
+    local plugin_count
+    plugin_count=$(find "$dest" -name 'manifest.yaml' | wc -l | tr -d ' ')
+    echo "    bundled plugins ($plugin_count package(s)); dropped $dropped_dirs non-target platform dirs"
+}

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 # Mirrors exactly what GitHub Actions does for the macOS build.
-# Usage: ./scripts/package-macos.sh [version]
+# Usage: [OPENRIG_PLUGINS_DIR=/path/to/plugins/source] ./scripts/package-macos.sh [version]
+# OPENRIG_PLUGINS_DIR overrides the bundled-plugins source (default: plugins/source).
 set -euo pipefail
 
 VERSION="${1:-dev}"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
+
+source scripts/lib/plugins-bundle.sh
+# Resolve (and validate) the plugins source up front — an invalid override
+# must fail here, not after two release builds.
+PLUGINS_SRC="$(plugins_src_dir)"
 
 # ── 1. Rust targets ──────────────────────────────────────────────────────────
 echo "==> Adding Rust targets..."
@@ -100,25 +106,11 @@ fi
 # Bundle plugins as a pre-extracted directory. plugin_loader::registry::
 # init_many scans <.app>/Contents/Resources/plugins (this path) plus the
 # user-writable root in parallel. No first-launch extraction step.
-# Skip silently in dev when the source tree isn't checked out alongside
-# OpenRig — registry::init falls back to the user root only.
-if [ -d plugins/source ]; then
-    cp -r plugins/source "$APP/Contents/Resources/plugins"
-    # Each LV2 plugin carries platform/{linux-*,macos-*,windows-*}
-    # binaries — macOS .app só carrega .dylib, então .so/.dll são MB
-    # inúteis. Drop tudo que não é macOS (issue #425).
-    dropped_dirs=0
-    for pattern in "linux-*" "windows-*"; do
-        while IFS= read -r dir; do
-            rm -rf "$dir"
-            dropped_dirs=$((dropped_dirs + 1))
-        done < <(find "$APP/Contents/Resources/plugins" -type d -path "*/platform/$pattern" 2>/dev/null)
-    done
-    PLUGIN_COUNT=$(find "$APP/Contents/Resources/plugins" -name 'manifest.yaml' | wc -l | tr -d ' ')
-    echo "    bundled plugins ($PLUGIN_COUNT package(s)); dropped $dropped_dirs non-macOS platform dirs"
-else
-    echo "    NOTE: plugins/source/ not found — .app ships without bundled plugins"
-fi
+# Source dir comes from plugins_src_dir (OPENRIG_PLUGINS_DIR override or
+# plugins/source); a missing default is a NOTE — registry::init falls
+# back to the user root only. macOS .app only loads .dylib, so the
+# linux-*/windows-* platform dirs are dropped (issue #425).
+bundle_plugins "$PLUGINS_SRC" "$APP/Contents/Resources/plugins" "linux-*" "windows-*"
 
 # Bundle gettext .mo translations. build.rs writes per-locale catalogs
 # under crates/adapter-gui/translations/<lang>/LC_MESSAGES/; we mirror

--- a/scripts/tests/plugins_bundle_test.sh
+++ b/scripts/tests/plugins_bundle_test.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Tests for scripts/lib/plugins-bundle.sh (issue #709).
+# Run: ./scripts/tests/plugins_bundle_test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB="$SCRIPT_DIR/../lib/plugins-bundle.sh"
+
+FAILURES=0
+fail() { echo "FAIL: $1" >&2; FAILURES=$((FAILURES + 1)); }
+pass() { echo "ok:   $1"; }
+
+if [ ! -f "$LIB" ]; then
+    echo "FAIL: $LIB does not exist" >&2
+    exit 1
+fi
+# shellcheck source=../lib/plugins-bundle.sh
+source "$LIB"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# ── plugins_src_dir: default is plugins/source ──────────────────────────────
+unset OPENRIG_PLUGINS_DIR
+if [ "$(plugins_src_dir)" = "plugins/source" ]; then
+    pass "plugins_src_dir defaults to plugins/source"
+else
+    fail "plugins_src_dir default: got '$(plugins_src_dir)'"
+fi
+
+# ── plugins_src_dir: OPENRIG_PLUGINS_DIR overrides the default ──────────────
+mkdir -p "$TMP/custom-plugins"
+if [ "$(OPENRIG_PLUGINS_DIR="$TMP/custom-plugins" plugins_src_dir)" = "$TMP/custom-plugins" ]; then
+    pass "plugins_src_dir honors OPENRIG_PLUGINS_DIR"
+else
+    fail "plugins_src_dir override: got '$(OPENRIG_PLUGINS_DIR="$TMP/custom-plugins" plugins_src_dir)'"
+fi
+
+# ── plugins_src_dir: explicit override pointing nowhere is FATAL ────────────
+if OPENRIG_PLUGINS_DIR="$TMP/does-not-exist" plugins_src_dir >/dev/null 2>&1; then
+    fail "plugins_src_dir must fail when OPENRIG_PLUGINS_DIR is not a directory"
+else
+    pass "plugins_src_dir fails loud on missing override dir"
+fi
+
+# ── bundle_plugins: stages from a custom src, drops non-target platforms ────
+SRC="$TMP/src"
+DEST="$TMP/dest/plugins"
+mkdir -p "$SRC/lv2/myplugin/platform/macos-universal" \
+         "$SRC/lv2/myplugin/platform/linux-x86_64" \
+         "$SRC/lv2/myplugin/platform/windows-x86_64"
+touch "$SRC/lv2/myplugin/manifest.yaml" \
+      "$SRC/lv2/myplugin/platform/macos-universal/p.dylib" \
+      "$SRC/lv2/myplugin/platform/linux-x86_64/p.so" \
+      "$SRC/lv2/myplugin/platform/windows-x86_64/p.dll"
+mkdir -p "$TMP/dest"
+
+bundle_plugins "$SRC" "$DEST" "linux-*" "windows-*" >/dev/null
+
+[ -f "$DEST/lv2/myplugin/manifest.yaml" ] \
+    && pass "bundle_plugins copies manifests from custom src" \
+    || fail "manifest.yaml missing in dest"
+[ -f "$DEST/lv2/myplugin/platform/macos-universal/p.dylib" ] \
+    && pass "bundle_plugins keeps target platform dirs" \
+    || fail "macos-universal dropped (should be kept)"
+[ ! -d "$DEST/lv2/myplugin/platform/linux-x86_64" ] \
+    && pass "bundle_plugins drops linux platform dirs" \
+    || fail "linux-x86_64 not dropped"
+[ ! -d "$DEST/lv2/myplugin/platform/windows-x86_64" ] \
+    && pass "bundle_plugins drops windows platform dirs" \
+    || fail "windows-x86_64 not dropped"
+
+# ── bundle_plugins: missing src is a NOTE, not an error ──────────────────────
+if OUT="$(bundle_plugins "$TMP/nope" "$TMP/dest2" "linux-*")"; then
+    case "$OUT" in
+        *NOTE*) pass "bundle_plugins notes missing src and returns 0" ;;
+        *) fail "bundle_plugins missing-src output lacks NOTE: '$OUT'" ;;
+    esac
+else
+    fail "bundle_plugins must return 0 on missing src"
+fi
+[ ! -d "$TMP/dest2" ] \
+    && pass "bundle_plugins creates nothing on missing src" \
+    || fail "dest created despite missing src"
+
+echo ""
+if [ "$FAILURES" -gt 0 ]; then
+    echo "$FAILURES failure(s)" >&2
+    exit 1
+fi
+echo "all tests passed"


### PR DESCRIPTION
Closes #709.

## What

`scripts/package-macos.sh` hardcoded `plugins/source` as the bundled-plugins source, forcing a copy/symlink before every packaging run when plugins live elsewhere (e.g. an OpenRig-plugins checkout).

- New `scripts/lib/plugins-bundle.sh`: `plugins_src_dir` resolves the source — `OPENRIG_PLUGINS_DIR` override (fatal when it is not a directory, so a typo can't ship an empty bundle) or the `plugins/source` default (NOTE when absent) — and `bundle_plugins` stages it, dropping non-target `platform/` dirs (#425 behavior preserved).
- `package-macos.sh` sources the lib and validates the source before the two release builds.
- New `scripts/tests/plugins_bundle_test.sh` (red-first): default resolution, override, fatal missing override, staging from a custom src, platform-dir dropping, missing-src NOTE.
- `docs/scripts.md` documents the env var.

## Usage

```bash
OPENRIG_PLUGINS_DIR=/path/to/plugins/source ./scripts/package-macos.sh [version]
```

CI (`release.yml`) calls the script without the env var → default path, behavior unchanged. Quality gate: passed (comparative vs origin/develop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)