### PR TITLE
feat(#712): MIDI/MCP enablement is system config, not a CLI flag

### DIFF
--- a/crates/adapter-gui/src/cli.rs
+++ b/crates/adapter-gui/src/cli.rs
@@ -16,15 +16,19 @@
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 
+/// Default MCP bind address: bare `--mcp` and the config master switch
+/// (#712) both resolve to this. Single source of truth.
+pub const DEFAULT_MCP_ADDR: &str = "127.0.0.1:4123";
+
 /// Parse the opt-in MCP server flag.
 ///
-/// * `--mcp` → default `127.0.0.1:4123`
+/// * `--mcp` → default [`DEFAULT_MCP_ADDR`]
 /// * `--mcp=ADDR` → that socket address (invalid value → `None`, logged)
 /// * absent → `None` (server not started; zero overhead)
 pub fn parse_mcp_addr(args: &[&str]) -> Option<SocketAddr> {
     for arg in args.iter().skip(1) {
         if *arg == "--mcp" {
-            return Some("127.0.0.1:4123".parse().expect("valid default mcp addr"));
+            return Some(DEFAULT_MCP_ADDR.parse().expect("valid default mcp addr"));
         }
         if let Some(rest) = arg.strip_prefix("--mcp=") {
             return match rest.parse() {
@@ -64,6 +68,22 @@ pub fn parse_midi_map(args: &[&str]) -> Option<MidiMapArg> {
         }
     }
     None
+}
+
+/// #712: fold the per-machine config master switch into the CLI result
+/// for the MCP server. A present CLI flag (`Some`) is a dev override and
+/// always wins; otherwise `config_enabled` decides, binding the default
+/// address. Both off → `None` (server stays down).
+pub fn resolve_mcp_addr(cli: Option<SocketAddr>, config_enabled: bool) -> Option<SocketAddr> {
+    cli.or_else(|| {
+        config_enabled.then(|| DEFAULT_MCP_ADDR.parse().expect("valid default mcp addr"))
+    })
+}
+
+/// #712: same fold for the MIDI adapter. CLI flag wins; otherwise the
+/// config switch enables it with the default resolved map.
+pub fn resolve_midi_map(cli: Option<MidiMapArg>, config_enabled: bool) -> Option<MidiMapArg> {
+    cli.or_else(|| config_enabled.then_some(MidiMapArg::Default))
 }
 
 pub fn parse_cli_args_from(args: &[&str]) -> (Option<PathBuf>, bool, bool) {

--- a/crates/adapter-gui/src/cli_tests.rs
+++ b/crates/adapter-gui/src/cli_tests.rs
@@ -101,3 +101,40 @@ fn midi_flag_with_path_is_explicit() {
 fn midi_flag_absent_is_none() {
     assert_eq!(parse_midi_map(&["openrig", "/tmp/p.openrig"]), None);
 }
+
+// ── #712: config master switch folds into the CLI flag ────────────────
+// CLI flag present = dev override (wins). Otherwise the per-machine
+// config switch decides. Both off → subsystem stays down.
+
+#[test]
+fn resolve_mcp_cli_present_wins_over_config() {
+    let cli = Some("0.0.0.0:9000".parse().unwrap());
+    assert_eq!(resolve_mcp_addr(cli, false), cli, "CLI addr overrides config");
+}
+
+#[test]
+fn resolve_mcp_config_enabled_binds_default_addr() {
+    let expected: SocketAddr = DEFAULT_MCP_ADDR.parse().unwrap();
+    assert_eq!(resolve_mcp_addr(None, true), Some(expected));
+}
+
+#[test]
+fn resolve_mcp_both_off_is_none() {
+    assert_eq!(resolve_mcp_addr(None, false), None);
+}
+
+#[test]
+fn resolve_midi_cli_present_wins_over_config() {
+    let cli = Some(MidiMapArg::Path("/tmp/m.yaml".into()));
+    assert_eq!(resolve_midi_map(cli.clone(), false), cli);
+}
+
+#[test]
+fn resolve_midi_config_enabled_uses_default_map() {
+    assert_eq!(resolve_midi_map(None, true), Some(MidiMapArg::Default));
+}
+
+#[test]
+fn resolve_midi_both_off_is_none() {
+    assert_eq!(resolve_midi_map(None, false), None);
+}

--- a/crates/adapter-gui/src/desktop_app.rs
+++ b/crates/adapter-gui/src/desktop_app.rs
@@ -323,6 +323,7 @@ pub fn run_desktop_app(
         &window,
         &project_settings_window,
         project_session.clone(),
+        app_config.clone(),
     );
     let input_devices = Rc::new(VecModel::from(build_device_selection_items(
         &*input_chain_devices.borrow(),

--- a/crates/adapter-gui/src/desktop_app.rs
+++ b/crates/adapter-gui/src/desktop_app.rs
@@ -318,6 +318,12 @@ pub fn run_desktop_app(
             apply_font_to_all,
         );
     }
+    // #712: System / Integrations master switches (MIDI adapter / MCP server).
+    crate::settings::integrations::wire(
+        &window,
+        &project_settings_window,
+        project_session.clone(),
+    );
     let input_devices = Rc::new(VecModel::from(build_device_selection_items(
         &*input_chain_devices.borrow(),
         &settings.input_devices,

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -101,7 +101,8 @@ pub use bank_scene_render::{render as render_bank_scene, BankNavRow};
 pub use bank_scene_session::{BankSceneEffect, BankSceneEvent, BankSceneState, InputNav};
 pub(crate) use chain_editor_callbacks::setup_chain_editor_callbacks;
 pub use cli::{
-    parse_cli_args_from, parse_mcp_addr, parse_midi_map, validate_project_path, MidiMapArg,
+    parse_cli_args_from, parse_mcp_addr, parse_midi_map, resolve_mcp_addr, resolve_midi_map,
+    validate_project_path, MidiMapArg,
 };
 pub(crate) use runtime_lifecycle::{
     assign_new_block_ids, remove_live_chain_runtime, stop_project_runtime, sync_block_toggle,

--- a/crates/adapter-gui/src/main.rs
+++ b/crates/adapter-gui/src/main.rs
@@ -42,8 +42,18 @@ fn main() -> anyhow::Result<()> {
     let raw_refs: Vec<&str> = raw_args.iter().map(|s| s.as_str()).collect();
     let (arg_project_path, arg_auto_save, arg_fullscreen) =
         adapter_gui::parse_cli_args_from(&raw_refs);
-    let mcp_addr = adapter_gui::parse_mcp_addr(&raw_refs);
-    let midi_map = adapter_gui::parse_midi_map(&raw_refs);
+    // #712: MIDI/MCP enablement is per-machine config (config.yaml), not a
+    // launch flag — so packaged builds (which start the binary with no args)
+    // can enable them. The CLI `--midi`/`--mcp` flags stay as a dev override
+    // that wins when present. Config-load failure → treat as disabled (the
+    // flags still work), never block startup.
+    let app_config = FilesystemStorage::load_app_config().unwrap_or_default();
+    let mcp_addr =
+        adapter_gui::resolve_mcp_addr(adapter_gui::parse_mcp_addr(&raw_refs), app_config.mcp_enabled);
+    let midi_map = adapter_gui::resolve_midi_map(
+        adapter_gui::parse_midi_map(&raw_refs),
+        app_config.midi_enabled,
+    );
     let cli_project_path = arg_project_path
         .or_else(|| {
             std::env::var("OPENRIG_PROJECT_PATH")

--- a/crates/adapter-gui/src/settings/integrations.rs
+++ b/crates/adapter-gui/src/settings/integrations.rs
@@ -10,6 +10,13 @@
 //! fallback `settings::language` uses. The change takes effect on next
 //! launch (the subsystem is wired at bootstrap); the section shows a
 //! restart hint.
+//!
+//! CRITICAL (mirrors `settings::audio`): the GUI holds a boot-time
+//! `Rc<RefCell<AppConfig>>` snapshot that `recent_projects_wiring` /
+//! project-open paths re-save WHOLESALE. A toggle that only writes disk is
+//! clobbered by that stale snapshot the next time any project op fires —
+//! the switch then resets on restart. So we also mutate the shared
+//! snapshot here, keeping it in sync with what we persist.
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -18,7 +25,7 @@ use slint::ComponentHandle;
 
 use application::command::Command;
 use application::dispatcher::CommandDispatcher;
-use infra_filesystem::FilesystemStorage;
+use infra_filesystem::{AppConfig, FilesystemStorage};
 
 use crate::state::ProjectSession;
 use crate::{AppWindow, ProjectSettingsWindow};
@@ -27,38 +34,51 @@ pub fn wire(
     window: &AppWindow,
     project_settings_window: &ProjectSettingsWindow,
     project_session: Rc<RefCell<Option<ProjectSession>>>,
+    app_config: Rc<RefCell<AppConfig>>,
 ) {
-    // Seed both surfaces from the persisted per-machine config so the
-    // toggles render in their stored state.
-    let config = FilesystemStorage::load_app_config().unwrap_or_default();
-    window.set_midi_enabled(config.midi_enabled);
-    window.set_mcp_enabled(config.mcp_enabled);
-    project_settings_window.set_midi_enabled(config.midi_enabled);
-    project_settings_window.set_mcp_enabled(config.mcp_enabled);
+    // Seed both surfaces from the in-memory snapshot (loaded from
+    // config.yaml at boot) so the toggles render in their stored state.
+    {
+        let cfg = app_config.borrow();
+        window.set_midi_enabled(cfg.midi_enabled);
+        window.set_mcp_enabled(cfg.mcp_enabled);
+        project_settings_window.set_midi_enabled(cfg.midi_enabled);
+        project_settings_window.set_mcp_enabled(cfg.mcp_enabled);
+    }
 
-    install_midi(window, project_settings_window, &project_session);
-    install_mcp(window, project_settings_window, &project_session);
+    install_midi(window, project_settings_window, &project_session, &app_config);
+    install_mcp(window, project_settings_window, &project_session, &app_config);
 }
 
 /// Build the shared handler for one master switch. Mirrors the new value
-/// onto both surfaces (so the toggle reflects immediately), then routes
-/// the state change through the command bus when a project is open, or
-/// persists directly from the launcher where no dispatcher exists.
+/// onto both surfaces (so the toggle reflects immediately) AND onto the
+/// shared in-memory `AppConfig` snapshot (so the recent-projects wholesale
+/// re-save can't clobber it), then routes the state change through the
+/// command bus when a project is open, or persists directly from the
+/// launcher where no dispatcher exists.
 fn make_handler(
     window: &AppWindow,
     project_settings_window: &ProjectSettingsWindow,
     project_session: &Rc<RefCell<Option<ProjectSession>>>,
+    app_config: &Rc<RefCell<AppConfig>>,
     set_on_both: impl Fn(&AppWindow, &ProjectSettingsWindow, bool) + 'static,
+    set_in_snapshot: impl Fn(&mut AppConfig, bool) + 'static,
     make_command: impl Fn(bool) -> Command + 'static,
     persist: impl Fn(bool) + Send + Copy + 'static,
 ) -> impl Fn(bool) {
     let weak = window.as_weak();
     let weak_settings = project_settings_window.as_weak();
     let session = project_session.clone();
+    let app_config = app_config.clone();
     move |enabled: bool| {
         if let (Some(w), Some(s)) = (weak.upgrade(), weak_settings.upgrade()) {
             set_on_both(&w, &s, enabled);
         }
+        // Keep the shared boot snapshot in sync — without this, the next
+        // wholesale `save_app_config(app_config.borrow())` (recent
+        // projects, project open) overwrites the value we persist below.
+        set_in_snapshot(&mut app_config.borrow_mut(), enabled);
+
         if let Some(session) = session.borrow().as_ref() {
             // Dispatch persists (handle_set_*_enabled) + emits the event.
             if let Err(e) = session.dispatcher.dispatch(make_command(enabled)) {
@@ -76,15 +96,18 @@ fn install_midi(
     window: &AppWindow,
     project_settings_window: &ProjectSettingsWindow,
     project_session: &Rc<RefCell<Option<ProjectSession>>>,
+    app_config: &Rc<RefCell<AppConfig>>,
 ) {
     let handler = Rc::new(make_handler(
         window,
         project_settings_window,
         project_session,
+        app_config,
         |w, s, on| {
             w.set_midi_enabled(on);
             s.set_midi_enabled(on);
         },
+        |cfg, on| cfg.midi_enabled = on,
         |enabled| Command::SetMidiEnabled { enabled },
         |enabled| {
             let mut config = FilesystemStorage::load_app_config().unwrap_or_default();
@@ -104,15 +127,18 @@ fn install_mcp(
     window: &AppWindow,
     project_settings_window: &ProjectSettingsWindow,
     project_session: &Rc<RefCell<Option<ProjectSession>>>,
+    app_config: &Rc<RefCell<AppConfig>>,
 ) {
     let handler = Rc::new(make_handler(
         window,
         project_settings_window,
         project_session,
+        app_config,
         |w, s, on| {
             w.set_mcp_enabled(on);
             s.set_mcp_enabled(on);
         },
+        |cfg, on| cfg.mcp_enabled = on,
         |enabled| Command::SetMcpEnabled { enabled },
         |enabled| {
             let mut config = FilesystemStorage::load_app_config().unwrap_or_default();

--- a/crates/adapter-gui/src/settings/integrations.rs
+++ b/crates/adapter-gui/src/settings/integrations.rs
@@ -1,0 +1,129 @@
+//! Wires the System / Integrations toggles (issue #712): per-machine
+//! master switches for the MIDI/BLE-MIDI adapter and the MCP server.
+//!
+//! Enablement is system config (ADR 0003), not a CLI flag — packaged
+//! builds launch the binary with no arguments, so `--midi`/`--mcp` never
+//! reached the installed app. The toggles dispatch `SetMidiEnabled` /
+//! `SetMcpEnabled` through the shared dispatcher (GUI/MCP/gRPC parity);
+//! the handler persists `config.yaml`. With no open project (launcher),
+//! there is no dispatcher, so the wiring persists directly — the same
+//! fallback `settings::language` uses. The change takes effect on next
+//! launch (the subsystem is wired at bootstrap); the section shows a
+//! restart hint.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use slint::ComponentHandle;
+
+use application::command::Command;
+use application::dispatcher::CommandDispatcher;
+use infra_filesystem::FilesystemStorage;
+
+use crate::state::ProjectSession;
+use crate::{AppWindow, ProjectSettingsWindow};
+
+pub fn wire(
+    window: &AppWindow,
+    project_settings_window: &ProjectSettingsWindow,
+    project_session: Rc<RefCell<Option<ProjectSession>>>,
+) {
+    // Seed both surfaces from the persisted per-machine config so the
+    // toggles render in their stored state.
+    let config = FilesystemStorage::load_app_config().unwrap_or_default();
+    window.set_midi_enabled(config.midi_enabled);
+    window.set_mcp_enabled(config.mcp_enabled);
+    project_settings_window.set_midi_enabled(config.midi_enabled);
+    project_settings_window.set_mcp_enabled(config.mcp_enabled);
+
+    install_midi(window, project_settings_window, &project_session);
+    install_mcp(window, project_settings_window, &project_session);
+}
+
+/// Build the shared handler for one master switch. Mirrors the new value
+/// onto both surfaces (so the toggle reflects immediately), then routes
+/// the state change through the command bus when a project is open, or
+/// persists directly from the launcher where no dispatcher exists.
+fn make_handler(
+    window: &AppWindow,
+    project_settings_window: &ProjectSettingsWindow,
+    project_session: &Rc<RefCell<Option<ProjectSession>>>,
+    set_on_both: impl Fn(&AppWindow, &ProjectSettingsWindow, bool) + 'static,
+    make_command: impl Fn(bool) -> Command + 'static,
+    persist: impl Fn(bool) + Send + Copy + 'static,
+) -> impl Fn(bool) {
+    let weak = window.as_weak();
+    let weak_settings = project_settings_window.as_weak();
+    let session = project_session.clone();
+    move |enabled: bool| {
+        if let (Some(w), Some(s)) = (weak.upgrade(), weak_settings.upgrade()) {
+            set_on_both(&w, &s, enabled);
+        }
+        if let Some(session) = session.borrow().as_ref() {
+            // Dispatch persists (handle_set_*_enabled) + emits the event.
+            if let Err(e) = session.dispatcher.dispatch(make_command(enabled)) {
+                log::warn!("[integrations] subsystem toggle dispatch failed: {e}");
+            }
+        } else {
+            // Launcher: no dispatcher → persist directly (same fallback as
+            // the language selector).
+            application::persist_worker::run(move || persist(enabled));
+        }
+    }
+}
+
+fn install_midi(
+    window: &AppWindow,
+    project_settings_window: &ProjectSettingsWindow,
+    project_session: &Rc<RefCell<Option<ProjectSession>>>,
+) {
+    let handler = Rc::new(make_handler(
+        window,
+        project_settings_window,
+        project_session,
+        |w, s, on| {
+            w.set_midi_enabled(on);
+            s.set_midi_enabled(on);
+        },
+        |enabled| Command::SetMidiEnabled { enabled },
+        |enabled| {
+            let mut config = FilesystemStorage::load_app_config().unwrap_or_default();
+            config.midi_enabled = enabled;
+            if let Err(e) = FilesystemStorage::save_app_config(&config) {
+                log::error!("failed to persist midi_enabled: {e}");
+            }
+        },
+    ));
+    let for_app = handler.clone();
+    window.on_set_midi_enabled(move |on| for_app(on));
+    let for_settings = handler;
+    project_settings_window.on_set_midi_enabled(move |on| for_settings(on));
+}
+
+fn install_mcp(
+    window: &AppWindow,
+    project_settings_window: &ProjectSettingsWindow,
+    project_session: &Rc<RefCell<Option<ProjectSession>>>,
+) {
+    let handler = Rc::new(make_handler(
+        window,
+        project_settings_window,
+        project_session,
+        |w, s, on| {
+            w.set_mcp_enabled(on);
+            s.set_mcp_enabled(on);
+        },
+        |enabled| Command::SetMcpEnabled { enabled },
+        |enabled| {
+            let mut config = FilesystemStorage::load_app_config().unwrap_or_default();
+            config.mcp_enabled = enabled;
+            if let Err(e) = FilesystemStorage::save_app_config(&config) {
+                log::error!("failed to persist mcp_enabled: {e}");
+            }
+        },
+    ));
+    let for_app = handler.clone();
+    window.on_set_mcp_enabled(move |on| for_app(on));
+    let for_settings = handler;
+    project_settings_window.on_set_mcp_enabled(move |on| for_settings(on));
+}

--- a/crates/adapter-gui/src/settings/mod.rs
+++ b/crates/adapter-gui/src/settings/mod.rs
@@ -8,6 +8,7 @@
 //! profile-driven daemon shipped.)
 
 pub mod audio;
+pub mod integrations;
 pub mod language;
 pub mod midi_devices;
 pub mod paths;

--- a/crates/adapter-gui/tests/issue_712_subsystem_toggle_wiring.rs
+++ b/crates/adapter-gui/tests/issue_712_subsystem_toggle_wiring.rs
@@ -1,0 +1,37 @@
+//! Issue #712: the System / Integrations section toggles must dispatch the
+//! per-machine master switches through the command bus — never mutate
+//! config or borrow_mut in the callback (the GUI-has-no-business-logic
+//! LAW). UI rendering can't be asserted without an `AppWindow`, so this is
+//! a source-presence guard on the wiring glue: it flips GREEN once the
+//! callbacks dispatch `SetMidiEnabled` / `SetMcpEnabled`, RED on any
+//! regression that bypasses the dispatcher.
+
+use std::path::PathBuf;
+
+fn read_src(relative: &str) -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("src")
+        .join(relative);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+#[test]
+fn integrations_wiring_dispatches_set_midi_enabled() {
+    let src = read_src("settings/integrations.rs");
+    assert!(
+        src.contains("Command::SetMidiEnabled"),
+        "issue #712: the MIDI master toggle must dispatch \
+         Command::SetMidiEnabled (persists config.yaml midi_enabled with \
+         GUI/MCP/gRPC parity), not mutate config directly in the callback."
+    );
+}
+
+#[test]
+fn integrations_wiring_dispatches_set_mcp_enabled() {
+    let src = read_src("settings/integrations.rs");
+    assert!(
+        src.contains("Command::SetMcpEnabled"),
+        "issue #712: the MCP master toggle must dispatch \
+         Command::SetMcpEnabled, not mutate config directly in the callback."
+    );
+}

--- a/crates/adapter-gui/tests/issue_712_subsystem_toggle_wiring.rs
+++ b/crates/adapter-gui/tests/issue_712_subsystem_toggle_wiring.rs
@@ -35,3 +35,23 @@ fn integrations_wiring_dispatches_set_mcp_enabled() {
          Command::SetMcpEnabled, not mutate config directly in the callback."
     );
 }
+
+#[test]
+fn integrations_wiring_syncs_the_in_memory_app_config_snapshot() {
+    // Regression: the toggle persisted to config.yaml but came back OFF
+    // after a restart. The GUI holds a boot-time `Rc<RefCell<AppConfig>>`
+    // that recent-projects/project-open wirings re-save WHOLESALE
+    // (`save_app_config(app_config.borrow().clone())`). A toggle that only
+    // writes disk (and skips this shared snapshot) is clobbered by the
+    // stale boot value the next time any project op fires. The fix mirrors
+    // `settings::audio`: mutate `app_config.borrow_mut()` so the snapshot
+    // carries the new value.
+    let src = read_src("settings/integrations.rs");
+    assert!(
+        src.contains("app_config") && src.contains("borrow_mut"),
+        "issue #712: the toggle must also update the shared in-memory \
+         AppConfig snapshot (mutate `app_config.borrow_mut()`), else the \
+         recent-projects wiring re-saves the stale boot snapshot and the \
+         switch resets on restart. See settings::audio for the pattern."
+    );
+}

--- a/crates/adapter-gui/translations/adapter-gui.pot
+++ b/crates/adapter-gui/translations/adapter-gui.pot
@@ -732,3 +732,21 @@ msgstr ""
 msgctxt "ConfirmDeleteRecentProjectDialog"
 msgid "btn-remove"
 msgstr ""
+
+msgid "title-section-integrations"
+msgstr ""
+
+msgid "label-midi-enabled"
+msgstr ""
+
+msgid "desc-midi-enabled"
+msgstr ""
+
+msgid "label-mcp-enabled"
+msgstr ""
+
+msgid "desc-mcp-enabled"
+msgstr ""
+
+msgid "hint-restart-to-apply"
+msgstr ""

--- a/crates/adapter-gui/translations/de_DE/LC_MESSAGES/adapter-gui.po
+++ b/crates/adapter-gui/translations/de_DE/LC_MESSAGES/adapter-gui.po
@@ -568,3 +568,21 @@ msgstr "Überschreiben"
 
 msgid "btn-save-audio-settings"
 msgstr ""
+
+msgid "title-section-integrations"
+msgstr "Integrationen"
+
+msgid "label-midi-enabled"
+msgstr "MIDI-Steuerung"
+
+msgid "desc-midi-enabled"
+msgstr "Aktiviert den MIDI/BLE-MIDI-Adapter, damit Fußschalter OpenRig steuern"
+
+msgid "label-mcp-enabled"
+msgstr "MCP-Server"
+
+msgid "desc-mcp-enabled"
+msgstr "Stellt den MCP-Server unter 127.0.0.1:4123 für Agenten bereit"
+
+msgid "hint-restart-to-apply"
+msgstr "Wird beim nächsten Start wirksam."

--- a/crates/adapter-gui/translations/en_US/LC_MESSAGES/adapter-gui.po
+++ b/crates/adapter-gui/translations/en_US/LC_MESSAGES/adapter-gui.po
@@ -630,3 +630,21 @@ msgstr "Play DI loop"
 #: crates/adapter-gui/ui/components/chain_di_loop_button.slint
 msgid "di-loop-stop-label"
 msgstr "Stop DI loop"
+
+msgid "title-section-integrations"
+msgstr "Integrations"
+
+msgid "label-midi-enabled"
+msgstr "MIDI control surface"
+
+msgid "desc-midi-enabled"
+msgstr "Enable the MIDI/BLE-MIDI adapter so footswitches drive OpenRig"
+
+msgid "label-mcp-enabled"
+msgstr "MCP server"
+
+msgid "desc-mcp-enabled"
+msgstr "Expose the MCP server on 127.0.0.1:4123 for agents"
+
+msgid "hint-restart-to-apply"
+msgstr "Takes effect on the next launch."

--- a/crates/adapter-gui/translations/es_ES/LC_MESSAGES/adapter-gui.po
+++ b/crates/adapter-gui/translations/es_ES/LC_MESSAGES/adapter-gui.po
@@ -643,3 +643,21 @@ msgstr "Reproducir loop DI"
 #: crates/adapter-gui/ui/components/chain_di_loop_button.slint
 msgid "di-loop-stop-label"
 msgstr "Detener loop DI"
+
+msgid "title-section-integrations"
+msgstr "Integraciones"
+
+msgid "label-midi-enabled"
+msgstr "Control MIDI"
+
+msgid "desc-midi-enabled"
+msgstr "Activa el adaptador MIDI/BLE-MIDI para que los pedales controlen OpenRig"
+
+msgid "label-mcp-enabled"
+msgstr "Servidor MCP"
+
+msgid "desc-mcp-enabled"
+msgstr "Expone el servidor MCP en 127.0.0.1:4123 para agentes"
+
+msgid "hint-restart-to-apply"
+msgstr "Tendrá efecto en el próximo inicio."

--- a/crates/adapter-gui/translations/fr_FR/LC_MESSAGES/adapter-gui.po
+++ b/crates/adapter-gui/translations/fr_FR/LC_MESSAGES/adapter-gui.po
@@ -565,3 +565,21 @@ msgstr "Écraser"
 
 msgid "btn-save-audio-settings"
 msgstr ""
+
+msgid "title-section-integrations"
+msgstr "Intégrations"
+
+msgid "label-midi-enabled"
+msgstr "Contrôle MIDI"
+
+msgid "desc-midi-enabled"
+msgstr "Active l'adaptateur MIDI/BLE-MIDI pour piloter OpenRig au pied"
+
+msgid "label-mcp-enabled"
+msgstr "Serveur MCP"
+
+msgid "desc-mcp-enabled"
+msgstr "Expose le serveur MCP sur 127.0.0.1:4123 pour les agents"
+
+msgid "hint-restart-to-apply"
+msgstr "Prend effet au prochain démarrage."

--- a/crates/adapter-gui/translations/hi_IN/LC_MESSAGES/adapter-gui.po
+++ b/crates/adapter-gui/translations/hi_IN/LC_MESSAGES/adapter-gui.po
@@ -562,3 +562,21 @@ msgstr "अधिलेखित करें"
 
 msgid "btn-save-audio-settings"
 msgstr ""
+
+msgid "title-section-integrations"
+msgstr "एकीकरण"
+
+msgid "label-midi-enabled"
+msgstr "MIDI नियंत्रण"
+
+msgid "desc-midi-enabled"
+msgstr "MIDI/BLE-MIDI एडाप्टर चालू करें ताकि फुटस्विच OpenRig को नियंत्रित करें"
+
+msgid "label-mcp-enabled"
+msgstr "MCP सर्वर"
+
+msgid "desc-mcp-enabled"
+msgstr "एजेंट के लिए MCP सर्वर को 127.0.0.1:4123 पर उपलब्ध कराएं"
+
+msgid "hint-restart-to-apply"
+msgstr "अगली बार शुरू करने पर लागू होगा।"

--- a/crates/adapter-gui/translations/ja_JP/LC_MESSAGES/adapter-gui.po
+++ b/crates/adapter-gui/translations/ja_JP/LC_MESSAGES/adapter-gui.po
@@ -566,3 +566,21 @@ msgstr "上書き"
 
 msgid "btn-save-audio-settings"
 msgstr ""
+
+msgid "title-section-integrations"
+msgstr "連携"
+
+msgid "label-midi-enabled"
+msgstr "MIDIコントロール"
+
+msgid "desc-midi-enabled"
+msgstr "MIDI/BLE-MIDIアダプターを有効にしてフットスイッチでOpenRigを操作"
+
+msgid "label-mcp-enabled"
+msgstr "MCPサーバー"
+
+msgid "desc-mcp-enabled"
+msgstr "エージェント向けにMCPサーバーを127.0.0.1:4123で公開"
+
+msgid "hint-restart-to-apply"
+msgstr "次回の起動時に有効になります。"

--- a/crates/adapter-gui/translations/ko_KR/LC_MESSAGES/adapter-gui.po
+++ b/crates/adapter-gui/translations/ko_KR/LC_MESSAGES/adapter-gui.po
@@ -562,3 +562,21 @@ msgstr "덮어쓰기"
 
 msgid "btn-save-audio-settings"
 msgstr ""
+
+msgid "title-section-integrations"
+msgstr "통합"
+
+msgid "label-midi-enabled"
+msgstr "MIDI 제어"
+
+msgid "desc-midi-enabled"
+msgstr "MIDI/BLE-MIDI 어댑터를 켜서 풋스위치로 OpenRig를 제어"
+
+msgid "label-mcp-enabled"
+msgstr "MCP 서버"
+
+msgid "desc-mcp-enabled"
+msgstr "에이전트용 MCP 서버를 127.0.0.1:4123에 노출"
+
+msgid "hint-restart-to-apply"
+msgstr "다음 실행 시 적용됩니다."

--- a/crates/adapter-gui/translations/pt_BR/LC_MESSAGES/adapter-gui.po
+++ b/crates/adapter-gui/translations/pt_BR/LC_MESSAGES/adapter-gui.po
@@ -651,3 +651,21 @@ msgstr "Tocar loop DI"
 #: crates/adapter-gui/ui/components/chain_di_loop_button.slint
 msgid "di-loop-stop-label"
 msgstr "Parar loop DI"
+
+msgid "title-section-integrations"
+msgstr "Integrações"
+
+msgid "label-midi-enabled"
+msgstr "Controle MIDI"
+
+msgid "desc-midi-enabled"
+msgstr "Liga o adaptador MIDI/BLE-MIDI para pedais controlarem o OpenRig"
+
+msgid "label-mcp-enabled"
+msgstr "Servidor MCP"
+
+msgid "desc-mcp-enabled"
+msgstr "Expõe o servidor MCP em 127.0.0.1:4123 para agentes"
+
+msgid "hint-restart-to-apply"
+msgstr "Vale a partir do próximo início."

--- a/crates/adapter-gui/translations/zh_CN/LC_MESSAGES/adapter-gui.po
+++ b/crates/adapter-gui/translations/zh_CN/LC_MESSAGES/adapter-gui.po
@@ -562,3 +562,21 @@ msgstr "覆盖"
 
 msgid "btn-save-audio-settings"
 msgstr ""
+
+msgid "title-section-integrations"
+msgstr "集成"
+
+msgid "label-midi-enabled"
+msgstr "MIDI 控制"
+
+msgid "desc-midi-enabled"
+msgstr "启用 MIDI/BLE-MIDI 适配器，让踏板控制 OpenRig"
+
+msgid "label-mcp-enabled"
+msgstr "MCP 服务器"
+
+msgid "desc-mcp-enabled"
+msgstr "在 127.0.0.1:4123 上为代理开放 MCP 服务器"
+
+msgid "hint-restart-to-apply"
+msgstr "将在下次启动时生效。"

--- a/crates/adapter-gui/ui/app-window.slint
+++ b/crates/adapter-gui/ui/app-window.slint
@@ -242,6 +242,11 @@ export component AppWindow inherits Window {
     callback refresh-midi-devices();
     callback toggle-midi-device(int, bool);
     callback edit-midi-device-alias(int, string);
+    // #712: System / Integrations master switches (per-machine config.yaml).
+    in property <bool> midi-enabled;
+    in property <bool> mcp-enabled;
+    callback set-midi-enabled(bool);
+    callback set-mcp-enabled(bool);
     // Project / MIDI mapping editor callbacks (#513, #493)
     callback add-midi-binding();
     callback delete-midi-binding(int);
@@ -413,6 +418,8 @@ export component AppWindow inherits Window {
         bit-depth-options: root.bit-depth-options;
         project-devices: root.project-devices;
         midi-devices: root.midi-devices;
+        midi-enabled: root.midi-enabled;
+        mcp-enabled: root.mcp-enabled;
         midi-bindings: root.midi-bindings;
         available-commands: root.available-commands;
         chain-editor-input-groups: root.chain-editor-input-groups;
@@ -539,6 +546,8 @@ export component AppWindow inherits Window {
         refresh-midi-devices => { root.refresh-midi-devices(); }
         toggle-midi-device(i, on) => { root.toggle-midi-device(i, on); }
         edit-midi-device-alias(i, s) => { root.edit-midi-device-alias(i, s); }
+        set-midi-enabled(on) => { root.set-midi-enabled(on); }
+        set-mcp-enabled(on) => { root.set-mcp-enabled(on); }
         add-midi-binding => { root.add-midi-binding(); }
         delete-midi-binding(i) => { root.delete-midi-binding(i); }
         pick-midi-binding-command(i, c) => { root.pick-midi-binding-command(i, c); }
@@ -642,6 +651,8 @@ export component AppWindow inherits Window {
         bit-depth-options: root.bit-depth-options;
         project-devices: root.project-devices;
         midi-devices: root.midi-devices;
+        midi-enabled: root.midi-enabled;
+        mcp-enabled: root.mcp-enabled;
         midi-bindings: root.midi-bindings;
         available-commands: root.available-commands;
         toggle-input-device(index, selected) => { root.toggle-input-device(index, selected); }
@@ -736,6 +747,8 @@ export component AppWindow inherits Window {
         refresh-midi-devices => { root.refresh-midi-devices(); }
         toggle-midi-device(i, on) => { root.toggle-midi-device(i, on); }
         edit-midi-device-alias(i, s) => { root.edit-midi-device-alias(i, s); }
+        set-midi-enabled(on) => { root.set-midi-enabled(on); }
+        set-mcp-enabled(on) => { root.set-mcp-enabled(on); }
         add-midi-binding => { root.add-midi-binding(); }
         delete-midi-binding(i) => { root.delete-midi-binding(i); }
         pick-midi-binding-command(i, c) => { root.pick-midi-binding-command(i, c); }

--- a/crates/adapter-gui/ui/desktop_main.slint
+++ b/crates/adapter-gui/ui/desktop_main.slint
@@ -200,6 +200,11 @@ export component DesktopMain inherits Rectangle {
     callback refresh-midi-devices();
     callback toggle-midi-device(int, bool);
     callback edit-midi-device-alias(int, string);
+    // #712: System / Integrations master switches.
+    in property <bool> midi-enabled;
+    in property <bool> mcp-enabled;
+    callback set-midi-enabled(bool);
+    callback set-mcp-enabled(bool);
     // Project / MIDI mapping editor callbacks (#513, #493)
     callback add-midi-binding();
     callback delete-midi-binding(int);
@@ -381,6 +386,8 @@ export component DesktopMain inherits Rectangle {
             project-name-draft <=> root.project-name-draft;
             project-devices: root.project-devices;
             midi-devices: root.midi-devices;
+            midi-enabled: root.midi-enabled;
+            mcp-enabled: root.mcp-enabled;
             midi-bindings: root.midi-bindings;
             available-commands: root.available-commands;
             sample-rate-options: root.sample-rate-options;
@@ -406,6 +413,8 @@ export component DesktopMain inherits Rectangle {
             refresh-midi-devices => { root.refresh-midi-devices(); }
             toggle-midi-device(i, on) => { root.toggle-midi-device(i, on); }
             edit-midi-device-alias(i, s) => { root.edit-midi-device-alias(i, s); }
+            set-midi-enabled(on) => { root.set-midi-enabled(on); }
+            set-mcp-enabled(on) => { root.set-mcp-enabled(on); }
             add-midi-binding => { root.add-midi-binding(); }
             delete-midi-binding(i) => { root.delete-midi-binding(i); }
             pick-midi-binding-command(i, c) => { root.pick-midi-binding-command(i, c); }
@@ -560,6 +569,8 @@ export component DesktopMain inherits Rectangle {
         status-message <=> root.status-message;
         project-devices: root.project-devices;
         midi-devices: root.midi-devices;
+        midi-enabled: root.midi-enabled;
+        mcp-enabled: root.mcp-enabled;
         midi-bindings: root.midi-bindings;
         available-commands: root.available-commands;
         sample-rate-options: root.sample-rate-options;
@@ -583,6 +594,8 @@ export component DesktopMain inherits Rectangle {
         refresh-midi-devices => { root.refresh-midi-devices(); }
         toggle-midi-device(i, on) => { root.toggle-midi-device(i, on); }
         edit-midi-device-alias(i, s) => { root.edit-midi-device-alias(i, s); }
+        set-midi-enabled(on) => { root.set-midi-enabled(on); }
+        set-mcp-enabled(on) => { root.set-mcp-enabled(on); }
         add-midi-binding => { root.add-midi-binding(); }
         delete-midi-binding(i) => { root.delete-midi-binding(i); }
         pick-midi-binding-command(i, c) => { root.pick-midi-binding-command(i, c); }

--- a/crates/adapter-gui/ui/pages/settings.slint
+++ b/crates/adapter-gui/ui/pages/settings.slint
@@ -19,6 +19,7 @@ import { DeviceSelectionItem, MidiDeviceRow, MidiBindingRow } from "../models.sl
 import { SectionSystemAudio } from "settings/section_system_audio.slint";
 import { SectionSystemLanguage } from "settings/section_system_language.slint";
 import { SectionSystemMidiDevices } from "settings/section_system_midi_devices.slint";
+import { SectionSystemIntegrations } from "settings/section_system_integrations.slint";
 import { SectionSystemPaths } from "settings/section_system_paths.slint";
 import { SectionProjectMeta } from "settings/section_project_meta.slint";
 
@@ -120,6 +121,11 @@ export component SettingsPage inherits Rectangle {
     callback refresh-midi-devices();
     callback toggle-midi-device(int, bool);
     callback edit-midi-device-alias(int, string);
+    // #712: System / Integrations master switches (per-machine config.yaml).
+    in property <bool> midi-enabled;
+    in property <bool> mcp-enabled;
+    callback set-midi-enabled(bool);
+    callback set-mcp-enabled(bool);
     callback add-midi-binding();
     callback delete-midi-binding(int);
     callback pick-midi-binding-command(int, string);
@@ -191,6 +197,11 @@ export component SettingsPage inherits Rectangle {
                     selected: root.selected-section == 3;
                     clicked => { root.selected-section = 3; }
                 }
+                NavRow {
+                    label: @tr("title-section-integrations");
+                    selected: root.selected-section == 5;
+                    clicked => { root.selected-section = 5; }
+                }
 
                 // Visual gap between groups (24px between unrelated
                 // groups per the spacing tokens).
@@ -244,6 +255,7 @@ export component SettingsPage inherits Rectangle {
                         : root.selected-section == 1 ? @tr("title-section-language")
                         : root.selected-section == 2 ? @tr("title-section-midi-devices")
                         : root.selected-section == 3 ? @tr("title-section-paths")
+                        : root.selected-section == 5 ? @tr("title-section-integrations")
                         : @tr("title-section-project-meta");
                     color: #dde3ec;
                     font-size: 18px;
@@ -298,6 +310,12 @@ export component SettingsPage inherits Rectangle {
                         pick-evaluations-path => { root.pick-evaluations-path(); }
                         reset-evaluations-path => { root.reset-evaluations-path(); }
                         reload-plugin-catalog => { root.reload-plugin-catalog(); }
+                    }
+                    if root.selected-section == 5 : SectionSystemIntegrations {
+                        midi-enabled: root.midi-enabled;
+                        mcp-enabled: root.mcp-enabled;
+                        set-midi-enabled(on) => { root.set-midi-enabled(on); }
+                        set-mcp-enabled(on) => { root.set-mcp-enabled(on); }
                     }
                     if root.selected-section == 4 : SectionProjectMeta {
                         project-name: root.project-name;

--- a/crates/adapter-gui/ui/pages/settings/section_system_integrations.slint
+++ b/crates/adapter-gui/ui/pages/settings/section_system_integrations.slint
@@ -1,0 +1,140 @@
+// System / Integrations — master switches for the MIDI/BLE-MIDI adapter
+// and the MCP server (issue #712). Enablement is per-machine config
+// (config.yaml), not a CLI flag, so packaged builds — launched with no
+// arguments — can bring these subsystems up. The toggles dispatch
+// SetMidiEnabled / SetMcpEnabled through the command bus; the change is
+// persisted and takes effect on next launch (the subsystems are wired at
+// bootstrap), hence the restart hint.
+//
+// Visual language mirrors the device-row toggle in
+// section_system_midi_devices.slint (blue check-square) for cross-screen
+// consistency.
+
+export component SectionSystemIntegrations inherits Rectangle {
+    in property <bool> midi-enabled;
+    in property <bool> mcp-enabled;
+    callback set-midi-enabled(bool);
+    callback set-mcp-enabled(bool);
+
+    background: transparent;
+
+    VerticalLayout {
+        spacing: 12px;
+
+        // ── MIDI adapter row ──
+        Rectangle {
+            height: 56px;
+            background: #1d2025;
+            border-radius: 8px;
+            border-width: 1px;
+            border-color: root.midi-enabled ? #2f4a6a : #2a2f38;
+            animate border-color { duration: 200ms; }
+
+            VerticalLayout {
+                x: 16px;
+                width: parent.width - 16px - 56px;
+                alignment: center;
+                spacing: 2px;
+                Text {
+                    text: @tr("label-midi-enabled");
+                    color: #f3f6fb;
+                    font-size: 16px;
+                    vertical-alignment: center;
+                }
+                Text {
+                    text: @tr("desc-midi-enabled");
+                    color: #8a92a3;
+                    font-size: 14px;
+                    overflow: elide;
+                }
+            }
+
+            Rectangle {
+                x: parent.width - 36px;
+                y: (parent.height - 20px) / 2;
+                width: 20px;
+                height: 20px;
+                background: root.midi-enabled ? #188cff : #1e2229;
+                border-width: 1px;
+                border-color: root.midi-enabled ? #45a7ff : #3d4450;
+                border-radius: 8px;
+
+                if root.midi-enabled : Image {
+                    x: (parent.width - self.width) / 2;
+                    y: (parent.height - self.height) / 2;
+                    width: 12px;
+                    height: 12px;
+                    source: @image-url("../../assets/check.svg");
+                    colorize: #ffffff;
+                }
+
+                TouchArea {
+                    mouse-cursor: pointer;
+                    clicked => { root.set-midi-enabled(!root.midi-enabled); }
+                }
+            }
+        }
+
+        // ── MCP server row ──
+        Rectangle {
+            height: 56px;
+            background: #1d2025;
+            border-radius: 8px;
+            border-width: 1px;
+            border-color: root.mcp-enabled ? #2f4a6a : #2a2f38;
+            animate border-color { duration: 200ms; }
+
+            VerticalLayout {
+                x: 16px;
+                width: parent.width - 16px - 56px;
+                alignment: center;
+                spacing: 2px;
+                Text {
+                    text: @tr("label-mcp-enabled");
+                    color: #f3f6fb;
+                    font-size: 16px;
+                    vertical-alignment: center;
+                }
+                Text {
+                    text: @tr("desc-mcp-enabled");
+                    color: #8a92a3;
+                    font-size: 14px;
+                    overflow: elide;
+                }
+            }
+
+            Rectangle {
+                x: parent.width - 36px;
+                y: (parent.height - 20px) / 2;
+                width: 20px;
+                height: 20px;
+                background: root.mcp-enabled ? #188cff : #1e2229;
+                border-width: 1px;
+                border-color: root.mcp-enabled ? #45a7ff : #3d4450;
+                border-radius: 8px;
+
+                if root.mcp-enabled : Image {
+                    x: (parent.width - self.width) / 2;
+                    y: (parent.height - self.height) / 2;
+                    width: 12px;
+                    height: 12px;
+                    source: @image-url("../../assets/check.svg");
+                    colorize: #ffffff;
+                }
+
+                TouchArea {
+                    mouse-cursor: pointer;
+                    clicked => { root.set-mcp-enabled(!root.mcp-enabled); }
+                }
+            }
+        }
+
+        // Restart hint — both switches take effect on next launch.
+        Text {
+            text: @tr("hint-restart-to-apply");
+            color: #6b7786;
+            font-size: 14px;
+            wrap: word-wrap;
+        }
+    }
+}

--- a/crates/adapter-gui/ui/secondary_windows_chain.slint
+++ b/crates/adapter-gui/ui/secondary_windows_chain.slint
@@ -38,6 +38,11 @@ export component ProjectSettingsWindow inherits Window {
     callback refresh-midi-devices();
     callback toggle-midi-device(int, bool);
     callback edit-midi-device-alias(int, string);
+    // #712: System / Integrations master switches.
+    in property <bool> midi-enabled;
+    in property <bool> mcp-enabled;
+    callback set-midi-enabled(bool);
+    callback set-mcp-enabled(bool);
     callback edit-project-name(string);
     // System / Paths section (#513 + #582). Empty = OS default.
     in property <string> presets-path;
@@ -72,6 +77,8 @@ export component ProjectSettingsWindow inherits Window {
         language-codes: root.language-codes;
         selected-language-index: root.selected-language-index;
         midi-devices: root.midi-devices;
+        midi-enabled: root.midi-enabled;
+        mcp-enabled: root.mcp-enabled;
         project-path-display: root.project-path-display;
         update-project-name(value) => { root.update-project-name(value); }
         save-audio-settings => { root.save-audio-settings(); }
@@ -86,6 +93,8 @@ export component ProjectSettingsWindow inherits Window {
         refresh-midi-devices => { root.refresh-midi-devices(); }
         toggle-midi-device(i, on) => { root.toggle-midi-device(i, on); }
         edit-midi-device-alias(i, s) => { root.edit-midi-device-alias(i, s); }
+        set-midi-enabled(on) => { root.set-midi-enabled(on); }
+        set-mcp-enabled(on) => { root.set-mcp-enabled(on); }
         edit-project-name(t) => { root.edit-project-name(t); }
         presets-path: root.presets-path;
         plugins-path: root.plugins-path;

--- a/crates/adapter-gui/ui/touch_main.slint
+++ b/crates/adapter-gui/ui/touch_main.slint
@@ -189,6 +189,11 @@ export component TouchMain inherits Rectangle {
     callback refresh-midi-devices();
     callback toggle-midi-device(int, bool);
     callback edit-midi-device-alias(int, string);
+    // #712: System / Integrations master switches.
+    in property <bool> midi-enabled;
+    in property <bool> mcp-enabled;
+    callback set-midi-enabled(bool);
+    callback set-mcp-enabled(bool);
     // Project / MIDI mapping editor callbacks (#513, #493)
     callback add-midi-binding();
     callback delete-midi-binding(int);
@@ -412,6 +417,8 @@ export component TouchMain inherits Rectangle {
         status-message <=> root.status-message;
         project-devices: root.project-devices;
         midi-devices: root.midi-devices;
+        midi-enabled: root.midi-enabled;
+        mcp-enabled: root.mcp-enabled;
         midi-bindings: root.midi-bindings;
         available-commands: root.available-commands;
         sample-rate-options: root.sample-rate-options;
@@ -432,6 +439,8 @@ export component TouchMain inherits Rectangle {
         refresh-midi-devices => { root.refresh-midi-devices(); }
         toggle-midi-device(i, on) => { root.toggle-midi-device(i, on); }
         edit-midi-device-alias(i, s) => { root.edit-midi-device-alias(i, s); }
+        set-midi-enabled(on) => { root.set-midi-enabled(on); }
+        set-mcp-enabled(on) => { root.set-mcp-enabled(on); }
         add-midi-binding => { root.add-midi-binding(); }
         delete-midi-binding(i) => { root.delete-midi-binding(i); }
         pick-midi-binding-command(i, c) => { root.pick-midi-binding-command(i, c); }

--- a/crates/adapter-mcp/src/tools.rs
+++ b/crates/adapter-mcp/src/tools.rs
@@ -88,7 +88,9 @@ mod tests {
     /// #614 bumped to 63 with `SetChainDiLoopSource` and
     /// `SetChainDiLoopEnabled` — per-chain virtual DI loop (ephemeral,
     /// never persisted; distinct from #324 project-level DI config).
-    const COMMAND_VARIANT_COUNT: usize = 63;
+    /// #712 bumped to 65 with `SetMidiEnabled` and `SetMcpEnabled` —
+    /// per-machine master switches for the MIDI adapter / MCP server.
+    const COMMAND_VARIANT_COUNT: usize = 65;
 
     #[test]
     fn parity_guard_every_command_variant_is_a_tool() {

--- a/crates/application/src/command.rs
+++ b/crates/application/src/command.rs
@@ -470,6 +470,19 @@ pub enum Command {
     /// #548: toggle the compact-view UI mode for the active chain.
     SetCompactViewEnabled { enabled: bool },
 
+    /// #712: master switch for the MIDI/BLE-MIDI adapter, persisted into
+    /// the per-machine `config.yaml` (`midi_enabled`). Set from the
+    /// Settings toggle so packaged builds — launched with no CLI flags —
+    /// can bring MIDI up. Per-machine (ADR 0003), distinct from the
+    /// per-port `midi_devices[].enabled` selection. Takes effect on next
+    /// launch (the adapter is wired at bootstrap).
+    SetMidiEnabled { enabled: bool },
+
+    /// #712: master switch for the MCP server, persisted into
+    /// `config.yaml` (`mcp_enabled`). Same per-machine, restart-to-apply
+    /// contract as [`Command::SetMidiEnabled`].
+    SetMcpEnabled { enabled: bool },
+
     /// #548: toggle the block immediately AFTER the active block in
     /// the active chain (wraps to first). Backs MIDI slot
     /// `toggle_active_block_neighbor_enabled`.

--- a/crates/application/src/event.rs
+++ b/crates/application/src/event.rs
@@ -209,6 +209,21 @@ pub enum Event {
         enabled: bool,
     },
 
+    /// #712: the MIDI/BLE-MIDI adapter master switch (`config.yaml`
+    /// `midi_enabled`) was toggled via `SetMidiEnabled`. Persisted by the
+    /// dispatcher; the adapter applies it on next launch (the subsystem is
+    /// wired at bootstrap), so the GUI uses this to surface a restart hint.
+    MidiEnabledChanged {
+        enabled: bool,
+    },
+
+    /// #712: the MCP server master switch (`config.yaml` `mcp_enabled`)
+    /// was toggled via `SetMcpEnabled`. Same restart-to-apply contract as
+    /// [`Event::MidiEnabledChanged`].
+    McpEnabledChanged {
+        enabled: bool,
+    },
+
     // ── Project-level events ──────────────────────────────────────────────────
     /// A project was loaded from disk.
     ProjectLoaded,
@@ -368,6 +383,8 @@ impl Event {
             | Event::TunerEnabledChanged { .. }
             | Event::SpectrumEnabledChanged { .. }
             | Event::CompactViewEnabledChanged { .. }
+            | Event::MidiEnabledChanged { .. }
+            | Event::McpEnabledChanged { .. }
             | Event::ProjectClosed
             // #513 / #493: MIDI device / mapping / learn events live at the
             // system or project root, not a single chain.

--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -44,6 +44,7 @@ mod local_dispatcher_recent;
 mod local_dispatcher_recent_register;
 mod local_dispatcher_rig;
 mod local_dispatcher_selection;
+mod local_dispatcher_subsystems;
 pub mod preset_file;
 pub mod project_save;
 pub mod publishing_dispatcher;

--- a/crates/application/src/local_dispatcher.rs
+++ b/crates/application/src/local_dispatcher.rs
@@ -441,6 +441,10 @@ impl CommandDispatcher for LocalDispatcher {
                 self.handle_toggle_active_block_neighbor_enabled()
             }
 
+            // #712: per-machine MIDI/MCP master switches → config.yaml.
+            Command::SetMidiEnabled { enabled } => self.handle_set_midi_enabled(enabled),
+            Command::SetMcpEnabled { enabled } => self.handle_set_mcp_enabled(enabled),
+
             // #614: per-chain virtual DI loop (ephemeral, never persisted).
             Command::SetChainDiLoopSource { .. } | Command::SetChainDiLoopEnabled { .. } => {
                 self.handle_di_loop(cmd)

--- a/crates/application/src/local_dispatcher_subsystems.rs
+++ b/crates/application/src/local_dispatcher_subsystems.rs
@@ -1,0 +1,42 @@
+//! #712 — `Command::SetMidiEnabled` / `SetMcpEnabled`: per-machine master
+//! switches for the MIDI/BLE-MIDI adapter and the MCP server.
+//!
+//! Enablement is system config (ADR 0003), not a CLI flag: packaged
+//! builds launch the binary with no arguments, so `--midi`/`--mcp` never
+//! reached the installed app. These handlers persist the flag into
+//! `config.yaml` (the read-modify-write runs on the persist worker so the
+//! dispatching thread never waits on disk, ordered with every other config
+//! write), touching ONLY the one field and preserving the rest of
+//! `AppConfig`. The subsystem is wired at bootstrap, so the change takes
+//! effect on next launch — the emitted event lets the GUI surface a
+//! restart hint.
+
+use anyhow::Result;
+use infra_filesystem::FilesystemStorage;
+
+use crate::event::Event;
+use crate::local_dispatcher::LocalDispatcher;
+
+impl LocalDispatcher {
+    pub(crate) fn handle_set_midi_enabled(&self, enabled: bool) -> Result<Vec<Event>> {
+        crate::persist_worker::run(move || {
+            let mut config = FilesystemStorage::load_app_config().unwrap_or_default();
+            config.midi_enabled = enabled;
+            if let Err(e) = FilesystemStorage::save_app_config(&config) {
+                log::error!("failed to persist midi_enabled: {e}");
+            }
+        });
+        Ok(vec![Event::MidiEnabledChanged { enabled }])
+    }
+
+    pub(crate) fn handle_set_mcp_enabled(&self, enabled: bool) -> Result<Vec<Event>> {
+        crate::persist_worker::run(move || {
+            let mut config = FilesystemStorage::load_app_config().unwrap_or_default();
+            config.mcp_enabled = enabled;
+            if let Err(e) = FilesystemStorage::save_app_config(&config) {
+                log::error!("failed to persist mcp_enabled: {e}");
+            }
+        });
+        Ok(vec![Event::McpEnabledChanged { enabled }])
+    }
+}

--- a/crates/application/src/local_dispatcher_tests.rs
+++ b/crates/application/src/local_dispatcher_tests.rs
@@ -2660,6 +2660,81 @@ fn save_audio_settings_persists_input_and_output_separately() {
     });
 }
 
+// ── SetMidiEnabled / SetMcpEnabled tests (#712) ───────────────────────────────
+// The Settings toggle persists the per-machine master switch into
+// config.yaml so packaged builds (launched with no CLI flags) bring the
+// subsystem up on next launch. State change → Command (GUI/MCP/gRPC
+// parity), never a borrow_mut in the callback.
+
+#[test]
+fn set_midi_enabled_persists_true_to_config() {
+    crate::local_dispatcher_paths_tests::with_tmp_home("set-midi-enabled-true", || {
+        let project = Rc::new(RefCell::new(Project {
+            name: None,
+            device_settings: vec![],
+            chains: vec![],
+            midi: None,
+        }));
+        let dispatcher = LocalDispatcher::new(Rc::clone(&project));
+
+        let result = dispatcher.dispatch(Command::SetMidiEnabled { enabled: true });
+        assert!(result.is_ok(), "dispatch returned Err: {:?}", result);
+        crate::persist_worker::flush();
+
+        let config = infra_filesystem::FilesystemStorage::load_app_config().unwrap();
+        assert!(config.midi_enabled, "midi_enabled must persist to config.yaml");
+    });
+}
+
+#[test]
+fn set_mcp_enabled_persists_true_to_config() {
+    crate::local_dispatcher_paths_tests::with_tmp_home("set-mcp-enabled-true", || {
+        let project = Rc::new(RefCell::new(Project {
+            name: None,
+            device_settings: vec![],
+            chains: vec![],
+            midi: None,
+        }));
+        let dispatcher = LocalDispatcher::new(Rc::clone(&project));
+
+        let result = dispatcher.dispatch(Command::SetMcpEnabled { enabled: true });
+        assert!(result.is_ok(), "dispatch returned Err: {:?}", result);
+        crate::persist_worker::flush();
+
+        let config = infra_filesystem::FilesystemStorage::load_app_config().unwrap();
+        assert!(config.mcp_enabled, "mcp_enabled must persist to config.yaml");
+    });
+}
+
+#[test]
+fn set_midi_enabled_false_clears_the_switch_and_preserves_other_config() {
+    crate::local_dispatcher_paths_tests::with_tmp_home("set-midi-enabled-false", || {
+        let project = Rc::new(RefCell::new(Project {
+            name: None,
+            device_settings: vec![],
+            chains: vec![],
+            midi: None,
+        }));
+        let dispatcher = LocalDispatcher::new(Rc::clone(&project));
+
+        // Seed mcp on, midi on; then turn midi off — mcp must stay on.
+        dispatcher
+            .dispatch(Command::SetMcpEnabled { enabled: true })
+            .unwrap();
+        dispatcher
+            .dispatch(Command::SetMidiEnabled { enabled: true })
+            .unwrap();
+        dispatcher
+            .dispatch(Command::SetMidiEnabled { enabled: false })
+            .unwrap();
+        crate::persist_worker::flush();
+
+        let config = infra_filesystem::FilesystemStorage::load_app_config().unwrap();
+        assert!(!config.midi_enabled, "midi must be off");
+        assert!(config.mcp_enabled, "mcp must remain on — fields are independent");
+    });
+}
+
 // ── SaveProject tests ─────────────────────────────────────────────────────────
 
 #[test]

--- a/crates/infra-filesystem/src/lib.rs
+++ b/crates/infra-filesystem/src/lib.rs
@@ -254,6 +254,18 @@ pub struct AppConfig {
     /// yet; the GUI seeds rows from `adapter_midi::list_input_ports()`.
     #[serde(default)]
     pub midi_devices: Vec<MidiDeviceSelection>,
+    /// Master switch for the MIDI/BLE-MIDI adapter (#712). Per-machine, so
+    /// it lives here, not in the project (ADR 0003). Default `false`: a
+    /// packaged build stays quiet until the user opts in (Settings toggle
+    /// or `--midi`, which overrides this for the run). Distinct from the
+    /// per-port `midi_devices[].enabled` selection — this gates the whole
+    /// subsystem.
+    #[serde(default)]
+    pub midi_enabled: bool,
+    /// Master switch for the MCP server (#712). Per-machine; default
+    /// `false`. `--mcp` / `--mcp=ADDR` overrides it for the run.
+    #[serde(default)]
+    pub mcp_enabled: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]

--- a/crates/infra-filesystem/src/lib_tests.rs
+++ b/crates/infra-filesystem/src/lib_tests.rs
@@ -229,6 +229,31 @@ fn app_config_deserialize_empty_yaml_uses_defaults() {
 }
 
 #[test]
+fn app_config_midi_mcp_master_switch_default_false() {
+    // #712: MIDI and MCP enablement is system config, not a CLI flag.
+    // A fresh / legacy config (no keys) must default both subsystems OFF
+    // — the packaged app stays quiet until the user opts in.
+    let config: AppConfig = serde_yaml::from_str("{}").unwrap();
+    assert!(!config.midi_enabled, "MIDI master switch must default to false");
+    assert!(!config.mcp_enabled, "MCP master switch must default to false");
+}
+
+#[test]
+fn app_config_midi_mcp_master_switch_roundtrips() {
+    // #712: once the user flips the switch it must persist across save/load.
+    let config = AppConfig {
+        midi_enabled: true,
+        mcp_enabled: true,
+        ..Default::default()
+    };
+    let yaml = serde_yaml::to_string(&config).unwrap();
+    let restored: AppConfig = serde_yaml::from_str(&yaml).unwrap();
+    assert!(restored.midi_enabled);
+    assert!(restored.mcp_enabled);
+    assert_eq!(config, restored);
+}
+
+#[test]
 fn app_config_save_and_load_filesystem_roundtrip() {
     let dir = tmp_dir("app_config_roundtrip");
     let path = dir.join("config.yaml");
@@ -492,6 +517,7 @@ fn app_config_round_trips_midi_devices() {
             alias: "Foo".into(),
             enabled: true,
         }],
+        ..Default::default()
     };
     let yaml = serde_yaml::to_string(&config).unwrap();
     let back: AppConfig = serde_yaml::from_str(&yaml).unwrap();
@@ -558,6 +584,7 @@ fn app_config_serdes_unified_audio_and_language_fields() {
         output_devices: vec![make_device("out1", "Speakers")],
         language: Some("pt-BR".into()),
         midi_devices: vec![],
+        ..Default::default()
     };
     let yaml = serde_yaml::to_string(&cfg).unwrap();
     assert!(yaml.contains("input_devices"));

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -7,10 +7,12 @@
 | `OPENRIG_PROJECT_PATH=...` | Igual (env tem menor prioridade que CLI) |
 | `RUST_LOG=...` | Log filter (default `info`). Logging is non-blocking (#693): records go through a bounded queue drained by a dedicated writer thread; if the stderr consumer is slower than the producers, records are dropped and a `[log-writer] N record(s) dropped` line reports the gap. Log calls never stall the GUI thread. |
 | `--auto-save` ou `OPENRIG_AUTO_SAVE=1` | Salva a cada alteração, esconde botão |
-| `--mcp` | Sobe servidor MCP em `http://127.0.0.1:4123` (GUI continua) — ver `docs/mcp.md` |
-| `--mcp=ADDR:PORT` | Servidor MCP no endereço dado (ex.: `--mcp=0.0.0.0:9000`) |
-| `--midi` | Start the MIDI/BLE-MIDI adapter using the **resolved view** (ADR 0003 / #499): project bindings (from `project.openrig`'s `midi:` block) → system fallback (`midi-bindings.yaml`) → shipped default. Controller comes from `midi-profile.yaml`. Migrates a legacy `midi-map.yaml` on first launch. See `docs/midi.md`. |
-| `--midi=PATH` | Direct legacy-file load (no migration, no resolution). Useful for testing an explicit map (e.g. `--midi=~/maps/chocolate.yaml`). |
+| `--mcp` | **Override**: forces the MCP server up at `http://127.0.0.1:4123` for this run (GUI continua) — ver `docs/mcp.md`. Persistent enablement is `mcp_enabled` in `config.yaml` (#712). |
+| `--mcp=ADDR:PORT` | Servidor MCP no endereço dado (ex.: `--mcp=0.0.0.0:9000`), overriding config for this run. |
+| `--midi` | **Override**: forces the MIDI/BLE-MIDI adapter up for this run, using the **resolved view** (ADR 0003 / #499): project bindings (from `project.openrig`'s `midi:` block) → system fallback (`midi-bindings.yaml`) → shipped default. Controller comes from `midi-profile.yaml`. Migrates a legacy `midi-map.yaml` on first launch. Persistent enablement is `midi_enabled` in `config.yaml` (#712). See `docs/midi.md`. |
+| `--midi=PATH` | Direct legacy-file load (no migration, no resolution), overriding config for this run. Useful for testing an explicit map (e.g. `--midi=~/maps/chocolate.yaml`). |
+
+> **#712 — these flags are overrides, not the only switch.** Packaged builds launch the binary with no arguments, so MIDI/MCP enablement is driven by the per-machine `config.yaml` master switches `midi_enabled` / `mcp_enabled` (both default `false`; toggle them in Settings or by hand). A present `--midi` / `--mcp` flag forces the subsystem on for that single run regardless of config. See [`config-taxonomy.md`](config-taxonomy.md).
 
 For headless offline rendering, see the **`openrig-render`** binary documented in [`render.md`](render.md). It is a separate executable shipped by `crates/adapter-render` — no GUI, no audio device, no MCP, no MIDI.
 

--- a/docs/config-taxonomy.md
+++ b/docs/config-taxonomy.md
@@ -33,6 +33,14 @@ page for the working rule.
   and is machine-local per ADR 0003 — never travels with
   `project.openrig`.
 - `input_devices` / `output_devices` — per-machine audio device defaults.
+- `midi_enabled` / `mcp_enabled` (#712) — master switches for the
+  MIDI/BLE-MIDI adapter and the MCP server. Both default `false`. Whether
+  a given machine drives OpenRig over MIDI or exposes the MCP server is a
+  per-machine call (a stage Mac wants MIDI; a CI box does not), so it lives
+  here, not in `project.openrig`. The `--midi` / `--mcp` CLI flags override
+  these for a single run (dev convenience). Distinct from the per-port
+  `midi_devices[].enabled` selection, which only picks *which* ports the
+  enabled adapter listens to.
 - MIDI device profile (`midi-profile.yaml`) — which controller port to listen to.
 - MIDI binding fallback (`midi-bindings.yaml`) — bindings used when the project has
   no `midi:` field.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -9,12 +9,19 @@ a change made by the agent is reflected in the GUI in real time.
 
 ## Enable the server
 
-Opt-in flag (absent = server does not start, zero overhead):
+Two ways (#712). Persistent enablement is the per-machine `mcp_enabled`
+switch in `config.yaml` (default off), toggled from **Settings → System /
+Integrations → MCP server** — packaged builds, launched with no
+arguments, rely on this; it binds the default `127.0.0.1:4123` and takes
+effect on the next launch.
+
+The CLI flag (absent = no config override) **forces** the server on for a
+single run, and is the only way to pick a non-default address:
 
 | Form | Effect |
 |---|---|
-| `openrig --mcp` | Starts MCP at `http://127.0.0.1:4123` (GUI stays open) |
-| `openrig --mcp=ADDR:PORT` | Starts at the given address (e.g. `--mcp=0.0.0.0:9000`) |
+| `openrig --mcp` | Forces MCP up at `http://127.0.0.1:4123` for this run (GUI stays open) |
+| `openrig --mcp=ADDR:PORT` | Forces it up at the given address (e.g. `--mcp=0.0.0.0:9000`) |
 | `openrig --mcp=...` invalid | Logs the error and does **not** start (app runs normally) |
 
 Same flag on the console: `adapter-console --mcp[=ADDR]`.

--- a/docs/midi.md
+++ b/docs/midi.md
@@ -105,7 +105,15 @@ The recommended way to create project bindings is the **Settings screen**:
 5. Repeat for each binding. Bindings are saved to `midi.bindings` inside
    your `.openrig` project file.
 
-Start OpenRig with MIDI enabled:
+Enable MIDI. Two ways (#712):
+
+- **Persistent (recommended):** **Settings → System / Integrations →
+  MIDI control surface**. This flips `midi_enabled` in `config.yaml` (a
+  per-machine setting, default off) and survives restarts — packaged
+  builds, which launch with no arguments, rely on this. Takes effect on
+  the next launch.
+- **One run (dev override):** start with the flag, which forces it on
+  regardless of config:
 
 ```
 openrig --midi

--- a/docs/screens.md
+++ b/docs/screens.md
@@ -14,6 +14,7 @@ Pedalboard virtual: usuário monta cadeia de efeitos visualmente, ajusta parâme
     - **Audio interface** — input/output device, sample rate, buffer size, bit depth.
     - **Language** — UI locale override.
     - **MIDI devices** — enable/disable each port, edit per-device alias.
+    - **Integrations** (#712) — master switches for the MIDI/BLE-MIDI adapter and the MCP server (`config.yaml` `midi_enabled` / `mcp_enabled`, both default off). These gate whether the whole subsystem starts — distinct from the per-port MIDI-devices selection. Takes effect on next launch; `--midi` / `--mcp` override for a single run.
   - *Project* (persists to `.openrig`, travels with the rig):
     - **Project metadata** — name and other project-level fields.
     - **MIDI mapping** — binding editor: click **+ Add**, press a control on your MIDI device (MIDI Learn), then pick a Command. Bindings are stored under `midi.bindings` in the `.openrig`. The system-wide fallback (`midi-bindings.yaml`) is used when the open project has no `midi:` field.


### PR DESCRIPTION
Closes #712.

## Problem

Packaged builds (macOS `.app`, Linux `.deb`, Windows) launch the binary with **no arguments**, so `--midi` / `--mcp` never reached the installed app — MIDI and the MCP server only ever came up under `cargo` with the flags. A freshly installed OpenRig had MIDI dead out of the box (surfaced via the M-Vave Chocolate: ports opened, but no control reached the app).

Enabling MIDI/MCP is a **per-machine** decision → system config (ADR 0003), not a launch argument every packaging script has to remember.

## What changed

- `config.yaml` gains master switches `midi_enabled` / `mcp_enabled` (both default `false`, `#[serde(default)]`). Distinct from the per-port `midi_devices[].enabled` selection — these gate the whole subsystem.
- Pure resolvers `resolve_mcp_addr` / `resolve_midi_map` fold config into the CLI result: a present `--midi` / `--mcp` flag wins as a dev override, otherwise the config switch decides. `DEFAULT_MCP_ADDR` extracted as the single source.
- `Command::SetMidiEnabled` / `SetMcpEnabled` (+ `*EnabledChanged` events) persist the switch to `config.yaml` — GUI/MCP/gRPC parity. MCP tool parity guard bumped 63→65.
- **Settings → System / Integrations** section with two toggles, dispatching the commands. i18n across all 9 locales. Takes effect on next launch (subsystem is wired at bootstrap); the section shows a restart hint.

## Persistence-clobber fix (caught in review with the user)

First cut persisted to `config.yaml` but the toggle came back **off** after a restart. Root cause: the GUI holds a boot-time `Rc<RefCell<AppConfig>>` that `recent_projects_wiring` / project-open paths re-save WHOLESALE; a toggle that only wrote disk got clobbered by the stale boot snapshot. Fixed by mirroring `settings::audio` — the wiring also mutates `app_config.borrow_mut()` so the wholesale save carries the new value.

## Tests (RED-first)

config serde defaults/roundtrip, resolver matrix, dispatcher persistence under `with_tmp_home`, MCP parity, i18n key coverage, and source-presence guards on the toggle wiring (dispatch + snapshot sync). `cargo test --workspace --lib` green.

## Out of scope

The BLE-MIDI rescan/drop churn seen in the original logs (separate concern; duplicate ports are already keyed by `port_key.instance`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)