### PR TITLE
chore(i18n): refresh stale Slint catalogs (#714)

### DIFF
--- a/crates/adapter-gui/translations/adapter-gui.pot
+++ b/crates/adapter-gui/translations/adapter-gui.pot
@@ -37,34 +37,96 @@ msgctxt "BlockValueStepper"
 msgid "+"
 msgstr ""
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:87
-msgctxt "PresetSelect"
-msgid "Preset selector"
+#: crates/adapter-gui/ui/components/chain_di_loop_button.slint:61
+msgctxt "ChainDiLoopButton"
+msgid "di-loop-button-label"
 msgstr ""
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:170
+#: crates/adapter-gui/ui/components/chain_di_loop_button.slint:138
+msgctxt "ChainDiLoopButton"
+msgid "di-loop-stop-label"
+msgstr ""
+
+#: crates/adapter-gui/ui/components/chain_di_loop_button.slint:138
+msgctxt "ChainDiLoopButton"
+msgid "di-loop-play-label"
+msgstr ""
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:77
 msgctxt "SceneBtn"
 msgid "Scene {}"
 msgstr ""
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:192
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:99
 msgctxt "SceneBar"
 msgid "Add scene"
 msgstr ""
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:201
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:108
 msgctxt "SceneBar"
 msgid "Remove last scene"
 msgstr ""
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:258
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:183
+msgctxt "ChainTitlePreset"
+msgid "tooltip-open-preset"
+msgstr ""
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:193
+msgctxt "ChainTitlePreset"
+msgid "tooltip-save-preset"
+msgstr ""
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:203
 msgctxt "ChainTitlePreset"
 msgid "Add preset"
+msgstr ""
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:213
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:213
+msgctxt "ChainTitlePreset"
+msgid "Rename preset"
+msgstr ""
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:224
+msgctxt "ChainTitlePreset"
+msgid "Remove preset"
+msgstr ""
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:316
+msgctxt "ChainTitlePreset"
+msgid "Cancel"
+msgstr ""
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:337
+msgctxt "ChainTitlePreset"
+msgid "OK"
 msgstr ""
 
 #: crates/adapter-gui/ui/components/chain_volume_button.slint:37
 msgctxt "ChainVolumeButton"
 msgid "Volume"
+msgstr ""
+
+#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:29
+msgctxt "ConfirmDeleteChainDialog"
+msgid "title-dialog-delete-chain"
+msgstr ""
+
+#. text directly.
+#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:39
+msgctxt "ConfirmDeleteChainDialog"
+msgid "Excluir a chain \"{}\"?"
+msgstr ""
+
+#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:58
+msgctxt "ConfirmDeleteChainDialog"
+msgid "btn-cancel"
+msgstr ""
+
+#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:75
+msgctxt "ConfirmDeleteChainDialog"
+msgid "btn-delete"
 msgstr ""
 
 #: crates/adapter-gui/ui/components/confirm_delete_dialog.slint:27
@@ -88,39 +150,110 @@ msgctxt "ConfirmDeleteBlockDialog"
 msgid "btn-delete"
 msgstr ""
 
+#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:30
+msgctxt "ConfirmDeleteRecentProjectDialog"
+msgid "title-dialog-delete-recent-project"
+msgstr ""
+
+#. Literal pt-BR source string with `{}` placeholder.
+#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:38
+msgctxt "ConfirmDeleteRecentProjectDialog"
+msgid "Remover o projeto \"{}\" dos recentes?"
+msgstr ""
+
+#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:57
+msgctxt "ConfirmDeleteRecentProjectDialog"
+msgid "btn-cancel"
+msgstr ""
+
+#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:74
+msgctxt "ConfirmDeleteRecentProjectDialog"
+msgid "btn-remove"
+msgstr ""
+
 #: crates/adapter-gui/ui/components/language_selector.slint:56
 msgctxt "LanguageSelector"
 msgid "accessible-language-selector"
 msgstr ""
 
-#: crates/adapter-gui/ui/components/model_select_with_search.slint:93
+#: crates/adapter-gui/ui/components/model_select_with_search.slint:96
 msgctxt "ModelSelectWithSearch"
 msgid "▼"
 msgstr ""
 
-#: crates/adapter-gui/ui/components/model_select_with_search.slint:175
+#: crates/adapter-gui/ui/components/model_select_with_search.slint:178
 msgctxt "ModelSelectWithSearch"
 msgid "placeholder-search-models"
+msgstr ""
+
+#: crates/adapter-gui/ui/components/model_select_with_search.slint:212
+msgctxt "ModelSelectWithSearch"
+msgid "status-no-models-found"
+msgstr ""
+
+#: crates/adapter-gui/ui/components/preset_picker_overlay.slint:34
+msgctxt "PresetPickerOverlay"
+msgid "btn-load-preset"
+msgstr ""
+
+#: crates/adapter-gui/ui/components/preset_picker_overlay.slint:40
+msgctxt "PresetPickerOverlay"
+msgid "preset-search-placeholder"
+msgstr ""
+
+#: crates/adapter-gui/ui/components/preset_picker_overlay.slint:106
+msgctxt "PresetPickerOverlay"
+msgid "btn-cancel"
+msgstr ""
+
+#: crates/adapter-gui/ui/components/preset_save_overlay.slint:38
+msgctxt "PresetSaveOverlay"
+msgid "title-dialog-save-preset"
+msgstr ""
+
+#: crates/adapter-gui/ui/components/preset_save_overlay.slint:63
+msgctxt "PresetSaveOverlay"
+msgid "btn-cancel"
+msgstr ""
+
+#: crates/adapter-gui/ui/components/preset_save_overlay.slint:82
+msgctxt "PresetSaveOverlay"
+msgid "btn-save"
+msgstr ""
+
+#: crates/adapter-gui/ui/components/preset_save_overlay.slint:119
+msgctxt "PresetOverwriteOverlay"
+msgid "title-dialog-overwrite-preset"
+msgstr ""
+
+#: crates/adapter-gui/ui/components/preset_save_overlay.slint:126
+msgctxt "PresetOverwriteOverlay"
+msgid "msg-overwrite-preset"
+msgstr ""
+
+#: crates/adapter-gui/ui/components/preset_save_overlay.slint:145
+msgctxt "PresetOverwriteOverlay"
+msgid "btn-cancel"
+msgstr ""
+
+#: crates/adapter-gui/ui/components/preset_save_overlay.slint:162
+msgctxt "PresetOverwriteOverlay"
+msgid "btn-overwrite"
+msgstr ""
+
+#: crates/adapter-gui/ui/components/preset_select.slint:72
+msgctxt "PresetSelect"
+msgid "Preset selector"
+msgstr ""
+
+#: crates/adapter-gui/ui/components/preset_select.slint:137
+msgctxt "PresetSelect"
+msgid "preset-search-placeholder"
 msgstr ""
 
 #: crates/adapter-gui/ui/components/preset_select.slint:170
 msgctxt "PresetSelect"
 msgid "status-no-presets-found"
-msgstr ""
-
-#: crates/adapter-gui/ui/components/model_select_with_search.slint:209
-msgctxt "ModelSelectWithSearch"
-msgid "status-no-models-found"
-msgstr ""
-
-#: crates/adapter-gui/ui/components/preset_picker_overlay.slint:32
-msgctxt "PresetPickerOverlay"
-msgid "btn-load-preset"
-msgstr ""
-
-#: crates/adapter-gui/ui/components/preset_picker_overlay.slint:97
-msgctxt "PresetPickerOverlay"
-msgid "btn-cancel"
 msgstr ""
 
 #: crates/adapter-gui/ui/pages/block_editor_panel.slint:122
@@ -133,12 +266,12 @@ msgctxt "BlockEditorPanel"
 msgid "–"
 msgstr ""
 
-#: crates/adapter-gui/ui/pages/block_panel_editor.slint:36
+#: crates/adapter-gui/ui/pages/block_panel_editor.slint:37
 msgctxt "BlockPanelEditor"
 msgid "btn-add"
 msgstr ""
 
-#: crates/adapter-gui/ui/pages/block_panel_editor.slint:301
+#: crates/adapter-gui/ui/pages/block_panel_editor.slint:323
 msgctxt "BlockPanelEditor"
 msgid "–"
 msgstr ""
@@ -317,47 +450,37 @@ msgctxt "ChainIoGroupsPage"
 msgid "btn-ok"
 msgstr ""
 
-#: crates/adapter-gui/ui/pages/chain_row.slint:140
+#: crates/adapter-gui/ui/pages/chain_row.slint:246
 msgctxt "ChainRow"
 msgid "tooltip-expand-blocks"
 msgstr ""
 
-#: crates/adapter-gui/ui/pages/chain_row.slint:148
+#: crates/adapter-gui/ui/pages/chain_row.slint:254
 msgctxt "ChainRow"
 msgid "tooltip-measure-latency"
 msgstr ""
 
-#: crates/adapter-gui/ui/pages/chain_row.slint:177
+#: crates/adapter-gui/ui/pages/chain_row.slint:283
 msgctxt "ChainRow"
 msgid "tooltip-configure"
 msgstr ""
 
-#: crates/adapter-gui/ui/pages/chain_row.slint:185
-msgctxt "ChainRow"
-msgid "tooltip-open-preset"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:193
-msgctxt "ChainRow"
-msgid "tooltip-save-preset"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:201
+#: crates/adapter-gui/ui/pages/chain_row.slint:291
 msgctxt "ChainRow"
 msgid "tooltip-delete"
 msgstr ""
 
-#: crates/adapter-gui/ui/pages/chain_row.slint:472
+#: crates/adapter-gui/ui/pages/chain_row.slint:564
 msgctxt "ChainRow"
 msgid "label-lat"
 msgstr ""
 
-#: crates/adapter-gui/ui/pages/chain_row.slint:521
+#: crates/adapter-gui/ui/pages/chain_row.slint:613
 msgctxt "ChainRow"
 msgid "label-input"
 msgstr ""
 
-#: crates/adapter-gui/ui/pages/chain_row.slint:567
+#: crates/adapter-gui/ui/pages/chain_row.slint:659
 msgctxt "ChainRow"
 msgid "label-output"
 msgstr ""
@@ -372,18 +495,38 @@ msgctxt "CompactBlockRow"
 msgid "btn-open-plugin"
 msgstr ""
 
-#: crates/adapter-gui/ui/pages/compact_chain_view.slint:83
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:160
+msgctxt "CompactChainViewPage"
+msgid "tooltip-measure-latency"
+msgstr ""
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:187
+msgctxt "CompactChainViewPage"
+msgid "label-lat"
+msgstr ""
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:216
+msgctxt "CompactChainViewPage"
+msgid "tooltip-configure"
+msgstr ""
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:230
 msgctxt "CompactChainViewPage"
 msgid "label-in"
 msgstr ""
 
-#: crates/adapter-gui/ui/pages/compact_chain_view.slint:111
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:251
 msgctxt "CompactChainViewPage"
 msgid "label-out"
 msgstr ""
 
-#: crates/adapter-gui/ui/pages/compact_chain_view.slint:162
-#: crates/adapter-gui/ui/pages/compact_chain_view.slint:162
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:267
+msgctxt "CompactChainViewPage"
+msgid "tooltip-delete"
+msgstr ""
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:313
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:313
 msgctxt "CompactChainViewPage"
 msgid "+"
 msgstr ""
@@ -393,109 +536,69 @@ msgctxt "PluginInfoPanel"
 msgid "·"
 msgstr ""
 
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:123
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:125
 msgctxt "PluginInfoPanel"
 msgid "label-description"
 msgstr ""
 
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:142
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:144
 msgctxt "PluginInfoPanel"
 msgid "label-license"
 msgstr ""
 
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:169
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:171
 msgctxt "PluginInfoPanel"
 msgid "↗"
 msgstr ""
 
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:175
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:177
 msgctxt "PluginInfoPanel"
 msgid "btn-open-homepage"
 msgstr ""
 
-#: crates/adapter-gui/ui/pages/project_chains.slint:136
+#: crates/adapter-gui/ui/pages/project_chains.slint:145
 msgctxt "ProjectChainsPage"
 msgid "tooltip-back"
 msgstr ""
 
-#: crates/adapter-gui/ui/pages/project_chains.slint:144
+#: crates/adapter-gui/ui/pages/project_chains.slint:153
 msgctxt "ProjectChainsPage"
 msgid "tooltip-spectrum"
 msgstr ""
 
-#: crates/adapter-gui/ui/pages/project_chains.slint:152
+#: crates/adapter-gui/ui/pages/project_chains.slint:161
 msgctxt "ProjectChainsPage"
 msgid "tooltip-tuner"
 msgstr ""
 
-#: crates/adapter-gui/ui/pages/project_chains.slint:160
+#: crates/adapter-gui/ui/pages/project_chains.slint:169
 msgctxt "ProjectChainsPage"
 msgid "tooltip-project-settings"
 msgstr ""
 
-#: crates/adapter-gui/ui/pages/project_chains.slint:169
+#: crates/adapter-gui/ui/pages/project_chains.slint:178
 msgctxt "ProjectChainsPage"
 msgid "tooltip-save"
 msgstr ""
 
-#: crates/adapter-gui/ui/pages/project_chains.slint:177
+#: crates/adapter-gui/ui/pages/project_chains.slint:186
 msgctxt "ProjectChainsPage"
 msgid "tooltip-new-chain"
 msgstr ""
 
-#: crates/adapter-gui/ui/pages/project_launcher.slint:185
+#: crates/adapter-gui/ui/pages/project_launcher.slint:184
 msgctxt "SearchField"
 msgid "placeholder-search-projects"
 msgstr ""
 
-#: crates/adapter-gui/ui/pages/project_launcher.slint:288
+#: crates/adapter-gui/ui/pages/project_launcher.slint:287
 msgctxt "ProjectLauncherPage"
 msgid "tooltip-open-project"
 msgstr ""
 
-#: crates/adapter-gui/ui/pages/project_launcher.slint:295
+#: crates/adapter-gui/ui/pages/project_launcher.slint:294
 msgctxt "ProjectLauncherPage"
 msgid "btn-new-project"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:120
-msgctxt "DeviceRow"
-msgid "✓"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:147
-msgctxt "DeviceRow"
-msgid "label-hz"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:170
-msgctxt "DeviceRow"
-msgid "label-buffer"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:193
-msgctxt "DeviceRow"
-msgid "label-bits"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:244
-msgctxt "ProjectSettingsPage"
-msgid "label-name"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:271
-msgctxt "ProjectSettingsPage"
-msgid "title-section-audio-devices"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:329
-msgctxt "ProjectSettingsPage"
-msgid "btn-cancel"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:336
-msgctxt "ProjectSettingsPage"
-msgid "btn-ok"
 msgstr ""
 
 #: crates/adapter-gui/ui/pages/project_setup.slint:55
@@ -521,6 +624,178 @@ msgstr ""
 #: crates/adapter-gui/ui/pages/project_setup.slint:211
 msgctxt "ProjectSetupPage"
 msgid "btn-create-project"
+msgstr ""
+
+#: crates/adapter-gui/ui/pages/settings.slint:170
+msgctxt "SettingsPage"
+msgid "nav-group-system"
+msgstr ""
+
+#: crates/adapter-gui/ui/pages/settings.slint:181
+#: crates/adapter-gui/ui/pages/settings.slint:181
+msgctxt "SettingsPage"
+msgid "title-section-audio-interface"
+msgstr ""
+
+#: crates/adapter-gui/ui/pages/settings.slint:186
+#: crates/adapter-gui/ui/pages/settings.slint:186
+msgctxt "SettingsPage"
+msgid "title-section-language"
+msgstr ""
+
+#: crates/adapter-gui/ui/pages/settings.slint:191
+#: crates/adapter-gui/ui/pages/settings.slint:191
+msgctxt "SettingsPage"
+msgid "title-section-midi-devices"
+msgstr ""
+
+#: crates/adapter-gui/ui/pages/settings.slint:196
+#: crates/adapter-gui/ui/pages/settings.slint:196
+msgctxt "SettingsPage"
+msgid "title-section-paths"
+msgstr ""
+
+#: crates/adapter-gui/ui/pages/settings.slint:201
+#: crates/adapter-gui/ui/pages/settings.slint:201
+msgctxt "SettingsPage"
+msgid "title-section-integrations"
+msgstr ""
+
+#: crates/adapter-gui/ui/pages/settings.slint:216
+msgctxt "SettingsPage"
+msgid "nav-group-project"
+msgstr ""
+
+#: crates/adapter-gui/ui/pages/settings.slint:227
+#: crates/adapter-gui/ui/pages/settings.slint:227
+msgctxt "SettingsPage"
+msgid "title-section-project-meta"
+msgstr ""
+
+#: crates/adapter-gui/ui/pages/settings.slint:335
+msgctxt "SettingsPage"
+msgid "btn-save-audio-settings"
+msgstr ""
+
+#: crates/adapter-gui/ui/pages/settings.slint:339
+msgctxt "SettingsPage"
+msgid "btn-close"
+msgstr ""
+
+#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint:27
+msgctxt "SectionProjectMeta"
+msgid "label-name"
+msgstr ""
+
+#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint:58
+msgctxt "SectionProjectMeta"
+msgid "label-file"
+msgstr ""
+
+#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint:66
+msgctxt "SectionProjectMeta"
+msgid "placeholder-project-unsaved"
+msgstr ""
+
+#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint:83
+msgctxt "SectionProjectMeta"
+msgid "btn-save-project"
+msgstr ""
+
+#: crates/adapter-gui/ui/pages/settings/section_system_audio.slint:95
+msgctxt "AudioDeviceRow"
+msgid "label-hz"
+msgstr ""
+
+#: crates/adapter-gui/ui/pages/settings/section_system_audio.slint:118
+msgctxt "AudioDeviceRow"
+msgid "label-buffer"
+msgstr ""
+
+#: crates/adapter-gui/ui/pages/settings/section_system_audio.slint:141
+msgctxt "AudioDeviceRow"
+msgid "label-bits"
+msgstr ""
+
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:39
+msgctxt "SectionSystemIntegrations"
+msgid "label-midi-enabled"
+msgstr ""
+
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:45
+msgctxt "SectionSystemIntegrations"
+msgid "desc-midi-enabled"
+msgstr ""
+
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:93
+msgctxt "SectionSystemIntegrations"
+msgid "label-mcp-enabled"
+msgstr ""
+
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:99
+msgctxt "SectionSystemIntegrations"
+msgid "desc-mcp-enabled"
+msgstr ""
+
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:134
+msgctxt "SectionSystemIntegrations"
+msgid "hint-restart-to-apply"
+msgstr ""
+
+#: crates/adapter-gui/ui/pages/settings/section_system_language.slint:25
+msgctxt "SectionSystemLanguage"
+msgid "label-language"
+msgstr ""
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:49
+msgctxt "SectionSystemPaths"
+msgid "label-presets-path"
+msgstr ""
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:57
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:57
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:57
+msgctxt "SectionSystemPaths"
+msgid "placeholder-default-path"
+msgstr ""
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:66
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:66
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:66
+msgctxt "SectionSystemPaths"
+msgid "btn-choose-path"
+msgstr ""
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:70
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:70
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:70
+msgctxt "SectionSystemPaths"
+msgid "btn-reset-path"
+msgstr ""
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:81
+msgctxt "SectionSystemPaths"
+msgid "label-plugins-path"
+msgstr ""
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:113
+msgctxt "SectionSystemPaths"
+msgid "label-evaluations-path"
+msgstr ""
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:145
+msgctxt "SectionSystemPaths"
+msgid "label-plugin-catalog"
+msgstr ""
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:153
+msgctxt "SectionSystemPaths"
+msgid "status-plugin-catalog-idle"
+msgstr ""
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:162
+msgctxt "SectionSystemPaths"
+msgid "btn-reload-plugin-catalog"
 msgstr ""
 
 #: crates/adapter-gui/ui/pages/spectrum_window.slint:73
@@ -598,155 +873,97 @@ msgctxt "TunerWindow"
 msgid "title-window-tuner"
 msgstr ""
 
-#: crates/adapter-gui/ui/secondary_windows_block.slint:28
+#: crates/adapter-gui/ui/secondary_windows_block.slint:30
 msgctxt "BlockEditorWindow"
 msgid "title-window-block-editor"
 msgstr ""
 
-#: crates/adapter-gui/ui/secondary_windows_block.slint:195
+#: crates/adapter-gui/ui/secondary_windows_block.slint:231
 msgctxt "CompactChainViewWindow"
 msgid "title-window-chain-view"
 msgstr ""
 
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:23
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:60
 msgctxt "ProjectSettingsWindow"
 msgid "title-window-project-settings"
 msgstr ""
 
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:96
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:159
 msgctxt "ChainEditorWindow"
 msgid "title-window-chain-editor"
 msgstr ""
 
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:129
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:192
 msgctxt "ChainEditorWindow"
 msgid "title-section-input"
 msgstr ""
 
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:147
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:210
 msgctxt "ChainEditorWindow"
 msgid "title-section-output"
 msgstr ""
 
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:177
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:240
 msgctxt "ChainInputWindow"
 msgid "title-window-chain-input"
 msgstr ""
 
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:187
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:250
 msgctxt "ChainInputWindow"
 msgid "title-section-input"
 msgstr ""
 
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:217
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:280
 msgctxt "ChainOutputWindow"
 msgid "title-window-chain-output"
 msgstr ""
 
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:227
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:290
 msgctxt "ChainOutputWindow"
 msgid "title-section-output"
 msgstr ""
 
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:258
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:321
 msgctxt "ChainInputGroupsWindow"
 msgid "title-window-chain-inputs"
 msgstr ""
 
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:268
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:331
 msgctxt "ChainInputGroupsWindow"
 msgid "title-section-inputs"
 msgstr ""
 
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:269
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:332
 msgctxt "ChainInputGroupsWindow"
 msgid "btn-add-input-row"
 msgstr ""
 
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:299
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:362
 msgctxt "ChainOutputGroupsWindow"
 msgid "title-window-chain-outputs"
 msgstr ""
 
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:309
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:372
 msgctxt "ChainOutputGroupsWindow"
 msgid "title-section-outputs"
 msgstr ""
 
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:310
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:373
 msgctxt "ChainOutputGroupsWindow"
 msgid "btn-add-output-row"
 msgstr ""
 
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:355
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:418
 msgctxt "ChainInsertWindow"
 msgid "title-window-chain-insert"
 msgstr ""
 
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:365
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:428
 msgctxt "ChainInsertWindow"
 msgid "title-section-configure-insert"
 msgstr ""
 
-#: crates/adapter-gui/ui/touch_main.slint:586
+#: crates/adapter-gui/ui/touch_main.slint:667
 msgctxt "TouchMain"
 msgid "⌨"
-msgstr ""
-
-#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:27
-msgctxt "ConfirmDeleteChainDialog"
-msgid "title-dialog-delete-chain"
-msgstr ""
-
-#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:37
-msgctxt "ConfirmDeleteChainDialog"
-msgid "Excluir a chain \"{}\"?"
-msgstr ""
-
-#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:58
-msgctxt "ConfirmDeleteChainDialog"
-msgid "btn-cancel"
-msgstr ""
-
-#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:75
-msgctxt "ConfirmDeleteChainDialog"
-msgid "btn-delete"
-msgstr ""
-
-#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:31
-msgctxt "ConfirmDeleteRecentProjectDialog"
-msgid "title-dialog-delete-recent-project"
-msgstr ""
-
-#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:41
-msgctxt "ConfirmDeleteRecentProjectDialog"
-msgid "Remover o projeto \"{}\" dos recentes?"
-msgstr ""
-
-#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:58
-msgctxt "ConfirmDeleteRecentProjectDialog"
-msgid "btn-cancel"
-msgstr ""
-
-#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:75
-msgctxt "ConfirmDeleteRecentProjectDialog"
-msgid "btn-remove"
-msgstr ""
-
-msgid "title-section-integrations"
-msgstr ""
-
-msgid "label-midi-enabled"
-msgstr ""
-
-msgid "desc-midi-enabled"
-msgstr ""
-
-msgid "label-mcp-enabled"
-msgstr ""
-
-msgid "desc-mcp-enabled"
-msgstr ""
-
-msgid "hint-restart-to-apply"
 msgstr ""

--- a/crates/adapter-gui/translations/de_DE/LC_MESSAGES/adapter-gui.po
+++ b/crates/adapter-gui/translations/de_DE/LC_MESSAGES/adapter-gui.po
@@ -12,577 +12,939 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: crates/adapter-gui/ui/blocks/header.slint:13
+msgctxt "Header"
 msgid "OpenRig"
 msgstr "OpenRig"
 
 #: crates/adapter-gui/ui/components/block_panel_parameter_item.slint:274
+msgctxt "BlockPanelParameterItem"
 msgid "btn-load-file"
 msgstr "Load"
 
 #: crates/adapter-gui/ui/components/block_stream_mini_display.slint:23
+msgctxt "BlockStreamMiniDisplay"
 msgid "–"
 msgstr "–"
 
 #: crates/adapter-gui/ui/components/block_value_widgets.slint:128
+msgctxt "BlockValueStepper"
 msgid "−"
 msgstr "−"
 
 #: crates/adapter-gui/ui/components/block_value_widgets.slint:194
+msgctxt "BlockValueStepper"
 msgid "+"
 msgstr "+"
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:87
-msgid "Preset selector"
-msgstr ""
+#: crates/adapter-gui/ui/components/chain_di_loop_button.slint:61
+msgctxt "ChainDiLoopButton"
+msgid "di-loop-button-label"
+msgstr "DI-Loop"
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:170
+#: crates/adapter-gui/ui/components/chain_di_loop_button.slint:138
+msgctxt "ChainDiLoopButton"
+msgid "di-loop-stop-label"
+msgstr "DI-Loop stoppen"
+
+#: crates/adapter-gui/ui/components/chain_di_loop_button.slint:138
+msgctxt "ChainDiLoopButton"
+msgid "di-loop-play-label"
+msgstr "DI-Loop abspielen"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:77
+msgctxt "SceneBtn"
 msgid "Scene {}"
 msgstr ""
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:192
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:99
+msgctxt "SceneBar"
 msgid "Add scene"
 msgstr ""
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:201
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:108
+msgctxt "SceneBar"
 msgid "Remove last scene"
 msgstr ""
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:258
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:183
+msgctxt "ChainTitlePreset"
+msgid "tooltip-open-preset"
+msgstr "Preset öffnen"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:193
+msgctxt "ChainTitlePreset"
+msgid "tooltip-save-preset"
+msgstr "Preset speichern"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:203
+msgctxt "ChainTitlePreset"
 msgid "Add preset"
 msgstr ""
 
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:213
+msgctxt "ChainTitlePreset"
+msgid "Rename preset"
+msgstr "Preset umbenennen"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:224
+msgctxt "ChainTitlePreset"
+msgid "Remove preset"
+msgstr "Preset entfernen"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:316
+msgctxt "ChainTitlePreset"
+msgid "Cancel"
+msgstr "Abbrechen"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:337
+msgctxt "ChainTitlePreset"
+msgid "OK"
+msgstr "OK"
+
 #: crates/adapter-gui/ui/components/chain_volume_button.slint:37
+msgctxt "ChainVolumeButton"
 msgid "Volume"
 msgstr ""
 
+#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:29
+msgctxt "ConfirmDeleteChainDialog"
+msgid "title-dialog-delete-chain"
+msgstr "Kette löschen"
+
+#. text directly.
+#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:39
+msgctxt "ConfirmDeleteChainDialog"
+msgid "Excluir a chain \"{}\"?"
+msgstr "Kette \"{}\" löschen?"
+
+#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:58
+msgctxt "ConfirmDeleteChainDialog"
+msgid "btn-cancel"
+msgstr "Abbrechen"
+
+#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:75
+msgctxt "ConfirmDeleteChainDialog"
+msgid "btn-delete"
+msgstr "Löschen"
+
 #: crates/adapter-gui/ui/components/confirm_delete_dialog.slint:27
+msgctxt "ConfirmDeleteBlockDialog"
 msgid "title-dialog-delete-block"
 msgstr "Block löschen"
 
 #. pt-BR source string with the placeholder.
 #: crates/adapter-gui/ui/components/confirm_delete_dialog.slint:36
+msgctxt "ConfirmDeleteBlockDialog"
 msgid "Excluir \"{}\"?"
 msgstr "\"{}\" löschen?"
 
 #: crates/adapter-gui/ui/components/confirm_delete_dialog.slint:55
+msgctxt "ConfirmDeleteBlockDialog"
 msgid "btn-cancel"
 msgstr "Abbrechen"
 
 #: crates/adapter-gui/ui/components/confirm_delete_dialog.slint:72
+msgctxt "ConfirmDeleteBlockDialog"
 msgid "btn-delete"
 msgstr "Löschen"
 
-#: crates/adapter-gui/ui/components/language_selector.slint:56
-msgid "accessible-language-selector"
-msgstr "Sprachauswahl"
-
-#: crates/adapter-gui/ui/components/model_select_with_search.slint:93
-msgid "▼"
-msgstr "▼"
-
-#: crates/adapter-gui/ui/components/model_select_with_search.slint:175
-msgid "placeholder-search-models"
-msgstr "Modelle suchen..."
-
-#: crates/adapter-gui/ui/components/preset_select.slint:170
-msgid "status-no-presets-found"
-msgstr "Keine Presets gefunden"
-
-#: crates/adapter-gui/ui/components/model_select_with_search.slint:209
-msgid "status-no-models-found"
-msgstr "Keine Modelle gefunden"
-
-#: crates/adapter-gui/ui/components/preset_picker_overlay.slint:32
-msgid "btn-load-preset"
-msgstr "Preset laden"
-
-#: crates/adapter-gui/ui/pages/block_editor_panel.slint:122
-msgid "tooltip-delete"
-msgstr "Löschen"
-
-#: crates/adapter-gui/ui/pages/block_panel_editor.slint:36
-msgid "btn-add"
-msgstr "Hinzufügen"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:195
-msgid "instrument-guitar"
-msgstr "Gitarre"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:196
-msgid "instrument-acoustic-guitar"
-msgstr "Akustikgitarre"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:197
-msgid "instrument-bass"
-msgstr "Bass"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:198
-msgid "instrument-voice"
-msgstr "Stimme"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:199
-msgid "instrument-keyboard"
-msgstr "Keyboard"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:200
-msgid "instrument-drums"
-msgstr "Schlagzeug"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:201
-msgid "instrument-other"
-msgstr "Andere"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:221
-msgid "title-new-chain"
-msgstr "Neue Kette"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:221
-msgid "title-configure-chain"
-msgstr "Kette konfigurieren"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:240
-msgid "label-name"
-msgstr "Name"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:267
-msgid "label-instrument"
-msgstr "Instrument"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:345
-msgid "title-section-inputs"
-msgstr "Eingänge"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:371
-msgid "btn-add-input"
-msgstr "+ Eingang hinzufügen"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:390
-msgid "title-section-outputs"
-msgstr "Ausgänge"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:416
-msgid "btn-add-output"
-msgstr "+ Ausgang hinzufügen"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:450
-msgid "btn-create-chain"
-msgstr "Kette erstellen"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:450
-msgid "btn-save-chain"
-msgstr "Kette speichern"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:66
-msgid "✓"
-msgstr "✓"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:140
-msgid "label-device"
-msgstr "Gerät"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:170
-msgid "label-mode"
-msgstr "Modus"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:229
-msgid "label-channels"
-msgstr "Kanäle"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:275
-msgid "btn-ok"
-msgstr "OK"
-
-#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:99
-msgid "title-section-configure-insert"
-msgstr "Insert konfigurieren"
-
-#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:214
-msgid "label-send"
-msgstr "Send"
-
-#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:344
-msgid "label-return"
-msgstr "Return"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:140
-msgid "tooltip-expand-blocks"
-msgstr "Blöcke erweitern"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:148
-msgid "tooltip-measure-latency"
-msgstr "Latenz messen (ein Piepton)"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:177
-msgid "tooltip-configure"
-msgstr "Konfigurieren"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:185
-msgid "tooltip-open-preset"
-msgstr "Preset öffnen"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:193
-msgid "tooltip-save-preset"
-msgstr "Preset speichern"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:472
-msgid "label-lat"
-msgstr "LAT"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:521
-msgid "label-input"
-msgstr "Eingang"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:567
-msgid "label-output"
-msgstr "Ausgang"
-
-#: crates/adapter-gui/ui/pages/compact_block_row.slint:493
-msgid "btn-open-plugin"
-msgstr "Plugin öffnen"
-
-#: crates/adapter-gui/ui/pages/compact_chain_view.slint:83
-msgid "label-in"
-msgstr "IN"
-
-#: crates/adapter-gui/ui/pages/compact_chain_view.slint:111
-msgid "label-out"
-msgstr "OUT"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:87
-msgid "·"
-msgstr "·"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:123
-msgid "label-description"
-msgstr "Description"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:142
-msgid "label-license"
-msgstr "License:"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:169
-msgid "↗"
-msgstr "↗"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:175
-msgid "btn-open-homepage"
-msgstr "Open Homepage"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:136
-msgid "tooltip-back"
-msgstr "Zurück"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:144
-msgid "tooltip-spectrum"
-msgstr "Spectrum"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:152
-msgid "tooltip-tuner"
-msgstr "Tuner"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:160
-msgid "tooltip-project-settings"
-msgstr "Projekt"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:169
-msgid "tooltip-save"
-msgstr "Speichern"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:177
-msgid "tooltip-new-chain"
-msgstr "Neue Kette"
-
-#: crates/adapter-gui/ui/pages/project_launcher.slint:185
-msgid "placeholder-search-projects"
-msgstr "Projekte suchen"
-
-#: crates/adapter-gui/ui/pages/project_launcher.slint:288
-msgid "tooltip-open-project"
-msgstr "Projekt öffnen"
-
-#: crates/adapter-gui/ui/pages/project_launcher.slint:295
-msgid "btn-new-project"
-msgstr "Neues Projekt"
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:147
-msgid "label-hz"
-msgstr "Hz"
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:170
-msgid "label-buffer"
-msgstr "Buffer"
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:193
-msgid "label-bits"
-msgstr "Bits"
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:271
-msgid "title-section-audio-devices"
-msgstr "Audiogeräte"
-
-#: crates/adapter-gui/ui/pages/project_setup.slint:55
-msgid "placeholder-project-name-example"
-msgstr "Bsp.: Live-Gitarre"
-
-#: crates/adapter-gui/ui/pages/project_setup.slint:151
-msgid "title-new-project"
-msgstr "Neues Projekt"
-
-#: crates/adapter-gui/ui/pages/project_setup.slint:164
-msgid "label-project-name"
-msgstr "Projektname"
-
-#: crates/adapter-gui/ui/pages/project_setup.slint:211
-msgid "btn-create-project"
-msgstr "Projekt erstellen"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:73
-msgid "—"
-msgstr "—"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:127
-msgid "20"
-msgstr "20"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:133
-msgid "100"
-msgstr "100"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:139
-msgid "1k"
-msgstr "1k"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:145
-msgid "10k"
-msgstr "10k"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:151
-msgid "20k"
-msgstr "20k"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:199
-msgid "label-spectrum"
-msgstr "SPECTRUM"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:241
-msgid "status-no-active-outputs"
-msgstr "NO ACTIVE OUTPUTS"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:251
-msgid "status-spectrum-empty-help"
-msgstr ""
-"Schalten Sie das Spektrum ein und aktivieren Sie eine Chain mit "
-"konfiguriertem Ausgang.Schalten Sie das Spektrum ein und aktivieren Sie eine "
-"Kette mit konfiguriertem Ausgang."
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:279
-msgid "title-window-spectrum"
-msgstr "OpenRig · Spectrum"
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:54
-msgid "label-mute"
-msgstr "MUTE"
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:316
-msgid "label-tuner"
-msgstr "TUNER"
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:368
-msgid "status-no-active-inputs"
-msgstr "NO ACTIVE INPUTS"
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:378
-msgid "status-tuner-empty-help"
-msgstr ""
-"Aktivieren Sie eine Chain mit konfiguriertem Eingang, um die Stimmgeräte "
-"hier zu sehen.Aktivieren Sie eine Kette mit konfiguriertem Eingang, um die "
-"Stimmgeräte hier zu sehen."
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:406
-msgid "title-window-tuner"
-msgstr "OpenRig · Tuner"
-
-#: crates/adapter-gui/ui/secondary_windows_block.slint:28
-msgid "title-window-block-editor"
-msgstr "OpenRig · Block"
-
-#: crates/adapter-gui/ui/secondary_windows_block.slint:195
-msgid "title-window-chain-view"
-msgstr "OpenRig · Kette"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:23
-msgid "title-window-project-settings"
-msgstr "OpenRig · Projekt konfigurieren"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:96
-msgid "title-window-chain-editor"
-msgstr "OpenRig · Kette konfigurieren"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:129
-msgid "title-section-input"
-msgstr "Eingang"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:147
-msgid "title-section-output"
-msgstr "Ausgang"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:177
-msgid "title-window-chain-input"
-msgstr "OpenRig · Kette-Eingang"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:217
-msgid "title-window-chain-output"
-msgstr "OpenRig · Kette-Ausgang"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:258
-msgid "title-window-chain-inputs"
-msgstr "OpenRig · Kette-Eingänge"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:269
-msgid "btn-add-input-row"
-msgstr "+ Eingang hinzufügen"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:299
-msgid "title-window-chain-outputs"
-msgstr "OpenRig · Kette-Ausgänge"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:310
-msgid "btn-add-output-row"
-msgstr "+ Ausgang hinzufügen"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:355
-msgid "title-window-chain-insert"
-msgstr "OpenRig · Insert konfigurieren"
-
-#: crates/adapter-gui/ui/touch_main.slint:586
-msgid "⌨"
-msgstr "⌨"
-
-#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:27
-msgid "title-dialog-delete-chain"
-msgstr "Kette löschen"
-
-#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:37
-msgid "Excluir a chain \"{}\"?"
-msgstr "Kette \"{}\" löschen?"
-
-#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:31
+#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:30
+msgctxt "ConfirmDeleteRecentProjectDialog"
 msgid "title-dialog-delete-recent-project"
 msgstr "Aus Liste entfernen"
 
-#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:41
+#. Literal pt-BR source string with `{}` placeholder.
+#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:38
+msgctxt "ConfirmDeleteRecentProjectDialog"
 msgid "Remover o projeto \"{}\" dos recentes?"
 msgstr "Projekt \"{}\" aus den letzten entfernen?"
 
-#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:75
+#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:57
+msgctxt "ConfirmDeleteRecentProjectDialog"
+msgid "btn-cancel"
+msgstr "Abbrechen"
+
+#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:74
+msgctxt "ConfirmDeleteRecentProjectDialog"
 msgid "btn-remove"
 msgstr "Entfernen"
 
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "tab-system"
-msgstr ""
+#: crates/adapter-gui/ui/components/language_selector.slint:56
+msgctxt "LanguageSelector"
+msgid "accessible-language-selector"
+msgstr "Sprachauswahl"
 
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "tab-project"
-msgstr ""
+#: crates/adapter-gui/ui/components/model_select_with_search.slint:96
+msgctxt "ModelSelectWithSearch"
+msgid "▼"
+msgstr "▼"
 
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "btn-close"
-msgstr ""
+#: crates/adapter-gui/ui/components/model_select_with_search.slint:178
+msgctxt "ModelSelectWithSearch"
+msgid "placeholder-search-models"
+msgstr "Modelle suchen..."
 
-#: crates/adapter-gui/ui/components/settings_section.slint
-msgid "badge-system"
-msgstr ""
+#: crates/adapter-gui/ui/components/model_select_with_search.slint:212
+msgctxt "ModelSelectWithSearch"
+msgid "status-no-models-found"
+msgstr "Keine Modelle gefunden"
 
-#: crates/adapter-gui/ui/components/settings_section.slint
-msgid "badge-project"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_system_audio.slint
-msgid "title-section-audio-interface"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_system_language.slint
-msgid "title-section-language"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_system_midi_devices.slint
-msgid "title-section-midi-devices"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint
-msgid "title-section-project-meta"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint
-msgid "label-file"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_project_midi_mapping.slint
-msgid "title-section-midi-mapping"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_project_midi_mapping.slint
-msgid "btn-add-midi-binding"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_project_midi_mapping.slint
-msgid "empty-midi-mapping-explain"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_project_midi_mapping.slint
-msgid "placeholder-midi-listen"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "nav-group-system"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "nav-group-project"
-msgstr ""
+#: crates/adapter-gui/ui/components/preset_picker_overlay.slint:34
+msgctxt "PresetPickerOverlay"
+msgid "btn-load-preset"
+msgstr "Preset laden"
 
 #: crates/adapter-gui/ui/components/preset_picker_overlay.slint:40
+msgctxt "PresetPickerOverlay"
 msgid "preset-search-placeholder"
 msgstr "Presets suchen…"
 
+#: crates/adapter-gui/ui/components/preset_picker_overlay.slint:106
+msgctxt "PresetPickerOverlay"
+msgid "btn-cancel"
+msgstr "Abbrechen"
+
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:38
+msgctxt "PresetSaveOverlay"
 msgid "title-dialog-save-preset"
 msgstr "Preset speichern"
 
+#: crates/adapter-gui/ui/components/preset_save_overlay.slint:63
+msgctxt "PresetSaveOverlay"
+msgid "btn-cancel"
+msgstr "Abbrechen"
+
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:82
+msgctxt "PresetSaveOverlay"
 msgid "btn-save"
 msgstr "Speichern"
 
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:119
+msgctxt "PresetOverwriteOverlay"
 msgid "title-dialog-overwrite-preset"
 msgstr "Preset überschreiben?"
 
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:126
+msgctxt "PresetOverwriteOverlay"
 msgid "msg-overwrite-preset"
 msgstr "Ein Preset namens \"{}\" existiert bereits. Überschreiben?"
 
+#: crates/adapter-gui/ui/components/preset_save_overlay.slint:145
+msgctxt "PresetOverwriteOverlay"
+msgid "btn-cancel"
+msgstr "Abbrechen"
+
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:162
+msgctxt "PresetOverwriteOverlay"
 msgid "btn-overwrite"
 msgstr "Überschreiben"
 
-msgid "btn-save-audio-settings"
+#: crates/adapter-gui/ui/components/preset_select.slint:72
+msgctxt "PresetSelect"
+msgid "Preset selector"
 msgstr ""
 
+#: crates/adapter-gui/ui/components/preset_select.slint:137
+msgctxt "PresetSelect"
+msgid "preset-search-placeholder"
+msgstr "Presets suchen…"
+
+#: crates/adapter-gui/ui/components/preset_select.slint:170
+msgctxt "PresetSelect"
+msgid "status-no-presets-found"
+msgstr "Keine Presets gefunden"
+
+#: crates/adapter-gui/ui/pages/block_editor_panel.slint:122
+msgctxt "BlockEditorPanel"
+msgid "tooltip-delete"
+msgstr "Löschen"
+
+#: crates/adapter-gui/ui/pages/block_editor_panel.slint:243
+msgctxt "BlockEditorPanel"
+msgid "–"
+msgstr "–"
+
+#: crates/adapter-gui/ui/pages/block_panel_editor.slint:37
+msgctxt "BlockPanelEditor"
+msgid "btn-add"
+msgstr "Hinzufügen"
+
+#: crates/adapter-gui/ui/pages/block_panel_editor.slint:323
+msgctxt "BlockPanelEditor"
+msgid "–"
+msgstr "–"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:195
+msgctxt "ChainEditorPage"
+msgid "instrument-guitar"
+msgstr "Gitarre"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:196
+msgctxt "ChainEditorPage"
+msgid "instrument-acoustic-guitar"
+msgstr "Akustikgitarre"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:197
+msgctxt "ChainEditorPage"
+msgid "instrument-bass"
+msgstr "Bass"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:198
+msgctxt "ChainEditorPage"
+msgid "instrument-voice"
+msgstr "Stimme"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:199
+msgctxt "ChainEditorPage"
+msgid "instrument-keyboard"
+msgstr "Keyboard"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:200
+msgctxt "ChainEditorPage"
+msgid "instrument-drums"
+msgstr "Schlagzeug"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:201
+msgctxt "ChainEditorPage"
+msgid "instrument-other"
+msgstr "Andere"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:221
+msgctxt "ChainEditorPage"
+msgid "title-new-chain"
+msgstr "Neue Kette"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:221
+msgctxt "ChainEditorPage"
+msgid "title-configure-chain"
+msgstr "Kette konfigurieren"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:240
+msgctxt "ChainEditorPage"
+msgid "label-name"
+msgstr "Name"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:267
+msgctxt "ChainEditorPage"
+msgid "label-instrument"
+msgstr "Instrument"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:345
+msgctxt "ChainEditorPage"
+msgid "title-section-inputs"
+msgstr "Eingänge"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:371
+msgctxt "ChainEditorPage"
+msgid "btn-add-input"
+msgstr "+ Eingang hinzufügen"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:390
+msgctxt "ChainEditorPage"
+msgid "title-section-outputs"
+msgstr "Ausgänge"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:416
+msgctxt "ChainEditorPage"
+msgid "btn-add-output"
+msgstr "+ Ausgang hinzufügen"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:443
+msgctxt "ChainEditorPage"
+msgid "btn-cancel"
+msgstr "Abbrechen"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:450
+msgctxt "ChainEditorPage"
+msgid "btn-create-chain"
+msgstr "Kette erstellen"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:450
+msgctxt "ChainEditorPage"
+msgid "btn-save-chain"
+msgstr "Kette speichern"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:66
+msgctxt "ChannelRow"
+msgid "✓"
+msgstr "✓"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:140
+msgctxt "ChainEndpointEditorPage"
+msgid "label-device"
+msgstr "Gerät"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:170
+msgctxt "ChainEndpointEditorPage"
+msgid "label-mode"
+msgstr "Modus"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:229
+msgctxt "ChainEndpointEditorPage"
+msgid "label-channels"
+msgstr "Kanäle"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:268
+msgctxt "ChainEndpointEditorPage"
+msgid "btn-cancel"
+msgstr "Abbrechen"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:275
+msgctxt "ChainEndpointEditorPage"
+msgid "btn-ok"
+msgstr "OK"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:99
+msgctxt "ChainInsertEditorPage"
+msgid "title-section-configure-insert"
+msgstr "Insert konfigurieren"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:214
+msgctxt "ChainInsertEditorPage"
+msgid "label-send"
+msgstr "Send"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:225
+msgctxt "ChainInsertEditorPage"
+msgid "label-device"
+msgstr "Gerät"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:247
+msgctxt "ChainInsertEditorPage"
+msgid "label-mode"
+msgstr "Modus"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:299
+msgctxt "ChainInsertEditorPage"
+msgid "label-channels"
+msgstr "Kanäle"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:344
+msgctxt "ChainInsertEditorPage"
+msgid "label-return"
+msgstr "Return"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:469
+msgctxt "ChainInsertEditorPage"
+msgid "btn-cancel"
+msgstr "Abbrechen"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:476
+msgctxt "ChainInsertEditorPage"
+msgid "btn-ok"
+msgstr "OK"
+
+#: crates/adapter-gui/ui/pages/chain_io_groups.slint:304
+msgctxt "ChainIoGroupsPage"
+msgid "btn-cancel"
+msgstr "Abbrechen"
+
+#: crates/adapter-gui/ui/pages/chain_io_groups.slint:311
+msgctxt "ChainIoGroupsPage"
+msgid "btn-ok"
+msgstr "OK"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:246
+msgctxt "ChainRow"
+msgid "tooltip-expand-blocks"
+msgstr "Blöcke erweitern"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:254
+msgctxt "ChainRow"
+msgid "tooltip-measure-latency"
+msgstr "Latenz messen (ein Piepton)"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:283
+msgctxt "ChainRow"
+msgid "tooltip-configure"
+msgstr "Konfigurieren"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:291
+msgctxt "ChainRow"
+msgid "tooltip-delete"
+msgstr "Löschen"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:564
+msgctxt "ChainRow"
+msgid "label-lat"
+msgstr "LAT"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:613
+msgctxt "ChainRow"
+msgid "label-input"
+msgstr "Eingang"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:659
+msgctxt "ChainRow"
+msgid "label-output"
+msgstr "Ausgang"
+
+#: crates/adapter-gui/ui/pages/compact_block_row.slint:415
+msgctxt "CompactBlockRow"
+msgid "▼"
+msgstr "▼"
+
+#: crates/adapter-gui/ui/pages/compact_block_row.slint:493
+msgctxt "CompactBlockRow"
+msgid "btn-open-plugin"
+msgstr "Plugin öffnen"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:160
+msgctxt "CompactChainViewPage"
+msgid "tooltip-measure-latency"
+msgstr "Latenz messen (ein Piepton)"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:187
+msgctxt "CompactChainViewPage"
+msgid "label-lat"
+msgstr "LAT"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:216
+msgctxt "CompactChainViewPage"
+msgid "tooltip-configure"
+msgstr "Konfigurieren"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:230
+msgctxt "CompactChainViewPage"
+msgid "label-in"
+msgstr "IN"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:251
+msgctxt "CompactChainViewPage"
+msgid "label-out"
+msgstr "OUT"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:267
+msgctxt "CompactChainViewPage"
+msgid "tooltip-delete"
+msgstr "Löschen"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:313
+msgctxt "CompactChainViewPage"
+msgid "+"
+msgstr "+"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:87
+msgctxt "PluginInfoPanel"
+msgid "·"
+msgstr "·"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:125
+msgctxt "PluginInfoPanel"
+msgid "label-description"
+msgstr "Description"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:144
+msgctxt "PluginInfoPanel"
+msgid "label-license"
+msgstr "License:"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:171
+msgctxt "PluginInfoPanel"
+msgid "↗"
+msgstr "↗"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:177
+msgctxt "PluginInfoPanel"
+msgid "btn-open-homepage"
+msgstr "Open Homepage"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:145
+msgctxt "ProjectChainsPage"
+msgid "tooltip-back"
+msgstr "Zurück"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:153
+msgctxt "ProjectChainsPage"
+msgid "tooltip-spectrum"
+msgstr "Spectrum"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:161
+msgctxt "ProjectChainsPage"
+msgid "tooltip-tuner"
+msgstr "Tuner"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:169
+msgctxt "ProjectChainsPage"
+msgid "tooltip-project-settings"
+msgstr "Projekt"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:178
+msgctxt "ProjectChainsPage"
+msgid "tooltip-save"
+msgstr "Speichern"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:186
+msgctxt "ProjectChainsPage"
+msgid "tooltip-new-chain"
+msgstr "Neue Kette"
+
+#: crates/adapter-gui/ui/pages/project_launcher.slint:184
+msgctxt "SearchField"
+msgid "placeholder-search-projects"
+msgstr "Projekte suchen"
+
+#: crates/adapter-gui/ui/pages/project_launcher.slint:287
+msgctxt "ProjectLauncherPage"
+msgid "tooltip-open-project"
+msgstr "Projekt öffnen"
+
+#: crates/adapter-gui/ui/pages/project_launcher.slint:294
+msgctxt "ProjectLauncherPage"
+msgid "btn-new-project"
+msgstr "Neues Projekt"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:55
+msgctxt "NameInput"
+msgid "placeholder-project-name-example"
+msgstr "Bsp.: Live-Gitarre"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:151
+msgctxt "ProjectSetupPage"
+msgid "title-new-project"
+msgstr "Neues Projekt"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:164
+msgctxt "ProjectSetupPage"
+msgid "label-project-name"
+msgstr "Projektname"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:204
+msgctxt "ProjectSetupPage"
+msgid "btn-cancel"
+msgstr "Abbrechen"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:211
+msgctxt "ProjectSetupPage"
+msgid "btn-create-project"
+msgstr "Projekt erstellen"
+
+#: crates/adapter-gui/ui/pages/settings.slint:170
+msgctxt "SettingsPage"
+msgid "nav-group-system"
+msgstr "SYSTEM"
+
+#: crates/adapter-gui/ui/pages/settings.slint:181
+msgctxt "SettingsPage"
+msgid "title-section-audio-interface"
+msgstr "Audio-Interface"
+
+#: crates/adapter-gui/ui/pages/settings.slint:186
+msgctxt "SettingsPage"
+msgid "title-section-language"
+msgstr "Sprache"
+
+#: crates/adapter-gui/ui/pages/settings.slint:191
+msgctxt "SettingsPage"
+msgid "title-section-midi-devices"
+msgstr "MIDI-Geräte"
+
+#: crates/adapter-gui/ui/pages/settings.slint:196
+msgctxt "SettingsPage"
+msgid "title-section-paths"
+msgstr "Pfade"
+
+#: crates/adapter-gui/ui/pages/settings.slint:201
+msgctxt "SettingsPage"
 msgid "title-section-integrations"
 msgstr "Integrationen"
 
+#: crates/adapter-gui/ui/pages/settings.slint:216
+msgctxt "SettingsPage"
+msgid "nav-group-project"
+msgstr "PROJEKT"
+
+#: crates/adapter-gui/ui/pages/settings.slint:227
+msgctxt "SettingsPage"
+msgid "title-section-project-meta"
+msgstr "Metadaten"
+
+#: crates/adapter-gui/ui/pages/settings.slint:335
+msgctxt "SettingsPage"
+msgid "btn-save-audio-settings"
+msgstr "Anwenden"
+
+#: crates/adapter-gui/ui/pages/settings.slint:339
+msgctxt "SettingsPage"
+msgid "btn-close"
+msgstr "Schließen"
+
+#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint:27
+msgctxt "SectionProjectMeta"
+msgid "label-name"
+msgstr "Name"
+
+#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint:58
+msgctxt "SectionProjectMeta"
+msgid "label-file"
+msgstr "Datei"
+
+#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint:66
+msgctxt "SectionProjectMeta"
+msgid "placeholder-project-unsaved"
+msgstr "(nicht gespeichert)"
+
+#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint:83
+msgctxt "SectionProjectMeta"
+msgid "btn-save-project"
+msgstr "Projekt speichern"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_audio.slint:95
+msgctxt "AudioDeviceRow"
+msgid "label-hz"
+msgstr "Hz"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_audio.slint:118
+msgctxt "AudioDeviceRow"
+msgid "label-buffer"
+msgstr "Buffer"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_audio.slint:141
+msgctxt "AudioDeviceRow"
+msgid "label-bits"
+msgstr "Bits"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:39
+msgctxt "SectionSystemIntegrations"
 msgid "label-midi-enabled"
 msgstr "MIDI-Steuerung"
 
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:45
+msgctxt "SectionSystemIntegrations"
 msgid "desc-midi-enabled"
 msgstr "Aktiviert den MIDI/BLE-MIDI-Adapter, damit Fußschalter OpenRig steuern"
 
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:93
+msgctxt "SectionSystemIntegrations"
 msgid "label-mcp-enabled"
 msgstr "MCP-Server"
 
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:99
+msgctxt "SectionSystemIntegrations"
 msgid "desc-mcp-enabled"
 msgstr "Stellt den MCP-Server unter 127.0.0.1:4123 für Agenten bereit"
 
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:134
+msgctxt "SectionSystemIntegrations"
 msgid "hint-restart-to-apply"
 msgstr "Wird beim nächsten Start wirksam."
+
+#: crates/adapter-gui/ui/pages/settings/section_system_language.slint:25
+msgctxt "SectionSystemLanguage"
+msgid "label-language"
+msgstr "Sprache"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:49
+msgctxt "SectionSystemPaths"
+msgid "label-presets-path"
+msgstr "Preset-Ordner"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:57
+msgctxt "SectionSystemPaths"
+msgid "placeholder-default-path"
+msgstr "(Standard)"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:66
+msgctxt "SectionSystemPaths"
+msgid "btn-choose-path"
+msgstr "Wählen…"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:70
+msgctxt "SectionSystemPaths"
+msgid "btn-reset-path"
+msgstr "Zurücksetzen"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:81
+msgctxt "SectionSystemPaths"
+msgid "label-plugins-path"
+msgstr "Plugin-Ordner"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:113
+msgctxt "SectionSystemPaths"
+msgid "label-evaluations-path"
+msgstr "Evaluierungsordner"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:145
+msgctxt "SectionSystemPaths"
+msgid "label-plugin-catalog"
+msgstr "Plugin-Katalog"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:153
+msgctxt "SectionSystemPaths"
+msgid "status-plugin-catalog-idle"
+msgstr "Noch nicht neu geladen"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:162
+msgctxt "SectionSystemPaths"
+msgid "btn-reload-plugin-catalog"
+msgstr "Neu laden"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:73
+msgctxt "SpectrumCard"
+msgid "—"
+msgstr "—"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:127
+msgctxt "SpectrumCard"
+msgid "20"
+msgstr "20"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:133
+msgctxt "SpectrumCard"
+msgid "100"
+msgstr "100"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:139
+msgctxt "SpectrumCard"
+msgid "1k"
+msgstr "1k"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:145
+msgctxt "SpectrumCard"
+msgid "10k"
+msgstr "10k"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:151
+msgctxt "SpectrumCard"
+msgid "20k"
+msgstr "20k"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:199
+msgctxt "SpectrumPanel"
+msgid "label-spectrum"
+msgstr "SPECTRUM"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:241
+msgctxt "SpectrumPanel"
+msgid "status-no-active-outputs"
+msgstr "NO ACTIVE OUTPUTS"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:251
+msgctxt "SpectrumPanel"
+msgid "status-spectrum-empty-help"
+msgstr "Schalte das Spektrum ein und aktiviere eine Chain mit konfiguriertem Ausgang."
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:279
+msgctxt "SpectrumWindow"
+msgid "title-window-spectrum"
+msgstr "OpenRig · Spectrum"
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:54
+msgctxt "MuteSwitch"
+msgid "label-mute"
+msgstr "MUTE"
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:316
+msgctxt "TunerPanel"
+msgid "label-tuner"
+msgstr "TUNER"
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:368
+msgctxt "TunerPanel"
+msgid "status-no-active-inputs"
+msgstr "NO ACTIVE INPUTS"
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:378
+msgctxt "TunerPanel"
+msgid "status-tuner-empty-help"
+msgstr "Aktiviere eine Chain mit konfiguriertem Eingang, um hier die Tuner zu sehen."
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:406
+msgctxt "TunerWindow"
+msgid "title-window-tuner"
+msgstr "OpenRig · Tuner"
+
+#: crates/adapter-gui/ui/secondary_windows_block.slint:30
+msgctxt "BlockEditorWindow"
+msgid "title-window-block-editor"
+msgstr "OpenRig · Block"
+
+#: crates/adapter-gui/ui/secondary_windows_block.slint:231
+msgctxt "CompactChainViewWindow"
+msgid "title-window-chain-view"
+msgstr "OpenRig · Kette"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:60
+msgctxt "ProjectSettingsWindow"
+msgid "title-window-project-settings"
+msgstr "OpenRig · Projekt konfigurieren"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:159
+msgctxt "ChainEditorWindow"
+msgid "title-window-chain-editor"
+msgstr "OpenRig · Kette konfigurieren"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:192
+msgctxt "ChainEditorWindow"
+msgid "title-section-input"
+msgstr "Eingang"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:210
+msgctxt "ChainEditorWindow"
+msgid "title-section-output"
+msgstr "Ausgang"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:240
+msgctxt "ChainInputWindow"
+msgid "title-window-chain-input"
+msgstr "OpenRig · Kette-Eingang"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:250
+msgctxt "ChainInputWindow"
+msgid "title-section-input"
+msgstr "Eingang"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:280
+msgctxt "ChainOutputWindow"
+msgid "title-window-chain-output"
+msgstr "OpenRig · Kette-Ausgang"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:290
+msgctxt "ChainOutputWindow"
+msgid "title-section-output"
+msgstr "Ausgang"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:321
+msgctxt "ChainInputGroupsWindow"
+msgid "title-window-chain-inputs"
+msgstr "OpenRig · Kette-Eingänge"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:331
+msgctxt "ChainInputGroupsWindow"
+msgid "title-section-inputs"
+msgstr "Eingänge"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:332
+msgctxt "ChainInputGroupsWindow"
+msgid "btn-add-input-row"
+msgstr "+ Eingang hinzufügen"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:362
+msgctxt "ChainOutputGroupsWindow"
+msgid "title-window-chain-outputs"
+msgstr "OpenRig · Kette-Ausgänge"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:372
+msgctxt "ChainOutputGroupsWindow"
+msgid "title-section-outputs"
+msgstr "Ausgänge"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:373
+msgctxt "ChainOutputGroupsWindow"
+msgid "btn-add-output-row"
+msgstr "+ Ausgang hinzufügen"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:418
+msgctxt "ChainInsertWindow"
+msgid "title-window-chain-insert"
+msgstr "OpenRig · Insert konfigurieren"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:428
+msgctxt "ChainInsertWindow"
+msgid "title-section-configure-insert"
+msgstr "Insert konfigurieren"
+
+#: crates/adapter-gui/ui/touch_main.slint:667
+msgctxt "TouchMain"
+msgid "⌨"
+msgstr "⌨"

--- a/crates/adapter-gui/translations/en_US/LC_MESSAGES/adapter-gui.po
+++ b/crates/adapter-gui/translations/en_US/LC_MESSAGES/adapter-gui.po
@@ -15,636 +15,939 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: crates/adapter-gui/ui/blocks/header.slint:13
+msgctxt "Header"
 msgid "OpenRig"
 msgstr "OpenRig"
 
 #: crates/adapter-gui/ui/components/block_panel_parameter_item.slint:274
+msgctxt "BlockPanelParameterItem"
 msgid "btn-load-file"
 msgstr "Load"
 
 #: crates/adapter-gui/ui/components/block_stream_mini_display.slint:23
+msgctxt "BlockStreamMiniDisplay"
 msgid "–"
 msgstr "–"
 
 #: crates/adapter-gui/ui/components/block_value_widgets.slint:128
+msgctxt "BlockValueStepper"
 msgid "−"
 msgstr "−"
 
 #: crates/adapter-gui/ui/components/block_value_widgets.slint:194
+msgctxt "BlockValueStepper"
 msgid "+"
 msgstr "+"
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:87
-msgid "Preset selector"
-msgstr ""
+#: crates/adapter-gui/ui/components/chain_di_loop_button.slint:61
+msgctxt "ChainDiLoopButton"
+msgid "di-loop-button-label"
+msgstr "DI Loop"
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:170
+#: crates/adapter-gui/ui/components/chain_di_loop_button.slint:138
+msgctxt "ChainDiLoopButton"
+msgid "di-loop-stop-label"
+msgstr "Stop DI loop"
+
+#: crates/adapter-gui/ui/components/chain_di_loop_button.slint:138
+msgctxt "ChainDiLoopButton"
+msgid "di-loop-play-label"
+msgstr "Play DI loop"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:77
+msgctxt "SceneBtn"
 msgid "Scene {}"
 msgstr ""
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:192
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:99
+msgctxt "SceneBar"
 msgid "Add scene"
 msgstr ""
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:201
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:108
+msgctxt "SceneBar"
 msgid "Remove last scene"
 msgstr ""
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:258
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:183
+msgctxt "ChainTitlePreset"
+msgid "tooltip-open-preset"
+msgstr "Open preset"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:193
+msgctxt "ChainTitlePreset"
+msgid "tooltip-save-preset"
+msgstr "Save preset"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:203
+msgctxt "ChainTitlePreset"
 msgid "Add preset"
 msgstr ""
 
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:213
+msgctxt "ChainTitlePreset"
+msgid "Rename preset"
+msgstr ""
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:224
+msgctxt "ChainTitlePreset"
+msgid "Remove preset"
+msgstr ""
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:316
+msgctxt "ChainTitlePreset"
+msgid "Cancel"
+msgstr ""
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:337
+msgctxt "ChainTitlePreset"
+msgid "OK"
+msgstr ""
+
 #: crates/adapter-gui/ui/components/chain_volume_button.slint:37
+msgctxt "ChainVolumeButton"
 msgid "Volume"
 msgstr ""
 
+#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:29
+msgctxt "ConfirmDeleteChainDialog"
+msgid "title-dialog-delete-chain"
+msgstr "Delete chain"
+
+#. text directly.
+#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:39
+msgctxt "ConfirmDeleteChainDialog"
+msgid "Excluir a chain \"{}\"?"
+msgstr "Delete chain \"{}\"?"
+
+#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:58
+msgctxt "ConfirmDeleteChainDialog"
+msgid "btn-cancel"
+msgstr "Cancel"
+
+#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:75
+msgctxt "ConfirmDeleteChainDialog"
+msgid "btn-delete"
+msgstr "Delete"
+
 #: crates/adapter-gui/ui/components/confirm_delete_dialog.slint:27
+msgctxt "ConfirmDeleteBlockDialog"
 msgid "title-dialog-delete-block"
 msgstr "Delete block"
 
 #. pt-BR source string with the placeholder.
 #: crates/adapter-gui/ui/components/confirm_delete_dialog.slint:36
+msgctxt "ConfirmDeleteBlockDialog"
 msgid "Excluir \"{}\"?"
 msgstr "Delete \"{}\"?"
 
 #: crates/adapter-gui/ui/components/confirm_delete_dialog.slint:55
+msgctxt "ConfirmDeleteBlockDialog"
 msgid "btn-cancel"
 msgstr "Cancel"
 
 #: crates/adapter-gui/ui/components/confirm_delete_dialog.slint:72
+msgctxt "ConfirmDeleteBlockDialog"
 msgid "btn-delete"
 msgstr "Delete"
 
-#: crates/adapter-gui/ui/components/language_selector.slint:56
-msgid "accessible-language-selector"
-msgstr "Language selector"
-
-#: crates/adapter-gui/ui/components/model_select_with_search.slint:93
-msgid "▼"
-msgstr "▼"
-
-#: crates/adapter-gui/ui/components/model_select_with_search.slint:175
-msgid "placeholder-search-models"
-msgstr "Search models..."
-
-#: crates/adapter-gui/ui/components/preset_select.slint:170
-msgid "status-no-presets-found"
-msgstr "No presets found"
-
-#: crates/adapter-gui/ui/components/model_select_with_search.slint:209
-msgid "status-no-models-found"
-msgstr "No models found"
-
-#: crates/adapter-gui/ui/components/preset_picker_overlay.slint:32
-msgid "btn-load-preset"
-msgstr "Load Preset"
-
-#: crates/adapter-gui/ui/pages/block_editor_panel.slint:122
-msgid "tooltip-delete"
-msgstr "Delete"
-
-#: crates/adapter-gui/ui/pages/block_panel_editor.slint:36
-msgid "btn-add"
-msgstr "Add"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:195
-msgid "instrument-guitar"
-msgstr "Guitar"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:196
-msgid "instrument-acoustic-guitar"
-msgstr "Acoustic guitar"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:197
-msgid "instrument-bass"
-msgstr "Bass"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:198
-msgid "instrument-voice"
-msgstr "Voice"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:199
-msgid "instrument-keyboard"
-msgstr "Keyboard"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:200
-msgid "instrument-drums"
-msgstr "Drums"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:201
-msgid "instrument-other"
-msgstr "Other"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:221
-msgid "title-new-chain"
-msgstr "New chain"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:221
-msgid "title-configure-chain"
-msgstr "Configure chain"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:240
-msgid "label-name"
-msgstr "Name"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:267
-msgid "label-instrument"
-msgstr "Instrument"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:345
-msgid "title-section-inputs"
-msgstr "Inputs"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:371
-msgid "btn-add-input"
-msgstr "+ Add input"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:390
-msgid "title-section-outputs"
-msgstr "Outputs"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:416
-msgid "btn-add-output"
-msgstr "+ Add output"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:450
-msgid "btn-create-chain"
-msgstr "Create chain"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:450
-msgid "btn-save-chain"
-msgstr "Save chain"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:66
-msgid "✓"
-msgstr "✓"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:140
-msgid "label-device"
-msgstr "Device"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:170
-msgid "label-mode"
-msgstr "Mode"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:229
-msgid "label-channels"
-msgstr "Channels"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:275
-msgid "btn-ok"
-msgstr "OK"
-
-#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:99
-msgid "title-section-configure-insert"
-msgstr "Configure Insert"
-
-#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:214
-msgid "label-send"
-msgstr "Send"
-
-#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:344
-msgid "label-return"
-msgstr "Return"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:140
-msgid "tooltip-expand-blocks"
-msgstr "Expand blocks"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:148
-msgid "tooltip-measure-latency"
-msgstr "Measure latency (emits a beep)"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:177
-msgid "tooltip-configure"
-msgstr "Configure"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:185
-msgid "tooltip-open-preset"
-msgstr "Open preset"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:193
-msgid "tooltip-save-preset"
-msgstr "Save preset"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:472
-msgid "label-lat"
-msgstr "LAT"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:521
-msgid "label-input"
-msgstr "Input"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:567
-msgid "label-output"
-msgstr "Output"
-
-#: crates/adapter-gui/ui/pages/compact_block_row.slint:493
-msgid "btn-open-plugin"
-msgstr "Open Plugin"
-
-#: crates/adapter-gui/ui/pages/compact_chain_view.slint:83
-msgid "label-in"
-msgstr "IN"
-
-#: crates/adapter-gui/ui/pages/compact_chain_view.slint:111
-msgid "label-out"
-msgstr "OUT"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:87
-msgid "·"
-msgstr "·"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:123
-msgid "label-description"
-msgstr "Description"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:142
-msgid "label-license"
-msgstr "License:"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:169
-msgid "↗"
-msgstr "↗"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:175
-msgid "btn-open-homepage"
-msgstr "Open Homepage"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:136
-msgid "tooltip-back"
-msgstr "Back"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:144
-msgid "tooltip-spectrum"
-msgstr "Spectrum"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:152
-msgid "tooltip-tuner"
-msgstr "Tuner"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:160
-msgid "tooltip-project-settings"
-msgstr "Project"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:169
-msgid "tooltip-save"
-msgstr "Save"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:177
-msgid "tooltip-new-chain"
-msgstr "New chain"
-
-#: crates/adapter-gui/ui/pages/project_launcher.slint:185
-msgid "placeholder-search-projects"
-msgstr "Search projects"
-
-#: crates/adapter-gui/ui/pages/project_launcher.slint:288
-msgid "tooltip-open-project"
-msgstr "Open project"
-
-#: crates/adapter-gui/ui/pages/project_launcher.slint:295
-msgid "btn-new-project"
-msgstr "New project"
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:147
-msgid "label-hz"
-msgstr "Hz"
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:170
-msgid "label-buffer"
-msgstr "Buffer"
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:193
-msgid "label-bits"
-msgstr "Bits"
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:271
-msgid "title-section-audio-devices"
-msgstr "Audio devices"
-
-#: crates/adapter-gui/ui/pages/project_setup.slint:55
-msgid "placeholder-project-name-example"
-msgstr "e.g. Live Guitar"
-
-#: crates/adapter-gui/ui/pages/project_setup.slint:151
-msgid "title-new-project"
-msgstr "New Project"
-
-#: crates/adapter-gui/ui/pages/project_setup.slint:164
-msgid "label-project-name"
-msgstr "Project name"
-
-#: crates/adapter-gui/ui/pages/project_setup.slint:211
-msgid "btn-create-project"
-msgstr "Create project"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:73
-msgid "—"
-msgstr "—"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:127
-msgid "20"
-msgstr "20"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:133
-msgid "100"
-msgstr "100"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:139
-msgid "1k"
-msgstr "1k"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:145
-msgid "10k"
-msgstr "10k"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:151
-msgid "20k"
-msgstr "20k"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:199
-msgid "label-spectrum"
-msgstr "SPECTRUM"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:241
-msgid "status-no-active-outputs"
-msgstr "NO ACTIVE OUTPUTS"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:251
-msgid "status-spectrum-empty-help"
-msgstr "Power on the spectrum and enable a chain with a configured output."
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:279
-msgid "title-window-spectrum"
-msgstr "OpenRig · Spectrum"
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:54
-msgid "label-mute"
-msgstr "MUTE"
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:316
-msgid "label-tuner"
-msgstr "TUNER"
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:368
-msgid "status-no-active-inputs"
-msgstr "NO ACTIVE INPUTS"
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:378
-msgid "status-tuner-empty-help"
-msgstr "Enable a chain with a configured input to see its tuners here."
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:406
-msgid "title-window-tuner"
-msgstr "OpenRig · Tuner"
-
-#: crates/adapter-gui/ui/secondary_windows_block.slint:28
-msgid "title-window-block-editor"
-msgstr "OpenRig · Block"
-
-#: crates/adapter-gui/ui/secondary_windows_block.slint:195
-msgid "title-window-chain-view"
-msgstr "OpenRig · Chain"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:23
-msgid "title-window-project-settings"
-msgstr "OpenRig · Configure project"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:96
-msgid "title-window-chain-editor"
-msgstr "OpenRig · Configure chain"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:129
-msgid "title-section-input"
-msgstr "Input"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:147
-msgid "title-section-output"
-msgstr "Output"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:177
-msgid "title-window-chain-input"
-msgstr "OpenRig · Chain input"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:217
-msgid "title-window-chain-output"
-msgstr "OpenRig · Chain output"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:258
-msgid "title-window-chain-inputs"
-msgstr "OpenRig · Chain inputs"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:269
-msgid "btn-add-input-row"
-msgstr "+ Add input"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:299
-msgid "title-window-chain-outputs"
-msgstr "OpenRig · Chain outputs"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:310
-msgid "btn-add-output-row"
-msgstr "+ Add output"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:355
-msgid "title-window-chain-insert"
-msgstr "OpenRig · Configure Insert"
-
-#: crates/adapter-gui/ui/touch_main.slint:586
-msgid "⌨"
-msgstr "⌨"
-
-#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:27
-msgid "title-dialog-delete-chain"
-msgstr "Delete chain"
-
-#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:37
-msgid "Excluir a chain \"{}\"?"
-msgstr "Delete chain \"{}\"?"
-
-#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:31
+#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:30
+msgctxt "ConfirmDeleteRecentProjectDialog"
 msgid "title-dialog-delete-recent-project"
 msgstr "Remove from recents"
 
-#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:41
+#. Literal pt-BR source string with `{}` placeholder.
+#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:38
+msgctxt "ConfirmDeleteRecentProjectDialog"
 msgid "Remover o projeto \"{}\" dos recentes?"
 msgstr "Remove project \"{}\" from recents?"
 
-#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:75
+#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:57
+msgctxt "ConfirmDeleteRecentProjectDialog"
+msgid "btn-cancel"
+msgstr "Cancel"
+
+#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:74
+msgctxt "ConfirmDeleteRecentProjectDialog"
 msgid "btn-remove"
 msgstr "Remove"
 
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "tab-system"
-msgstr "System"
+#: crates/adapter-gui/ui/components/language_selector.slint:56
+msgctxt "LanguageSelector"
+msgid "accessible-language-selector"
+msgstr "Language selector"
 
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "tab-project"
-msgstr "Project"
+#: crates/adapter-gui/ui/components/model_select_with_search.slint:96
+msgctxt "ModelSelectWithSearch"
+msgid "▼"
+msgstr "▼"
 
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "btn-close"
-msgstr "Close"
+#: crates/adapter-gui/ui/components/model_select_with_search.slint:178
+msgctxt "ModelSelectWithSearch"
+msgid "placeholder-search-models"
+msgstr "Search models..."
 
-#: crates/adapter-gui/ui/components/settings_section.slint
-msgid "badge-system"
-msgstr "System"
+#: crates/adapter-gui/ui/components/model_select_with_search.slint:212
+msgctxt "ModelSelectWithSearch"
+msgid "status-no-models-found"
+msgstr "No models found"
 
-#: crates/adapter-gui/ui/components/settings_section.slint
-msgid "badge-project"
-msgstr "Project"
-
-#: crates/adapter-gui/ui/pages/settings/section_system_audio.slint
-msgid "title-section-audio-interface"
-msgstr "Audio interface"
-
-#: crates/adapter-gui/ui/pages/settings/section_system_language.slint
-msgid "title-section-language"
-msgstr "Language"
-
-#: crates/adapter-gui/ui/pages/settings/section_system_midi_devices.slint
-msgid "title-section-midi-devices"
-msgstr "MIDI devices"
-
-#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint
-msgid "title-section-project-meta"
-msgstr "Metadata"
-
-#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint
-msgid "label-file"
-msgstr "File"
-
-#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint
-msgid "placeholder-project-unsaved"
-msgstr "(unsaved)"
-
-#: crates/adapter-gui/ui/pages/settings/section_project_midi_mapping.slint
-msgid "title-section-midi-mapping"
-msgstr "MIDI mapping"
-
-#: crates/adapter-gui/ui/pages/settings/section_project_midi_mapping.slint
-msgid "btn-add-midi-binding"
-msgstr "+ Add"
-
-#: crates/adapter-gui/ui/pages/settings/section_project_midi_mapping.slint
-msgid "empty-midi-mapping-explain"
-msgstr "No MIDI bindings yet. Add one to map a controller to an OpenRig command."
-"No MIDI bindings yet. Add one to map a controller to an OpenRig command."
-
-#: crates/adapter-gui/ui/pages/settings/section_project_midi_mapping.slint
-msgid "placeholder-midi-listen"
-msgstr "Press a MIDI control…"
-
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "nav-group-system"
-msgstr "SYSTEM"
-
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "nav-group-project"
-msgstr "PROJECT"
+#: crates/adapter-gui/ui/components/preset_picker_overlay.slint:34
+msgctxt "PresetPickerOverlay"
+msgid "btn-load-preset"
+msgstr "Load Preset"
 
 #: crates/adapter-gui/ui/components/preset_picker_overlay.slint:40
+msgctxt "PresetPickerOverlay"
 msgid "preset-search-placeholder"
 msgstr "Search presets…"
 
+#: crates/adapter-gui/ui/components/preset_picker_overlay.slint:106
+msgctxt "PresetPickerOverlay"
+msgid "btn-cancel"
+msgstr "Cancel"
+
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:38
+msgctxt "PresetSaveOverlay"
 msgid "title-dialog-save-preset"
 msgstr "Save preset"
 
+#: crates/adapter-gui/ui/components/preset_save_overlay.slint:63
+msgctxt "PresetSaveOverlay"
+msgid "btn-cancel"
+msgstr "Cancel"
+
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:82
+msgctxt "PresetSaveOverlay"
 msgid "btn-save"
 msgstr "Save"
 
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:119
+msgctxt "PresetOverwriteOverlay"
 msgid "title-dialog-overwrite-preset"
 msgstr "Overwrite preset?"
 
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:126
+msgctxt "PresetOverwriteOverlay"
 msgid "msg-overwrite-preset"
 msgstr "A preset called \"{}\" already exists. Overwrite it?"
 
+#: crates/adapter-gui/ui/components/preset_save_overlay.slint:145
+msgctxt "PresetOverwriteOverlay"
+msgid "btn-cancel"
+msgstr "Cancel"
+
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:162
+msgctxt "PresetOverwriteOverlay"
 msgid "btn-overwrite"
 msgstr "Overwrite"
-#: crates/adapter-gui/ui/pages/settings.slint
-#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint
+
+#: crates/adapter-gui/ui/components/preset_select.slint:72
+msgctxt "PresetSelect"
+msgid "Preset selector"
+msgstr ""
+
+#: crates/adapter-gui/ui/components/preset_select.slint:137
+msgctxt "PresetSelect"
+msgid "preset-search-placeholder"
+msgstr "Search presets…"
+
+#: crates/adapter-gui/ui/components/preset_select.slint:170
+msgctxt "PresetSelect"
+msgid "status-no-presets-found"
+msgstr "No presets found"
+
+#: crates/adapter-gui/ui/pages/block_editor_panel.slint:122
+msgctxt "BlockEditorPanel"
+msgid "tooltip-delete"
+msgstr "Delete"
+
+#: crates/adapter-gui/ui/pages/block_editor_panel.slint:243
+msgctxt "BlockEditorPanel"
+msgid "–"
+msgstr "–"
+
+#: crates/adapter-gui/ui/pages/block_panel_editor.slint:37
+msgctxt "BlockPanelEditor"
+msgid "btn-add"
+msgstr "Add"
+
+#: crates/adapter-gui/ui/pages/block_panel_editor.slint:323
+msgctxt "BlockPanelEditor"
+msgid "–"
+msgstr "–"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:195
+msgctxt "ChainEditorPage"
+msgid "instrument-guitar"
+msgstr "Guitar"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:196
+msgctxt "ChainEditorPage"
+msgid "instrument-acoustic-guitar"
+msgstr "Acoustic guitar"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:197
+msgctxt "ChainEditorPage"
+msgid "instrument-bass"
+msgstr "Bass"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:198
+msgctxt "ChainEditorPage"
+msgid "instrument-voice"
+msgstr "Voice"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:199
+msgctxt "ChainEditorPage"
+msgid "instrument-keyboard"
+msgstr "Keyboard"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:200
+msgctxt "ChainEditorPage"
+msgid "instrument-drums"
+msgstr "Drums"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:201
+msgctxt "ChainEditorPage"
+msgid "instrument-other"
+msgstr "Other"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:221
+msgctxt "ChainEditorPage"
+msgid "title-new-chain"
+msgstr "New chain"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:221
+msgctxt "ChainEditorPage"
+msgid "title-configure-chain"
+msgstr "Configure chain"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:240
+msgctxt "ChainEditorPage"
+msgid "label-name"
+msgstr "Name"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:267
+msgctxt "ChainEditorPage"
+msgid "label-instrument"
+msgstr "Instrument"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:345
+msgctxt "ChainEditorPage"
+msgid "title-section-inputs"
+msgstr "Inputs"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:371
+msgctxt "ChainEditorPage"
+msgid "btn-add-input"
+msgstr "+ Add input"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:390
+msgctxt "ChainEditorPage"
+msgid "title-section-outputs"
+msgstr "Outputs"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:416
+msgctxt "ChainEditorPage"
+msgid "btn-add-output"
+msgstr "+ Add output"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:443
+msgctxt "ChainEditorPage"
+msgid "btn-cancel"
+msgstr "Cancel"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:450
+msgctxt "ChainEditorPage"
+msgid "btn-create-chain"
+msgstr "Create chain"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:450
+msgctxt "ChainEditorPage"
+msgid "btn-save-chain"
+msgstr "Save chain"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:66
+msgctxt "ChannelRow"
+msgid "✓"
+msgstr "✓"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:140
+msgctxt "ChainEndpointEditorPage"
+msgid "label-device"
+msgstr "Device"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:170
+msgctxt "ChainEndpointEditorPage"
+msgid "label-mode"
+msgstr "Mode"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:229
+msgctxt "ChainEndpointEditorPage"
+msgid "label-channels"
+msgstr "Channels"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:268
+msgctxt "ChainEndpointEditorPage"
+msgid "btn-cancel"
+msgstr "Cancel"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:275
+msgctxt "ChainEndpointEditorPage"
+msgid "btn-ok"
+msgstr "OK"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:99
+msgctxt "ChainInsertEditorPage"
+msgid "title-section-configure-insert"
+msgstr "Configure Insert"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:214
+msgctxt "ChainInsertEditorPage"
+msgid "label-send"
+msgstr "Send"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:225
+msgctxt "ChainInsertEditorPage"
+msgid "label-device"
+msgstr "Device"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:247
+msgctxt "ChainInsertEditorPage"
+msgid "label-mode"
+msgstr "Mode"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:299
+msgctxt "ChainInsertEditorPage"
+msgid "label-channels"
+msgstr "Channels"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:344
+msgctxt "ChainInsertEditorPage"
+msgid "label-return"
+msgstr "Return"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:469
+msgctxt "ChainInsertEditorPage"
+msgid "btn-cancel"
+msgstr "Cancel"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:476
+msgctxt "ChainInsertEditorPage"
+msgid "btn-ok"
+msgstr "OK"
+
+#: crates/adapter-gui/ui/pages/chain_io_groups.slint:304
+msgctxt "ChainIoGroupsPage"
+msgid "btn-cancel"
+msgstr "Cancel"
+
+#: crates/adapter-gui/ui/pages/chain_io_groups.slint:311
+msgctxt "ChainIoGroupsPage"
+msgid "btn-ok"
+msgstr "OK"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:246
+msgctxt "ChainRow"
+msgid "tooltip-expand-blocks"
+msgstr "Expand blocks"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:254
+msgctxt "ChainRow"
+msgid "tooltip-measure-latency"
+msgstr "Measure latency (emits a beep)"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:283
+msgctxt "ChainRow"
+msgid "tooltip-configure"
+msgstr "Configure"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:291
+msgctxt "ChainRow"
+msgid "tooltip-delete"
+msgstr "Delete"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:564
+msgctxt "ChainRow"
+msgid "label-lat"
+msgstr "LAT"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:613
+msgctxt "ChainRow"
+msgid "label-input"
+msgstr "Input"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:659
+msgctxt "ChainRow"
+msgid "label-output"
+msgstr "Output"
+
+#: crates/adapter-gui/ui/pages/compact_block_row.slint:415
+msgctxt "CompactBlockRow"
+msgid "▼"
+msgstr "▼"
+
+#: crates/adapter-gui/ui/pages/compact_block_row.slint:493
+msgctxt "CompactBlockRow"
+msgid "btn-open-plugin"
+msgstr "Open Plugin"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:160
+msgctxt "CompactChainViewPage"
+msgid "tooltip-measure-latency"
+msgstr "Measure latency (emits a beep)"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:187
+msgctxt "CompactChainViewPage"
+msgid "label-lat"
+msgstr "LAT"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:216
+msgctxt "CompactChainViewPage"
+msgid "tooltip-configure"
+msgstr "Configure"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:230
+msgctxt "CompactChainViewPage"
+msgid "label-in"
+msgstr "IN"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:251
+msgctxt "CompactChainViewPage"
+msgid "label-out"
+msgstr "OUT"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:267
+msgctxt "CompactChainViewPage"
+msgid "tooltip-delete"
+msgstr "Delete"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:313
+msgctxt "CompactChainViewPage"
+msgid "+"
+msgstr "+"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:87
+msgctxt "PluginInfoPanel"
+msgid "·"
+msgstr "·"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:125
+msgctxt "PluginInfoPanel"
+msgid "label-description"
+msgstr "Description"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:144
+msgctxt "PluginInfoPanel"
+msgid "label-license"
+msgstr "License:"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:171
+msgctxt "PluginInfoPanel"
+msgid "↗"
+msgstr "↗"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:177
+msgctxt "PluginInfoPanel"
+msgid "btn-open-homepage"
+msgstr "Open Homepage"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:145
+msgctxt "ProjectChainsPage"
+msgid "tooltip-back"
+msgstr "Back"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:153
+msgctxt "ProjectChainsPage"
+msgid "tooltip-spectrum"
+msgstr "Spectrum"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:161
+msgctxt "ProjectChainsPage"
+msgid "tooltip-tuner"
+msgstr "Tuner"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:169
+msgctxt "ProjectChainsPage"
+msgid "tooltip-project-settings"
+msgstr "Project"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:178
+msgctxt "ProjectChainsPage"
+msgid "tooltip-save"
+msgstr "Save"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:186
+msgctxt "ProjectChainsPage"
+msgid "tooltip-new-chain"
+msgstr "New chain"
+
+#: crates/adapter-gui/ui/pages/project_launcher.slint:184
+msgctxt "SearchField"
+msgid "placeholder-search-projects"
+msgstr "Search projects"
+
+#: crates/adapter-gui/ui/pages/project_launcher.slint:287
+msgctxt "ProjectLauncherPage"
+msgid "tooltip-open-project"
+msgstr "Open project"
+
+#: crates/adapter-gui/ui/pages/project_launcher.slint:294
+msgctxt "ProjectLauncherPage"
+msgid "btn-new-project"
+msgstr "New project"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:55
+msgctxt "NameInput"
+msgid "placeholder-project-name-example"
+msgstr "e.g. Live Guitar"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:151
+msgctxt "ProjectSetupPage"
+msgid "title-new-project"
+msgstr "New Project"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:164
+msgctxt "ProjectSetupPage"
+msgid "label-project-name"
+msgstr "Project name"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:204
+msgctxt "ProjectSetupPage"
+msgid "btn-cancel"
+msgstr "Cancel"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:211
+msgctxt "ProjectSetupPage"
+msgid "btn-create-project"
+msgstr "Create project"
+
+#: crates/adapter-gui/ui/pages/settings.slint:170
+msgctxt "SettingsPage"
+msgid "nav-group-system"
+msgstr "SYSTEM"
+
+#: crates/adapter-gui/ui/pages/settings.slint:181
+msgctxt "SettingsPage"
+msgid "title-section-audio-interface"
+msgstr "Audio interface"
+
+#: crates/adapter-gui/ui/pages/settings.slint:186
+msgctxt "SettingsPage"
+msgid "title-section-language"
+msgstr "Language"
+
+#: crates/adapter-gui/ui/pages/settings.slint:191
+msgctxt "SettingsPage"
+msgid "title-section-midi-devices"
+msgstr "MIDI devices"
+
+#: crates/adapter-gui/ui/pages/settings.slint:196
+msgctxt "SettingsPage"
 msgid "title-section-paths"
 msgstr "Paths"
 
-#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint
-msgid "label-presets-path"
-msgstr "Presets folder"
-
-#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint
-msgid "label-plugins-path"
-msgstr "Plugins folder"
-
-#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint
-msgid "label-evaluations-path"
-msgstr "Evaluations folder"
-
-#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint
-msgid "btn-choose-path"
-msgstr "Choose…"
-
-#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint
-msgid "btn-reset-path"
-msgstr "Reset"
-
-#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint
-msgid "placeholder-default-path"
-msgstr "(default)"
-
-#: crates/adapter-gui/ui/pages/settings/section_system_language.slint
-msgid "label-language"
-msgstr "Language"
-
-#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint
-msgid "btn-save-project"
-msgstr "Save project"
-
-msgid "btn-save-audio-settings"
-msgstr "Apply"
-
-#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint
-msgid "label-plugin-catalog"
-msgstr "Plugin catalog"
-
-#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint
-msgid "btn-reload-plugin-catalog"
-msgstr "Reload"
-
-#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint
-msgid "status-plugin-catalog-idle"
-msgstr "Not reloaded yet"
-
-#: crates/adapter-gui/ui/components/chain_di_loop_button.slint
-msgid "di-loop-button-label"
-msgstr "DI Loop"
-
-#: crates/adapter-gui/ui/components/chain_di_loop_button.slint
-msgid "di-loop-play-label"
-msgstr "Play DI loop"
-
-#: crates/adapter-gui/ui/components/chain_di_loop_button.slint
-msgid "di-loop-stop-label"
-msgstr "Stop DI loop"
-
+#: crates/adapter-gui/ui/pages/settings.slint:201
+msgctxt "SettingsPage"
 msgid "title-section-integrations"
 msgstr "Integrations"
 
+#: crates/adapter-gui/ui/pages/settings.slint:216
+msgctxt "SettingsPage"
+msgid "nav-group-project"
+msgstr "PROJECT"
+
+#: crates/adapter-gui/ui/pages/settings.slint:227
+msgctxt "SettingsPage"
+msgid "title-section-project-meta"
+msgstr "Metadata"
+
+#: crates/adapter-gui/ui/pages/settings.slint:335
+msgctxt "SettingsPage"
+msgid "btn-save-audio-settings"
+msgstr "Apply"
+
+#: crates/adapter-gui/ui/pages/settings.slint:339
+msgctxt "SettingsPage"
+msgid "btn-close"
+msgstr "Close"
+
+#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint:27
+msgctxt "SectionProjectMeta"
+msgid "label-name"
+msgstr "Name"
+
+#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint:58
+msgctxt "SectionProjectMeta"
+msgid "label-file"
+msgstr "File"
+
+#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint:66
+msgctxt "SectionProjectMeta"
+msgid "placeholder-project-unsaved"
+msgstr "(unsaved)"
+
+#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint:83
+msgctxt "SectionProjectMeta"
+msgid "btn-save-project"
+msgstr "Save project"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_audio.slint:95
+msgctxt "AudioDeviceRow"
+msgid "label-hz"
+msgstr "Hz"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_audio.slint:118
+msgctxt "AudioDeviceRow"
+msgid "label-buffer"
+msgstr "Buffer"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_audio.slint:141
+msgctxt "AudioDeviceRow"
+msgid "label-bits"
+msgstr "Bits"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:39
+msgctxt "SectionSystemIntegrations"
 msgid "label-midi-enabled"
 msgstr "MIDI control surface"
 
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:45
+msgctxt "SectionSystemIntegrations"
 msgid "desc-midi-enabled"
 msgstr "Enable the MIDI/BLE-MIDI adapter so footswitches drive OpenRig"
 
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:93
+msgctxt "SectionSystemIntegrations"
 msgid "label-mcp-enabled"
 msgstr "MCP server"
 
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:99
+msgctxt "SectionSystemIntegrations"
 msgid "desc-mcp-enabled"
 msgstr "Expose the MCP server on 127.0.0.1:4123 for agents"
 
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:134
+msgctxt "SectionSystemIntegrations"
 msgid "hint-restart-to-apply"
 msgstr "Takes effect on the next launch."
+
+#: crates/adapter-gui/ui/pages/settings/section_system_language.slint:25
+msgctxt "SectionSystemLanguage"
+msgid "label-language"
+msgstr "Language"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:49
+msgctxt "SectionSystemPaths"
+msgid "label-presets-path"
+msgstr "Presets folder"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:57
+msgctxt "SectionSystemPaths"
+msgid "placeholder-default-path"
+msgstr "(default)"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:66
+msgctxt "SectionSystemPaths"
+msgid "btn-choose-path"
+msgstr "Choose…"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:70
+msgctxt "SectionSystemPaths"
+msgid "btn-reset-path"
+msgstr "Reset"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:81
+msgctxt "SectionSystemPaths"
+msgid "label-plugins-path"
+msgstr "Plugins folder"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:113
+msgctxt "SectionSystemPaths"
+msgid "label-evaluations-path"
+msgstr "Evaluations folder"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:145
+msgctxt "SectionSystemPaths"
+msgid "label-plugin-catalog"
+msgstr "Plugin catalog"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:153
+msgctxt "SectionSystemPaths"
+msgid "status-plugin-catalog-idle"
+msgstr "Not reloaded yet"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:162
+msgctxt "SectionSystemPaths"
+msgid "btn-reload-plugin-catalog"
+msgstr "Reload"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:73
+msgctxt "SpectrumCard"
+msgid "—"
+msgstr "—"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:127
+msgctxt "SpectrumCard"
+msgid "20"
+msgstr "20"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:133
+msgctxt "SpectrumCard"
+msgid "100"
+msgstr "100"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:139
+msgctxt "SpectrumCard"
+msgid "1k"
+msgstr "1k"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:145
+msgctxt "SpectrumCard"
+msgid "10k"
+msgstr "10k"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:151
+msgctxt "SpectrumCard"
+msgid "20k"
+msgstr "20k"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:199
+msgctxt "SpectrumPanel"
+msgid "label-spectrum"
+msgstr "SPECTRUM"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:241
+msgctxt "SpectrumPanel"
+msgid "status-no-active-outputs"
+msgstr "NO ACTIVE OUTPUTS"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:251
+msgctxt "SpectrumPanel"
+msgid "status-spectrum-empty-help"
+msgstr "Power on the spectrum and enable a chain with a configured output."
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:279
+msgctxt "SpectrumWindow"
+msgid "title-window-spectrum"
+msgstr "OpenRig · Spectrum"
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:54
+msgctxt "MuteSwitch"
+msgid "label-mute"
+msgstr "MUTE"
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:316
+msgctxt "TunerPanel"
+msgid "label-tuner"
+msgstr "TUNER"
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:368
+msgctxt "TunerPanel"
+msgid "status-no-active-inputs"
+msgstr "NO ACTIVE INPUTS"
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:378
+msgctxt "TunerPanel"
+msgid "status-tuner-empty-help"
+msgstr "Enable a chain with a configured input to see its tuners here."
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:406
+msgctxt "TunerWindow"
+msgid "title-window-tuner"
+msgstr "OpenRig · Tuner"
+
+#: crates/adapter-gui/ui/secondary_windows_block.slint:30
+msgctxt "BlockEditorWindow"
+msgid "title-window-block-editor"
+msgstr "OpenRig · Block"
+
+#: crates/adapter-gui/ui/secondary_windows_block.slint:231
+msgctxt "CompactChainViewWindow"
+msgid "title-window-chain-view"
+msgstr "OpenRig · Chain"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:60
+msgctxt "ProjectSettingsWindow"
+msgid "title-window-project-settings"
+msgstr "OpenRig · Configure project"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:159
+msgctxt "ChainEditorWindow"
+msgid "title-window-chain-editor"
+msgstr "OpenRig · Configure chain"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:192
+msgctxt "ChainEditorWindow"
+msgid "title-section-input"
+msgstr "Input"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:210
+msgctxt "ChainEditorWindow"
+msgid "title-section-output"
+msgstr "Output"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:240
+msgctxt "ChainInputWindow"
+msgid "title-window-chain-input"
+msgstr "OpenRig · Chain input"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:250
+msgctxt "ChainInputWindow"
+msgid "title-section-input"
+msgstr "Input"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:280
+msgctxt "ChainOutputWindow"
+msgid "title-window-chain-output"
+msgstr "OpenRig · Chain output"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:290
+msgctxt "ChainOutputWindow"
+msgid "title-section-output"
+msgstr "Output"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:321
+msgctxt "ChainInputGroupsWindow"
+msgid "title-window-chain-inputs"
+msgstr "OpenRig · Chain inputs"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:331
+msgctxt "ChainInputGroupsWindow"
+msgid "title-section-inputs"
+msgstr "Inputs"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:332
+msgctxt "ChainInputGroupsWindow"
+msgid "btn-add-input-row"
+msgstr "+ Add input"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:362
+msgctxt "ChainOutputGroupsWindow"
+msgid "title-window-chain-outputs"
+msgstr "OpenRig · Chain outputs"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:372
+msgctxt "ChainOutputGroupsWindow"
+msgid "title-section-outputs"
+msgstr "Outputs"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:373
+msgctxt "ChainOutputGroupsWindow"
+msgid "btn-add-output-row"
+msgstr "+ Add output"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:418
+msgctxt "ChainInsertWindow"
+msgid "title-window-chain-insert"
+msgstr "OpenRig · Configure Insert"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:428
+msgctxt "ChainInsertWindow"
+msgid "title-section-configure-insert"
+msgstr "Configure Insert"
+
+#: crates/adapter-gui/ui/touch_main.slint:667
+msgctxt "TouchMain"
+msgid "⌨"
+msgstr "⌨"

--- a/crates/adapter-gui/translations/es_ES/LC_MESSAGES/adapter-gui.po
+++ b/crates/adapter-gui/translations/es_ES/LC_MESSAGES/adapter-gui.po
@@ -12,652 +12,939 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: crates/adapter-gui/ui/blocks/header.slint:13
+msgctxt "Header"
 msgid "OpenRig"
 msgstr "OpenRig"
 
 #: crates/adapter-gui/ui/components/block_panel_parameter_item.slint:274
+msgctxt "BlockPanelParameterItem"
 msgid "btn-load-file"
 msgstr "Load"
 
 #: crates/adapter-gui/ui/components/block_stream_mini_display.slint:23
+msgctxt "BlockStreamMiniDisplay"
 msgid "–"
 msgstr "–"
 
 #: crates/adapter-gui/ui/components/block_value_widgets.slint:128
+msgctxt "BlockValueStepper"
 msgid "−"
 msgstr "−"
 
 #: crates/adapter-gui/ui/components/block_value_widgets.slint:194
+msgctxt "BlockValueStepper"
 msgid "+"
 msgstr "+"
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:87
-msgid "Preset selector"
-msgstr "Selector de preset"
+#: crates/adapter-gui/ui/components/chain_di_loop_button.slint:61
+msgctxt "ChainDiLoopButton"
+msgid "di-loop-button-label"
+msgstr "Loop DI"
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:170
+#: crates/adapter-gui/ui/components/chain_di_loop_button.slint:138
+msgctxt "ChainDiLoopButton"
+msgid "di-loop-stop-label"
+msgstr "Detener loop DI"
+
+#: crates/adapter-gui/ui/components/chain_di_loop_button.slint:138
+msgctxt "ChainDiLoopButton"
+msgid "di-loop-play-label"
+msgstr "Reproducir loop DI"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:77
+msgctxt "SceneBtn"
 msgid "Scene {}"
 msgstr "Escena {}"
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:192
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:99
+msgctxt "SceneBar"
 msgid "Add scene"
 msgstr "Añadir escena"
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:201
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:108
+msgctxt "SceneBar"
 msgid "Remove last scene"
 msgstr "Eliminar última escena"
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:258
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:183
+msgctxt "ChainTitlePreset"
+msgid "tooltip-open-preset"
+msgstr "Abrir preset"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:193
+msgctxt "ChainTitlePreset"
+msgid "tooltip-save-preset"
+msgstr "Guardar preset"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:203
+msgctxt "ChainTitlePreset"
 msgid "Add preset"
 msgstr "Añadir preset"
 
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:213
+msgctxt "ChainTitlePreset"
+msgid "Rename preset"
+msgstr "Renombrar preset"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:224
+msgctxt "ChainTitlePreset"
+msgid "Remove preset"
+msgstr "Eliminar preset"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:316
+msgctxt "ChainTitlePreset"
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:337
+msgctxt "ChainTitlePreset"
+msgid "OK"
+msgstr "OK"
+
 #: crates/adapter-gui/ui/components/chain_volume_button.slint:37
+msgctxt "ChainVolumeButton"
 msgid "Volume"
 msgstr "Volumen"
 
+#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:29
+msgctxt "ConfirmDeleteChainDialog"
+msgid "title-dialog-delete-chain"
+msgstr "Eliminar cadena"
+
+#. text directly.
+#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:39
+msgctxt "ConfirmDeleteChainDialog"
+msgid "Excluir a chain \"{}\"?"
+msgstr "¿Eliminar la cadena \"{}\"?"
+
+#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:58
+msgctxt "ConfirmDeleteChainDialog"
+msgid "btn-cancel"
+msgstr "Cancelar"
+
+#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:75
+msgctxt "ConfirmDeleteChainDialog"
+msgid "btn-delete"
+msgstr "Eliminar"
+
 #: crates/adapter-gui/ui/components/confirm_delete_dialog.slint:27
+msgctxt "ConfirmDeleteBlockDialog"
 msgid "title-dialog-delete-block"
 msgstr "Eliminar bloque"
 
 #. pt-BR source string with the placeholder.
 #: crates/adapter-gui/ui/components/confirm_delete_dialog.slint:36
+msgctxt "ConfirmDeleteBlockDialog"
 msgid "Excluir \"{}\"?"
 msgstr "¿Eliminar \"{}\"?"
 
 #: crates/adapter-gui/ui/components/confirm_delete_dialog.slint:55
+msgctxt "ConfirmDeleteBlockDialog"
 msgid "btn-cancel"
 msgstr "Cancelar"
 
 #: crates/adapter-gui/ui/components/confirm_delete_dialog.slint:72
+msgctxt "ConfirmDeleteBlockDialog"
 msgid "btn-delete"
 msgstr "Eliminar"
 
-#: crates/adapter-gui/ui/components/language_selector.slint:56
-msgid "accessible-language-selector"
-msgstr "Selector de idioma"
-
-#: crates/adapter-gui/ui/components/model_select_with_search.slint:93
-msgid "▼"
-msgstr "▼"
-
-#: crates/adapter-gui/ui/components/model_select_with_search.slint:175
-msgid "placeholder-search-models"
-msgstr "Buscar modelos..."
-
-#: crates/adapter-gui/ui/components/preset_select.slint:170
-msgid "status-no-presets-found"
-msgstr "Ningún preset encontrado"
-
-#: crates/adapter-gui/ui/components/model_select_with_search.slint:209
-msgid "status-no-models-found"
-msgstr "Ningún modelo encontrado"
-
-#: crates/adapter-gui/ui/components/preset_picker_overlay.slint:32
-msgid "btn-load-preset"
-msgstr "Cargar Preset"
-
-#: crates/adapter-gui/ui/pages/block_editor_panel.slint:122
-msgid "tooltip-delete"
-msgstr "Eliminar"
-
-#: crates/adapter-gui/ui/pages/block_panel_editor.slint:36
-msgid "btn-add"
-msgstr "Añadir"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:195
-msgid "instrument-guitar"
-msgstr "Guitarra"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:196
-msgid "instrument-acoustic-guitar"
-msgstr "Guitarra acústica"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:197
-msgid "instrument-bass"
-msgstr "Bajo"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:198
-msgid "instrument-voice"
-msgstr "Voz"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:199
-msgid "instrument-keyboard"
-msgstr "Teclado"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:200
-msgid "instrument-drums"
-msgstr "Batería"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:201
-msgid "instrument-other"
-msgstr "Otro"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:221
-msgid "title-new-chain"
-msgstr "Nueva cadena"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:221
-msgid "title-configure-chain"
-msgstr "Configurar cadena"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:240
-msgid "label-name"
-msgstr "Nombre"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:267
-msgid "label-instrument"
-msgstr "Instrumento"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:345
-msgid "title-section-inputs"
-msgstr "Entradas"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:371
-msgid "btn-add-input"
-msgstr "+ Añadir entrada"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:390
-msgid "title-section-outputs"
-msgstr "Salidas"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:416
-msgid "btn-add-output"
-msgstr "+ Añadir salida"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:450
-msgid "btn-create-chain"
-msgstr "Crear cadena"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:450
-msgid "btn-save-chain"
-msgstr "Guardar cadena"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:66
-msgid "✓"
-msgstr "✓"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:140
-msgid "label-device"
-msgstr "Dispositivo"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:170
-msgid "label-mode"
-msgstr "Modo"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:229
-msgid "label-channels"
-msgstr "Canales"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:275
-msgid "btn-ok"
-msgstr "OK"
-
-#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:99
-msgid "title-section-configure-insert"
-msgstr "Configurar Insert"
-
-#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:214
-msgid "label-send"
-msgstr "Envío"
-
-#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:344
-msgid "label-return"
-msgstr "Retorno"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:140
-msgid "tooltip-expand-blocks"
-msgstr "Expandir bloques"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:148
-msgid "tooltip-measure-latency"
-msgstr "Medir latencia (emite un pitido)"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:177
-msgid "tooltip-configure"
-msgstr "Configurar"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:185
-msgid "tooltip-open-preset"
-msgstr "Abrir preset"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:193
-msgid "tooltip-save-preset"
-msgstr "Guardar preset"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:472
-msgid "label-lat"
-msgstr "LAT"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:521
-msgid "label-input"
-msgstr "Entrada"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:567
-msgid "label-output"
-msgstr "Salida"
-
-#: crates/adapter-gui/ui/pages/compact_block_row.slint:493
-msgid "btn-open-plugin"
-msgstr "Abrir Plugin"
-
-#: crates/adapter-gui/ui/pages/compact_chain_view.slint:83
-msgid "label-in"
-msgstr "IN"
-
-#: crates/adapter-gui/ui/pages/compact_chain_view.slint:111
-msgid "label-out"
-msgstr "OUT"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:87
-msgid "·"
-msgstr "·"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:123
-msgid "label-description"
-msgstr "Description"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:142
-msgid "label-license"
-msgstr "License:"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:169
-msgid "↗"
-msgstr "↗"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:175
-msgid "btn-open-homepage"
-msgstr "Open Homepage"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:136
-msgid "tooltip-back"
-msgstr "Atrás"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:144
-msgid "tooltip-spectrum"
-msgstr "Spectrum"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:152
-msgid "tooltip-tuner"
-msgstr "Tuner"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:160
-msgid "tooltip-project-settings"
-msgstr "Proyecto"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:169
-msgid "tooltip-save"
-msgstr "Guardar"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:177
-msgid "tooltip-new-chain"
-msgstr "Nueva cadena"
-
-#: crates/adapter-gui/ui/pages/project_launcher.slint:185
-msgid "placeholder-search-projects"
-msgstr "Buscar proyectos"
-
-#: crates/adapter-gui/ui/pages/project_launcher.slint:288
-msgid "tooltip-open-project"
-msgstr "Abrir proyecto"
-
-#: crates/adapter-gui/ui/pages/project_launcher.slint:295
-msgid "btn-new-project"
-msgstr "Nuevo proyecto"
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:147
-msgid "label-hz"
-msgstr "Hz"
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:170
-msgid "label-buffer"
-msgstr "Buffer"
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:193
-msgid "label-bits"
-msgstr "Bits"
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:271
-msgid "title-section-audio-devices"
-msgstr "Dispositivos de audio"
-
-#: crates/adapter-gui/ui/pages/project_setup.slint:55
-msgid "placeholder-project-name-example"
-msgstr "Ej.: Guitarra en vivo"
-
-#: crates/adapter-gui/ui/pages/project_setup.slint:151
-msgid "title-new-project"
-msgstr "Nuevo Proyecto"
-
-#: crates/adapter-gui/ui/pages/project_setup.slint:164
-msgid "label-project-name"
-msgstr "Nombre del proyecto"
-
-#: crates/adapter-gui/ui/pages/project_setup.slint:211
-msgid "btn-create-project"
-msgstr "Crear proyecto"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:73
-msgid "—"
-msgstr "—"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:127
-msgid "20"
-msgstr "20"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:133
-msgid "100"
-msgstr "100"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:139
-msgid "1k"
-msgstr "1k"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:145
-msgid "10k"
-msgstr "10k"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:151
-msgid "20k"
-msgstr "20k"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:199
-msgid "label-spectrum"
-msgstr "SPECTRUM"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:241
-msgid "status-no-active-outputs"
-msgstr "NO ACTIVE OUTPUTS"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:251
-msgid "status-spectrum-empty-help"
-msgstr "Encienda el espectro y active una cadena con una salida configurada."
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:279
-msgid "title-window-spectrum"
-msgstr "OpenRig · Spectrum"
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:54
-msgid "label-mute"
-msgstr "MUTE"
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:316
-msgid "label-tuner"
-msgstr "TUNER"
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:368
-msgid "status-no-active-inputs"
-msgstr "NO ACTIVE INPUTS"
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:378
-msgid "status-tuner-empty-help"
-msgstr "Activa una chain con entrada configurada para ver los afinadores aquí."
-"Activa una cadena con una entrada configurada para ver sus afinadores "
-"aquí.Habilita una cadena con una entrada configurada para ver los afinadores "
-"aquí."
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:406
-msgid "title-window-tuner"
-msgstr "OpenRig · Tuner"
-
-#: crates/adapter-gui/ui/secondary_windows_block.slint:28
-msgid "title-window-block-editor"
-msgstr "OpenRig · Block"
-
-#: crates/adapter-gui/ui/secondary_windows_block.slint:195
-msgid "title-window-chain-view"
-msgstr "OpenRig · Cadena"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:23
-msgid "title-window-project-settings"
-msgstr "OpenRig · Configurar proyecto"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:96
-msgid "title-window-chain-editor"
-msgstr "OpenRig · Configurar cadena"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:129
-msgid "title-section-input"
-msgstr "Entrada"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:147
-msgid "title-section-output"
-msgstr "Salida"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:177
-msgid "title-window-chain-input"
-msgstr "OpenRig · Entrada de la cadena"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:217
-msgid "title-window-chain-output"
-msgstr "OpenRig · Salida de la cadena"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:258
-msgid "title-window-chain-inputs"
-msgstr "OpenRig · Entradas de la cadena"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:269
-msgid "btn-add-input-row"
-msgstr "+ Añadir entrada"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:299
-msgid "title-window-chain-outputs"
-msgstr "OpenRig · Salidas de la cadena"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:310
-msgid "btn-add-output-row"
-msgstr "+ Añadir salida"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:355
-msgid "title-window-chain-insert"
-msgstr "OpenRig · Configurar Insert"
-
-#: crates/adapter-gui/ui/touch_main.slint:586
-msgid "⌨"
-msgstr "⌨"
-
-#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:27
-msgid "title-dialog-delete-chain"
-msgstr "Eliminar cadena"
-
-#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:37
-msgid "Excluir a chain \"{}\"?"
-msgstr "¿Eliminar la cadena \"{}\"?"
-
-#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:31
+#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:30
+msgctxt "ConfirmDeleteRecentProjectDialog"
 msgid "title-dialog-delete-recent-project"
 msgstr "Quitar de recientes"
 
-#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:41
+#. Literal pt-BR source string with `{}` placeholder.
+#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:38
+msgctxt "ConfirmDeleteRecentProjectDialog"
 msgid "Remover o projeto \"{}\" dos recentes?"
 msgstr "¿Quitar el proyecto \"{}\" de recientes?"
 
-#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:75
+#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:57
+msgctxt "ConfirmDeleteRecentProjectDialog"
+msgid "btn-cancel"
+msgstr "Cancelar"
+
+#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:74
+msgctxt "ConfirmDeleteRecentProjectDialog"
 msgid "btn-remove"
 msgstr "Quitar"
 
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "tab-system"
-msgstr "Sistema"
+#: crates/adapter-gui/ui/components/language_selector.slint:56
+msgctxt "LanguageSelector"
+msgid "accessible-language-selector"
+msgstr "Selector de idioma"
 
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "tab-project"
-msgstr "Proyecto"
+#: crates/adapter-gui/ui/components/model_select_with_search.slint:96
+msgctxt "ModelSelectWithSearch"
+msgid "▼"
+msgstr "▼"
 
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "btn-close"
-msgstr "Cerrar"
+#: crates/adapter-gui/ui/components/model_select_with_search.slint:178
+msgctxt "ModelSelectWithSearch"
+msgid "placeholder-search-models"
+msgstr "Buscar modelos..."
 
-#: crates/adapter-gui/ui/components/settings_section.slint
-msgid "badge-system"
-msgstr "Sistema"
+#: crates/adapter-gui/ui/components/model_select_with_search.slint:212
+msgctxt "ModelSelectWithSearch"
+msgid "status-no-models-found"
+msgstr "Ningún modelo encontrado"
 
-#: crates/adapter-gui/ui/components/settings_section.slint
-msgid "badge-project"
-msgstr "Proyecto"
-
-#: crates/adapter-gui/ui/pages/settings/section_system_audio.slint
-msgid "title-section-audio-interface"
-msgstr "Interfaz de audio"
-
-#: crates/adapter-gui/ui/pages/settings/section_system_language.slint
-msgid "title-section-language"
-msgstr "Idioma"
-
-#: crates/adapter-gui/ui/pages/settings/section_system_midi_devices.slint
-msgid "title-section-midi-devices"
-msgstr "Dispositivos MIDI"
-
-#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint
-msgid "title-section-project-meta"
-msgstr "Metadatos"
-
-#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint
-msgid "placeholder-project-unsaved"
-msgstr "(sin guardar)"
-
-#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint
-msgid "label-file"
-msgstr "Archivo"
-
-#: crates/adapter-gui/ui/pages/settings/section_project_midi_mapping.slint
-msgid "title-section-midi-mapping"
-msgstr "Mapeo MIDI"
-
-#: crates/adapter-gui/ui/pages/settings/section_project_midi_mapping.slint
-msgid "btn-add-midi-binding"
-msgstr "+ Añadir"
-
-#: crates/adapter-gui/ui/pages/settings/section_project_midi_mapping.slint
-msgid "empty-midi-mapping-explain"
-msgstr "Aún no hay asignaciones MIDI. Añade una para vincular un controlador a un comando de OpenRig."
-"Aún no hay asignaciones MIDI. Añade una para vincular un controlador a un "
-"comando de OpenRig."
-
-#: crates/adapter-gui/ui/pages/settings/section_project_midi_mapping.slint
-msgid "placeholder-midi-listen"
-msgstr "Pulsa un control MIDI…"
-
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "nav-group-system"
-msgstr "SISTEMA"
-
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "nav-group-project"
-msgstr "PROYECTO"
-
-msgid "Cancel"
-msgstr "Cancelar"
-
-msgid "OK"
-msgstr "OK"
-
-msgid "Remove preset"
-msgstr "Eliminar preset"
-
-msgid "Rename preset"
-msgstr "Renombrar preset"
+#: crates/adapter-gui/ui/components/preset_picker_overlay.slint:34
+msgctxt "PresetPickerOverlay"
+msgid "btn-load-preset"
+msgstr "Cargar Preset"
 
 #: crates/adapter-gui/ui/components/preset_picker_overlay.slint:40
+msgctxt "PresetPickerOverlay"
 msgid "preset-search-placeholder"
 msgstr "Buscar presets…"
 
+#: crates/adapter-gui/ui/components/preset_picker_overlay.slint:106
+msgctxt "PresetPickerOverlay"
+msgid "btn-cancel"
+msgstr "Cancelar"
+
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:38
+msgctxt "PresetSaveOverlay"
 msgid "title-dialog-save-preset"
 msgstr "Guardar preset"
 
+#: crates/adapter-gui/ui/components/preset_save_overlay.slint:63
+msgctxt "PresetSaveOverlay"
+msgid "btn-cancel"
+msgstr "Cancelar"
+
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:82
+msgctxt "PresetSaveOverlay"
 msgid "btn-save"
 msgstr "Guardar"
 
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:119
+msgctxt "PresetOverwriteOverlay"
 msgid "title-dialog-overwrite-preset"
 msgstr "¿Sobrescribir preset?"
 
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:126
+msgctxt "PresetOverwriteOverlay"
 msgid "msg-overwrite-preset"
 msgstr "Ya existe un preset llamado \"{}\". ¿Sobrescribir?"
 
+#: crates/adapter-gui/ui/components/preset_save_overlay.slint:145
+msgctxt "PresetOverwriteOverlay"
+msgid "btn-cancel"
+msgstr "Cancelar"
+
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:162
+msgctxt "PresetOverwriteOverlay"
 msgid "btn-overwrite"
 msgstr "Sobrescribir"
-#: crates/adapter-gui/ui/pages/settings.slint
-#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint
+
+#: crates/adapter-gui/ui/components/preset_select.slint:72
+msgctxt "PresetSelect"
+msgid "Preset selector"
+msgstr "Selector de preset"
+
+#: crates/adapter-gui/ui/components/preset_select.slint:137
+msgctxt "PresetSelect"
+msgid "preset-search-placeholder"
+msgstr "Buscar presets…"
+
+#: crates/adapter-gui/ui/components/preset_select.slint:170
+msgctxt "PresetSelect"
+msgid "status-no-presets-found"
+msgstr "Ningún preset encontrado"
+
+#: crates/adapter-gui/ui/pages/block_editor_panel.slint:122
+msgctxt "BlockEditorPanel"
+msgid "tooltip-delete"
+msgstr "Eliminar"
+
+#: crates/adapter-gui/ui/pages/block_editor_panel.slint:243
+msgctxt "BlockEditorPanel"
+msgid "–"
+msgstr "–"
+
+#: crates/adapter-gui/ui/pages/block_panel_editor.slint:37
+msgctxt "BlockPanelEditor"
+msgid "btn-add"
+msgstr "Añadir"
+
+#: crates/adapter-gui/ui/pages/block_panel_editor.slint:323
+msgctxt "BlockPanelEditor"
+msgid "–"
+msgstr "–"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:195
+msgctxt "ChainEditorPage"
+msgid "instrument-guitar"
+msgstr "Guitarra"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:196
+msgctxt "ChainEditorPage"
+msgid "instrument-acoustic-guitar"
+msgstr "Guitarra acústica"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:197
+msgctxt "ChainEditorPage"
+msgid "instrument-bass"
+msgstr "Bajo"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:198
+msgctxt "ChainEditorPage"
+msgid "instrument-voice"
+msgstr "Voz"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:199
+msgctxt "ChainEditorPage"
+msgid "instrument-keyboard"
+msgstr "Teclado"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:200
+msgctxt "ChainEditorPage"
+msgid "instrument-drums"
+msgstr "Batería"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:201
+msgctxt "ChainEditorPage"
+msgid "instrument-other"
+msgstr "Otro"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:221
+msgctxt "ChainEditorPage"
+msgid "title-new-chain"
+msgstr "Nueva cadena"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:221
+msgctxt "ChainEditorPage"
+msgid "title-configure-chain"
+msgstr "Configurar cadena"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:240
+msgctxt "ChainEditorPage"
+msgid "label-name"
+msgstr "Nombre"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:267
+msgctxt "ChainEditorPage"
+msgid "label-instrument"
+msgstr "Instrumento"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:345
+msgctxt "ChainEditorPage"
+msgid "title-section-inputs"
+msgstr "Entradas"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:371
+msgctxt "ChainEditorPage"
+msgid "btn-add-input"
+msgstr "+ Añadir entrada"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:390
+msgctxt "ChainEditorPage"
+msgid "title-section-outputs"
+msgstr "Salidas"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:416
+msgctxt "ChainEditorPage"
+msgid "btn-add-output"
+msgstr "+ Añadir salida"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:443
+msgctxt "ChainEditorPage"
+msgid "btn-cancel"
+msgstr "Cancelar"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:450
+msgctxt "ChainEditorPage"
+msgid "btn-create-chain"
+msgstr "Crear cadena"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:450
+msgctxt "ChainEditorPage"
+msgid "btn-save-chain"
+msgstr "Guardar cadena"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:66
+msgctxt "ChannelRow"
+msgid "✓"
+msgstr "✓"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:140
+msgctxt "ChainEndpointEditorPage"
+msgid "label-device"
+msgstr "Dispositivo"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:170
+msgctxt "ChainEndpointEditorPage"
+msgid "label-mode"
+msgstr "Modo"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:229
+msgctxt "ChainEndpointEditorPage"
+msgid "label-channels"
+msgstr "Canales"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:268
+msgctxt "ChainEndpointEditorPage"
+msgid "btn-cancel"
+msgstr "Cancelar"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:275
+msgctxt "ChainEndpointEditorPage"
+msgid "btn-ok"
+msgstr "OK"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:99
+msgctxt "ChainInsertEditorPage"
+msgid "title-section-configure-insert"
+msgstr "Configurar Insert"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:214
+msgctxt "ChainInsertEditorPage"
+msgid "label-send"
+msgstr "Envío"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:225
+msgctxt "ChainInsertEditorPage"
+msgid "label-device"
+msgstr "Dispositivo"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:247
+msgctxt "ChainInsertEditorPage"
+msgid "label-mode"
+msgstr "Modo"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:299
+msgctxt "ChainInsertEditorPage"
+msgid "label-channels"
+msgstr "Canales"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:344
+msgctxt "ChainInsertEditorPage"
+msgid "label-return"
+msgstr "Retorno"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:469
+msgctxt "ChainInsertEditorPage"
+msgid "btn-cancel"
+msgstr "Cancelar"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:476
+msgctxt "ChainInsertEditorPage"
+msgid "btn-ok"
+msgstr "OK"
+
+#: crates/adapter-gui/ui/pages/chain_io_groups.slint:304
+msgctxt "ChainIoGroupsPage"
+msgid "btn-cancel"
+msgstr "Cancelar"
+
+#: crates/adapter-gui/ui/pages/chain_io_groups.slint:311
+msgctxt "ChainIoGroupsPage"
+msgid "btn-ok"
+msgstr "OK"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:246
+msgctxt "ChainRow"
+msgid "tooltip-expand-blocks"
+msgstr "Expandir bloques"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:254
+msgctxt "ChainRow"
+msgid "tooltip-measure-latency"
+msgstr "Medir latencia (emite un pitido)"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:283
+msgctxt "ChainRow"
+msgid "tooltip-configure"
+msgstr "Configurar"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:291
+msgctxt "ChainRow"
+msgid "tooltip-delete"
+msgstr "Eliminar"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:564
+msgctxt "ChainRow"
+msgid "label-lat"
+msgstr "LAT"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:613
+msgctxt "ChainRow"
+msgid "label-input"
+msgstr "Entrada"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:659
+msgctxt "ChainRow"
+msgid "label-output"
+msgstr "Salida"
+
+#: crates/adapter-gui/ui/pages/compact_block_row.slint:415
+msgctxt "CompactBlockRow"
+msgid "▼"
+msgstr "▼"
+
+#: crates/adapter-gui/ui/pages/compact_block_row.slint:493
+msgctxt "CompactBlockRow"
+msgid "btn-open-plugin"
+msgstr "Abrir Plugin"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:160
+msgctxt "CompactChainViewPage"
+msgid "tooltip-measure-latency"
+msgstr "Medir latencia (emite un pitido)"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:187
+msgctxt "CompactChainViewPage"
+msgid "label-lat"
+msgstr "LAT"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:216
+msgctxt "CompactChainViewPage"
+msgid "tooltip-configure"
+msgstr "Configurar"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:230
+msgctxt "CompactChainViewPage"
+msgid "label-in"
+msgstr "IN"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:251
+msgctxt "CompactChainViewPage"
+msgid "label-out"
+msgstr "OUT"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:267
+msgctxt "CompactChainViewPage"
+msgid "tooltip-delete"
+msgstr "Eliminar"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:313
+msgctxt "CompactChainViewPage"
+msgid "+"
+msgstr "+"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:87
+msgctxt "PluginInfoPanel"
+msgid "·"
+msgstr "·"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:125
+msgctxt "PluginInfoPanel"
+msgid "label-description"
+msgstr "Description"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:144
+msgctxt "PluginInfoPanel"
+msgid "label-license"
+msgstr "License:"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:171
+msgctxt "PluginInfoPanel"
+msgid "↗"
+msgstr "↗"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:177
+msgctxt "PluginInfoPanel"
+msgid "btn-open-homepage"
+msgstr "Open Homepage"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:145
+msgctxt "ProjectChainsPage"
+msgid "tooltip-back"
+msgstr "Atrás"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:153
+msgctxt "ProjectChainsPage"
+msgid "tooltip-spectrum"
+msgstr "Spectrum"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:161
+msgctxt "ProjectChainsPage"
+msgid "tooltip-tuner"
+msgstr "Tuner"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:169
+msgctxt "ProjectChainsPage"
+msgid "tooltip-project-settings"
+msgstr "Proyecto"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:178
+msgctxt "ProjectChainsPage"
+msgid "tooltip-save"
+msgstr "Guardar"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:186
+msgctxt "ProjectChainsPage"
+msgid "tooltip-new-chain"
+msgstr "Nueva cadena"
+
+#: crates/adapter-gui/ui/pages/project_launcher.slint:184
+msgctxt "SearchField"
+msgid "placeholder-search-projects"
+msgstr "Buscar proyectos"
+
+#: crates/adapter-gui/ui/pages/project_launcher.slint:287
+msgctxt "ProjectLauncherPage"
+msgid "tooltip-open-project"
+msgstr "Abrir proyecto"
+
+#: crates/adapter-gui/ui/pages/project_launcher.slint:294
+msgctxt "ProjectLauncherPage"
+msgid "btn-new-project"
+msgstr "Nuevo proyecto"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:55
+msgctxt "NameInput"
+msgid "placeholder-project-name-example"
+msgstr "Ej.: Guitarra en vivo"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:151
+msgctxt "ProjectSetupPage"
+msgid "title-new-project"
+msgstr "Nuevo Proyecto"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:164
+msgctxt "ProjectSetupPage"
+msgid "label-project-name"
+msgstr "Nombre del proyecto"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:204
+msgctxt "ProjectSetupPage"
+msgid "btn-cancel"
+msgstr "Cancelar"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:211
+msgctxt "ProjectSetupPage"
+msgid "btn-create-project"
+msgstr "Crear proyecto"
+
+#: crates/adapter-gui/ui/pages/settings.slint:170
+msgctxt "SettingsPage"
+msgid "nav-group-system"
+msgstr "SISTEMA"
+
+#: crates/adapter-gui/ui/pages/settings.slint:181
+msgctxt "SettingsPage"
+msgid "title-section-audio-interface"
+msgstr "Interfaz de audio"
+
+#: crates/adapter-gui/ui/pages/settings.slint:186
+msgctxt "SettingsPage"
+msgid "title-section-language"
+msgstr "Idioma"
+
+#: crates/adapter-gui/ui/pages/settings.slint:191
+msgctxt "SettingsPage"
+msgid "title-section-midi-devices"
+msgstr "Dispositivos MIDI"
+
+#: crates/adapter-gui/ui/pages/settings.slint:196
+msgctxt "SettingsPage"
 msgid "title-section-paths"
 msgstr "Carpetas"
 
-#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint
-msgid "label-presets-path"
-msgstr "Carpeta de presets"
-
-#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint
-msgid "label-plugins-path"
-msgstr "Carpeta de plugins"
-
-#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint
-msgid "label-evaluations-path"
-msgstr "Carpeta de evaluaciones"
-
-#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint
-msgid "btn-choose-path"
-msgstr "Elegir…"
-
-#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint
-msgid "btn-reset-path"
-msgstr "Restablecer"
-
-#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint
-msgid "placeholder-default-path"
-msgstr "(predeterminado)"
-
-#: crates/adapter-gui/ui/pages/settings/section_system_language.slint
-msgid "label-language"
-msgstr "Idioma"
-
-#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint
-msgid "btn-save-project"
-msgstr "Guardar proyecto"
-
-msgid "btn-save-audio-settings"
-msgstr "Aplicar"
-
-#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint
-msgid "label-plugin-catalog"
-msgstr "Catálogo de plugins"
-
-#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint
-msgid "btn-reload-plugin-catalog"
-msgstr "Recargar"
-
-#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint
-msgid "status-plugin-catalog-idle"
-msgstr "Aún no recargado"
-
-#: crates/adapter-gui/ui/components/chain_di_loop_button.slint
-msgid "di-loop-button-label"
-msgstr "Loop DI"
-
-#: crates/adapter-gui/ui/components/chain_di_loop_button.slint
-msgid "di-loop-play-label"
-msgstr "Reproducir loop DI"
-
-#: crates/adapter-gui/ui/components/chain_di_loop_button.slint
-msgid "di-loop-stop-label"
-msgstr "Detener loop DI"
-
+#: crates/adapter-gui/ui/pages/settings.slint:201
+msgctxt "SettingsPage"
 msgid "title-section-integrations"
 msgstr "Integraciones"
 
+#: crates/adapter-gui/ui/pages/settings.slint:216
+msgctxt "SettingsPage"
+msgid "nav-group-project"
+msgstr "PROYECTO"
+
+#: crates/adapter-gui/ui/pages/settings.slint:227
+msgctxt "SettingsPage"
+msgid "title-section-project-meta"
+msgstr "Metadatos"
+
+#: crates/adapter-gui/ui/pages/settings.slint:335
+msgctxt "SettingsPage"
+msgid "btn-save-audio-settings"
+msgstr "Aplicar"
+
+#: crates/adapter-gui/ui/pages/settings.slint:339
+msgctxt "SettingsPage"
+msgid "btn-close"
+msgstr "Cerrar"
+
+#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint:27
+msgctxt "SectionProjectMeta"
+msgid "label-name"
+msgstr "Nombre"
+
+#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint:58
+msgctxt "SectionProjectMeta"
+msgid "label-file"
+msgstr "Archivo"
+
+#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint:66
+msgctxt "SectionProjectMeta"
+msgid "placeholder-project-unsaved"
+msgstr "(sin guardar)"
+
+#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint:83
+msgctxt "SectionProjectMeta"
+msgid "btn-save-project"
+msgstr "Guardar proyecto"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_audio.slint:95
+msgctxt "AudioDeviceRow"
+msgid "label-hz"
+msgstr "Hz"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_audio.slint:118
+msgctxt "AudioDeviceRow"
+msgid "label-buffer"
+msgstr "Buffer"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_audio.slint:141
+msgctxt "AudioDeviceRow"
+msgid "label-bits"
+msgstr "Bits"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:39
+msgctxt "SectionSystemIntegrations"
 msgid "label-midi-enabled"
 msgstr "Control MIDI"
 
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:45
+msgctxt "SectionSystemIntegrations"
 msgid "desc-midi-enabled"
 msgstr "Activa el adaptador MIDI/BLE-MIDI para que los pedales controlen OpenRig"
 
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:93
+msgctxt "SectionSystemIntegrations"
 msgid "label-mcp-enabled"
 msgstr "Servidor MCP"
 
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:99
+msgctxt "SectionSystemIntegrations"
 msgid "desc-mcp-enabled"
 msgstr "Expone el servidor MCP en 127.0.0.1:4123 para agentes"
 
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:134
+msgctxt "SectionSystemIntegrations"
 msgid "hint-restart-to-apply"
 msgstr "Tendrá efecto en el próximo inicio."
+
+#: crates/adapter-gui/ui/pages/settings/section_system_language.slint:25
+msgctxt "SectionSystemLanguage"
+msgid "label-language"
+msgstr "Idioma"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:49
+msgctxt "SectionSystemPaths"
+msgid "label-presets-path"
+msgstr "Carpeta de presets"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:57
+msgctxt "SectionSystemPaths"
+msgid "placeholder-default-path"
+msgstr "(predeterminado)"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:66
+msgctxt "SectionSystemPaths"
+msgid "btn-choose-path"
+msgstr "Elegir…"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:70
+msgctxt "SectionSystemPaths"
+msgid "btn-reset-path"
+msgstr "Restablecer"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:81
+msgctxt "SectionSystemPaths"
+msgid "label-plugins-path"
+msgstr "Carpeta de plugins"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:113
+msgctxt "SectionSystemPaths"
+msgid "label-evaluations-path"
+msgstr "Carpeta de evaluaciones"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:145
+msgctxt "SectionSystemPaths"
+msgid "label-plugin-catalog"
+msgstr "Catálogo de plugins"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:153
+msgctxt "SectionSystemPaths"
+msgid "status-plugin-catalog-idle"
+msgstr "Aún no recargado"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:162
+msgctxt "SectionSystemPaths"
+msgid "btn-reload-plugin-catalog"
+msgstr "Recargar"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:73
+msgctxt "SpectrumCard"
+msgid "—"
+msgstr "—"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:127
+msgctxt "SpectrumCard"
+msgid "20"
+msgstr "20"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:133
+msgctxt "SpectrumCard"
+msgid "100"
+msgstr "100"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:139
+msgctxt "SpectrumCard"
+msgid "1k"
+msgstr "1k"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:145
+msgctxt "SpectrumCard"
+msgid "10k"
+msgstr "10k"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:151
+msgctxt "SpectrumCard"
+msgid "20k"
+msgstr "20k"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:199
+msgctxt "SpectrumPanel"
+msgid "label-spectrum"
+msgstr "SPECTRUM"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:241
+msgctxt "SpectrumPanel"
+msgid "status-no-active-outputs"
+msgstr "NO ACTIVE OUTPUTS"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:251
+msgctxt "SpectrumPanel"
+msgid "status-spectrum-empty-help"
+msgstr "Enciende el espectro y habilita una chain con salida configurada."
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:279
+msgctxt "SpectrumWindow"
+msgid "title-window-spectrum"
+msgstr "OpenRig · Spectrum"
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:54
+msgctxt "MuteSwitch"
+msgid "label-mute"
+msgstr "MUTE"
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:316
+msgctxt "TunerPanel"
+msgid "label-tuner"
+msgstr "TUNER"
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:368
+msgctxt "TunerPanel"
+msgid "status-no-active-inputs"
+msgstr "NO ACTIVE INPUTS"
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:378
+msgctxt "TunerPanel"
+msgid "status-tuner-empty-help"
+msgstr "Habilita una chain con entrada configurada para ver sus tuners aquí."
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:406
+msgctxt "TunerWindow"
+msgid "title-window-tuner"
+msgstr "OpenRig · Tuner"
+
+#: crates/adapter-gui/ui/secondary_windows_block.slint:30
+msgctxt "BlockEditorWindow"
+msgid "title-window-block-editor"
+msgstr "OpenRig · Block"
+
+#: crates/adapter-gui/ui/secondary_windows_block.slint:231
+msgctxt "CompactChainViewWindow"
+msgid "title-window-chain-view"
+msgstr "OpenRig · Cadena"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:60
+msgctxt "ProjectSettingsWindow"
+msgid "title-window-project-settings"
+msgstr "OpenRig · Configurar proyecto"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:159
+msgctxt "ChainEditorWindow"
+msgid "title-window-chain-editor"
+msgstr "OpenRig · Configurar cadena"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:192
+msgctxt "ChainEditorWindow"
+msgid "title-section-input"
+msgstr "Entrada"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:210
+msgctxt "ChainEditorWindow"
+msgid "title-section-output"
+msgstr "Salida"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:240
+msgctxt "ChainInputWindow"
+msgid "title-window-chain-input"
+msgstr "OpenRig · Entrada de la cadena"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:250
+msgctxt "ChainInputWindow"
+msgid "title-section-input"
+msgstr "Entrada"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:280
+msgctxt "ChainOutputWindow"
+msgid "title-window-chain-output"
+msgstr "OpenRig · Salida de la cadena"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:290
+msgctxt "ChainOutputWindow"
+msgid "title-section-output"
+msgstr "Salida"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:321
+msgctxt "ChainInputGroupsWindow"
+msgid "title-window-chain-inputs"
+msgstr "OpenRig · Entradas de la cadena"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:331
+msgctxt "ChainInputGroupsWindow"
+msgid "title-section-inputs"
+msgstr "Entradas"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:332
+msgctxt "ChainInputGroupsWindow"
+msgid "btn-add-input-row"
+msgstr "+ Añadir entrada"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:362
+msgctxt "ChainOutputGroupsWindow"
+msgid "title-window-chain-outputs"
+msgstr "OpenRig · Salidas de la cadena"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:372
+msgctxt "ChainOutputGroupsWindow"
+msgid "title-section-outputs"
+msgstr "Salidas"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:373
+msgctxt "ChainOutputGroupsWindow"
+msgid "btn-add-output-row"
+msgstr "+ Añadir salida"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:418
+msgctxt "ChainInsertWindow"
+msgid "title-window-chain-insert"
+msgstr "OpenRig · Configurar Insert"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:428
+msgctxt "ChainInsertWindow"
+msgid "title-section-configure-insert"
+msgstr "Configurar Insert"
+
+#: crates/adapter-gui/ui/touch_main.slint:667
+msgctxt "TouchMain"
+msgid "⌨"
+msgstr "⌨"

--- a/crates/adapter-gui/translations/fr_FR/LC_MESSAGES/adapter-gui.po
+++ b/crates/adapter-gui/translations/fr_FR/LC_MESSAGES/adapter-gui.po
@@ -12,574 +12,939 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #: crates/adapter-gui/ui/blocks/header.slint:13
+msgctxt "Header"
 msgid "OpenRig"
 msgstr "OpenRig"
 
 #: crates/adapter-gui/ui/components/block_panel_parameter_item.slint:274
+msgctxt "BlockPanelParameterItem"
 msgid "btn-load-file"
 msgstr "Load"
 
 #: crates/adapter-gui/ui/components/block_stream_mini_display.slint:23
+msgctxt "BlockStreamMiniDisplay"
 msgid "–"
 msgstr "–"
 
 #: crates/adapter-gui/ui/components/block_value_widgets.slint:128
+msgctxt "BlockValueStepper"
 msgid "−"
 msgstr "−"
 
 #: crates/adapter-gui/ui/components/block_value_widgets.slint:194
+msgctxt "BlockValueStepper"
 msgid "+"
 msgstr "+"
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:87
-msgid "Preset selector"
-msgstr ""
+#: crates/adapter-gui/ui/components/chain_di_loop_button.slint:61
+msgctxt "ChainDiLoopButton"
+msgid "di-loop-button-label"
+msgstr "Loop DI"
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:170
+#: crates/adapter-gui/ui/components/chain_di_loop_button.slint:138
+msgctxt "ChainDiLoopButton"
+msgid "di-loop-stop-label"
+msgstr "Arrêter le loop DI"
+
+#: crates/adapter-gui/ui/components/chain_di_loop_button.slint:138
+msgctxt "ChainDiLoopButton"
+msgid "di-loop-play-label"
+msgstr "Lire le loop DI"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:77
+msgctxt "SceneBtn"
 msgid "Scene {}"
 msgstr ""
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:192
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:99
+msgctxt "SceneBar"
 msgid "Add scene"
 msgstr ""
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:201
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:108
+msgctxt "SceneBar"
 msgid "Remove last scene"
 msgstr ""
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:258
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:183
+msgctxt "ChainTitlePreset"
+msgid "tooltip-open-preset"
+msgstr "Ouvrir le preset"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:193
+msgctxt "ChainTitlePreset"
+msgid "tooltip-save-preset"
+msgstr "Enregistrer le preset"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:203
+msgctxt "ChainTitlePreset"
 msgid "Add preset"
 msgstr ""
 
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:213
+msgctxt "ChainTitlePreset"
+msgid "Rename preset"
+msgstr "Renommer le preset"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:224
+msgctxt "ChainTitlePreset"
+msgid "Remove preset"
+msgstr "Supprimer le preset"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:316
+msgctxt "ChainTitlePreset"
+msgid "Cancel"
+msgstr "Annuler"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:337
+msgctxt "ChainTitlePreset"
+msgid "OK"
+msgstr "OK"
+
 #: crates/adapter-gui/ui/components/chain_volume_button.slint:37
+msgctxt "ChainVolumeButton"
 msgid "Volume"
 msgstr ""
 
+#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:29
+msgctxt "ConfirmDeleteChainDialog"
+msgid "title-dialog-delete-chain"
+msgstr "Supprimer la chaîne"
+
+#. text directly.
+#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:39
+msgctxt "ConfirmDeleteChainDialog"
+msgid "Excluir a chain \"{}\"?"
+msgstr "Supprimer la chaîne « {} » ?"
+
+#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:58
+msgctxt "ConfirmDeleteChainDialog"
+msgid "btn-cancel"
+msgstr "Annuler"
+
+#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:75
+msgctxt "ConfirmDeleteChainDialog"
+msgid "btn-delete"
+msgstr "Supprimer"
+
 #: crates/adapter-gui/ui/components/confirm_delete_dialog.slint:27
+msgctxt "ConfirmDeleteBlockDialog"
 msgid "title-dialog-delete-block"
 msgstr "Supprimer le bloc"
 
 #. pt-BR source string with the placeholder.
 #: crates/adapter-gui/ui/components/confirm_delete_dialog.slint:36
+msgctxt "ConfirmDeleteBlockDialog"
 msgid "Excluir \"{}\"?"
 msgstr "Supprimer \"{}\" ?"
 
 #: crates/adapter-gui/ui/components/confirm_delete_dialog.slint:55
+msgctxt "ConfirmDeleteBlockDialog"
 msgid "btn-cancel"
 msgstr "Annuler"
 
 #: crates/adapter-gui/ui/components/confirm_delete_dialog.slint:72
+msgctxt "ConfirmDeleteBlockDialog"
 msgid "btn-delete"
 msgstr "Supprimer"
 
-#: crates/adapter-gui/ui/components/language_selector.slint:56
-msgid "accessible-language-selector"
-msgstr "Sélecteur de langue"
-
-#: crates/adapter-gui/ui/components/model_select_with_search.slint:93
-msgid "▼"
-msgstr "▼"
-
-#: crates/adapter-gui/ui/components/model_select_with_search.slint:175
-msgid "placeholder-search-models"
-msgstr "Rechercher des modèles..."
-
-#: crates/adapter-gui/ui/components/preset_select.slint:170
-msgid "status-no-presets-found"
-msgstr "Aucun preset trouvé"
-
-#: crates/adapter-gui/ui/components/model_select_with_search.slint:209
-msgid "status-no-models-found"
-msgstr "Aucun modèle trouvé"
-
-#: crates/adapter-gui/ui/components/preset_picker_overlay.slint:32
-msgid "btn-load-preset"
-msgstr "Charger Preset"
-
-#: crates/adapter-gui/ui/pages/block_editor_panel.slint:122
-msgid "tooltip-delete"
-msgstr "Supprimer"
-
-#: crates/adapter-gui/ui/pages/block_panel_editor.slint:36
-msgid "btn-add"
-msgstr "Ajouter"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:195
-msgid "instrument-guitar"
-msgstr "Guitare"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:196
-msgid "instrument-acoustic-guitar"
-msgstr "Guitare acoustique"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:197
-msgid "instrument-bass"
-msgstr "Basse"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:198
-msgid "instrument-voice"
-msgstr "Voix"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:199
-msgid "instrument-keyboard"
-msgstr "Clavier"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:200
-msgid "instrument-drums"
-msgstr "Batterie"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:201
-msgid "instrument-other"
-msgstr "Autre"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:221
-msgid "title-new-chain"
-msgstr "Nouvelle chaîne"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:221
-msgid "title-configure-chain"
-msgstr "Configurer la chaîne"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:240
-msgid "label-name"
-msgstr "Nom"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:267
-msgid "label-instrument"
-msgstr "Instrument"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:345
-msgid "title-section-inputs"
-msgstr "Entrées"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:371
-msgid "btn-add-input"
-msgstr "+ Ajouter une entrée"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:390
-msgid "title-section-outputs"
-msgstr "Sorties"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:416
-msgid "btn-add-output"
-msgstr "+ Ajouter une sortie"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:450
-msgid "btn-create-chain"
-msgstr "Créer la chaîne"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:450
-msgid "btn-save-chain"
-msgstr "Enregistrer la chaîne"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:66
-msgid "✓"
-msgstr "✓"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:140
-msgid "label-device"
-msgstr "Appareil"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:170
-msgid "label-mode"
-msgstr "Mode"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:229
-msgid "label-channels"
-msgstr "Canaux"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:275
-msgid "btn-ok"
-msgstr "OK"
-
-#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:99
-msgid "title-section-configure-insert"
-msgstr "Configurer Insert"
-
-#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:214
-msgid "label-send"
-msgstr "Envoi"
-
-#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:344
-msgid "label-return"
-msgstr "Retour"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:140
-msgid "tooltip-expand-blocks"
-msgstr "Développer les blocs"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:148
-msgid "tooltip-measure-latency"
-msgstr "Mesurer la latence (émet un bip)"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:177
-msgid "tooltip-configure"
-msgstr "Configurer"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:185
-msgid "tooltip-open-preset"
-msgstr "Ouvrir le preset"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:193
-msgid "tooltip-save-preset"
-msgstr "Enregistrer le preset"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:472
-msgid "label-lat"
-msgstr "LAT"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:521
-msgid "label-input"
-msgstr "Entrée"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:567
-msgid "label-output"
-msgstr "Sortie"
-
-#: crates/adapter-gui/ui/pages/compact_block_row.slint:493
-msgid "btn-open-plugin"
-msgstr "Ouvrir Plugin"
-
-#: crates/adapter-gui/ui/pages/compact_chain_view.slint:83
-msgid "label-in"
-msgstr "IN"
-
-#: crates/adapter-gui/ui/pages/compact_chain_view.slint:111
-msgid "label-out"
-msgstr "OUT"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:87
-msgid "·"
-msgstr "·"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:123
-msgid "label-description"
-msgstr "Description"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:142
-msgid "label-license"
-msgstr "License:"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:169
-msgid "↗"
-msgstr "↗"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:175
-msgid "btn-open-homepage"
-msgstr "Open Homepage"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:136
-msgid "tooltip-back"
-msgstr "Retour"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:144
-msgid "tooltip-spectrum"
-msgstr "Spectrum"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:152
-msgid "tooltip-tuner"
-msgstr "Tuner"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:160
-msgid "tooltip-project-settings"
-msgstr "Projet"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:169
-msgid "tooltip-save"
-msgstr "Enregistrer"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:177
-msgid "tooltip-new-chain"
-msgstr "Nouvelle chaîne"
-
-#: crates/adapter-gui/ui/pages/project_launcher.slint:185
-msgid "placeholder-search-projects"
-msgstr "Rechercher des projets"
-
-#: crates/adapter-gui/ui/pages/project_launcher.slint:288
-msgid "tooltip-open-project"
-msgstr "Ouvrir un projet"
-
-#: crates/adapter-gui/ui/pages/project_launcher.slint:295
-msgid "btn-new-project"
-msgstr "Nouveau projet"
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:147
-msgid "label-hz"
-msgstr "Hz"
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:170
-msgid "label-buffer"
-msgstr "Buffer"
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:193
-msgid "label-bits"
-msgstr "Bits"
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:271
-msgid "title-section-audio-devices"
-msgstr "Périphériques audio"
-
-#: crates/adapter-gui/ui/pages/project_setup.slint:55
-msgid "placeholder-project-name-example"
-msgstr "Ex : Guitare en direct"
-
-#: crates/adapter-gui/ui/pages/project_setup.slint:151
-msgid "title-new-project"
-msgstr "Nouveau Projet"
-
-#: crates/adapter-gui/ui/pages/project_setup.slint:164
-msgid "label-project-name"
-msgstr "Nom du projet"
-
-#: crates/adapter-gui/ui/pages/project_setup.slint:211
-msgid "btn-create-project"
-msgstr "Créer le projet"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:73
-msgid "—"
-msgstr "—"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:127
-msgid "20"
-msgstr "20"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:133
-msgid "100"
-msgstr "100"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:139
-msgid "1k"
-msgstr "1k"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:145
-msgid "10k"
-msgstr "10k"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:151
-msgid "20k"
-msgstr "20k"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:199
-msgid "label-spectrum"
-msgstr "SPECTRUM"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:241
-msgid "status-no-active-outputs"
-msgstr "NO ACTIVE OUTPUTS"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:251
-msgid "status-spectrum-empty-help"
-msgstr "Activez le spectre et activez une chaîne avec une sortie configurée."
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:279
-msgid "title-window-spectrum"
-msgstr "OpenRig · Spectrum"
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:54
-msgid "label-mute"
-msgstr "MUTE"
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:316
-msgid "label-tuner"
-msgstr "TUNER"
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:368
-msgid "status-no-active-inputs"
-msgstr "NO ACTIVE INPUTS"
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:378
-msgid "status-tuner-empty-help"
-msgstr ""
-"Activez une chaîne avec une entrée configurée pour voir ses accordeurs "
-"ici.Activez une chaîne avec une entrée configurée pour voir les accordeurs "
-"ici."
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:406
-msgid "title-window-tuner"
-msgstr "OpenRig · Tuner"
-
-#: crates/adapter-gui/ui/secondary_windows_block.slint:28
-msgid "title-window-block-editor"
-msgstr "OpenRig · Block"
-
-#: crates/adapter-gui/ui/secondary_windows_block.slint:195
-msgid "title-window-chain-view"
-msgstr "OpenRig · Chaîne"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:23
-msgid "title-window-project-settings"
-msgstr "OpenRig · Configurer le projet"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:96
-msgid "title-window-chain-editor"
-msgstr "OpenRig · Configurer la chaîne"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:129
-msgid "title-section-input"
-msgstr "Entrée"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:147
-msgid "title-section-output"
-msgstr "Sortie"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:177
-msgid "title-window-chain-input"
-msgstr "OpenRig · Entrée de la chaîne"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:217
-msgid "title-window-chain-output"
-msgstr "OpenRig · Sortie de la chaîne"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:258
-msgid "title-window-chain-inputs"
-msgstr "OpenRig · Entrées de la chaîne"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:269
-msgid "btn-add-input-row"
-msgstr "+ Ajouter une entrée"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:299
-msgid "title-window-chain-outputs"
-msgstr "OpenRig · Sorties de la chaîne"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:310
-msgid "btn-add-output-row"
-msgstr "+ Ajouter une sortie"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:355
-msgid "title-window-chain-insert"
-msgstr "OpenRig · Configurer Insert"
-
-#: crates/adapter-gui/ui/touch_main.slint:586
-msgid "⌨"
-msgstr "⌨"
-
-#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:27
-msgid "title-dialog-delete-chain"
-msgstr "Supprimer la chaîne"
-
-#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:37
-msgid "Excluir a chain \"{}\"?"
-msgstr "Supprimer la chaîne « {} » ?"
-
-#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:31
+#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:30
+msgctxt "ConfirmDeleteRecentProjectDialog"
 msgid "title-dialog-delete-recent-project"
 msgstr "Retirer des récents"
 
-#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:41
+#. Literal pt-BR source string with `{}` placeholder.
+#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:38
+msgctxt "ConfirmDeleteRecentProjectDialog"
 msgid "Remover o projeto \"{}\" dos recentes?"
 msgstr "Retirer le projet \"{}\" des récents ?"
 
-#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:75
+#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:57
+msgctxt "ConfirmDeleteRecentProjectDialog"
+msgid "btn-cancel"
+msgstr "Annuler"
+
+#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:74
+msgctxt "ConfirmDeleteRecentProjectDialog"
 msgid "btn-remove"
 msgstr "Retirer"
 
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "tab-system"
-msgstr ""
+#: crates/adapter-gui/ui/components/language_selector.slint:56
+msgctxt "LanguageSelector"
+msgid "accessible-language-selector"
+msgstr "Sélecteur de langue"
 
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "tab-project"
-msgstr ""
+#: crates/adapter-gui/ui/components/model_select_with_search.slint:96
+msgctxt "ModelSelectWithSearch"
+msgid "▼"
+msgstr "▼"
 
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "btn-close"
-msgstr ""
+#: crates/adapter-gui/ui/components/model_select_with_search.slint:178
+msgctxt "ModelSelectWithSearch"
+msgid "placeholder-search-models"
+msgstr "Rechercher des modèles..."
 
-#: crates/adapter-gui/ui/components/settings_section.slint
-msgid "badge-system"
-msgstr ""
+#: crates/adapter-gui/ui/components/model_select_with_search.slint:212
+msgctxt "ModelSelectWithSearch"
+msgid "status-no-models-found"
+msgstr "Aucun modèle trouvé"
 
-#: crates/adapter-gui/ui/components/settings_section.slint
-msgid "badge-project"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_system_audio.slint
-msgid "title-section-audio-interface"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_system_language.slint
-msgid "title-section-language"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_system_midi_devices.slint
-msgid "title-section-midi-devices"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint
-msgid "title-section-project-meta"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint
-msgid "label-file"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_project_midi_mapping.slint
-msgid "title-section-midi-mapping"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_project_midi_mapping.slint
-msgid "btn-add-midi-binding"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_project_midi_mapping.slint
-msgid "empty-midi-mapping-explain"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_project_midi_mapping.slint
-msgid "placeholder-midi-listen"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "nav-group-system"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "nav-group-project"
-msgstr ""
+#: crates/adapter-gui/ui/components/preset_picker_overlay.slint:34
+msgctxt "PresetPickerOverlay"
+msgid "btn-load-preset"
+msgstr "Charger Preset"
 
 #: crates/adapter-gui/ui/components/preset_picker_overlay.slint:40
+msgctxt "PresetPickerOverlay"
 msgid "preset-search-placeholder"
 msgstr "Rechercher des presets…"
 
+#: crates/adapter-gui/ui/components/preset_picker_overlay.slint:106
+msgctxt "PresetPickerOverlay"
+msgid "btn-cancel"
+msgstr "Annuler"
+
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:38
+msgctxt "PresetSaveOverlay"
 msgid "title-dialog-save-preset"
 msgstr "Enregistrer le preset"
 
+#: crates/adapter-gui/ui/components/preset_save_overlay.slint:63
+msgctxt "PresetSaveOverlay"
+msgid "btn-cancel"
+msgstr "Annuler"
+
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:82
+msgctxt "PresetSaveOverlay"
 msgid "btn-save"
 msgstr "Enregistrer"
 
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:119
+msgctxt "PresetOverwriteOverlay"
 msgid "title-dialog-overwrite-preset"
 msgstr "Écraser le preset ?"
 
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:126
+msgctxt "PresetOverwriteOverlay"
 msgid "msg-overwrite-preset"
 msgstr "Un preset nommé \"{}\" existe déjà. L'écraser ?"
 
+#: crates/adapter-gui/ui/components/preset_save_overlay.slint:145
+msgctxt "PresetOverwriteOverlay"
+msgid "btn-cancel"
+msgstr "Annuler"
+
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:162
+msgctxt "PresetOverwriteOverlay"
 msgid "btn-overwrite"
 msgstr "Écraser"
 
-msgid "btn-save-audio-settings"
+#: crates/adapter-gui/ui/components/preset_select.slint:72
+msgctxt "PresetSelect"
+msgid "Preset selector"
 msgstr ""
 
+#: crates/adapter-gui/ui/components/preset_select.slint:137
+msgctxt "PresetSelect"
+msgid "preset-search-placeholder"
+msgstr "Rechercher des presets…"
+
+#: crates/adapter-gui/ui/components/preset_select.slint:170
+msgctxt "PresetSelect"
+msgid "status-no-presets-found"
+msgstr "Aucun preset trouvé"
+
+#: crates/adapter-gui/ui/pages/block_editor_panel.slint:122
+msgctxt "BlockEditorPanel"
+msgid "tooltip-delete"
+msgstr "Supprimer"
+
+#: crates/adapter-gui/ui/pages/block_editor_panel.slint:243
+msgctxt "BlockEditorPanel"
+msgid "–"
+msgstr "–"
+
+#: crates/adapter-gui/ui/pages/block_panel_editor.slint:37
+msgctxt "BlockPanelEditor"
+msgid "btn-add"
+msgstr "Ajouter"
+
+#: crates/adapter-gui/ui/pages/block_panel_editor.slint:323
+msgctxt "BlockPanelEditor"
+msgid "–"
+msgstr "–"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:195
+msgctxt "ChainEditorPage"
+msgid "instrument-guitar"
+msgstr "Guitare"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:196
+msgctxt "ChainEditorPage"
+msgid "instrument-acoustic-guitar"
+msgstr "Guitare acoustique"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:197
+msgctxt "ChainEditorPage"
+msgid "instrument-bass"
+msgstr "Basse"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:198
+msgctxt "ChainEditorPage"
+msgid "instrument-voice"
+msgstr "Voix"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:199
+msgctxt "ChainEditorPage"
+msgid "instrument-keyboard"
+msgstr "Clavier"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:200
+msgctxt "ChainEditorPage"
+msgid "instrument-drums"
+msgstr "Batterie"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:201
+msgctxt "ChainEditorPage"
+msgid "instrument-other"
+msgstr "Autre"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:221
+msgctxt "ChainEditorPage"
+msgid "title-new-chain"
+msgstr "Nouvelle chaîne"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:221
+msgctxt "ChainEditorPage"
+msgid "title-configure-chain"
+msgstr "Configurer la chaîne"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:240
+msgctxt "ChainEditorPage"
+msgid "label-name"
+msgstr "Nom"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:267
+msgctxt "ChainEditorPage"
+msgid "label-instrument"
+msgstr "Instrument"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:345
+msgctxt "ChainEditorPage"
+msgid "title-section-inputs"
+msgstr "Entrées"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:371
+msgctxt "ChainEditorPage"
+msgid "btn-add-input"
+msgstr "+ Ajouter une entrée"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:390
+msgctxt "ChainEditorPage"
+msgid "title-section-outputs"
+msgstr "Sorties"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:416
+msgctxt "ChainEditorPage"
+msgid "btn-add-output"
+msgstr "+ Ajouter une sortie"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:443
+msgctxt "ChainEditorPage"
+msgid "btn-cancel"
+msgstr "Annuler"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:450
+msgctxt "ChainEditorPage"
+msgid "btn-create-chain"
+msgstr "Créer la chaîne"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:450
+msgctxt "ChainEditorPage"
+msgid "btn-save-chain"
+msgstr "Enregistrer la chaîne"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:66
+msgctxt "ChannelRow"
+msgid "✓"
+msgstr "✓"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:140
+msgctxt "ChainEndpointEditorPage"
+msgid "label-device"
+msgstr "Appareil"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:170
+msgctxt "ChainEndpointEditorPage"
+msgid "label-mode"
+msgstr "Mode"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:229
+msgctxt "ChainEndpointEditorPage"
+msgid "label-channels"
+msgstr "Canaux"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:268
+msgctxt "ChainEndpointEditorPage"
+msgid "btn-cancel"
+msgstr "Annuler"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:275
+msgctxt "ChainEndpointEditorPage"
+msgid "btn-ok"
+msgstr "OK"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:99
+msgctxt "ChainInsertEditorPage"
+msgid "title-section-configure-insert"
+msgstr "Configurer Insert"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:214
+msgctxt "ChainInsertEditorPage"
+msgid "label-send"
+msgstr "Envoi"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:225
+msgctxt "ChainInsertEditorPage"
+msgid "label-device"
+msgstr "Appareil"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:247
+msgctxt "ChainInsertEditorPage"
+msgid "label-mode"
+msgstr "Mode"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:299
+msgctxt "ChainInsertEditorPage"
+msgid "label-channels"
+msgstr "Canaux"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:344
+msgctxt "ChainInsertEditorPage"
+msgid "label-return"
+msgstr "Retour"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:469
+msgctxt "ChainInsertEditorPage"
+msgid "btn-cancel"
+msgstr "Annuler"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:476
+msgctxt "ChainInsertEditorPage"
+msgid "btn-ok"
+msgstr "OK"
+
+#: crates/adapter-gui/ui/pages/chain_io_groups.slint:304
+msgctxt "ChainIoGroupsPage"
+msgid "btn-cancel"
+msgstr "Annuler"
+
+#: crates/adapter-gui/ui/pages/chain_io_groups.slint:311
+msgctxt "ChainIoGroupsPage"
+msgid "btn-ok"
+msgstr "OK"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:246
+msgctxt "ChainRow"
+msgid "tooltip-expand-blocks"
+msgstr "Développer les blocs"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:254
+msgctxt "ChainRow"
+msgid "tooltip-measure-latency"
+msgstr "Mesurer la latence (émet un bip)"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:283
+msgctxt "ChainRow"
+msgid "tooltip-configure"
+msgstr "Configurer"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:291
+msgctxt "ChainRow"
+msgid "tooltip-delete"
+msgstr "Supprimer"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:564
+msgctxt "ChainRow"
+msgid "label-lat"
+msgstr "LAT"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:613
+msgctxt "ChainRow"
+msgid "label-input"
+msgstr "Entrée"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:659
+msgctxt "ChainRow"
+msgid "label-output"
+msgstr "Sortie"
+
+#: crates/adapter-gui/ui/pages/compact_block_row.slint:415
+msgctxt "CompactBlockRow"
+msgid "▼"
+msgstr "▼"
+
+#: crates/adapter-gui/ui/pages/compact_block_row.slint:493
+msgctxt "CompactBlockRow"
+msgid "btn-open-plugin"
+msgstr "Ouvrir Plugin"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:160
+msgctxt "CompactChainViewPage"
+msgid "tooltip-measure-latency"
+msgstr "Mesurer la latence (émet un bip)"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:187
+msgctxt "CompactChainViewPage"
+msgid "label-lat"
+msgstr "LAT"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:216
+msgctxt "CompactChainViewPage"
+msgid "tooltip-configure"
+msgstr "Configurer"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:230
+msgctxt "CompactChainViewPage"
+msgid "label-in"
+msgstr "IN"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:251
+msgctxt "CompactChainViewPage"
+msgid "label-out"
+msgstr "OUT"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:267
+msgctxt "CompactChainViewPage"
+msgid "tooltip-delete"
+msgstr "Supprimer"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:313
+msgctxt "CompactChainViewPage"
+msgid "+"
+msgstr "+"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:87
+msgctxt "PluginInfoPanel"
+msgid "·"
+msgstr "·"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:125
+msgctxt "PluginInfoPanel"
+msgid "label-description"
+msgstr "Description"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:144
+msgctxt "PluginInfoPanel"
+msgid "label-license"
+msgstr "License:"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:171
+msgctxt "PluginInfoPanel"
+msgid "↗"
+msgstr "↗"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:177
+msgctxt "PluginInfoPanel"
+msgid "btn-open-homepage"
+msgstr "Open Homepage"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:145
+msgctxt "ProjectChainsPage"
+msgid "tooltip-back"
+msgstr "Retour"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:153
+msgctxt "ProjectChainsPage"
+msgid "tooltip-spectrum"
+msgstr "Spectrum"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:161
+msgctxt "ProjectChainsPage"
+msgid "tooltip-tuner"
+msgstr "Tuner"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:169
+msgctxt "ProjectChainsPage"
+msgid "tooltip-project-settings"
+msgstr "Projet"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:178
+msgctxt "ProjectChainsPage"
+msgid "tooltip-save"
+msgstr "Enregistrer"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:186
+msgctxt "ProjectChainsPage"
+msgid "tooltip-new-chain"
+msgstr "Nouvelle chaîne"
+
+#: crates/adapter-gui/ui/pages/project_launcher.slint:184
+msgctxt "SearchField"
+msgid "placeholder-search-projects"
+msgstr "Rechercher des projets"
+
+#: crates/adapter-gui/ui/pages/project_launcher.slint:287
+msgctxt "ProjectLauncherPage"
+msgid "tooltip-open-project"
+msgstr "Ouvrir un projet"
+
+#: crates/adapter-gui/ui/pages/project_launcher.slint:294
+msgctxt "ProjectLauncherPage"
+msgid "btn-new-project"
+msgstr "Nouveau projet"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:55
+msgctxt "NameInput"
+msgid "placeholder-project-name-example"
+msgstr "Ex : Guitare en direct"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:151
+msgctxt "ProjectSetupPage"
+msgid "title-new-project"
+msgstr "Nouveau Projet"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:164
+msgctxt "ProjectSetupPage"
+msgid "label-project-name"
+msgstr "Nom du projet"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:204
+msgctxt "ProjectSetupPage"
+msgid "btn-cancel"
+msgstr "Annuler"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:211
+msgctxt "ProjectSetupPage"
+msgid "btn-create-project"
+msgstr "Créer le projet"
+
+#: crates/adapter-gui/ui/pages/settings.slint:170
+msgctxt "SettingsPage"
+msgid "nav-group-system"
+msgstr "SYSTÈME"
+
+#: crates/adapter-gui/ui/pages/settings.slint:181
+msgctxt "SettingsPage"
+msgid "title-section-audio-interface"
+msgstr "Interface audio"
+
+#: crates/adapter-gui/ui/pages/settings.slint:186
+msgctxt "SettingsPage"
+msgid "title-section-language"
+msgstr "Langue"
+
+#: crates/adapter-gui/ui/pages/settings.slint:191
+msgctxt "SettingsPage"
+msgid "title-section-midi-devices"
+msgstr "Périphériques MIDI"
+
+#: crates/adapter-gui/ui/pages/settings.slint:196
+msgctxt "SettingsPage"
+msgid "title-section-paths"
+msgstr "Chemins"
+
+#: crates/adapter-gui/ui/pages/settings.slint:201
+msgctxt "SettingsPage"
 msgid "title-section-integrations"
 msgstr "Intégrations"
 
+#: crates/adapter-gui/ui/pages/settings.slint:216
+msgctxt "SettingsPage"
+msgid "nav-group-project"
+msgstr "PROJET"
+
+#: crates/adapter-gui/ui/pages/settings.slint:227
+msgctxt "SettingsPage"
+msgid "title-section-project-meta"
+msgstr "Métadonnées"
+
+#: crates/adapter-gui/ui/pages/settings.slint:335
+msgctxt "SettingsPage"
+msgid "btn-save-audio-settings"
+msgstr "Appliquer"
+
+#: crates/adapter-gui/ui/pages/settings.slint:339
+msgctxt "SettingsPage"
+msgid "btn-close"
+msgstr "Fermer"
+
+#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint:27
+msgctxt "SectionProjectMeta"
+msgid "label-name"
+msgstr "Nom"
+
+#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint:58
+msgctxt "SectionProjectMeta"
+msgid "label-file"
+msgstr "Fichier"
+
+#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint:66
+msgctxt "SectionProjectMeta"
+msgid "placeholder-project-unsaved"
+msgstr "(non enregistré)"
+
+#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint:83
+msgctxt "SectionProjectMeta"
+msgid "btn-save-project"
+msgstr "Enregistrer le projet"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_audio.slint:95
+msgctxt "AudioDeviceRow"
+msgid "label-hz"
+msgstr "Hz"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_audio.slint:118
+msgctxt "AudioDeviceRow"
+msgid "label-buffer"
+msgstr "Buffer"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_audio.slint:141
+msgctxt "AudioDeviceRow"
+msgid "label-bits"
+msgstr "Bits"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:39
+msgctxt "SectionSystemIntegrations"
 msgid "label-midi-enabled"
 msgstr "Contrôle MIDI"
 
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:45
+msgctxt "SectionSystemIntegrations"
 msgid "desc-midi-enabled"
 msgstr "Active l'adaptateur MIDI/BLE-MIDI pour piloter OpenRig au pied"
 
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:93
+msgctxt "SectionSystemIntegrations"
 msgid "label-mcp-enabled"
 msgstr "Serveur MCP"
 
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:99
+msgctxt "SectionSystemIntegrations"
 msgid "desc-mcp-enabled"
 msgstr "Expose le serveur MCP sur 127.0.0.1:4123 pour les agents"
 
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:134
+msgctxt "SectionSystemIntegrations"
 msgid "hint-restart-to-apply"
 msgstr "Prend effet au prochain démarrage."
+
+#: crates/adapter-gui/ui/pages/settings/section_system_language.slint:25
+msgctxt "SectionSystemLanguage"
+msgid "label-language"
+msgstr "Langue"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:49
+msgctxt "SectionSystemPaths"
+msgid "label-presets-path"
+msgstr "Dossier des presets"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:57
+msgctxt "SectionSystemPaths"
+msgid "placeholder-default-path"
+msgstr "(par défaut)"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:66
+msgctxt "SectionSystemPaths"
+msgid "btn-choose-path"
+msgstr "Choisir…"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:70
+msgctxt "SectionSystemPaths"
+msgid "btn-reset-path"
+msgstr "Réinitialiser"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:81
+msgctxt "SectionSystemPaths"
+msgid "label-plugins-path"
+msgstr "Dossier des plugins"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:113
+msgctxt "SectionSystemPaths"
+msgid "label-evaluations-path"
+msgstr "Dossier des évaluations"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:145
+msgctxt "SectionSystemPaths"
+msgid "label-plugin-catalog"
+msgstr "Catalogue de plugins"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:153
+msgctxt "SectionSystemPaths"
+msgid "status-plugin-catalog-idle"
+msgstr "Pas encore rechargé"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:162
+msgctxt "SectionSystemPaths"
+msgid "btn-reload-plugin-catalog"
+msgstr "Recharger"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:73
+msgctxt "SpectrumCard"
+msgid "—"
+msgstr "—"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:127
+msgctxt "SpectrumCard"
+msgid "20"
+msgstr "20"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:133
+msgctxt "SpectrumCard"
+msgid "100"
+msgstr "100"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:139
+msgctxt "SpectrumCard"
+msgid "1k"
+msgstr "1k"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:145
+msgctxt "SpectrumCard"
+msgid "10k"
+msgstr "10k"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:151
+msgctxt "SpectrumCard"
+msgid "20k"
+msgstr "20k"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:199
+msgctxt "SpectrumPanel"
+msgid "label-spectrum"
+msgstr "SPECTRUM"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:241
+msgctxt "SpectrumPanel"
+msgid "status-no-active-outputs"
+msgstr "NO ACTIVE OUTPUTS"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:251
+msgctxt "SpectrumPanel"
+msgid "status-spectrum-empty-help"
+msgstr "Allume le spectre et active une chain avec une sortie configurée."
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:279
+msgctxt "SpectrumWindow"
+msgid "title-window-spectrum"
+msgstr "OpenRig · Spectrum"
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:54
+msgctxt "MuteSwitch"
+msgid "label-mute"
+msgstr "MUTE"
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:316
+msgctxt "TunerPanel"
+msgid "label-tuner"
+msgstr "TUNER"
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:368
+msgctxt "TunerPanel"
+msgid "status-no-active-inputs"
+msgstr "NO ACTIVE INPUTS"
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:378
+msgctxt "TunerPanel"
+msgid "status-tuner-empty-help"
+msgstr "Active une chain avec une entrée configurée pour voir ses tuners ici."
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:406
+msgctxt "TunerWindow"
+msgid "title-window-tuner"
+msgstr "OpenRig · Tuner"
+
+#: crates/adapter-gui/ui/secondary_windows_block.slint:30
+msgctxt "BlockEditorWindow"
+msgid "title-window-block-editor"
+msgstr "OpenRig · Block"
+
+#: crates/adapter-gui/ui/secondary_windows_block.slint:231
+msgctxt "CompactChainViewWindow"
+msgid "title-window-chain-view"
+msgstr "OpenRig · Chaîne"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:60
+msgctxt "ProjectSettingsWindow"
+msgid "title-window-project-settings"
+msgstr "OpenRig · Configurer le projet"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:159
+msgctxt "ChainEditorWindow"
+msgid "title-window-chain-editor"
+msgstr "OpenRig · Configurer la chaîne"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:192
+msgctxt "ChainEditorWindow"
+msgid "title-section-input"
+msgstr "Entrée"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:210
+msgctxt "ChainEditorWindow"
+msgid "title-section-output"
+msgstr "Sortie"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:240
+msgctxt "ChainInputWindow"
+msgid "title-window-chain-input"
+msgstr "OpenRig · Entrée de la chaîne"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:250
+msgctxt "ChainInputWindow"
+msgid "title-section-input"
+msgstr "Entrée"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:280
+msgctxt "ChainOutputWindow"
+msgid "title-window-chain-output"
+msgstr "OpenRig · Sortie de la chaîne"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:290
+msgctxt "ChainOutputWindow"
+msgid "title-section-output"
+msgstr "Sortie"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:321
+msgctxt "ChainInputGroupsWindow"
+msgid "title-window-chain-inputs"
+msgstr "OpenRig · Entrées de la chaîne"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:331
+msgctxt "ChainInputGroupsWindow"
+msgid "title-section-inputs"
+msgstr "Entrées"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:332
+msgctxt "ChainInputGroupsWindow"
+msgid "btn-add-input-row"
+msgstr "+ Ajouter une entrée"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:362
+msgctxt "ChainOutputGroupsWindow"
+msgid "title-window-chain-outputs"
+msgstr "OpenRig · Sorties de la chaîne"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:372
+msgctxt "ChainOutputGroupsWindow"
+msgid "title-section-outputs"
+msgstr "Sorties"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:373
+msgctxt "ChainOutputGroupsWindow"
+msgid "btn-add-output-row"
+msgstr "+ Ajouter une sortie"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:418
+msgctxt "ChainInsertWindow"
+msgid "title-window-chain-insert"
+msgstr "OpenRig · Configurer Insert"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:428
+msgctxt "ChainInsertWindow"
+msgid "title-section-configure-insert"
+msgstr "Configurer Insert"
+
+#: crates/adapter-gui/ui/touch_main.slint:667
+msgctxt "TouchMain"
+msgid "⌨"
+msgstr "⌨"

--- a/crates/adapter-gui/translations/hi_IN/LC_MESSAGES/adapter-gui.po
+++ b/crates/adapter-gui/translations/hi_IN/LC_MESSAGES/adapter-gui.po
@@ -12,571 +12,939 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: crates/adapter-gui/ui/blocks/header.slint:13
+msgctxt "Header"
 msgid "OpenRig"
 msgstr "OpenRig"
 
 #: crates/adapter-gui/ui/components/block_panel_parameter_item.slint:274
+msgctxt "BlockPanelParameterItem"
 msgid "btn-load-file"
 msgstr "Load"
 
 #: crates/adapter-gui/ui/components/block_stream_mini_display.slint:23
+msgctxt "BlockStreamMiniDisplay"
 msgid "–"
 msgstr "–"
 
 #: crates/adapter-gui/ui/components/block_value_widgets.slint:128
+msgctxt "BlockValueStepper"
 msgid "−"
 msgstr "−"
 
 #: crates/adapter-gui/ui/components/block_value_widgets.slint:194
+msgctxt "BlockValueStepper"
 msgid "+"
 msgstr "+"
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:87
-msgid "Preset selector"
-msgstr ""
+#: crates/adapter-gui/ui/components/chain_di_loop_button.slint:61
+msgctxt "ChainDiLoopButton"
+msgid "di-loop-button-label"
+msgstr "DI लूप"
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:170
+#: crates/adapter-gui/ui/components/chain_di_loop_button.slint:138
+msgctxt "ChainDiLoopButton"
+msgid "di-loop-stop-label"
+msgstr "DI लूप रोकें"
+
+#: crates/adapter-gui/ui/components/chain_di_loop_button.slint:138
+msgctxt "ChainDiLoopButton"
+msgid "di-loop-play-label"
+msgstr "DI लूप चलाएं"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:77
+msgctxt "SceneBtn"
 msgid "Scene {}"
 msgstr ""
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:192
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:99
+msgctxt "SceneBar"
 msgid "Add scene"
 msgstr ""
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:201
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:108
+msgctxt "SceneBar"
 msgid "Remove last scene"
 msgstr ""
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:258
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:183
+msgctxt "ChainTitlePreset"
+msgid "tooltip-open-preset"
+msgstr "प्रीसेट खोलें"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:193
+msgctxt "ChainTitlePreset"
+msgid "tooltip-save-preset"
+msgstr "प्रीसेट सहेजें"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:203
+msgctxt "ChainTitlePreset"
 msgid "Add preset"
 msgstr ""
 
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:213
+msgctxt "ChainTitlePreset"
+msgid "Rename preset"
+msgstr "प्रीसेट का नाम बदलें"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:224
+msgctxt "ChainTitlePreset"
+msgid "Remove preset"
+msgstr "प्रीसेट हटाएं"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:316
+msgctxt "ChainTitlePreset"
+msgid "Cancel"
+msgstr "रद्द करें"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:337
+msgctxt "ChainTitlePreset"
+msgid "OK"
+msgstr "ठीक है"
+
 #: crates/adapter-gui/ui/components/chain_volume_button.slint:37
+msgctxt "ChainVolumeButton"
 msgid "Volume"
 msgstr ""
 
+#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:29
+msgctxt "ConfirmDeleteChainDialog"
+msgid "title-dialog-delete-chain"
+msgstr "चेन हटाएं"
+
+#. text directly.
+#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:39
+msgctxt "ConfirmDeleteChainDialog"
+msgid "Excluir a chain \"{}\"?"
+msgstr "चेन \"{}\" हटाएं?"
+
+#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:58
+msgctxt "ConfirmDeleteChainDialog"
+msgid "btn-cancel"
+msgstr "रद्द करें"
+
+#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:75
+msgctxt "ConfirmDeleteChainDialog"
+msgid "btn-delete"
+msgstr "हटाएं"
+
 #: crates/adapter-gui/ui/components/confirm_delete_dialog.slint:27
+msgctxt "ConfirmDeleteBlockDialog"
 msgid "title-dialog-delete-block"
 msgstr "ब्लॉक हटाएं"
 
 #. pt-BR source string with the placeholder.
 #: crates/adapter-gui/ui/components/confirm_delete_dialog.slint:36
+msgctxt "ConfirmDeleteBlockDialog"
 msgid "Excluir \"{}\"?"
 msgstr "\"{}\" हटाएं?"
 
 #: crates/adapter-gui/ui/components/confirm_delete_dialog.slint:55
+msgctxt "ConfirmDeleteBlockDialog"
 msgid "btn-cancel"
 msgstr "रद्द करें"
 
 #: crates/adapter-gui/ui/components/confirm_delete_dialog.slint:72
+msgctxt "ConfirmDeleteBlockDialog"
 msgid "btn-delete"
 msgstr "हटाएं"
 
-#: crates/adapter-gui/ui/components/language_selector.slint:56
-msgid "accessible-language-selector"
-msgstr "भाषा चयनकर्ता"
-
-#: crates/adapter-gui/ui/components/model_select_with_search.slint:93
-msgid "▼"
-msgstr "▼"
-
-#: crates/adapter-gui/ui/components/model_select_with_search.slint:175
-msgid "placeholder-search-models"
-msgstr "मॉडल खोजें..."
-
-#: crates/adapter-gui/ui/components/preset_select.slint:170
-msgid "status-no-presets-found"
-msgstr "कोई प्रीसेट नहीं मिला"
-
-#: crates/adapter-gui/ui/components/model_select_with_search.slint:209
-msgid "status-no-models-found"
-msgstr "कोई मॉडल नहीं मिला"
-
-#: crates/adapter-gui/ui/components/preset_picker_overlay.slint:32
-msgid "btn-load-preset"
-msgstr "प्रीसेट लोड करें"
-
-#: crates/adapter-gui/ui/pages/block_editor_panel.slint:122
-msgid "tooltip-delete"
-msgstr "हटाएं"
-
-#: crates/adapter-gui/ui/pages/block_panel_editor.slint:36
-msgid "btn-add"
-msgstr "जोड़ें"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:195
-msgid "instrument-guitar"
-msgstr "गिटार"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:196
-msgid "instrument-acoustic-guitar"
-msgstr "ध्वनिक गिटार"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:197
-msgid "instrument-bass"
-msgstr "बास"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:198
-msgid "instrument-voice"
-msgstr "आवाज़"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:199
-msgid "instrument-keyboard"
-msgstr "कीबोर्ड"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:200
-msgid "instrument-drums"
-msgstr "ड्रम"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:201
-msgid "instrument-other"
-msgstr "अन्य"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:221
-msgid "title-new-chain"
-msgstr "नई चेन"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:221
-msgid "title-configure-chain"
-msgstr "चेन कॉन्फ़िगर करें"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:240
-msgid "label-name"
-msgstr "नाम"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:267
-msgid "label-instrument"
-msgstr "वाद्य यंत्र"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:345
-msgid "title-section-inputs"
-msgstr "इनपुट"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:371
-msgid "btn-add-input"
-msgstr "+ इनपुट जोड़ें"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:390
-msgid "title-section-outputs"
-msgstr "आउटपुट"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:416
-msgid "btn-add-output"
-msgstr "+ आउटपुट जोड़ें"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:450
-msgid "btn-create-chain"
-msgstr "चेन बनाएं"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:450
-msgid "btn-save-chain"
-msgstr "चेन सहेजें"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:66
-msgid "✓"
-msgstr "✓"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:140
-msgid "label-device"
-msgstr "डिवाइस"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:170
-msgid "label-mode"
-msgstr "मोड"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:229
-msgid "label-channels"
-msgstr "चैनल"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:275
-msgid "btn-ok"
-msgstr "ठीक है"
-
-#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:99
-msgid "title-section-configure-insert"
-msgstr "Insert कॉन्फ़िगर करें"
-
-#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:214
-msgid "label-send"
-msgstr "सेंड"
-
-#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:344
-msgid "label-return"
-msgstr "रिटर्न"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:140
-msgid "tooltip-expand-blocks"
-msgstr "ब्लॉक विस्तृत करें"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:148
-msgid "tooltip-measure-latency"
-msgstr "विलंबता मापें (बीप करता है)"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:177
-msgid "tooltip-configure"
-msgstr "कॉन्फ़िगर करें"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:185
-msgid "tooltip-open-preset"
-msgstr "प्रीसेट खोलें"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:193
-msgid "tooltip-save-preset"
-msgstr "प्रीसेट सहेजें"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:472
-msgid "label-lat"
-msgstr "LAT"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:521
-msgid "label-input"
-msgstr "इनपुट"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:567
-msgid "label-output"
-msgstr "आउटपुट"
-
-#: crates/adapter-gui/ui/pages/compact_block_row.slint:493
-msgid "btn-open-plugin"
-msgstr "प्लगइन खोलें"
-
-#: crates/adapter-gui/ui/pages/compact_chain_view.slint:83
-msgid "label-in"
-msgstr "IN"
-
-#: crates/adapter-gui/ui/pages/compact_chain_view.slint:111
-msgid "label-out"
-msgstr "OUT"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:87
-msgid "·"
-msgstr "·"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:123
-msgid "label-description"
-msgstr "Description"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:142
-msgid "label-license"
-msgstr "License:"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:169
-msgid "↗"
-msgstr "↗"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:175
-msgid "btn-open-homepage"
-msgstr "Open Homepage"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:136
-msgid "tooltip-back"
-msgstr "वापस"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:144
-msgid "tooltip-spectrum"
-msgstr "Spectrum"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:152
-msgid "tooltip-tuner"
-msgstr "Tuner"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:160
-msgid "tooltip-project-settings"
-msgstr "प्रोजेक्ट"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:169
-msgid "tooltip-save"
-msgstr "सहेजें"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:177
-msgid "tooltip-new-chain"
-msgstr "नई चेन"
-
-#: crates/adapter-gui/ui/pages/project_launcher.slint:185
-msgid "placeholder-search-projects"
-msgstr "प्रोजेक्ट खोजें"
-
-#: crates/adapter-gui/ui/pages/project_launcher.slint:288
-msgid "tooltip-open-project"
-msgstr "प्रोजेक्ट खोलें"
-
-#: crates/adapter-gui/ui/pages/project_launcher.slint:295
-msgid "btn-new-project"
-msgstr "नया प्रोजेक्ट"
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:147
-msgid "label-hz"
-msgstr "Hz"
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:170
-msgid "label-buffer"
-msgstr "Buffer"
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:193
-msgid "label-bits"
-msgstr "Bits"
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:271
-msgid "title-section-audio-devices"
-msgstr "ऑडियो डिवाइस"
-
-#: crates/adapter-gui/ui/pages/project_setup.slint:55
-msgid "placeholder-project-name-example"
-msgstr "उदा.: लाइव गिटार"
-
-#: crates/adapter-gui/ui/pages/project_setup.slint:151
-msgid "title-new-project"
-msgstr "नया प्रोजेक्ट"
-
-#: crates/adapter-gui/ui/pages/project_setup.slint:164
-msgid "label-project-name"
-msgstr "प्रोजेक्ट नाम"
-
-#: crates/adapter-gui/ui/pages/project_setup.slint:211
-msgid "btn-create-project"
-msgstr "प्रोजेक्ट बनाएं"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:73
-msgid "—"
-msgstr "—"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:127
-msgid "20"
-msgstr "20"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:133
-msgid "100"
-msgstr "100"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:139
-msgid "1k"
-msgstr "1k"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:145
-msgid "10k"
-msgstr "10k"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:151
-msgid "20k"
-msgstr "20k"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:199
-msgid "label-spectrum"
-msgstr "SPECTRUM"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:241
-msgid "status-no-active-outputs"
-msgstr "NO ACTIVE OUTPUTS"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:251
-msgid "status-spectrum-empty-help"
-msgstr "स्पेक्ट्रम चालू करें और कॉन्फ़िगर किए गए आउटपुट के साथ एक चेन सक्षम करें。"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:279
-msgid "title-window-spectrum"
-msgstr "OpenRig · Spectrum"
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:54
-msgid "label-mute"
-msgstr "MUTE"
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:316
-msgid "label-tuner"
-msgstr "TUNER"
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:368
-msgid "status-no-active-inputs"
-msgstr "NO ACTIVE INPUTS"
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:378
-msgid "status-tuner-empty-help"
-msgstr "यहां ट्यूनर देखने के लिए कॉन्फ़िगर किए गए इनपुट के साथ एक चेन सक्षम करें。"
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:406
-msgid "title-window-tuner"
-msgstr "OpenRig · Tuner"
-
-#: crates/adapter-gui/ui/secondary_windows_block.slint:28
-msgid "title-window-block-editor"
-msgstr "OpenRig · Block"
-
-#: crates/adapter-gui/ui/secondary_windows_block.slint:195
-msgid "title-window-chain-view"
-msgstr "OpenRig · चेन"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:23
-msgid "title-window-project-settings"
-msgstr "OpenRig · प्रोजेक्ट कॉन्फ़िगर करें"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:96
-msgid "title-window-chain-editor"
-msgstr "OpenRig · चेन कॉन्फ़िगर करें"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:129
-msgid "title-section-input"
-msgstr "इनपुट"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:147
-msgid "title-section-output"
-msgstr "आउटपुट"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:177
-msgid "title-window-chain-input"
-msgstr "OpenRig · चेन इनपुट"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:217
-msgid "title-window-chain-output"
-msgstr "OpenRig · चेन आउटपुट"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:258
-msgid "title-window-chain-inputs"
-msgstr "OpenRig · चेन इनपुट"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:269
-msgid "btn-add-input-row"
-msgstr "+ इनपुट जोड़ें"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:299
-msgid "title-window-chain-outputs"
-msgstr "OpenRig · चेन आउटपुट"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:310
-msgid "btn-add-output-row"
-msgstr "+ आउटपुट जोड़ें"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:355
-msgid "title-window-chain-insert"
-msgstr "OpenRig · Insert कॉन्फ़िगर करें"
-
-#: crates/adapter-gui/ui/touch_main.slint:586
-msgid "⌨"
-msgstr "⌨"
-
-#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:27
-msgid "title-dialog-delete-chain"
-msgstr "चेन हटाएं"
-
-#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:37
-msgid "Excluir a chain \"{}\"?"
-msgstr "चेन \"{}\" हटाएं?"
-
-#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:31
+#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:30
+msgctxt "ConfirmDeleteRecentProjectDialog"
 msgid "title-dialog-delete-recent-project"
 msgstr "हाल से हटाएं"
 
-#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:41
+#. Literal pt-BR source string with `{}` placeholder.
+#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:38
+msgctxt "ConfirmDeleteRecentProjectDialog"
 msgid "Remover o projeto \"{}\" dos recentes?"
 msgstr "क्या प्रोजेक्ट \"{}\" को हाल से हटाएं?"
 
-#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:75
+#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:57
+msgctxt "ConfirmDeleteRecentProjectDialog"
+msgid "btn-cancel"
+msgstr "रद्द करें"
+
+#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:74
+msgctxt "ConfirmDeleteRecentProjectDialog"
 msgid "btn-remove"
 msgstr "हटाएं"
 
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "tab-system"
-msgstr ""
+#: crates/adapter-gui/ui/components/language_selector.slint:56
+msgctxt "LanguageSelector"
+msgid "accessible-language-selector"
+msgstr "भाषा चयनकर्ता"
 
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "tab-project"
-msgstr ""
+#: crates/adapter-gui/ui/components/model_select_with_search.slint:96
+msgctxt "ModelSelectWithSearch"
+msgid "▼"
+msgstr "▼"
 
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "btn-close"
-msgstr ""
+#: crates/adapter-gui/ui/components/model_select_with_search.slint:178
+msgctxt "ModelSelectWithSearch"
+msgid "placeholder-search-models"
+msgstr "मॉडल खोजें..."
 
-#: crates/adapter-gui/ui/components/settings_section.slint
-msgid "badge-system"
-msgstr ""
+#: crates/adapter-gui/ui/components/model_select_with_search.slint:212
+msgctxt "ModelSelectWithSearch"
+msgid "status-no-models-found"
+msgstr "कोई मॉडल नहीं मिला"
 
-#: crates/adapter-gui/ui/components/settings_section.slint
-msgid "badge-project"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_system_audio.slint
-msgid "title-section-audio-interface"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_system_language.slint
-msgid "title-section-language"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_system_midi_devices.slint
-msgid "title-section-midi-devices"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint
-msgid "title-section-project-meta"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint
-msgid "label-file"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_project_midi_mapping.slint
-msgid "title-section-midi-mapping"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_project_midi_mapping.slint
-msgid "btn-add-midi-binding"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_project_midi_mapping.slint
-msgid "empty-midi-mapping-explain"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_project_midi_mapping.slint
-msgid "placeholder-midi-listen"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "nav-group-system"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "nav-group-project"
-msgstr ""
+#: crates/adapter-gui/ui/components/preset_picker_overlay.slint:34
+msgctxt "PresetPickerOverlay"
+msgid "btn-load-preset"
+msgstr "प्रीसेट लोड करें"
 
 #: crates/adapter-gui/ui/components/preset_picker_overlay.slint:40
+msgctxt "PresetPickerOverlay"
 msgid "preset-search-placeholder"
 msgstr "प्रीसेट खोजें…"
 
+#: crates/adapter-gui/ui/components/preset_picker_overlay.slint:106
+msgctxt "PresetPickerOverlay"
+msgid "btn-cancel"
+msgstr "रद्द करें"
+
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:38
+msgctxt "PresetSaveOverlay"
 msgid "title-dialog-save-preset"
 msgstr "प्रीसेट सहेजें"
 
+#: crates/adapter-gui/ui/components/preset_save_overlay.slint:63
+msgctxt "PresetSaveOverlay"
+msgid "btn-cancel"
+msgstr "रद्द करें"
+
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:82
+msgctxt "PresetSaveOverlay"
 msgid "btn-save"
 msgstr "सहेजें"
 
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:119
+msgctxt "PresetOverwriteOverlay"
 msgid "title-dialog-overwrite-preset"
 msgstr "प्रीसेट अधिलेखित करें?"
 
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:126
+msgctxt "PresetOverwriteOverlay"
 msgid "msg-overwrite-preset"
 msgstr "\"{}\" नाम का प्रीसेट पहले से मौजूद है। अधिलेखित करें?"
 
+#: crates/adapter-gui/ui/components/preset_save_overlay.slint:145
+msgctxt "PresetOverwriteOverlay"
+msgid "btn-cancel"
+msgstr "रद्द करें"
+
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:162
+msgctxt "PresetOverwriteOverlay"
 msgid "btn-overwrite"
 msgstr "अधिलेखित करें"
 
-msgid "btn-save-audio-settings"
+#: crates/adapter-gui/ui/components/preset_select.slint:72
+msgctxt "PresetSelect"
+msgid "Preset selector"
 msgstr ""
 
+#: crates/adapter-gui/ui/components/preset_select.slint:137
+msgctxt "PresetSelect"
+msgid "preset-search-placeholder"
+msgstr "प्रीसेट खोजें…"
+
+#: crates/adapter-gui/ui/components/preset_select.slint:170
+msgctxt "PresetSelect"
+msgid "status-no-presets-found"
+msgstr "कोई प्रीसेट नहीं मिला"
+
+#: crates/adapter-gui/ui/pages/block_editor_panel.slint:122
+msgctxt "BlockEditorPanel"
+msgid "tooltip-delete"
+msgstr "हटाएं"
+
+#: crates/adapter-gui/ui/pages/block_editor_panel.slint:243
+msgctxt "BlockEditorPanel"
+msgid "–"
+msgstr "–"
+
+#: crates/adapter-gui/ui/pages/block_panel_editor.slint:37
+msgctxt "BlockPanelEditor"
+msgid "btn-add"
+msgstr "जोड़ें"
+
+#: crates/adapter-gui/ui/pages/block_panel_editor.slint:323
+msgctxt "BlockPanelEditor"
+msgid "–"
+msgstr "–"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:195
+msgctxt "ChainEditorPage"
+msgid "instrument-guitar"
+msgstr "गिटार"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:196
+msgctxt "ChainEditorPage"
+msgid "instrument-acoustic-guitar"
+msgstr "ध्वनिक गिटार"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:197
+msgctxt "ChainEditorPage"
+msgid "instrument-bass"
+msgstr "बास"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:198
+msgctxt "ChainEditorPage"
+msgid "instrument-voice"
+msgstr "आवाज़"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:199
+msgctxt "ChainEditorPage"
+msgid "instrument-keyboard"
+msgstr "कीबोर्ड"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:200
+msgctxt "ChainEditorPage"
+msgid "instrument-drums"
+msgstr "ड्रम"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:201
+msgctxt "ChainEditorPage"
+msgid "instrument-other"
+msgstr "अन्य"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:221
+msgctxt "ChainEditorPage"
+msgid "title-new-chain"
+msgstr "नई चेन"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:221
+msgctxt "ChainEditorPage"
+msgid "title-configure-chain"
+msgstr "चेन कॉन्फ़िगर करें"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:240
+msgctxt "ChainEditorPage"
+msgid "label-name"
+msgstr "नाम"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:267
+msgctxt "ChainEditorPage"
+msgid "label-instrument"
+msgstr "वाद्य यंत्र"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:345
+msgctxt "ChainEditorPage"
+msgid "title-section-inputs"
+msgstr "इनपुट"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:371
+msgctxt "ChainEditorPage"
+msgid "btn-add-input"
+msgstr "+ इनपुट जोड़ें"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:390
+msgctxt "ChainEditorPage"
+msgid "title-section-outputs"
+msgstr "आउटपुट"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:416
+msgctxt "ChainEditorPage"
+msgid "btn-add-output"
+msgstr "+ आउटपुट जोड़ें"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:443
+msgctxt "ChainEditorPage"
+msgid "btn-cancel"
+msgstr "रद्द करें"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:450
+msgctxt "ChainEditorPage"
+msgid "btn-create-chain"
+msgstr "चेन बनाएं"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:450
+msgctxt "ChainEditorPage"
+msgid "btn-save-chain"
+msgstr "चेन सहेजें"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:66
+msgctxt "ChannelRow"
+msgid "✓"
+msgstr "✓"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:140
+msgctxt "ChainEndpointEditorPage"
+msgid "label-device"
+msgstr "डिवाइस"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:170
+msgctxt "ChainEndpointEditorPage"
+msgid "label-mode"
+msgstr "मोड"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:229
+msgctxt "ChainEndpointEditorPage"
+msgid "label-channels"
+msgstr "चैनल"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:268
+msgctxt "ChainEndpointEditorPage"
+msgid "btn-cancel"
+msgstr "रद्द करें"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:275
+msgctxt "ChainEndpointEditorPage"
+msgid "btn-ok"
+msgstr "ठीक है"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:99
+msgctxt "ChainInsertEditorPage"
+msgid "title-section-configure-insert"
+msgstr "Insert कॉन्फ़िगर करें"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:214
+msgctxt "ChainInsertEditorPage"
+msgid "label-send"
+msgstr "सेंड"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:225
+msgctxt "ChainInsertEditorPage"
+msgid "label-device"
+msgstr "डिवाइस"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:247
+msgctxt "ChainInsertEditorPage"
+msgid "label-mode"
+msgstr "मोड"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:299
+msgctxt "ChainInsertEditorPage"
+msgid "label-channels"
+msgstr "चैनल"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:344
+msgctxt "ChainInsertEditorPage"
+msgid "label-return"
+msgstr "रिटर्न"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:469
+msgctxt "ChainInsertEditorPage"
+msgid "btn-cancel"
+msgstr "रद्द करें"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:476
+msgctxt "ChainInsertEditorPage"
+msgid "btn-ok"
+msgstr "ठीक है"
+
+#: crates/adapter-gui/ui/pages/chain_io_groups.slint:304
+msgctxt "ChainIoGroupsPage"
+msgid "btn-cancel"
+msgstr "रद्द करें"
+
+#: crates/adapter-gui/ui/pages/chain_io_groups.slint:311
+msgctxt "ChainIoGroupsPage"
+msgid "btn-ok"
+msgstr "ठीक है"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:246
+msgctxt "ChainRow"
+msgid "tooltip-expand-blocks"
+msgstr "ब्लॉक विस्तृत करें"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:254
+msgctxt "ChainRow"
+msgid "tooltip-measure-latency"
+msgstr "विलंबता मापें (बीप करता है)"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:283
+msgctxt "ChainRow"
+msgid "tooltip-configure"
+msgstr "कॉन्फ़िगर करें"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:291
+msgctxt "ChainRow"
+msgid "tooltip-delete"
+msgstr "हटाएं"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:564
+msgctxt "ChainRow"
+msgid "label-lat"
+msgstr "LAT"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:613
+msgctxt "ChainRow"
+msgid "label-input"
+msgstr "इनपुट"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:659
+msgctxt "ChainRow"
+msgid "label-output"
+msgstr "आउटपुट"
+
+#: crates/adapter-gui/ui/pages/compact_block_row.slint:415
+msgctxt "CompactBlockRow"
+msgid "▼"
+msgstr "▼"
+
+#: crates/adapter-gui/ui/pages/compact_block_row.slint:493
+msgctxt "CompactBlockRow"
+msgid "btn-open-plugin"
+msgstr "प्लगइन खोलें"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:160
+msgctxt "CompactChainViewPage"
+msgid "tooltip-measure-latency"
+msgstr "विलंबता मापें (बीप करता है)"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:187
+msgctxt "CompactChainViewPage"
+msgid "label-lat"
+msgstr "LAT"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:216
+msgctxt "CompactChainViewPage"
+msgid "tooltip-configure"
+msgstr "कॉन्फ़िगर करें"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:230
+msgctxt "CompactChainViewPage"
+msgid "label-in"
+msgstr "IN"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:251
+msgctxt "CompactChainViewPage"
+msgid "label-out"
+msgstr "OUT"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:267
+msgctxt "CompactChainViewPage"
+msgid "tooltip-delete"
+msgstr "हटाएं"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:313
+msgctxt "CompactChainViewPage"
+msgid "+"
+msgstr "+"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:87
+msgctxt "PluginInfoPanel"
+msgid "·"
+msgstr "·"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:125
+msgctxt "PluginInfoPanel"
+msgid "label-description"
+msgstr "Description"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:144
+msgctxt "PluginInfoPanel"
+msgid "label-license"
+msgstr "License:"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:171
+msgctxt "PluginInfoPanel"
+msgid "↗"
+msgstr "↗"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:177
+msgctxt "PluginInfoPanel"
+msgid "btn-open-homepage"
+msgstr "Open Homepage"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:145
+msgctxt "ProjectChainsPage"
+msgid "tooltip-back"
+msgstr "वापस"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:153
+msgctxt "ProjectChainsPage"
+msgid "tooltip-spectrum"
+msgstr "Spectrum"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:161
+msgctxt "ProjectChainsPage"
+msgid "tooltip-tuner"
+msgstr "Tuner"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:169
+msgctxt "ProjectChainsPage"
+msgid "tooltip-project-settings"
+msgstr "प्रोजेक्ट"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:178
+msgctxt "ProjectChainsPage"
+msgid "tooltip-save"
+msgstr "सहेजें"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:186
+msgctxt "ProjectChainsPage"
+msgid "tooltip-new-chain"
+msgstr "नई चेन"
+
+#: crates/adapter-gui/ui/pages/project_launcher.slint:184
+msgctxt "SearchField"
+msgid "placeholder-search-projects"
+msgstr "प्रोजेक्ट खोजें"
+
+#: crates/adapter-gui/ui/pages/project_launcher.slint:287
+msgctxt "ProjectLauncherPage"
+msgid "tooltip-open-project"
+msgstr "प्रोजेक्ट खोलें"
+
+#: crates/adapter-gui/ui/pages/project_launcher.slint:294
+msgctxt "ProjectLauncherPage"
+msgid "btn-new-project"
+msgstr "नया प्रोजेक्ट"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:55
+msgctxt "NameInput"
+msgid "placeholder-project-name-example"
+msgstr "उदा.: लाइव गिटार"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:151
+msgctxt "ProjectSetupPage"
+msgid "title-new-project"
+msgstr "नया प्रोजेक्ट"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:164
+msgctxt "ProjectSetupPage"
+msgid "label-project-name"
+msgstr "प्रोजेक्ट नाम"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:204
+msgctxt "ProjectSetupPage"
+msgid "btn-cancel"
+msgstr "रद्द करें"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:211
+msgctxt "ProjectSetupPage"
+msgid "btn-create-project"
+msgstr "प्रोजेक्ट बनाएं"
+
+#: crates/adapter-gui/ui/pages/settings.slint:170
+msgctxt "SettingsPage"
+msgid "nav-group-system"
+msgstr "सिस्टम"
+
+#: crates/adapter-gui/ui/pages/settings.slint:181
+msgctxt "SettingsPage"
+msgid "title-section-audio-interface"
+msgstr "ऑडियो इंटरफ़ेस"
+
+#: crates/adapter-gui/ui/pages/settings.slint:186
+msgctxt "SettingsPage"
+msgid "title-section-language"
+msgstr "भाषा"
+
+#: crates/adapter-gui/ui/pages/settings.slint:191
+msgctxt "SettingsPage"
+msgid "title-section-midi-devices"
+msgstr "MIDI डिवाइस"
+
+#: crates/adapter-gui/ui/pages/settings.slint:196
+msgctxt "SettingsPage"
+msgid "title-section-paths"
+msgstr "पथ"
+
+#: crates/adapter-gui/ui/pages/settings.slint:201
+msgctxt "SettingsPage"
 msgid "title-section-integrations"
 msgstr "एकीकरण"
 
+#: crates/adapter-gui/ui/pages/settings.slint:216
+msgctxt "SettingsPage"
+msgid "nav-group-project"
+msgstr "प्रोजेक्ट"
+
+#: crates/adapter-gui/ui/pages/settings.slint:227
+msgctxt "SettingsPage"
+msgid "title-section-project-meta"
+msgstr "मेटाडेटा"
+
+#: crates/adapter-gui/ui/pages/settings.slint:335
+msgctxt "SettingsPage"
+msgid "btn-save-audio-settings"
+msgstr "लागू करें"
+
+#: crates/adapter-gui/ui/pages/settings.slint:339
+msgctxt "SettingsPage"
+msgid "btn-close"
+msgstr "बंद करें"
+
+#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint:27
+msgctxt "SectionProjectMeta"
+msgid "label-name"
+msgstr "नाम"
+
+#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint:58
+msgctxt "SectionProjectMeta"
+msgid "label-file"
+msgstr "फ़ाइल"
+
+#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint:66
+msgctxt "SectionProjectMeta"
+msgid "placeholder-project-unsaved"
+msgstr "(असहेजा)"
+
+#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint:83
+msgctxt "SectionProjectMeta"
+msgid "btn-save-project"
+msgstr "प्रोजेक्ट सहेजें"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_audio.slint:95
+msgctxt "AudioDeviceRow"
+msgid "label-hz"
+msgstr "Hz"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_audio.slint:118
+msgctxt "AudioDeviceRow"
+msgid "label-buffer"
+msgstr "Buffer"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_audio.slint:141
+msgctxt "AudioDeviceRow"
+msgid "label-bits"
+msgstr "Bits"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:39
+msgctxt "SectionSystemIntegrations"
 msgid "label-midi-enabled"
 msgstr "MIDI नियंत्रण"
 
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:45
+msgctxt "SectionSystemIntegrations"
 msgid "desc-midi-enabled"
 msgstr "MIDI/BLE-MIDI एडाप्टर चालू करें ताकि फुटस्विच OpenRig को नियंत्रित करें"
 
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:93
+msgctxt "SectionSystemIntegrations"
 msgid "label-mcp-enabled"
 msgstr "MCP सर्वर"
 
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:99
+msgctxt "SectionSystemIntegrations"
 msgid "desc-mcp-enabled"
 msgstr "एजेंट के लिए MCP सर्वर को 127.0.0.1:4123 पर उपलब्ध कराएं"
 
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:134
+msgctxt "SectionSystemIntegrations"
 msgid "hint-restart-to-apply"
 msgstr "अगली बार शुरू करने पर लागू होगा।"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_language.slint:25
+msgctxt "SectionSystemLanguage"
+msgid "label-language"
+msgstr "भाषा"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:49
+msgctxt "SectionSystemPaths"
+msgid "label-presets-path"
+msgstr "प्रीसेट फ़ोल्डर"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:57
+msgctxt "SectionSystemPaths"
+msgid "placeholder-default-path"
+msgstr "(डिफ़ॉल्ट)"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:66
+msgctxt "SectionSystemPaths"
+msgid "btn-choose-path"
+msgstr "चुनें…"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:70
+msgctxt "SectionSystemPaths"
+msgid "btn-reset-path"
+msgstr "रीसेट करें"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:81
+msgctxt "SectionSystemPaths"
+msgid "label-plugins-path"
+msgstr "प्लगइन फ़ोल्डर"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:113
+msgctxt "SectionSystemPaths"
+msgid "label-evaluations-path"
+msgstr "मूल्यांकन फ़ोल्डर"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:145
+msgctxt "SectionSystemPaths"
+msgid "label-plugin-catalog"
+msgstr "प्लगइन कैटलॉग"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:153
+msgctxt "SectionSystemPaths"
+msgid "status-plugin-catalog-idle"
+msgstr "अभी तक पुनः लोड नहीं किया गया"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:162
+msgctxt "SectionSystemPaths"
+msgid "btn-reload-plugin-catalog"
+msgstr "पुनः लोड करें"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:73
+msgctxt "SpectrumCard"
+msgid "—"
+msgstr "—"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:127
+msgctxt "SpectrumCard"
+msgid "20"
+msgstr "20"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:133
+msgctxt "SpectrumCard"
+msgid "100"
+msgstr "100"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:139
+msgctxt "SpectrumCard"
+msgid "1k"
+msgstr "1k"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:145
+msgctxt "SpectrumCard"
+msgid "10k"
+msgstr "10k"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:151
+msgctxt "SpectrumCard"
+msgid "20k"
+msgstr "20k"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:199
+msgctxt "SpectrumPanel"
+msgid "label-spectrum"
+msgstr "SPECTRUM"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:241
+msgctxt "SpectrumPanel"
+msgid "status-no-active-outputs"
+msgstr "NO ACTIVE OUTPUTS"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:251
+msgctxt "SpectrumPanel"
+msgid "status-spectrum-empty-help"
+msgstr "स्पेक्ट्रम चालू करें और कॉन्फ़िगर किए गए आउटपुट के साथ एक चेन सक्षम करें。"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:279
+msgctxt "SpectrumWindow"
+msgid "title-window-spectrum"
+msgstr "OpenRig · Spectrum"
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:54
+msgctxt "MuteSwitch"
+msgid "label-mute"
+msgstr "MUTE"
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:316
+msgctxt "TunerPanel"
+msgid "label-tuner"
+msgstr "TUNER"
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:368
+msgctxt "TunerPanel"
+msgid "status-no-active-inputs"
+msgstr "NO ACTIVE INPUTS"
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:378
+msgctxt "TunerPanel"
+msgid "status-tuner-empty-help"
+msgstr "यहां ट्यूनर देखने के लिए कॉन्फ़िगर किए गए इनपुट के साथ एक चेन सक्षम करें。"
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:406
+msgctxt "TunerWindow"
+msgid "title-window-tuner"
+msgstr "OpenRig · Tuner"
+
+#: crates/adapter-gui/ui/secondary_windows_block.slint:30
+msgctxt "BlockEditorWindow"
+msgid "title-window-block-editor"
+msgstr "OpenRig · Block"
+
+#: crates/adapter-gui/ui/secondary_windows_block.slint:231
+msgctxt "CompactChainViewWindow"
+msgid "title-window-chain-view"
+msgstr "OpenRig · चेन"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:60
+msgctxt "ProjectSettingsWindow"
+msgid "title-window-project-settings"
+msgstr "OpenRig · प्रोजेक्ट कॉन्फ़िगर करें"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:159
+msgctxt "ChainEditorWindow"
+msgid "title-window-chain-editor"
+msgstr "OpenRig · चेन कॉन्फ़िगर करें"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:192
+msgctxt "ChainEditorWindow"
+msgid "title-section-input"
+msgstr "इनपुट"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:210
+msgctxt "ChainEditorWindow"
+msgid "title-section-output"
+msgstr "आउटपुट"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:240
+msgctxt "ChainInputWindow"
+msgid "title-window-chain-input"
+msgstr "OpenRig · चेन इनपुट"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:250
+msgctxt "ChainInputWindow"
+msgid "title-section-input"
+msgstr "इनपुट"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:280
+msgctxt "ChainOutputWindow"
+msgid "title-window-chain-output"
+msgstr "OpenRig · चेन आउटपुट"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:290
+msgctxt "ChainOutputWindow"
+msgid "title-section-output"
+msgstr "आउटपुट"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:321
+msgctxt "ChainInputGroupsWindow"
+msgid "title-window-chain-inputs"
+msgstr "OpenRig · चेन इनपुट"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:331
+msgctxt "ChainInputGroupsWindow"
+msgid "title-section-inputs"
+msgstr "इनपुट"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:332
+msgctxt "ChainInputGroupsWindow"
+msgid "btn-add-input-row"
+msgstr "+ इनपुट जोड़ें"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:362
+msgctxt "ChainOutputGroupsWindow"
+msgid "title-window-chain-outputs"
+msgstr "OpenRig · चेन आउटपुट"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:372
+msgctxt "ChainOutputGroupsWindow"
+msgid "title-section-outputs"
+msgstr "आउटपुट"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:373
+msgctxt "ChainOutputGroupsWindow"
+msgid "btn-add-output-row"
+msgstr "+ आउटपुट जोड़ें"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:418
+msgctxt "ChainInsertWindow"
+msgid "title-window-chain-insert"
+msgstr "OpenRig · Insert कॉन्फ़िगर करें"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:428
+msgctxt "ChainInsertWindow"
+msgid "title-section-configure-insert"
+msgstr "Insert कॉन्फ़िगर करें"
+
+#: crates/adapter-gui/ui/touch_main.slint:667
+msgctxt "TouchMain"
+msgid "⌨"
+msgstr "⌨"

--- a/crates/adapter-gui/translations/ja_JP/LC_MESSAGES/adapter-gui.po
+++ b/crates/adapter-gui/translations/ja_JP/LC_MESSAGES/adapter-gui.po
@@ -12,575 +12,939 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #: crates/adapter-gui/ui/blocks/header.slint:13
+msgctxt "Header"
 msgid "OpenRig"
 msgstr "OpenRig"
 
 #: crates/adapter-gui/ui/components/block_panel_parameter_item.slint:274
+msgctxt "BlockPanelParameterItem"
 msgid "btn-load-file"
 msgstr "Load"
 
 #: crates/adapter-gui/ui/components/block_stream_mini_display.slint:23
+msgctxt "BlockStreamMiniDisplay"
 msgid "–"
 msgstr "–"
 
 #: crates/adapter-gui/ui/components/block_value_widgets.slint:128
+msgctxt "BlockValueStepper"
 msgid "−"
 msgstr "−"
 
 #: crates/adapter-gui/ui/components/block_value_widgets.slint:194
+msgctxt "BlockValueStepper"
 msgid "+"
 msgstr "+"
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:87
-msgid "Preset selector"
-msgstr ""
+#: crates/adapter-gui/ui/components/chain_di_loop_button.slint:61
+msgctxt "ChainDiLoopButton"
+msgid "di-loop-button-label"
+msgstr "DIループ"
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:170
+#: crates/adapter-gui/ui/components/chain_di_loop_button.slint:138
+msgctxt "ChainDiLoopButton"
+msgid "di-loop-stop-label"
+msgstr "DIループを停止"
+
+#: crates/adapter-gui/ui/components/chain_di_loop_button.slint:138
+msgctxt "ChainDiLoopButton"
+msgid "di-loop-play-label"
+msgstr "DIループを再生"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:77
+msgctxt "SceneBtn"
 msgid "Scene {}"
 msgstr ""
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:192
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:99
+msgctxt "SceneBar"
 msgid "Add scene"
 msgstr ""
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:201
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:108
+msgctxt "SceneBar"
 msgid "Remove last scene"
 msgstr ""
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:258
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:183
+msgctxt "ChainTitlePreset"
+msgid "tooltip-open-preset"
+msgstr "プリセットを開く"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:193
+msgctxt "ChainTitlePreset"
+msgid "tooltip-save-preset"
+msgstr "プリセットを保存"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:203
+msgctxt "ChainTitlePreset"
 msgid "Add preset"
 msgstr ""
 
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:213
+msgctxt "ChainTitlePreset"
+msgid "Rename preset"
+msgstr "プリセット名を変更"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:224
+msgctxt "ChainTitlePreset"
+msgid "Remove preset"
+msgstr "プリセットを削除"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:316
+msgctxt "ChainTitlePreset"
+msgid "Cancel"
+msgstr "キャンセル"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:337
+msgctxt "ChainTitlePreset"
+msgid "OK"
+msgstr "OK"
+
 #: crates/adapter-gui/ui/components/chain_volume_button.slint:37
+msgctxt "ChainVolumeButton"
 msgid "Volume"
 msgstr ""
 
+#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:29
+msgctxt "ConfirmDeleteChainDialog"
+msgid "title-dialog-delete-chain"
+msgstr "チェーンを削除"
+
+#. text directly.
+#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:39
+msgctxt "ConfirmDeleteChainDialog"
+msgid "Excluir a chain \"{}\"?"
+msgstr "チェーン \"{}\" を削除しますか?"
+
+#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:58
+msgctxt "ConfirmDeleteChainDialog"
+msgid "btn-cancel"
+msgstr "キャンセル"
+
+#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:75
+msgctxt "ConfirmDeleteChainDialog"
+msgid "btn-delete"
+msgstr "削除"
+
 #: crates/adapter-gui/ui/components/confirm_delete_dialog.slint:27
+msgctxt "ConfirmDeleteBlockDialog"
 msgid "title-dialog-delete-block"
 msgstr "ブロックを削除"
 
 #. pt-BR source string with the placeholder.
 #: crates/adapter-gui/ui/components/confirm_delete_dialog.slint:36
+msgctxt "ConfirmDeleteBlockDialog"
 msgid "Excluir \"{}\"?"
 msgstr "\"{}\" を削除しますか？"
 
 #: crates/adapter-gui/ui/components/confirm_delete_dialog.slint:55
+msgctxt "ConfirmDeleteBlockDialog"
 msgid "btn-cancel"
 msgstr "キャンセル"
 
 #: crates/adapter-gui/ui/components/confirm_delete_dialog.slint:72
+msgctxt "ConfirmDeleteBlockDialog"
 msgid "btn-delete"
 msgstr "削除"
 
-#: crates/adapter-gui/ui/components/language_selector.slint:56
-msgid "accessible-language-selector"
-msgstr "言語セレクター"
-
-#: crates/adapter-gui/ui/components/model_select_with_search.slint:93
-msgid "▼"
-msgstr "▼"
-
-#: crates/adapter-gui/ui/components/model_select_with_search.slint:175
-msgid "placeholder-search-models"
-msgstr "モデルを検索..."
-
-#: crates/adapter-gui/ui/components/preset_select.slint:170
-msgid "status-no-presets-found"
-msgstr "プリセットが見つかりません"
-
-#: crates/adapter-gui/ui/components/model_select_with_search.slint:209
-msgid "status-no-models-found"
-msgstr "モデルが見つかりません"
-
-#: crates/adapter-gui/ui/components/preset_picker_overlay.slint:32
-msgid "btn-load-preset"
-msgstr "プリセットを読み込む"
-
-#: crates/adapter-gui/ui/pages/block_editor_panel.slint:122
-msgid "tooltip-delete"
-msgstr "削除"
-
-#: crates/adapter-gui/ui/pages/block_panel_editor.slint:36
-msgid "btn-add"
-msgstr "追加"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:195
-msgid "instrument-guitar"
-msgstr "ギター"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:196
-msgid "instrument-acoustic-guitar"
-msgstr "アコースティックギター"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:197
-msgid "instrument-bass"
-msgstr "ベース"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:198
-msgid "instrument-voice"
-msgstr "ボーカル"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:199
-msgid "instrument-keyboard"
-msgstr "キーボード"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:200
-msgid "instrument-drums"
-msgstr "ドラム"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:201
-msgid "instrument-other"
-msgstr "その他"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:221
-msgid "title-new-chain"
-msgstr "新しいチェーン"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:221
-msgid "title-configure-chain"
-msgstr "チェーンを構成"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:240
-msgid "label-name"
-msgstr "名前"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:267
-msgid "label-instrument"
-msgstr "楽器"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:345
-msgid "title-section-inputs"
-msgstr "入力"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:371
-msgid "btn-add-input"
-msgstr "+ 入力を追加"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:390
-msgid "title-section-outputs"
-msgstr "出力"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:416
-msgid "btn-add-output"
-msgstr "+ 出力を追加"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:450
-msgid "btn-create-chain"
-msgstr "チェーンを作成"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:450
-msgid "btn-save-chain"
-msgstr "チェーンを保存"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:66
-msgid "✓"
-msgstr "✓"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:140
-msgid "label-device"
-msgstr "デバイス"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:170
-msgid "label-mode"
-msgstr "モード"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:229
-msgid "label-channels"
-msgstr "チャンネル"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:275
-msgid "btn-ok"
-msgstr "確認"
-
-#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:99
-msgid "title-section-configure-insert"
-msgstr "Insertを構成"
-
-#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:214
-msgid "label-send"
-msgstr "センド"
-
-#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:344
-msgid "label-return"
-msgstr "リターン"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:140
-msgid "tooltip-expand-blocks"
-msgstr "ブロックを展開"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:148
-msgid "tooltip-measure-latency"
-msgstr "レイテンシ計測（ビープ音が鳴ります）"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:177
-msgid "tooltip-configure"
-msgstr "設定"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:185
-msgid "tooltip-open-preset"
-msgstr "プリセットを開く"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:193
-msgid "tooltip-save-preset"
-msgstr "プリセットを保存"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:472
-msgid "label-lat"
-msgstr "LAT"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:521
-msgid "label-input"
-msgstr "入力"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:567
-msgid "label-output"
-msgstr "出力"
-
-#: crates/adapter-gui/ui/pages/compact_block_row.slint:493
-msgid "btn-open-plugin"
-msgstr "プラグインを開く"
-
-#: crates/adapter-gui/ui/pages/compact_chain_view.slint:83
-msgid "label-in"
-msgstr "IN"
-
-#: crates/adapter-gui/ui/pages/compact_chain_view.slint:111
-msgid "label-out"
-msgstr "OUT"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:87
-msgid "·"
-msgstr "·"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:123
-msgid "label-description"
-msgstr "Description"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:142
-msgid "label-license"
-msgstr "License:"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:169
-msgid "↗"
-msgstr "↗"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:175
-msgid "btn-open-homepage"
-msgstr "Open Homepage"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:136
-msgid "tooltip-back"
-msgstr "戻る"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:144
-msgid "tooltip-spectrum"
-msgstr "Spectrum"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:152
-msgid "tooltip-tuner"
-msgstr "Tuner"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:160
-msgid "tooltip-project-settings"
-msgstr "プロジェクト"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:169
-msgid "tooltip-save"
-msgstr "保存"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:177
-msgid "tooltip-new-chain"
-msgstr "新しい チェーン"
-
-#: crates/adapter-gui/ui/pages/project_launcher.slint:185
-msgid "placeholder-search-projects"
-msgstr "プロジェクトを検索"
-
-#: crates/adapter-gui/ui/pages/project_launcher.slint:288
-msgid "tooltip-open-project"
-msgstr "プロジェクトを開く"
-
-#: crates/adapter-gui/ui/pages/project_launcher.slint:295
-msgid "btn-new-project"
-msgstr "新規プロジェクト"
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:147
-msgid "label-hz"
-msgstr "Hz"
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:170
-msgid "label-buffer"
-msgstr "Buffer"
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:193
-msgid "label-bits"
-msgstr "Bits"
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:271
-msgid "title-section-audio-devices"
-msgstr "オーディオデバイス"
-
-#: crates/adapter-gui/ui/pages/project_setup.slint:55
-msgid "placeholder-project-name-example"
-msgstr "例: ライブギター"
-
-#: crates/adapter-gui/ui/pages/project_setup.slint:151
-msgid "title-new-project"
-msgstr "新規プロジェクト"
-
-#: crates/adapter-gui/ui/pages/project_setup.slint:164
-msgid "label-project-name"
-msgstr "プロジェクト名"
-
-#: crates/adapter-gui/ui/pages/project_setup.slint:211
-msgid "btn-create-project"
-msgstr "プロジェクトを作成"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:73
-msgid "—"
-msgstr "—"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:127
-msgid "20"
-msgstr "20"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:133
-msgid "100"
-msgstr "100"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:139
-msgid "1k"
-msgstr "1k"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:145
-msgid "10k"
-msgstr "10k"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:151
-msgid "20k"
-msgstr "20k"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:199
-msgid "label-spectrum"
-msgstr "SPECTRUM"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:241
-msgid "status-no-active-outputs"
-msgstr "NO ACTIVE OUTPUTS"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:251
-msgid "status-spectrum-empty-help"
-msgstr ""
-"スペクトラムをオンにし、出力が構成されたチェーンを有効にしてください。スペク"
-"トラムを電源ONにし、出力が構成されたチェーンを有効にしてください。"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:279
-msgid "title-window-spectrum"
-msgstr "OpenRig · Spectrum"
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:54
-msgid "label-mute"
-msgstr "MUTE"
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:316
-msgid "label-tuner"
-msgstr "TUNER"
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:368
-msgid "status-no-active-inputs"
-msgstr "NO ACTIVE INPUTS"
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:378
-msgid "status-tuner-empty-help"
-msgstr ""
-"入力が構成されたチェーンを有効にすると、ここにチューナーが表示されます。入力"
-"が構成されたチェーンを有効にすると、ここにチューナーが表示されます。"
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:406
-msgid "title-window-tuner"
-msgstr "OpenRig · Tuner"
-
-#: crates/adapter-gui/ui/secondary_windows_block.slint:28
-msgid "title-window-block-editor"
-msgstr "OpenRig · Block"
-
-#: crates/adapter-gui/ui/secondary_windows_block.slint:195
-msgid "title-window-chain-view"
-msgstr "OpenRig · チェーン"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:23
-msgid "title-window-project-settings"
-msgstr "OpenRig · プロジェクトを構成"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:96
-msgid "title-window-chain-editor"
-msgstr "OpenRig · チェーンを構成"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:129
-msgid "title-section-input"
-msgstr "入力"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:147
-msgid "title-section-output"
-msgstr "出力"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:177
-msgid "title-window-chain-input"
-msgstr "OpenRig · チェーン入力"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:217
-msgid "title-window-chain-output"
-msgstr "OpenRig · チェーン出力"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:258
-msgid "title-window-chain-inputs"
-msgstr "OpenRig · チェーン入力"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:269
-msgid "btn-add-input-row"
-msgstr "+ 入力を追加"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:299
-msgid "title-window-chain-outputs"
-msgstr "OpenRig · チェーン出力"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:310
-msgid "btn-add-output-row"
-msgstr "+ 出力を追加"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:355
-msgid "title-window-chain-insert"
-msgstr "OpenRig · Insertを構成"
-
-#: crates/adapter-gui/ui/touch_main.slint:586
-msgid "⌨"
-msgstr "⌨"
-
-#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:27
-msgid "title-dialog-delete-chain"
-msgstr "チェーンを削除"
-
-#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:37
-msgid "Excluir a chain \"{}\"?"
-msgstr "チェーン \"{}\" を削除しますか?"
-
-#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:31
+#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:30
+msgctxt "ConfirmDeleteRecentProjectDialog"
 msgid "title-dialog-delete-recent-project"
 msgstr "最近から削除"
 
-#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:41
+#. Literal pt-BR source string with `{}` placeholder.
+#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:38
+msgctxt "ConfirmDeleteRecentProjectDialog"
 msgid "Remover o projeto \"{}\" dos recentes?"
 msgstr "プロジェクト \"{}\" を最近から削除しますか?"
 
-#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:75
+#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:57
+msgctxt "ConfirmDeleteRecentProjectDialog"
+msgid "btn-cancel"
+msgstr "キャンセル"
+
+#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:74
+msgctxt "ConfirmDeleteRecentProjectDialog"
 msgid "btn-remove"
 msgstr "削除"
 
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "tab-system"
-msgstr ""
+#: crates/adapter-gui/ui/components/language_selector.slint:56
+msgctxt "LanguageSelector"
+msgid "accessible-language-selector"
+msgstr "言語セレクター"
 
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "tab-project"
-msgstr ""
+#: crates/adapter-gui/ui/components/model_select_with_search.slint:96
+msgctxt "ModelSelectWithSearch"
+msgid "▼"
+msgstr "▼"
 
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "btn-close"
-msgstr ""
+#: crates/adapter-gui/ui/components/model_select_with_search.slint:178
+msgctxt "ModelSelectWithSearch"
+msgid "placeholder-search-models"
+msgstr "モデルを検索..."
 
-#: crates/adapter-gui/ui/components/settings_section.slint
-msgid "badge-system"
-msgstr ""
+#: crates/adapter-gui/ui/components/model_select_with_search.slint:212
+msgctxt "ModelSelectWithSearch"
+msgid "status-no-models-found"
+msgstr "モデルが見つかりません"
 
-#: crates/adapter-gui/ui/components/settings_section.slint
-msgid "badge-project"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_system_audio.slint
-msgid "title-section-audio-interface"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_system_language.slint
-msgid "title-section-language"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_system_midi_devices.slint
-msgid "title-section-midi-devices"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint
-msgid "title-section-project-meta"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint
-msgid "label-file"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_project_midi_mapping.slint
-msgid "title-section-midi-mapping"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_project_midi_mapping.slint
-msgid "btn-add-midi-binding"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_project_midi_mapping.slint
-msgid "empty-midi-mapping-explain"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_project_midi_mapping.slint
-msgid "placeholder-midi-listen"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "nav-group-system"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "nav-group-project"
-msgstr ""
+#: crates/adapter-gui/ui/components/preset_picker_overlay.slint:34
+msgctxt "PresetPickerOverlay"
+msgid "btn-load-preset"
+msgstr "プリセットを読み込む"
 
 #: crates/adapter-gui/ui/components/preset_picker_overlay.slint:40
+msgctxt "PresetPickerOverlay"
 msgid "preset-search-placeholder"
 msgstr "プリセットを検索…"
 
+#: crates/adapter-gui/ui/components/preset_picker_overlay.slint:106
+msgctxt "PresetPickerOverlay"
+msgid "btn-cancel"
+msgstr "キャンセル"
+
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:38
+msgctxt "PresetSaveOverlay"
 msgid "title-dialog-save-preset"
 msgstr "プリセットを保存"
 
+#: crates/adapter-gui/ui/components/preset_save_overlay.slint:63
+msgctxt "PresetSaveOverlay"
+msgid "btn-cancel"
+msgstr "キャンセル"
+
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:82
+msgctxt "PresetSaveOverlay"
 msgid "btn-save"
 msgstr "保存"
 
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:119
+msgctxt "PresetOverwriteOverlay"
 msgid "title-dialog-overwrite-preset"
 msgstr "プリセットを上書きしますか?"
 
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:126
+msgctxt "PresetOverwriteOverlay"
 msgid "msg-overwrite-preset"
 msgstr "「{}」というプリセットがすでに存在します。上書きしますか?"
 
+#: crates/adapter-gui/ui/components/preset_save_overlay.slint:145
+msgctxt "PresetOverwriteOverlay"
+msgid "btn-cancel"
+msgstr "キャンセル"
+
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:162
+msgctxt "PresetOverwriteOverlay"
 msgid "btn-overwrite"
 msgstr "上書き"
 
-msgid "btn-save-audio-settings"
+#: crates/adapter-gui/ui/components/preset_select.slint:72
+msgctxt "PresetSelect"
+msgid "Preset selector"
 msgstr ""
 
+#: crates/adapter-gui/ui/components/preset_select.slint:137
+msgctxt "PresetSelect"
+msgid "preset-search-placeholder"
+msgstr "プリセットを検索…"
+
+#: crates/adapter-gui/ui/components/preset_select.slint:170
+msgctxt "PresetSelect"
+msgid "status-no-presets-found"
+msgstr "プリセットが見つかりません"
+
+#: crates/adapter-gui/ui/pages/block_editor_panel.slint:122
+msgctxt "BlockEditorPanel"
+msgid "tooltip-delete"
+msgstr "削除"
+
+#: crates/adapter-gui/ui/pages/block_editor_panel.slint:243
+msgctxt "BlockEditorPanel"
+msgid "–"
+msgstr "–"
+
+#: crates/adapter-gui/ui/pages/block_panel_editor.slint:37
+msgctxt "BlockPanelEditor"
+msgid "btn-add"
+msgstr "追加"
+
+#: crates/adapter-gui/ui/pages/block_panel_editor.slint:323
+msgctxt "BlockPanelEditor"
+msgid "–"
+msgstr "–"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:195
+msgctxt "ChainEditorPage"
+msgid "instrument-guitar"
+msgstr "ギター"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:196
+msgctxt "ChainEditorPage"
+msgid "instrument-acoustic-guitar"
+msgstr "アコースティックギター"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:197
+msgctxt "ChainEditorPage"
+msgid "instrument-bass"
+msgstr "ベース"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:198
+msgctxt "ChainEditorPage"
+msgid "instrument-voice"
+msgstr "ボーカル"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:199
+msgctxt "ChainEditorPage"
+msgid "instrument-keyboard"
+msgstr "キーボード"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:200
+msgctxt "ChainEditorPage"
+msgid "instrument-drums"
+msgstr "ドラム"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:201
+msgctxt "ChainEditorPage"
+msgid "instrument-other"
+msgstr "その他"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:221
+msgctxt "ChainEditorPage"
+msgid "title-new-chain"
+msgstr "新しいチェーン"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:221
+msgctxt "ChainEditorPage"
+msgid "title-configure-chain"
+msgstr "チェーンを構成"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:240
+msgctxt "ChainEditorPage"
+msgid "label-name"
+msgstr "名前"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:267
+msgctxt "ChainEditorPage"
+msgid "label-instrument"
+msgstr "楽器"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:345
+msgctxt "ChainEditorPage"
+msgid "title-section-inputs"
+msgstr "入力"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:371
+msgctxt "ChainEditorPage"
+msgid "btn-add-input"
+msgstr "+ 入力を追加"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:390
+msgctxt "ChainEditorPage"
+msgid "title-section-outputs"
+msgstr "出力"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:416
+msgctxt "ChainEditorPage"
+msgid "btn-add-output"
+msgstr "+ 出力を追加"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:443
+msgctxt "ChainEditorPage"
+msgid "btn-cancel"
+msgstr "キャンセル"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:450
+msgctxt "ChainEditorPage"
+msgid "btn-create-chain"
+msgstr "チェーンを作成"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:450
+msgctxt "ChainEditorPage"
+msgid "btn-save-chain"
+msgstr "チェーンを保存"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:66
+msgctxt "ChannelRow"
+msgid "✓"
+msgstr "✓"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:140
+msgctxt "ChainEndpointEditorPage"
+msgid "label-device"
+msgstr "デバイス"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:170
+msgctxt "ChainEndpointEditorPage"
+msgid "label-mode"
+msgstr "モード"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:229
+msgctxt "ChainEndpointEditorPage"
+msgid "label-channels"
+msgstr "チャンネル"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:268
+msgctxt "ChainEndpointEditorPage"
+msgid "btn-cancel"
+msgstr "キャンセル"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:275
+msgctxt "ChainEndpointEditorPage"
+msgid "btn-ok"
+msgstr "確認"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:99
+msgctxt "ChainInsertEditorPage"
+msgid "title-section-configure-insert"
+msgstr "Insertを構成"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:214
+msgctxt "ChainInsertEditorPage"
+msgid "label-send"
+msgstr "センド"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:225
+msgctxt "ChainInsertEditorPage"
+msgid "label-device"
+msgstr "デバイス"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:247
+msgctxt "ChainInsertEditorPage"
+msgid "label-mode"
+msgstr "モード"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:299
+msgctxt "ChainInsertEditorPage"
+msgid "label-channels"
+msgstr "チャンネル"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:344
+msgctxt "ChainInsertEditorPage"
+msgid "label-return"
+msgstr "リターン"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:469
+msgctxt "ChainInsertEditorPage"
+msgid "btn-cancel"
+msgstr "キャンセル"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:476
+msgctxt "ChainInsertEditorPage"
+msgid "btn-ok"
+msgstr "確認"
+
+#: crates/adapter-gui/ui/pages/chain_io_groups.slint:304
+msgctxt "ChainIoGroupsPage"
+msgid "btn-cancel"
+msgstr "キャンセル"
+
+#: crates/adapter-gui/ui/pages/chain_io_groups.slint:311
+msgctxt "ChainIoGroupsPage"
+msgid "btn-ok"
+msgstr "確認"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:246
+msgctxt "ChainRow"
+msgid "tooltip-expand-blocks"
+msgstr "ブロックを展開"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:254
+msgctxt "ChainRow"
+msgid "tooltip-measure-latency"
+msgstr "レイテンシ計測（ビープ音が鳴ります）"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:283
+msgctxt "ChainRow"
+msgid "tooltip-configure"
+msgstr "設定"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:291
+msgctxt "ChainRow"
+msgid "tooltip-delete"
+msgstr "削除"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:564
+msgctxt "ChainRow"
+msgid "label-lat"
+msgstr "LAT"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:613
+msgctxt "ChainRow"
+msgid "label-input"
+msgstr "入力"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:659
+msgctxt "ChainRow"
+msgid "label-output"
+msgstr "出力"
+
+#: crates/adapter-gui/ui/pages/compact_block_row.slint:415
+msgctxt "CompactBlockRow"
+msgid "▼"
+msgstr "▼"
+
+#: crates/adapter-gui/ui/pages/compact_block_row.slint:493
+msgctxt "CompactBlockRow"
+msgid "btn-open-plugin"
+msgstr "プラグインを開く"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:160
+msgctxt "CompactChainViewPage"
+msgid "tooltip-measure-latency"
+msgstr "レイテンシ計測（ビープ音が鳴ります）"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:187
+msgctxt "CompactChainViewPage"
+msgid "label-lat"
+msgstr "LAT"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:216
+msgctxt "CompactChainViewPage"
+msgid "tooltip-configure"
+msgstr "設定"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:230
+msgctxt "CompactChainViewPage"
+msgid "label-in"
+msgstr "IN"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:251
+msgctxt "CompactChainViewPage"
+msgid "label-out"
+msgstr "OUT"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:267
+msgctxt "CompactChainViewPage"
+msgid "tooltip-delete"
+msgstr "削除"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:313
+msgctxt "CompactChainViewPage"
+msgid "+"
+msgstr "+"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:87
+msgctxt "PluginInfoPanel"
+msgid "·"
+msgstr "·"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:125
+msgctxt "PluginInfoPanel"
+msgid "label-description"
+msgstr "Description"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:144
+msgctxt "PluginInfoPanel"
+msgid "label-license"
+msgstr "License:"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:171
+msgctxt "PluginInfoPanel"
+msgid "↗"
+msgstr "↗"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:177
+msgctxt "PluginInfoPanel"
+msgid "btn-open-homepage"
+msgstr "Open Homepage"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:145
+msgctxt "ProjectChainsPage"
+msgid "tooltip-back"
+msgstr "戻る"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:153
+msgctxt "ProjectChainsPage"
+msgid "tooltip-spectrum"
+msgstr "Spectrum"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:161
+msgctxt "ProjectChainsPage"
+msgid "tooltip-tuner"
+msgstr "Tuner"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:169
+msgctxt "ProjectChainsPage"
+msgid "tooltip-project-settings"
+msgstr "プロジェクト"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:178
+msgctxt "ProjectChainsPage"
+msgid "tooltip-save"
+msgstr "保存"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:186
+msgctxt "ProjectChainsPage"
+msgid "tooltip-new-chain"
+msgstr "新しい チェーン"
+
+#: crates/adapter-gui/ui/pages/project_launcher.slint:184
+msgctxt "SearchField"
+msgid "placeholder-search-projects"
+msgstr "プロジェクトを検索"
+
+#: crates/adapter-gui/ui/pages/project_launcher.slint:287
+msgctxt "ProjectLauncherPage"
+msgid "tooltip-open-project"
+msgstr "プロジェクトを開く"
+
+#: crates/adapter-gui/ui/pages/project_launcher.slint:294
+msgctxt "ProjectLauncherPage"
+msgid "btn-new-project"
+msgstr "新規プロジェクト"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:55
+msgctxt "NameInput"
+msgid "placeholder-project-name-example"
+msgstr "例: ライブギター"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:151
+msgctxt "ProjectSetupPage"
+msgid "title-new-project"
+msgstr "新規プロジェクト"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:164
+msgctxt "ProjectSetupPage"
+msgid "label-project-name"
+msgstr "プロジェクト名"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:204
+msgctxt "ProjectSetupPage"
+msgid "btn-cancel"
+msgstr "キャンセル"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:211
+msgctxt "ProjectSetupPage"
+msgid "btn-create-project"
+msgstr "プロジェクトを作成"
+
+#: crates/adapter-gui/ui/pages/settings.slint:170
+msgctxt "SettingsPage"
+msgid "nav-group-system"
+msgstr "システム"
+
+#: crates/adapter-gui/ui/pages/settings.slint:181
+msgctxt "SettingsPage"
+msgid "title-section-audio-interface"
+msgstr "オーディオインターフェース"
+
+#: crates/adapter-gui/ui/pages/settings.slint:186
+msgctxt "SettingsPage"
+msgid "title-section-language"
+msgstr "言語"
+
+#: crates/adapter-gui/ui/pages/settings.slint:191
+msgctxt "SettingsPage"
+msgid "title-section-midi-devices"
+msgstr "MIDIデバイス"
+
+#: crates/adapter-gui/ui/pages/settings.slint:196
+msgctxt "SettingsPage"
+msgid "title-section-paths"
+msgstr "パス"
+
+#: crates/adapter-gui/ui/pages/settings.slint:201
+msgctxt "SettingsPage"
 msgid "title-section-integrations"
 msgstr "連携"
 
+#: crates/adapter-gui/ui/pages/settings.slint:216
+msgctxt "SettingsPage"
+msgid "nav-group-project"
+msgstr "プロジェクト"
+
+#: crates/adapter-gui/ui/pages/settings.slint:227
+msgctxt "SettingsPage"
+msgid "title-section-project-meta"
+msgstr "メタデータ"
+
+#: crates/adapter-gui/ui/pages/settings.slint:335
+msgctxt "SettingsPage"
+msgid "btn-save-audio-settings"
+msgstr "適用"
+
+#: crates/adapter-gui/ui/pages/settings.slint:339
+msgctxt "SettingsPage"
+msgid "btn-close"
+msgstr "閉じる"
+
+#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint:27
+msgctxt "SectionProjectMeta"
+msgid "label-name"
+msgstr "名前"
+
+#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint:58
+msgctxt "SectionProjectMeta"
+msgid "label-file"
+msgstr "ファイル"
+
+#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint:66
+msgctxt "SectionProjectMeta"
+msgid "placeholder-project-unsaved"
+msgstr "(未保存)"
+
+#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint:83
+msgctxt "SectionProjectMeta"
+msgid "btn-save-project"
+msgstr "プロジェクトを保存"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_audio.slint:95
+msgctxt "AudioDeviceRow"
+msgid "label-hz"
+msgstr "Hz"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_audio.slint:118
+msgctxt "AudioDeviceRow"
+msgid "label-buffer"
+msgstr "Buffer"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_audio.slint:141
+msgctxt "AudioDeviceRow"
+msgid "label-bits"
+msgstr "Bits"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:39
+msgctxt "SectionSystemIntegrations"
 msgid "label-midi-enabled"
 msgstr "MIDIコントロール"
 
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:45
+msgctxt "SectionSystemIntegrations"
 msgid "desc-midi-enabled"
 msgstr "MIDI/BLE-MIDIアダプターを有効にしてフットスイッチでOpenRigを操作"
 
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:93
+msgctxt "SectionSystemIntegrations"
 msgid "label-mcp-enabled"
 msgstr "MCPサーバー"
 
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:99
+msgctxt "SectionSystemIntegrations"
 msgid "desc-mcp-enabled"
 msgstr "エージェント向けにMCPサーバーを127.0.0.1:4123で公開"
 
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:134
+msgctxt "SectionSystemIntegrations"
 msgid "hint-restart-to-apply"
 msgstr "次回の起動時に有効になります。"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_language.slint:25
+msgctxt "SectionSystemLanguage"
+msgid "label-language"
+msgstr "言語"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:49
+msgctxt "SectionSystemPaths"
+msgid "label-presets-path"
+msgstr "プリセットフォルダ"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:57
+msgctxt "SectionSystemPaths"
+msgid "placeholder-default-path"
+msgstr "(デフォルト)"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:66
+msgctxt "SectionSystemPaths"
+msgid "btn-choose-path"
+msgstr "選択…"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:70
+msgctxt "SectionSystemPaths"
+msgid "btn-reset-path"
+msgstr "リセット"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:81
+msgctxt "SectionSystemPaths"
+msgid "label-plugins-path"
+msgstr "プラグインフォルダ"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:113
+msgctxt "SectionSystemPaths"
+msgid "label-evaluations-path"
+msgstr "評価フォルダ"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:145
+msgctxt "SectionSystemPaths"
+msgid "label-plugin-catalog"
+msgstr "プラグインカタログ"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:153
+msgctxt "SectionSystemPaths"
+msgid "status-plugin-catalog-idle"
+msgstr "まだ再読み込みされていません"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:162
+msgctxt "SectionSystemPaths"
+msgid "btn-reload-plugin-catalog"
+msgstr "再読み込み"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:73
+msgctxt "SpectrumCard"
+msgid "—"
+msgstr "—"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:127
+msgctxt "SpectrumCard"
+msgid "20"
+msgstr "20"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:133
+msgctxt "SpectrumCard"
+msgid "100"
+msgstr "100"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:139
+msgctxt "SpectrumCard"
+msgid "1k"
+msgstr "1k"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:145
+msgctxt "SpectrumCard"
+msgid "10k"
+msgstr "10k"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:151
+msgctxt "SpectrumCard"
+msgid "20k"
+msgstr "20k"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:199
+msgctxt "SpectrumPanel"
+msgid "label-spectrum"
+msgstr "SPECTRUM"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:241
+msgctxt "SpectrumPanel"
+msgid "status-no-active-outputs"
+msgstr "NO ACTIVE OUTPUTS"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:251
+msgctxt "SpectrumPanel"
+msgid "status-spectrum-empty-help"
+msgstr "スペクトラムをオンにして、出力が設定されたチェーンを有効にしてください。"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:279
+msgctxt "SpectrumWindow"
+msgid "title-window-spectrum"
+msgstr "OpenRig · Spectrum"
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:54
+msgctxt "MuteSwitch"
+msgid "label-mute"
+msgstr "MUTE"
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:316
+msgctxt "TunerPanel"
+msgid "label-tuner"
+msgstr "TUNER"
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:368
+msgctxt "TunerPanel"
+msgid "status-no-active-inputs"
+msgstr "NO ACTIVE INPUTS"
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:378
+msgctxt "TunerPanel"
+msgid "status-tuner-empty-help"
+msgstr "入力が設定されたチェーンを有効にすると、ここにチューナーが表示されます。"
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:406
+msgctxt "TunerWindow"
+msgid "title-window-tuner"
+msgstr "OpenRig · Tuner"
+
+#: crates/adapter-gui/ui/secondary_windows_block.slint:30
+msgctxt "BlockEditorWindow"
+msgid "title-window-block-editor"
+msgstr "OpenRig · Block"
+
+#: crates/adapter-gui/ui/secondary_windows_block.slint:231
+msgctxt "CompactChainViewWindow"
+msgid "title-window-chain-view"
+msgstr "OpenRig · チェーン"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:60
+msgctxt "ProjectSettingsWindow"
+msgid "title-window-project-settings"
+msgstr "OpenRig · プロジェクトを構成"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:159
+msgctxt "ChainEditorWindow"
+msgid "title-window-chain-editor"
+msgstr "OpenRig · チェーンを構成"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:192
+msgctxt "ChainEditorWindow"
+msgid "title-section-input"
+msgstr "入力"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:210
+msgctxt "ChainEditorWindow"
+msgid "title-section-output"
+msgstr "出力"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:240
+msgctxt "ChainInputWindow"
+msgid "title-window-chain-input"
+msgstr "OpenRig · チェーン入力"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:250
+msgctxt "ChainInputWindow"
+msgid "title-section-input"
+msgstr "入力"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:280
+msgctxt "ChainOutputWindow"
+msgid "title-window-chain-output"
+msgstr "OpenRig · チェーン出力"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:290
+msgctxt "ChainOutputWindow"
+msgid "title-section-output"
+msgstr "出力"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:321
+msgctxt "ChainInputGroupsWindow"
+msgid "title-window-chain-inputs"
+msgstr "OpenRig · チェーン入力"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:331
+msgctxt "ChainInputGroupsWindow"
+msgid "title-section-inputs"
+msgstr "入力"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:332
+msgctxt "ChainInputGroupsWindow"
+msgid "btn-add-input-row"
+msgstr "+ 入力を追加"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:362
+msgctxt "ChainOutputGroupsWindow"
+msgid "title-window-chain-outputs"
+msgstr "OpenRig · チェーン出力"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:372
+msgctxt "ChainOutputGroupsWindow"
+msgid "title-section-outputs"
+msgstr "出力"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:373
+msgctxt "ChainOutputGroupsWindow"
+msgid "btn-add-output-row"
+msgstr "+ 出力を追加"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:418
+msgctxt "ChainInsertWindow"
+msgid "title-window-chain-insert"
+msgstr "OpenRig · Insertを構成"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:428
+msgctxt "ChainInsertWindow"
+msgid "title-section-configure-insert"
+msgstr "Insertを構成"
+
+#: crates/adapter-gui/ui/touch_main.slint:667
+msgctxt "TouchMain"
+msgid "⌨"
+msgstr "⌨"

--- a/crates/adapter-gui/translations/ko_KR/LC_MESSAGES/adapter-gui.po
+++ b/crates/adapter-gui/translations/ko_KR/LC_MESSAGES/adapter-gui.po
@@ -12,571 +12,939 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #: crates/adapter-gui/ui/blocks/header.slint:13
+msgctxt "Header"
 msgid "OpenRig"
 msgstr "OpenRig"
 
 #: crates/adapter-gui/ui/components/block_panel_parameter_item.slint:274
+msgctxt "BlockPanelParameterItem"
 msgid "btn-load-file"
 msgstr "Load"
 
 #: crates/adapter-gui/ui/components/block_stream_mini_display.slint:23
+msgctxt "BlockStreamMiniDisplay"
 msgid "–"
 msgstr "–"
 
 #: crates/adapter-gui/ui/components/block_value_widgets.slint:128
+msgctxt "BlockValueStepper"
 msgid "−"
 msgstr "−"
 
 #: crates/adapter-gui/ui/components/block_value_widgets.slint:194
+msgctxt "BlockValueStepper"
 msgid "+"
 msgstr "+"
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:87
-msgid "Preset selector"
-msgstr ""
+#: crates/adapter-gui/ui/components/chain_di_loop_button.slint:61
+msgctxt "ChainDiLoopButton"
+msgid "di-loop-button-label"
+msgstr "DI 루프"
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:170
+#: crates/adapter-gui/ui/components/chain_di_loop_button.slint:138
+msgctxt "ChainDiLoopButton"
+msgid "di-loop-stop-label"
+msgstr "DI 루프 정지"
+
+#: crates/adapter-gui/ui/components/chain_di_loop_button.slint:138
+msgctxt "ChainDiLoopButton"
+msgid "di-loop-play-label"
+msgstr "DI 루프 재생"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:77
+msgctxt "SceneBtn"
 msgid "Scene {}"
 msgstr ""
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:192
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:99
+msgctxt "SceneBar"
 msgid "Add scene"
 msgstr ""
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:201
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:108
+msgctxt "SceneBar"
 msgid "Remove last scene"
 msgstr ""
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:258
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:183
+msgctxt "ChainTitlePreset"
+msgid "tooltip-open-preset"
+msgstr "프리셋 열기"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:193
+msgctxt "ChainTitlePreset"
+msgid "tooltip-save-preset"
+msgstr "프리셋 저장"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:203
+msgctxt "ChainTitlePreset"
 msgid "Add preset"
 msgstr ""
 
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:213
+msgctxt "ChainTitlePreset"
+msgid "Rename preset"
+msgstr "프리셋 이름 변경"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:224
+msgctxt "ChainTitlePreset"
+msgid "Remove preset"
+msgstr "프리셋 제거"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:316
+msgctxt "ChainTitlePreset"
+msgid "Cancel"
+msgstr "취소"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:337
+msgctxt "ChainTitlePreset"
+msgid "OK"
+msgstr "확인"
+
 #: crates/adapter-gui/ui/components/chain_volume_button.slint:37
+msgctxt "ChainVolumeButton"
 msgid "Volume"
 msgstr ""
 
+#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:29
+msgctxt "ConfirmDeleteChainDialog"
+msgid "title-dialog-delete-chain"
+msgstr "체인 삭제"
+
+#. text directly.
+#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:39
+msgctxt "ConfirmDeleteChainDialog"
+msgid "Excluir a chain \"{}\"?"
+msgstr "체인 \"{}\"을(를) 삭제하시겠습니까?"
+
+#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:58
+msgctxt "ConfirmDeleteChainDialog"
+msgid "btn-cancel"
+msgstr "취소"
+
+#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:75
+msgctxt "ConfirmDeleteChainDialog"
+msgid "btn-delete"
+msgstr "삭제"
+
 #: crates/adapter-gui/ui/components/confirm_delete_dialog.slint:27
+msgctxt "ConfirmDeleteBlockDialog"
 msgid "title-dialog-delete-block"
 msgstr "블록 삭제"
 
 #. pt-BR source string with the placeholder.
 #: crates/adapter-gui/ui/components/confirm_delete_dialog.slint:36
+msgctxt "ConfirmDeleteBlockDialog"
 msgid "Excluir \"{}\"?"
 msgstr "\"{}\" 삭제하시겠습니까?"
 
 #: crates/adapter-gui/ui/components/confirm_delete_dialog.slint:55
+msgctxt "ConfirmDeleteBlockDialog"
 msgid "btn-cancel"
 msgstr "취소"
 
 #: crates/adapter-gui/ui/components/confirm_delete_dialog.slint:72
+msgctxt "ConfirmDeleteBlockDialog"
 msgid "btn-delete"
 msgstr "삭제"
 
-#: crates/adapter-gui/ui/components/language_selector.slint:56
-msgid "accessible-language-selector"
-msgstr "언어 선택기"
-
-#: crates/adapter-gui/ui/components/model_select_with_search.slint:93
-msgid "▼"
-msgstr "▼"
-
-#: crates/adapter-gui/ui/components/model_select_with_search.slint:175
-msgid "placeholder-search-models"
-msgstr "모델 검색..."
-
-#: crates/adapter-gui/ui/components/preset_select.slint:170
-msgid "status-no-presets-found"
-msgstr "프리셋을 찾을 수 없음"
-
-#: crates/adapter-gui/ui/components/model_select_with_search.slint:209
-msgid "status-no-models-found"
-msgstr "모델을 찾을 수 없음"
-
-#: crates/adapter-gui/ui/components/preset_picker_overlay.slint:32
-msgid "btn-load-preset"
-msgstr "프리셋 불러오기"
-
-#: crates/adapter-gui/ui/pages/block_editor_panel.slint:122
-msgid "tooltip-delete"
-msgstr "삭제"
-
-#: crates/adapter-gui/ui/pages/block_panel_editor.slint:36
-msgid "btn-add"
-msgstr "추가"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:195
-msgid "instrument-guitar"
-msgstr "기타"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:196
-msgid "instrument-acoustic-guitar"
-msgstr "어쿠스틱 기타"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:197
-msgid "instrument-bass"
-msgstr "베이스"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:198
-msgid "instrument-voice"
-msgstr "보컬"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:199
-msgid "instrument-keyboard"
-msgstr "키보드"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:200
-msgid "instrument-drums"
-msgstr "드럼"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:201
-msgid "instrument-other"
-msgstr "기타 악기"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:221
-msgid "title-new-chain"
-msgstr "새 체인"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:221
-msgid "title-configure-chain"
-msgstr "체인 구성"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:240
-msgid "label-name"
-msgstr "이름"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:267
-msgid "label-instrument"
-msgstr "악기"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:345
-msgid "title-section-inputs"
-msgstr "입력"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:371
-msgid "btn-add-input"
-msgstr "+ 입력 추가"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:390
-msgid "title-section-outputs"
-msgstr "출력"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:416
-msgid "btn-add-output"
-msgstr "+ 출력 추가"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:450
-msgid "btn-create-chain"
-msgstr "체인 만들기"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:450
-msgid "btn-save-chain"
-msgstr "체인 저장"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:66
-msgid "✓"
-msgstr "✓"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:140
-msgid "label-device"
-msgstr "장치"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:170
-msgid "label-mode"
-msgstr "모드"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:229
-msgid "label-channels"
-msgstr "채널"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:275
-msgid "btn-ok"
-msgstr "확인"
-
-#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:99
-msgid "title-section-configure-insert"
-msgstr "Insert 구성"
-
-#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:214
-msgid "label-send"
-msgstr "센드"
-
-#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:344
-msgid "label-return"
-msgstr "리턴"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:140
-msgid "tooltip-expand-blocks"
-msgstr "블록 확장"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:148
-msgid "tooltip-measure-latency"
-msgstr "지연시간 측정 (삑 소리가 납니다)"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:177
-msgid "tooltip-configure"
-msgstr "구성"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:185
-msgid "tooltip-open-preset"
-msgstr "프리셋 열기"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:193
-msgid "tooltip-save-preset"
-msgstr "프리셋 저장"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:472
-msgid "label-lat"
-msgstr "LAT"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:521
-msgid "label-input"
-msgstr "입력"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:567
-msgid "label-output"
-msgstr "출력"
-
-#: crates/adapter-gui/ui/pages/compact_block_row.slint:493
-msgid "btn-open-plugin"
-msgstr "플러그인 열기"
-
-#: crates/adapter-gui/ui/pages/compact_chain_view.slint:83
-msgid "label-in"
-msgstr "IN"
-
-#: crates/adapter-gui/ui/pages/compact_chain_view.slint:111
-msgid "label-out"
-msgstr "OUT"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:87
-msgid "·"
-msgstr "·"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:123
-msgid "label-description"
-msgstr "Description"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:142
-msgid "label-license"
-msgstr "License:"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:169
-msgid "↗"
-msgstr "↗"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:175
-msgid "btn-open-homepage"
-msgstr "Open Homepage"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:136
-msgid "tooltip-back"
-msgstr "뒤로"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:144
-msgid "tooltip-spectrum"
-msgstr "Spectrum"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:152
-msgid "tooltip-tuner"
-msgstr "Tuner"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:160
-msgid "tooltip-project-settings"
-msgstr "프로젝트"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:169
-msgid "tooltip-save"
-msgstr "저장"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:177
-msgid "tooltip-new-chain"
-msgstr "새 체인"
-
-#: crates/adapter-gui/ui/pages/project_launcher.slint:185
-msgid "placeholder-search-projects"
-msgstr "프로젝트 검색"
-
-#: crates/adapter-gui/ui/pages/project_launcher.slint:288
-msgid "tooltip-open-project"
-msgstr "프로젝트 열기"
-
-#: crates/adapter-gui/ui/pages/project_launcher.slint:295
-msgid "btn-new-project"
-msgstr "새 프로젝트"
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:147
-msgid "label-hz"
-msgstr "Hz"
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:170
-msgid "label-buffer"
-msgstr "Buffer"
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:193
-msgid "label-bits"
-msgstr "Bits"
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:271
-msgid "title-section-audio-devices"
-msgstr "오디오 장치"
-
-#: crates/adapter-gui/ui/pages/project_setup.slint:55
-msgid "placeholder-project-name-example"
-msgstr "예: 라이브 기타"
-
-#: crates/adapter-gui/ui/pages/project_setup.slint:151
-msgid "title-new-project"
-msgstr "새 프로젝트"
-
-#: crates/adapter-gui/ui/pages/project_setup.slint:164
-msgid "label-project-name"
-msgstr "프로젝트 이름"
-
-#: crates/adapter-gui/ui/pages/project_setup.slint:211
-msgid "btn-create-project"
-msgstr "프로젝트 만들기"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:73
-msgid "—"
-msgstr "—"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:127
-msgid "20"
-msgstr "20"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:133
-msgid "100"
-msgstr "100"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:139
-msgid "1k"
-msgstr "1k"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:145
-msgid "10k"
-msgstr "10k"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:151
-msgid "20k"
-msgstr "20k"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:199
-msgid "label-spectrum"
-msgstr "SPECTRUM"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:241
-msgid "status-no-active-outputs"
-msgstr "NO ACTIVE OUTPUTS"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:251
-msgid "status-spectrum-empty-help"
-msgstr "스펙트럼을 켜고 출력이 구성된 체인을 활성화하세요."
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:279
-msgid "title-window-spectrum"
-msgstr "OpenRig · Spectrum"
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:54
-msgid "label-mute"
-msgstr "MUTE"
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:316
-msgid "label-tuner"
-msgstr "TUNER"
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:368
-msgid "status-no-active-inputs"
-msgstr "NO ACTIVE INPUTS"
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:378
-msgid "status-tuner-empty-help"
-msgstr "입력이 구성된 체인을 활성화하면 여기에 튜너가 표시됩니다."
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:406
-msgid "title-window-tuner"
-msgstr "OpenRig · Tuner"
-
-#: crates/adapter-gui/ui/secondary_windows_block.slint:28
-msgid "title-window-block-editor"
-msgstr "OpenRig · Block"
-
-#: crates/adapter-gui/ui/secondary_windows_block.slint:195
-msgid "title-window-chain-view"
-msgstr "OpenRig · 체인"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:23
-msgid "title-window-project-settings"
-msgstr "OpenRig · 프로젝트 구성"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:96
-msgid "title-window-chain-editor"
-msgstr "OpenRig · 체인 구성"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:129
-msgid "title-section-input"
-msgstr "입력"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:147
-msgid "title-section-output"
-msgstr "출력"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:177
-msgid "title-window-chain-input"
-msgstr "OpenRig · 체인 입력"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:217
-msgid "title-window-chain-output"
-msgstr "OpenRig · 체인 출력"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:258
-msgid "title-window-chain-inputs"
-msgstr "OpenRig · 체인 입력"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:269
-msgid "btn-add-input-row"
-msgstr "+ 입력 추가"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:299
-msgid "title-window-chain-outputs"
-msgstr "OpenRig · 체인 출력"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:310
-msgid "btn-add-output-row"
-msgstr "+ 출력 추가"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:355
-msgid "title-window-chain-insert"
-msgstr "OpenRig · Insert 구성"
-
-#: crates/adapter-gui/ui/touch_main.slint:586
-msgid "⌨"
-msgstr "⌨"
-
-#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:27
-msgid "title-dialog-delete-chain"
-msgstr "체인 삭제"
-
-#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:37
-msgid "Excluir a chain \"{}\"?"
-msgstr "체인 \"{}\"을(를) 삭제하시겠습니까?"
-
-#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:31
+#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:30
+msgctxt "ConfirmDeleteRecentProjectDialog"
 msgid "title-dialog-delete-recent-project"
 msgstr "최근에서 제거"
 
-#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:41
+#. Literal pt-BR source string with `{}` placeholder.
+#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:38
+msgctxt "ConfirmDeleteRecentProjectDialog"
 msgid "Remover o projeto \"{}\" dos recentes?"
 msgstr "프로젝트 \"{}\" 을(를) 최근에서 제거하시겠습니까?"
 
-#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:75
+#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:57
+msgctxt "ConfirmDeleteRecentProjectDialog"
+msgid "btn-cancel"
+msgstr "취소"
+
+#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:74
+msgctxt "ConfirmDeleteRecentProjectDialog"
 msgid "btn-remove"
 msgstr "제거"
 
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "tab-system"
-msgstr ""
+#: crates/adapter-gui/ui/components/language_selector.slint:56
+msgctxt "LanguageSelector"
+msgid "accessible-language-selector"
+msgstr "언어 선택기"
 
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "tab-project"
-msgstr ""
+#: crates/adapter-gui/ui/components/model_select_with_search.slint:96
+msgctxt "ModelSelectWithSearch"
+msgid "▼"
+msgstr "▼"
 
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "btn-close"
-msgstr ""
+#: crates/adapter-gui/ui/components/model_select_with_search.slint:178
+msgctxt "ModelSelectWithSearch"
+msgid "placeholder-search-models"
+msgstr "모델 검색..."
 
-#: crates/adapter-gui/ui/components/settings_section.slint
-msgid "badge-system"
-msgstr ""
+#: crates/adapter-gui/ui/components/model_select_with_search.slint:212
+msgctxt "ModelSelectWithSearch"
+msgid "status-no-models-found"
+msgstr "모델을 찾을 수 없음"
 
-#: crates/adapter-gui/ui/components/settings_section.slint
-msgid "badge-project"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_system_audio.slint
-msgid "title-section-audio-interface"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_system_language.slint
-msgid "title-section-language"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_system_midi_devices.slint
-msgid "title-section-midi-devices"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint
-msgid "title-section-project-meta"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint
-msgid "label-file"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_project_midi_mapping.slint
-msgid "title-section-midi-mapping"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_project_midi_mapping.slint
-msgid "btn-add-midi-binding"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_project_midi_mapping.slint
-msgid "empty-midi-mapping-explain"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_project_midi_mapping.slint
-msgid "placeholder-midi-listen"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "nav-group-system"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "nav-group-project"
-msgstr ""
+#: crates/adapter-gui/ui/components/preset_picker_overlay.slint:34
+msgctxt "PresetPickerOverlay"
+msgid "btn-load-preset"
+msgstr "프리셋 불러오기"
 
 #: crates/adapter-gui/ui/components/preset_picker_overlay.slint:40
+msgctxt "PresetPickerOverlay"
 msgid "preset-search-placeholder"
 msgstr "프리셋 검색…"
 
+#: crates/adapter-gui/ui/components/preset_picker_overlay.slint:106
+msgctxt "PresetPickerOverlay"
+msgid "btn-cancel"
+msgstr "취소"
+
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:38
+msgctxt "PresetSaveOverlay"
 msgid "title-dialog-save-preset"
 msgstr "프리셋 저장"
 
+#: crates/adapter-gui/ui/components/preset_save_overlay.slint:63
+msgctxt "PresetSaveOverlay"
+msgid "btn-cancel"
+msgstr "취소"
+
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:82
+msgctxt "PresetSaveOverlay"
 msgid "btn-save"
 msgstr "저장"
 
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:119
+msgctxt "PresetOverwriteOverlay"
 msgid "title-dialog-overwrite-preset"
 msgstr "프리셋을 덮어쓸까요?"
 
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:126
+msgctxt "PresetOverwriteOverlay"
 msgid "msg-overwrite-preset"
 msgstr "\"{}\"라는 프리셋이 이미 존재합니다. 덮어쓸까요?"
 
+#: crates/adapter-gui/ui/components/preset_save_overlay.slint:145
+msgctxt "PresetOverwriteOverlay"
+msgid "btn-cancel"
+msgstr "취소"
+
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:162
+msgctxt "PresetOverwriteOverlay"
 msgid "btn-overwrite"
 msgstr "덮어쓰기"
 
-msgid "btn-save-audio-settings"
+#: crates/adapter-gui/ui/components/preset_select.slint:72
+msgctxt "PresetSelect"
+msgid "Preset selector"
 msgstr ""
 
+#: crates/adapter-gui/ui/components/preset_select.slint:137
+msgctxt "PresetSelect"
+msgid "preset-search-placeholder"
+msgstr "프리셋 검색…"
+
+#: crates/adapter-gui/ui/components/preset_select.slint:170
+msgctxt "PresetSelect"
+msgid "status-no-presets-found"
+msgstr "프리셋을 찾을 수 없음"
+
+#: crates/adapter-gui/ui/pages/block_editor_panel.slint:122
+msgctxt "BlockEditorPanel"
+msgid "tooltip-delete"
+msgstr "삭제"
+
+#: crates/adapter-gui/ui/pages/block_editor_panel.slint:243
+msgctxt "BlockEditorPanel"
+msgid "–"
+msgstr "–"
+
+#: crates/adapter-gui/ui/pages/block_panel_editor.slint:37
+msgctxt "BlockPanelEditor"
+msgid "btn-add"
+msgstr "추가"
+
+#: crates/adapter-gui/ui/pages/block_panel_editor.slint:323
+msgctxt "BlockPanelEditor"
+msgid "–"
+msgstr "–"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:195
+msgctxt "ChainEditorPage"
+msgid "instrument-guitar"
+msgstr "기타"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:196
+msgctxt "ChainEditorPage"
+msgid "instrument-acoustic-guitar"
+msgstr "어쿠스틱 기타"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:197
+msgctxt "ChainEditorPage"
+msgid "instrument-bass"
+msgstr "베이스"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:198
+msgctxt "ChainEditorPage"
+msgid "instrument-voice"
+msgstr "보컬"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:199
+msgctxt "ChainEditorPage"
+msgid "instrument-keyboard"
+msgstr "키보드"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:200
+msgctxt "ChainEditorPage"
+msgid "instrument-drums"
+msgstr "드럼"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:201
+msgctxt "ChainEditorPage"
+msgid "instrument-other"
+msgstr "기타 악기"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:221
+msgctxt "ChainEditorPage"
+msgid "title-new-chain"
+msgstr "새 체인"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:221
+msgctxt "ChainEditorPage"
+msgid "title-configure-chain"
+msgstr "체인 구성"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:240
+msgctxt "ChainEditorPage"
+msgid "label-name"
+msgstr "이름"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:267
+msgctxt "ChainEditorPage"
+msgid "label-instrument"
+msgstr "악기"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:345
+msgctxt "ChainEditorPage"
+msgid "title-section-inputs"
+msgstr "입력"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:371
+msgctxt "ChainEditorPage"
+msgid "btn-add-input"
+msgstr "+ 입력 추가"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:390
+msgctxt "ChainEditorPage"
+msgid "title-section-outputs"
+msgstr "출력"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:416
+msgctxt "ChainEditorPage"
+msgid "btn-add-output"
+msgstr "+ 출력 추가"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:443
+msgctxt "ChainEditorPage"
+msgid "btn-cancel"
+msgstr "취소"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:450
+msgctxt "ChainEditorPage"
+msgid "btn-create-chain"
+msgstr "체인 만들기"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:450
+msgctxt "ChainEditorPage"
+msgid "btn-save-chain"
+msgstr "체인 저장"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:66
+msgctxt "ChannelRow"
+msgid "✓"
+msgstr "✓"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:140
+msgctxt "ChainEndpointEditorPage"
+msgid "label-device"
+msgstr "장치"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:170
+msgctxt "ChainEndpointEditorPage"
+msgid "label-mode"
+msgstr "모드"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:229
+msgctxt "ChainEndpointEditorPage"
+msgid "label-channels"
+msgstr "채널"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:268
+msgctxt "ChainEndpointEditorPage"
+msgid "btn-cancel"
+msgstr "취소"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:275
+msgctxt "ChainEndpointEditorPage"
+msgid "btn-ok"
+msgstr "확인"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:99
+msgctxt "ChainInsertEditorPage"
+msgid "title-section-configure-insert"
+msgstr "Insert 구성"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:214
+msgctxt "ChainInsertEditorPage"
+msgid "label-send"
+msgstr "센드"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:225
+msgctxt "ChainInsertEditorPage"
+msgid "label-device"
+msgstr "장치"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:247
+msgctxt "ChainInsertEditorPage"
+msgid "label-mode"
+msgstr "모드"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:299
+msgctxt "ChainInsertEditorPage"
+msgid "label-channels"
+msgstr "채널"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:344
+msgctxt "ChainInsertEditorPage"
+msgid "label-return"
+msgstr "리턴"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:469
+msgctxt "ChainInsertEditorPage"
+msgid "btn-cancel"
+msgstr "취소"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:476
+msgctxt "ChainInsertEditorPage"
+msgid "btn-ok"
+msgstr "확인"
+
+#: crates/adapter-gui/ui/pages/chain_io_groups.slint:304
+msgctxt "ChainIoGroupsPage"
+msgid "btn-cancel"
+msgstr "취소"
+
+#: crates/adapter-gui/ui/pages/chain_io_groups.slint:311
+msgctxt "ChainIoGroupsPage"
+msgid "btn-ok"
+msgstr "확인"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:246
+msgctxt "ChainRow"
+msgid "tooltip-expand-blocks"
+msgstr "블록 확장"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:254
+msgctxt "ChainRow"
+msgid "tooltip-measure-latency"
+msgstr "지연시간 측정 (삑 소리가 납니다)"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:283
+msgctxt "ChainRow"
+msgid "tooltip-configure"
+msgstr "구성"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:291
+msgctxt "ChainRow"
+msgid "tooltip-delete"
+msgstr "삭제"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:564
+msgctxt "ChainRow"
+msgid "label-lat"
+msgstr "LAT"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:613
+msgctxt "ChainRow"
+msgid "label-input"
+msgstr "입력"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:659
+msgctxt "ChainRow"
+msgid "label-output"
+msgstr "출력"
+
+#: crates/adapter-gui/ui/pages/compact_block_row.slint:415
+msgctxt "CompactBlockRow"
+msgid "▼"
+msgstr "▼"
+
+#: crates/adapter-gui/ui/pages/compact_block_row.slint:493
+msgctxt "CompactBlockRow"
+msgid "btn-open-plugin"
+msgstr "플러그인 열기"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:160
+msgctxt "CompactChainViewPage"
+msgid "tooltip-measure-latency"
+msgstr "지연시간 측정 (삑 소리가 납니다)"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:187
+msgctxt "CompactChainViewPage"
+msgid "label-lat"
+msgstr "LAT"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:216
+msgctxt "CompactChainViewPage"
+msgid "tooltip-configure"
+msgstr "구성"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:230
+msgctxt "CompactChainViewPage"
+msgid "label-in"
+msgstr "IN"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:251
+msgctxt "CompactChainViewPage"
+msgid "label-out"
+msgstr "OUT"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:267
+msgctxt "CompactChainViewPage"
+msgid "tooltip-delete"
+msgstr "삭제"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:313
+msgctxt "CompactChainViewPage"
+msgid "+"
+msgstr "+"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:87
+msgctxt "PluginInfoPanel"
+msgid "·"
+msgstr "·"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:125
+msgctxt "PluginInfoPanel"
+msgid "label-description"
+msgstr "Description"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:144
+msgctxt "PluginInfoPanel"
+msgid "label-license"
+msgstr "License:"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:171
+msgctxt "PluginInfoPanel"
+msgid "↗"
+msgstr "↗"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:177
+msgctxt "PluginInfoPanel"
+msgid "btn-open-homepage"
+msgstr "Open Homepage"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:145
+msgctxt "ProjectChainsPage"
+msgid "tooltip-back"
+msgstr "뒤로"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:153
+msgctxt "ProjectChainsPage"
+msgid "tooltip-spectrum"
+msgstr "Spectrum"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:161
+msgctxt "ProjectChainsPage"
+msgid "tooltip-tuner"
+msgstr "Tuner"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:169
+msgctxt "ProjectChainsPage"
+msgid "tooltip-project-settings"
+msgstr "프로젝트"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:178
+msgctxt "ProjectChainsPage"
+msgid "tooltip-save"
+msgstr "저장"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:186
+msgctxt "ProjectChainsPage"
+msgid "tooltip-new-chain"
+msgstr "새 체인"
+
+#: crates/adapter-gui/ui/pages/project_launcher.slint:184
+msgctxt "SearchField"
+msgid "placeholder-search-projects"
+msgstr "프로젝트 검색"
+
+#: crates/adapter-gui/ui/pages/project_launcher.slint:287
+msgctxt "ProjectLauncherPage"
+msgid "tooltip-open-project"
+msgstr "프로젝트 열기"
+
+#: crates/adapter-gui/ui/pages/project_launcher.slint:294
+msgctxt "ProjectLauncherPage"
+msgid "btn-new-project"
+msgstr "새 프로젝트"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:55
+msgctxt "NameInput"
+msgid "placeholder-project-name-example"
+msgstr "예: 라이브 기타"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:151
+msgctxt "ProjectSetupPage"
+msgid "title-new-project"
+msgstr "새 프로젝트"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:164
+msgctxt "ProjectSetupPage"
+msgid "label-project-name"
+msgstr "프로젝트 이름"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:204
+msgctxt "ProjectSetupPage"
+msgid "btn-cancel"
+msgstr "취소"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:211
+msgctxt "ProjectSetupPage"
+msgid "btn-create-project"
+msgstr "프로젝트 만들기"
+
+#: crates/adapter-gui/ui/pages/settings.slint:170
+msgctxt "SettingsPage"
+msgid "nav-group-system"
+msgstr "시스템"
+
+#: crates/adapter-gui/ui/pages/settings.slint:181
+msgctxt "SettingsPage"
+msgid "title-section-audio-interface"
+msgstr "오디오 인터페이스"
+
+#: crates/adapter-gui/ui/pages/settings.slint:186
+msgctxt "SettingsPage"
+msgid "title-section-language"
+msgstr "언어"
+
+#: crates/adapter-gui/ui/pages/settings.slint:191
+msgctxt "SettingsPage"
+msgid "title-section-midi-devices"
+msgstr "MIDI 장치"
+
+#: crates/adapter-gui/ui/pages/settings.slint:196
+msgctxt "SettingsPage"
+msgid "title-section-paths"
+msgstr "경로"
+
+#: crates/adapter-gui/ui/pages/settings.slint:201
+msgctxt "SettingsPage"
 msgid "title-section-integrations"
 msgstr "통합"
 
+#: crates/adapter-gui/ui/pages/settings.slint:216
+msgctxt "SettingsPage"
+msgid "nav-group-project"
+msgstr "프로젝트"
+
+#: crates/adapter-gui/ui/pages/settings.slint:227
+msgctxt "SettingsPage"
+msgid "title-section-project-meta"
+msgstr "메타데이터"
+
+#: crates/adapter-gui/ui/pages/settings.slint:335
+msgctxt "SettingsPage"
+msgid "btn-save-audio-settings"
+msgstr "적용"
+
+#: crates/adapter-gui/ui/pages/settings.slint:339
+msgctxt "SettingsPage"
+msgid "btn-close"
+msgstr "닫기"
+
+#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint:27
+msgctxt "SectionProjectMeta"
+msgid "label-name"
+msgstr "이름"
+
+#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint:58
+msgctxt "SectionProjectMeta"
+msgid "label-file"
+msgstr "파일"
+
+#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint:66
+msgctxt "SectionProjectMeta"
+msgid "placeholder-project-unsaved"
+msgstr "(저장 안 됨)"
+
+#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint:83
+msgctxt "SectionProjectMeta"
+msgid "btn-save-project"
+msgstr "프로젝트 저장"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_audio.slint:95
+msgctxt "AudioDeviceRow"
+msgid "label-hz"
+msgstr "Hz"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_audio.slint:118
+msgctxt "AudioDeviceRow"
+msgid "label-buffer"
+msgstr "Buffer"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_audio.slint:141
+msgctxt "AudioDeviceRow"
+msgid "label-bits"
+msgstr "Bits"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:39
+msgctxt "SectionSystemIntegrations"
 msgid "label-midi-enabled"
 msgstr "MIDI 제어"
 
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:45
+msgctxt "SectionSystemIntegrations"
 msgid "desc-midi-enabled"
 msgstr "MIDI/BLE-MIDI 어댑터를 켜서 풋스위치로 OpenRig를 제어"
 
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:93
+msgctxt "SectionSystemIntegrations"
 msgid "label-mcp-enabled"
 msgstr "MCP 서버"
 
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:99
+msgctxt "SectionSystemIntegrations"
 msgid "desc-mcp-enabled"
 msgstr "에이전트용 MCP 서버를 127.0.0.1:4123에 노출"
 
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:134
+msgctxt "SectionSystemIntegrations"
 msgid "hint-restart-to-apply"
 msgstr "다음 실행 시 적용됩니다."
+
+#: crates/adapter-gui/ui/pages/settings/section_system_language.slint:25
+msgctxt "SectionSystemLanguage"
+msgid "label-language"
+msgstr "언어"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:49
+msgctxt "SectionSystemPaths"
+msgid "label-presets-path"
+msgstr "프리셋 폴더"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:57
+msgctxt "SectionSystemPaths"
+msgid "placeholder-default-path"
+msgstr "(기본값)"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:66
+msgctxt "SectionSystemPaths"
+msgid "btn-choose-path"
+msgstr "선택…"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:70
+msgctxt "SectionSystemPaths"
+msgid "btn-reset-path"
+msgstr "재설정"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:81
+msgctxt "SectionSystemPaths"
+msgid "label-plugins-path"
+msgstr "플러그인 폴더"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:113
+msgctxt "SectionSystemPaths"
+msgid "label-evaluations-path"
+msgstr "평가 폴더"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:145
+msgctxt "SectionSystemPaths"
+msgid "label-plugin-catalog"
+msgstr "플러그인 카탈로그"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:153
+msgctxt "SectionSystemPaths"
+msgid "status-plugin-catalog-idle"
+msgstr "아직 새로고침되지 않음"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:162
+msgctxt "SectionSystemPaths"
+msgid "btn-reload-plugin-catalog"
+msgstr "새로고침"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:73
+msgctxt "SpectrumCard"
+msgid "—"
+msgstr "—"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:127
+msgctxt "SpectrumCard"
+msgid "20"
+msgstr "20"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:133
+msgctxt "SpectrumCard"
+msgid "100"
+msgstr "100"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:139
+msgctxt "SpectrumCard"
+msgid "1k"
+msgstr "1k"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:145
+msgctxt "SpectrumCard"
+msgid "10k"
+msgstr "10k"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:151
+msgctxt "SpectrumCard"
+msgid "20k"
+msgstr "20k"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:199
+msgctxt "SpectrumPanel"
+msgid "label-spectrum"
+msgstr "SPECTRUM"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:241
+msgctxt "SpectrumPanel"
+msgid "status-no-active-outputs"
+msgstr "NO ACTIVE OUTPUTS"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:251
+msgctxt "SpectrumPanel"
+msgid "status-spectrum-empty-help"
+msgstr "스펙트럼을 켜고 출력이 구성된 체인을 활성화하세요."
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:279
+msgctxt "SpectrumWindow"
+msgid "title-window-spectrum"
+msgstr "OpenRig · Spectrum"
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:54
+msgctxt "MuteSwitch"
+msgid "label-mute"
+msgstr "MUTE"
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:316
+msgctxt "TunerPanel"
+msgid "label-tuner"
+msgstr "TUNER"
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:368
+msgctxt "TunerPanel"
+msgid "status-no-active-inputs"
+msgstr "NO ACTIVE INPUTS"
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:378
+msgctxt "TunerPanel"
+msgid "status-tuner-empty-help"
+msgstr "입력이 구성된 체인을 활성화하면 여기에 튜너가 표시됩니다."
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:406
+msgctxt "TunerWindow"
+msgid "title-window-tuner"
+msgstr "OpenRig · Tuner"
+
+#: crates/adapter-gui/ui/secondary_windows_block.slint:30
+msgctxt "BlockEditorWindow"
+msgid "title-window-block-editor"
+msgstr "OpenRig · Block"
+
+#: crates/adapter-gui/ui/secondary_windows_block.slint:231
+msgctxt "CompactChainViewWindow"
+msgid "title-window-chain-view"
+msgstr "OpenRig · 체인"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:60
+msgctxt "ProjectSettingsWindow"
+msgid "title-window-project-settings"
+msgstr "OpenRig · 프로젝트 구성"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:159
+msgctxt "ChainEditorWindow"
+msgid "title-window-chain-editor"
+msgstr "OpenRig · 체인 구성"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:192
+msgctxt "ChainEditorWindow"
+msgid "title-section-input"
+msgstr "입력"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:210
+msgctxt "ChainEditorWindow"
+msgid "title-section-output"
+msgstr "출력"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:240
+msgctxt "ChainInputWindow"
+msgid "title-window-chain-input"
+msgstr "OpenRig · 체인 입력"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:250
+msgctxt "ChainInputWindow"
+msgid "title-section-input"
+msgstr "입력"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:280
+msgctxt "ChainOutputWindow"
+msgid "title-window-chain-output"
+msgstr "OpenRig · 체인 출력"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:290
+msgctxt "ChainOutputWindow"
+msgid "title-section-output"
+msgstr "출력"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:321
+msgctxt "ChainInputGroupsWindow"
+msgid "title-window-chain-inputs"
+msgstr "OpenRig · 체인 입력"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:331
+msgctxt "ChainInputGroupsWindow"
+msgid "title-section-inputs"
+msgstr "입력"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:332
+msgctxt "ChainInputGroupsWindow"
+msgid "btn-add-input-row"
+msgstr "+ 입력 추가"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:362
+msgctxt "ChainOutputGroupsWindow"
+msgid "title-window-chain-outputs"
+msgstr "OpenRig · 체인 출력"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:372
+msgctxt "ChainOutputGroupsWindow"
+msgid "title-section-outputs"
+msgstr "출력"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:373
+msgctxt "ChainOutputGroupsWindow"
+msgid "btn-add-output-row"
+msgstr "+ 출력 추가"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:418
+msgctxt "ChainInsertWindow"
+msgid "title-window-chain-insert"
+msgstr "OpenRig · Insert 구성"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:428
+msgctxt "ChainInsertWindow"
+msgid "title-section-configure-insert"
+msgstr "Insert 구성"
+
+#: crates/adapter-gui/ui/touch_main.slint:667
+msgctxt "TouchMain"
+msgid "⌨"
+msgstr "⌨"

--- a/crates/adapter-gui/translations/pt_BR/LC_MESSAGES/adapter-gui.po
+++ b/crates/adapter-gui/translations/pt_BR/LC_MESSAGES/adapter-gui.po
@@ -21,651 +21,939 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #: crates/adapter-gui/ui/blocks/header.slint:13
+msgctxt "Header"
 msgid "OpenRig"
 msgstr "OpenRig"
 
 #: crates/adapter-gui/ui/components/block_panel_parameter_item.slint:274
+msgctxt "BlockPanelParameterItem"
 msgid "btn-load-file"
 msgstr "Load"
 
 #: crates/adapter-gui/ui/components/block_stream_mini_display.slint:23
+msgctxt "BlockStreamMiniDisplay"
 msgid "–"
 msgstr "–"
 
 #: crates/adapter-gui/ui/components/block_value_widgets.slint:128
+msgctxt "BlockValueStepper"
 msgid "−"
 msgstr "−"
 
 #: crates/adapter-gui/ui/components/block_value_widgets.slint:194
+msgctxt "BlockValueStepper"
 msgid "+"
 msgstr "+"
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:87
-msgid "Preset selector"
-msgstr "Seletor de preset"
+#: crates/adapter-gui/ui/components/chain_di_loop_button.slint:61
+msgctxt "ChainDiLoopButton"
+msgid "di-loop-button-label"
+msgstr "Loop DI"
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:170
+#: crates/adapter-gui/ui/components/chain_di_loop_button.slint:138
+msgctxt "ChainDiLoopButton"
+msgid "di-loop-stop-label"
+msgstr "Parar loop DI"
+
+#: crates/adapter-gui/ui/components/chain_di_loop_button.slint:138
+msgctxt "ChainDiLoopButton"
+msgid "di-loop-play-label"
+msgstr "Tocar loop DI"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:77
+msgctxt "SceneBtn"
 msgid "Scene {}"
 msgstr "Cena {}"
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:192
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:99
+msgctxt "SceneBar"
 msgid "Add scene"
 msgstr "Adicionar cena"
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:201
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:108
+msgctxt "SceneBar"
 msgid "Remove last scene"
 msgstr "Remover última cena"
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:258
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:183
+msgctxt "ChainTitlePreset"
+msgid "tooltip-open-preset"
+msgstr "Abrir preset"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:193
+msgctxt "ChainTitlePreset"
+msgid "tooltip-save-preset"
+msgstr "Salvar preset"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:203
+msgctxt "ChainTitlePreset"
 msgid "Add preset"
 msgstr "Adicionar preset"
 
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:213
+msgctxt "ChainTitlePreset"
+msgid "Rename preset"
+msgstr "Renomear preset"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:224
+msgctxt "ChainTitlePreset"
+msgid "Remove preset"
+msgstr "Remover preset"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:316
+msgctxt "ChainTitlePreset"
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:337
+msgctxt "ChainTitlePreset"
+msgid "OK"
+msgstr "OK"
+
 #: crates/adapter-gui/ui/components/chain_volume_button.slint:37
+msgctxt "ChainVolumeButton"
 msgid "Volume"
 msgstr "Volume"
 
+#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:29
+msgctxt "ConfirmDeleteChainDialog"
+msgid "title-dialog-delete-chain"
+msgstr "Excluir chain"
+
+#. text directly.
+#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:39
+msgctxt "ConfirmDeleteChainDialog"
+msgid "Excluir a chain \"{}\"?"
+msgstr "Excluir a chain \"{}\"?"
+
+#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:58
+msgctxt "ConfirmDeleteChainDialog"
+msgid "btn-cancel"
+msgstr "Cancelar"
+
+#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:75
+msgctxt "ConfirmDeleteChainDialog"
+msgid "btn-delete"
+msgstr "Excluir"
+
 #: crates/adapter-gui/ui/components/confirm_delete_dialog.slint:27
+msgctxt "ConfirmDeleteBlockDialog"
 msgid "title-dialog-delete-block"
 msgstr "Excluir bloco"
 
 #. pt-BR source string with the placeholder.
 #: crates/adapter-gui/ui/components/confirm_delete_dialog.slint:36
+msgctxt "ConfirmDeleteBlockDialog"
 msgid "Excluir \"{}\"?"
 msgstr "Excluir \"{}\"?"
 
 #: crates/adapter-gui/ui/components/confirm_delete_dialog.slint:55
+msgctxt "ConfirmDeleteBlockDialog"
 msgid "btn-cancel"
 msgstr "Cancelar"
 
 #: crates/adapter-gui/ui/components/confirm_delete_dialog.slint:72
+msgctxt "ConfirmDeleteBlockDialog"
 msgid "btn-delete"
 msgstr "Excluir"
 
-#: crates/adapter-gui/ui/components/language_selector.slint:56
-msgid "accessible-language-selector"
-msgstr "Seletor de idioma"
-
-#: crates/adapter-gui/ui/components/model_select_with_search.slint:93
-msgid "▼"
-msgstr "▼"
-
-#: crates/adapter-gui/ui/components/model_select_with_search.slint:175
-msgid "placeholder-search-models"
-msgstr "Buscar modelos..."
-
-#: crates/adapter-gui/ui/components/preset_select.slint:170
-msgid "status-no-presets-found"
-msgstr "Nenhum preset encontrado"
-
-#: crates/adapter-gui/ui/components/model_select_with_search.slint:209
-msgid "status-no-models-found"
-msgstr "Nenhum modelo encontrado"
-
-#: crates/adapter-gui/ui/components/preset_picker_overlay.slint:32
-msgid "btn-load-preset"
-msgstr "Carregar Preset"
-
-#: crates/adapter-gui/ui/pages/block_editor_panel.slint:122
-msgid "tooltip-delete"
-msgstr "Excluir"
-
-#: crates/adapter-gui/ui/pages/block_panel_editor.slint:36
-msgid "btn-add"
-msgstr "Adicionar"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:195
-msgid "instrument-guitar"
-msgstr "Guitarra"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:196
-msgid "instrument-acoustic-guitar"
-msgstr "Violão"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:197
-msgid "instrument-bass"
-msgstr "Baixo"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:198
-msgid "instrument-voice"
-msgstr "Voz"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:199
-msgid "instrument-keyboard"
-msgstr "Teclado"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:200
-msgid "instrument-drums"
-msgstr "Bateria"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:201
-msgid "instrument-other"
-msgstr "Outro"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:221
-msgid "title-new-chain"
-msgstr "Nova chain"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:221
-msgid "title-configure-chain"
-msgstr "Configurar chain"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:240
-msgid "label-name"
-msgstr "Nome"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:267
-msgid "label-instrument"
-msgstr "Instrumento"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:345
-msgid "title-section-inputs"
-msgstr "Entradas"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:371
-msgid "btn-add-input"
-msgstr "+ Adicionar entrada"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:390
-msgid "title-section-outputs"
-msgstr "Saídas"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:416
-msgid "btn-add-output"
-msgstr "+ Adicionar saída"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:450
-msgid "btn-create-chain"
-msgstr "Criar chain"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:450
-msgid "btn-save-chain"
-msgstr "Salvar chain"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:66
-msgid "✓"
-msgstr "✓"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:140
-msgid "label-device"
-msgstr "Dispositivo"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:170
-msgid "label-mode"
-msgstr "Modo"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:229
-msgid "label-channels"
-msgstr "Canais"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:275
-msgid "btn-ok"
-msgstr "OK"
-
-#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:99
-msgid "title-section-configure-insert"
-msgstr "Configurar Insert"
-
-#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:214
-msgid "label-send"
-msgstr "Envio"
-
-#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:344
-msgid "label-return"
-msgstr "Retorno"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:140
-msgid "tooltip-expand-blocks"
-msgstr "Expandir blocos"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:148
-msgid "tooltip-measure-latency"
-msgstr "Medir latência (emite um bipe)"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:177
-msgid "tooltip-configure"
-msgstr "Configurar"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:185
-msgid "tooltip-open-preset"
-msgstr "Abrir preset"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:193
-msgid "tooltip-save-preset"
-msgstr "Salvar preset"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:472
-msgid "label-lat"
-msgstr "LAT"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:521
-msgid "label-input"
-msgstr "Entrada"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:567
-msgid "label-output"
-msgstr "Saída"
-
-#: crates/adapter-gui/ui/pages/compact_block_row.slint:493
-msgid "btn-open-plugin"
-msgstr "Abrir Plugin"
-
-#: crates/adapter-gui/ui/pages/compact_chain_view.slint:83
-msgid "label-in"
-msgstr "IN"
-
-#: crates/adapter-gui/ui/pages/compact_chain_view.slint:111
-msgid "label-out"
-msgstr "OUT"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:87
-msgid "·"
-msgstr "·"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:123
-msgid "label-description"
-msgstr "Description"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:142
-msgid "label-license"
-msgstr "License:"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:169
-msgid "↗"
-msgstr "↗"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:175
-msgid "btn-open-homepage"
-msgstr "Open Homepage"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:136
-msgid "tooltip-back"
-msgstr "Voltar"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:144
-msgid "tooltip-spectrum"
-msgstr "Spectrum"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:152
-msgid "tooltip-tuner"
-msgstr "Tuner"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:160
-msgid "tooltip-project-settings"
-msgstr "Projeto"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:169
-msgid "tooltip-save"
-msgstr "Salvar"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:177
-msgid "tooltip-new-chain"
-msgstr "Nova chain"
-
-#: crates/adapter-gui/ui/pages/project_launcher.slint:185
-msgid "placeholder-search-projects"
-msgstr "Buscar projetos"
-
-#: crates/adapter-gui/ui/pages/project_launcher.slint:288
-msgid "tooltip-open-project"
-msgstr "Abrir projeto"
-
-#: crates/adapter-gui/ui/pages/project_launcher.slint:295
-msgid "btn-new-project"
-msgstr "Novo projeto"
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:147
-msgid "label-hz"
-msgstr "Hz"
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:170
-msgid "label-buffer"
-msgstr "Buffer"
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:193
-msgid "label-bits"
-msgstr "Bits"
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:271
-msgid "title-section-audio-devices"
-msgstr "Dispositivos de áudio"
-
-#: crates/adapter-gui/ui/pages/project_setup.slint:55
-msgid "placeholder-project-name-example"
-msgstr "Ex: Guitarra ao vivo"
-
-#: crates/adapter-gui/ui/pages/project_setup.slint:151
-msgid "title-new-project"
-msgstr "Novo Projeto"
-
-#: crates/adapter-gui/ui/pages/project_setup.slint:164
-msgid "label-project-name"
-msgstr "Nome do projeto"
-
-#: crates/adapter-gui/ui/pages/project_setup.slint:211
-msgid "btn-create-project"
-msgstr "Criar projeto"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:73
-msgid "—"
-msgstr "—"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:127
-msgid "20"
-msgstr "20"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:133
-msgid "100"
-msgstr "100"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:139
-msgid "1k"
-msgstr "1k"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:145
-msgid "10k"
-msgstr "10k"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:151
-msgid "20k"
-msgstr "20k"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:199
-msgid "label-spectrum"
-msgstr "SPECTRUM"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:241
-msgid "status-no-active-outputs"
-msgstr "NO ACTIVE OUTPUTS"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:251
-msgid "status-spectrum-empty-help"
-msgstr "Ligue o espectro e habilite uma chain com saída configurada."
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:279
-msgid "title-window-spectrum"
-msgstr "OpenRig · Spectrum"
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:54
-msgid "label-mute"
-msgstr "MUTE"
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:316
-msgid "label-tuner"
-msgstr "TUNER"
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:368
-msgid "status-no-active-inputs"
-msgstr "NO ACTIVE INPUTS"
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:378
-msgid "status-tuner-empty-help"
-msgstr "Ative uma chain com entrada configurada para ver os afinadores aqui."
-"Habilite uma chain com entrada configurada para ver os afinadores "
-"aqui.Habilite uma chain com entrada configurada para ver os afinadores aqui."
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:406
-msgid "title-window-tuner"
-msgstr "OpenRig · Tuner"
-
-#: crates/adapter-gui/ui/secondary_windows_block.slint:28
-msgid "title-window-block-editor"
-msgstr "OpenRig · Block"
-
-#: crates/adapter-gui/ui/secondary_windows_block.slint:195
-msgid "title-window-chain-view"
-msgstr "OpenRig · Chain"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:23
-msgid "title-window-project-settings"
-msgstr "OpenRig · Configurar projeto"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:96
-msgid "title-window-chain-editor"
-msgstr "OpenRig · Configurar chain"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:129
-msgid "title-section-input"
-msgstr "Entrada"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:147
-msgid "title-section-output"
-msgstr "Saída"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:177
-msgid "title-window-chain-input"
-msgstr "OpenRig · Entrada da chain"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:217
-msgid "title-window-chain-output"
-msgstr "OpenRig · Saída da chain"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:258
-msgid "title-window-chain-inputs"
-msgstr "OpenRig · Entradas da chain"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:269
-msgid "btn-add-input-row"
-msgstr "+ Adicionar entrada"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:299
-msgid "title-window-chain-outputs"
-msgstr "OpenRig · Saídas da chain"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:310
-msgid "btn-add-output-row"
-msgstr "+ Adicionar saída"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:355
-msgid "title-window-chain-insert"
-msgstr "OpenRig · Configurar Insert"
-
-#: crates/adapter-gui/ui/touch_main.slint:586
-msgid "⌨"
-msgstr "⌨"
-
-#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:27
-msgid "title-dialog-delete-chain"
-msgstr "Excluir chain"
-
-#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:37
-msgid "Excluir a chain \"{}\"?"
-msgstr "Excluir a chain \"{}\"?"
-
-#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:31
+#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:30
+msgctxt "ConfirmDeleteRecentProjectDialog"
 msgid "title-dialog-delete-recent-project"
 msgstr "Remover dos recentes"
 
-#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:41
+#. Literal pt-BR source string with `{}` placeholder.
+#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:38
+msgctxt "ConfirmDeleteRecentProjectDialog"
 msgid "Remover o projeto \"{}\" dos recentes?"
 msgstr "Remover o projeto \"{}\" dos recentes?"
 
-#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:75
+#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:57
+msgctxt "ConfirmDeleteRecentProjectDialog"
+msgid "btn-cancel"
+msgstr "Cancelar"
+
+#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:74
+msgctxt "ConfirmDeleteRecentProjectDialog"
 msgid "btn-remove"
 msgstr "Remover"
 
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "tab-system"
-msgstr "Sistema"
+#: crates/adapter-gui/ui/components/language_selector.slint:56
+msgctxt "LanguageSelector"
+msgid "accessible-language-selector"
+msgstr "Seletor de idioma"
 
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "tab-project"
-msgstr "Projeto"
+#: crates/adapter-gui/ui/components/model_select_with_search.slint:96
+msgctxt "ModelSelectWithSearch"
+msgid "▼"
+msgstr "▼"
 
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "btn-close"
-msgstr "Fechar"
+#: crates/adapter-gui/ui/components/model_select_with_search.slint:178
+msgctxt "ModelSelectWithSearch"
+msgid "placeholder-search-models"
+msgstr "Buscar modelos..."
 
-#: crates/adapter-gui/ui/components/settings_section.slint
-msgid "badge-system"
-msgstr "Sistema"
+#: crates/adapter-gui/ui/components/model_select_with_search.slint:212
+msgctxt "ModelSelectWithSearch"
+msgid "status-no-models-found"
+msgstr "Nenhum modelo encontrado"
 
-#: crates/adapter-gui/ui/components/settings_section.slint
-msgid "badge-project"
-msgstr "Projeto"
-
-#: crates/adapter-gui/ui/pages/settings/section_system_audio.slint
-msgid "title-section-audio-interface"
-msgstr "Interface de áudio"
-
-#: crates/adapter-gui/ui/pages/settings/section_system_language.slint
-msgid "title-section-language"
-msgstr "Idioma"
-
-#: crates/adapter-gui/ui/pages/settings/section_system_midi_devices.slint
-msgid "title-section-midi-devices"
-msgstr "Dispositivos MIDI"
-
-#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint
-msgid "title-section-project-meta"
-msgstr "Metadados"
-
-#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint
-msgid "placeholder-project-unsaved"
-msgstr "(não salvo)"
-
-#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint
-msgid "label-file"
-msgstr "Arquivo"
-
-#: crates/adapter-gui/ui/pages/settings/section_project_midi_mapping.slint
-msgid "title-section-midi-mapping"
-msgstr "Mapeamento MIDI"
-
-#: crates/adapter-gui/ui/pages/settings/section_project_midi_mapping.slint
-msgid "btn-add-midi-binding"
-msgstr "+ Adicionar"
-
-#: crates/adapter-gui/ui/pages/settings/section_project_midi_mapping.slint
-msgid "empty-midi-mapping-explain"
-msgstr "Sem mapeamentos MIDI. Adicione um para vincular um controlador a um comando do OpenRig."
-"Sem mapeamentos MIDI. Adicione um para vincular um controlador a um comando "
-"do OpenRig."
-
-#: crates/adapter-gui/ui/pages/settings/section_project_midi_mapping.slint
-msgid "placeholder-midi-listen"
-msgstr "Pressione um controle MIDI…"
-
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "nav-group-system"
-msgstr "SISTEMA"
-
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "nav-group-project"
-msgstr "PROJETO"
-
-msgid "Cancel"
-msgstr "Cancelar"
-
-msgid "OK"
-msgstr "OK"
-
-msgid "Remove preset"
-msgstr "Remover preset"
-
-msgid "Rename preset"
-msgstr "Renomear preset"
+#: crates/adapter-gui/ui/components/preset_picker_overlay.slint:34
+msgctxt "PresetPickerOverlay"
+msgid "btn-load-preset"
+msgstr "Carregar Preset"
 
 #: crates/adapter-gui/ui/components/preset_picker_overlay.slint:40
+msgctxt "PresetPickerOverlay"
 msgid "preset-search-placeholder"
 msgstr "Buscar presets…"
 
+#: crates/adapter-gui/ui/components/preset_picker_overlay.slint:106
+msgctxt "PresetPickerOverlay"
+msgid "btn-cancel"
+msgstr "Cancelar"
+
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:38
+msgctxt "PresetSaveOverlay"
 msgid "title-dialog-save-preset"
 msgstr "Salvar preset"
 
+#: crates/adapter-gui/ui/components/preset_save_overlay.slint:63
+msgctxt "PresetSaveOverlay"
+msgid "btn-cancel"
+msgstr "Cancelar"
+
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:82
+msgctxt "PresetSaveOverlay"
 msgid "btn-save"
 msgstr "Salvar"
 
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:119
+msgctxt "PresetOverwriteOverlay"
 msgid "title-dialog-overwrite-preset"
 msgstr "Sobrescrever preset?"
 
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:126
+msgctxt "PresetOverwriteOverlay"
 msgid "msg-overwrite-preset"
 msgstr "Já existe um preset com nome \"{}\". Sobrescrever?"
 
+#: crates/adapter-gui/ui/components/preset_save_overlay.slint:145
+msgctxt "PresetOverwriteOverlay"
+msgid "btn-cancel"
+msgstr "Cancelar"
+
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:162
+msgctxt "PresetOverwriteOverlay"
 msgid "btn-overwrite"
 msgstr "Sobrescrever"
-#: crates/adapter-gui/ui/pages/settings.slint
-#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint
+
+#: crates/adapter-gui/ui/components/preset_select.slint:72
+msgctxt "PresetSelect"
+msgid "Preset selector"
+msgstr "Seletor de preset"
+
+#: crates/adapter-gui/ui/components/preset_select.slint:137
+msgctxt "PresetSelect"
+msgid "preset-search-placeholder"
+msgstr "Buscar presets…"
+
+#: crates/adapter-gui/ui/components/preset_select.slint:170
+msgctxt "PresetSelect"
+msgid "status-no-presets-found"
+msgstr "Nenhum preset encontrado"
+
+#: crates/adapter-gui/ui/pages/block_editor_panel.slint:122
+msgctxt "BlockEditorPanel"
+msgid "tooltip-delete"
+msgstr "Excluir"
+
+#: crates/adapter-gui/ui/pages/block_editor_panel.slint:243
+msgctxt "BlockEditorPanel"
+msgid "–"
+msgstr "–"
+
+#: crates/adapter-gui/ui/pages/block_panel_editor.slint:37
+msgctxt "BlockPanelEditor"
+msgid "btn-add"
+msgstr "Adicionar"
+
+#: crates/adapter-gui/ui/pages/block_panel_editor.slint:323
+msgctxt "BlockPanelEditor"
+msgid "–"
+msgstr "–"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:195
+msgctxt "ChainEditorPage"
+msgid "instrument-guitar"
+msgstr "Guitarra"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:196
+msgctxt "ChainEditorPage"
+msgid "instrument-acoustic-guitar"
+msgstr "Violão"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:197
+msgctxt "ChainEditorPage"
+msgid "instrument-bass"
+msgstr "Baixo"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:198
+msgctxt "ChainEditorPage"
+msgid "instrument-voice"
+msgstr "Voz"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:199
+msgctxt "ChainEditorPage"
+msgid "instrument-keyboard"
+msgstr "Teclado"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:200
+msgctxt "ChainEditorPage"
+msgid "instrument-drums"
+msgstr "Bateria"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:201
+msgctxt "ChainEditorPage"
+msgid "instrument-other"
+msgstr "Outro"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:221
+msgctxt "ChainEditorPage"
+msgid "title-new-chain"
+msgstr "Nova chain"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:221
+msgctxt "ChainEditorPage"
+msgid "title-configure-chain"
+msgstr "Configurar chain"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:240
+msgctxt "ChainEditorPage"
+msgid "label-name"
+msgstr "Nome"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:267
+msgctxt "ChainEditorPage"
+msgid "label-instrument"
+msgstr "Instrumento"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:345
+msgctxt "ChainEditorPage"
+msgid "title-section-inputs"
+msgstr "Entradas"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:371
+msgctxt "ChainEditorPage"
+msgid "btn-add-input"
+msgstr "+ Adicionar entrada"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:390
+msgctxt "ChainEditorPage"
+msgid "title-section-outputs"
+msgstr "Saídas"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:416
+msgctxt "ChainEditorPage"
+msgid "btn-add-output"
+msgstr "+ Adicionar saída"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:443
+msgctxt "ChainEditorPage"
+msgid "btn-cancel"
+msgstr "Cancelar"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:450
+msgctxt "ChainEditorPage"
+msgid "btn-create-chain"
+msgstr "Criar chain"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:450
+msgctxt "ChainEditorPage"
+msgid "btn-save-chain"
+msgstr "Salvar chain"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:66
+msgctxt "ChannelRow"
+msgid "✓"
+msgstr "✓"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:140
+msgctxt "ChainEndpointEditorPage"
+msgid "label-device"
+msgstr "Dispositivo"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:170
+msgctxt "ChainEndpointEditorPage"
+msgid "label-mode"
+msgstr "Modo"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:229
+msgctxt "ChainEndpointEditorPage"
+msgid "label-channels"
+msgstr "Canais"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:268
+msgctxt "ChainEndpointEditorPage"
+msgid "btn-cancel"
+msgstr "Cancelar"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:275
+msgctxt "ChainEndpointEditorPage"
+msgid "btn-ok"
+msgstr "OK"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:99
+msgctxt "ChainInsertEditorPage"
+msgid "title-section-configure-insert"
+msgstr "Configurar Insert"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:214
+msgctxt "ChainInsertEditorPage"
+msgid "label-send"
+msgstr "Envio"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:225
+msgctxt "ChainInsertEditorPage"
+msgid "label-device"
+msgstr "Dispositivo"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:247
+msgctxt "ChainInsertEditorPage"
+msgid "label-mode"
+msgstr "Modo"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:299
+msgctxt "ChainInsertEditorPage"
+msgid "label-channels"
+msgstr "Canais"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:344
+msgctxt "ChainInsertEditorPage"
+msgid "label-return"
+msgstr "Retorno"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:469
+msgctxt "ChainInsertEditorPage"
+msgid "btn-cancel"
+msgstr "Cancelar"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:476
+msgctxt "ChainInsertEditorPage"
+msgid "btn-ok"
+msgstr "OK"
+
+#: crates/adapter-gui/ui/pages/chain_io_groups.slint:304
+msgctxt "ChainIoGroupsPage"
+msgid "btn-cancel"
+msgstr "Cancelar"
+
+#: crates/adapter-gui/ui/pages/chain_io_groups.slint:311
+msgctxt "ChainIoGroupsPage"
+msgid "btn-ok"
+msgstr "OK"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:246
+msgctxt "ChainRow"
+msgid "tooltip-expand-blocks"
+msgstr "Expandir blocos"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:254
+msgctxt "ChainRow"
+msgid "tooltip-measure-latency"
+msgstr "Medir latência (emite um bipe)"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:283
+msgctxt "ChainRow"
+msgid "tooltip-configure"
+msgstr "Configurar"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:291
+msgctxt "ChainRow"
+msgid "tooltip-delete"
+msgstr "Excluir"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:564
+msgctxt "ChainRow"
+msgid "label-lat"
+msgstr "LAT"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:613
+msgctxt "ChainRow"
+msgid "label-input"
+msgstr "Entrada"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:659
+msgctxt "ChainRow"
+msgid "label-output"
+msgstr "Saída"
+
+#: crates/adapter-gui/ui/pages/compact_block_row.slint:415
+msgctxt "CompactBlockRow"
+msgid "▼"
+msgstr "▼"
+
+#: crates/adapter-gui/ui/pages/compact_block_row.slint:493
+msgctxt "CompactBlockRow"
+msgid "btn-open-plugin"
+msgstr "Abrir Plugin"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:160
+msgctxt "CompactChainViewPage"
+msgid "tooltip-measure-latency"
+msgstr "Medir latência (emite um bipe)"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:187
+msgctxt "CompactChainViewPage"
+msgid "label-lat"
+msgstr "LAT"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:216
+msgctxt "CompactChainViewPage"
+msgid "tooltip-configure"
+msgstr "Configurar"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:230
+msgctxt "CompactChainViewPage"
+msgid "label-in"
+msgstr "IN"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:251
+msgctxt "CompactChainViewPage"
+msgid "label-out"
+msgstr "OUT"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:267
+msgctxt "CompactChainViewPage"
+msgid "tooltip-delete"
+msgstr "Excluir"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:313
+msgctxt "CompactChainViewPage"
+msgid "+"
+msgstr "+"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:87
+msgctxt "PluginInfoPanel"
+msgid "·"
+msgstr "·"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:125
+msgctxt "PluginInfoPanel"
+msgid "label-description"
+msgstr "Description"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:144
+msgctxt "PluginInfoPanel"
+msgid "label-license"
+msgstr "License:"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:171
+msgctxt "PluginInfoPanel"
+msgid "↗"
+msgstr "↗"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:177
+msgctxt "PluginInfoPanel"
+msgid "btn-open-homepage"
+msgstr "Open Homepage"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:145
+msgctxt "ProjectChainsPage"
+msgid "tooltip-back"
+msgstr "Voltar"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:153
+msgctxt "ProjectChainsPage"
+msgid "tooltip-spectrum"
+msgstr "Spectrum"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:161
+msgctxt "ProjectChainsPage"
+msgid "tooltip-tuner"
+msgstr "Tuner"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:169
+msgctxt "ProjectChainsPage"
+msgid "tooltip-project-settings"
+msgstr "Projeto"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:178
+msgctxt "ProjectChainsPage"
+msgid "tooltip-save"
+msgstr "Salvar"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:186
+msgctxt "ProjectChainsPage"
+msgid "tooltip-new-chain"
+msgstr "Nova chain"
+
+#: crates/adapter-gui/ui/pages/project_launcher.slint:184
+msgctxt "SearchField"
+msgid "placeholder-search-projects"
+msgstr "Buscar projetos"
+
+#: crates/adapter-gui/ui/pages/project_launcher.slint:287
+msgctxt "ProjectLauncherPage"
+msgid "tooltip-open-project"
+msgstr "Abrir projeto"
+
+#: crates/adapter-gui/ui/pages/project_launcher.slint:294
+msgctxt "ProjectLauncherPage"
+msgid "btn-new-project"
+msgstr "Novo projeto"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:55
+msgctxt "NameInput"
+msgid "placeholder-project-name-example"
+msgstr "Ex: Guitarra ao vivo"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:151
+msgctxt "ProjectSetupPage"
+msgid "title-new-project"
+msgstr "Novo Projeto"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:164
+msgctxt "ProjectSetupPage"
+msgid "label-project-name"
+msgstr "Nome do projeto"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:204
+msgctxt "ProjectSetupPage"
+msgid "btn-cancel"
+msgstr "Cancelar"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:211
+msgctxt "ProjectSetupPage"
+msgid "btn-create-project"
+msgstr "Criar projeto"
+
+#: crates/adapter-gui/ui/pages/settings.slint:170
+msgctxt "SettingsPage"
+msgid "nav-group-system"
+msgstr "SISTEMA"
+
+#: crates/adapter-gui/ui/pages/settings.slint:181
+msgctxt "SettingsPage"
+msgid "title-section-audio-interface"
+msgstr "Interface de áudio"
+
+#: crates/adapter-gui/ui/pages/settings.slint:186
+msgctxt "SettingsPage"
+msgid "title-section-language"
+msgstr "Idioma"
+
+#: crates/adapter-gui/ui/pages/settings.slint:191
+msgctxt "SettingsPage"
+msgid "title-section-midi-devices"
+msgstr "Dispositivos MIDI"
+
+#: crates/adapter-gui/ui/pages/settings.slint:196
+msgctxt "SettingsPage"
 msgid "title-section-paths"
 msgstr "Caminhos"
 
-#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint
-msgid "label-presets-path"
-msgstr "Pasta de presets"
-
-#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint
-msgid "label-plugins-path"
-msgstr "Pasta de plugins"
-
-#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint
-msgid "label-evaluations-path"
-msgstr "Pasta de avaliações"
-
-#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint
-msgid "btn-choose-path"
-msgstr "Escolher…"
-
-#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint
-msgid "btn-reset-path"
-msgstr "Restaurar"
-
-#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint
-msgid "placeholder-default-path"
-msgstr "(padrão)"
-
-#: crates/adapter-gui/ui/pages/settings/section_system_language.slint
-msgid "label-language"
-msgstr "Idioma"
-
-#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint
-msgid "btn-save-project"
-msgstr "Salvar projeto"
-
-msgid "btn-save-audio-settings"
-msgstr "Aplicar"
-
-#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint
-msgid "label-plugin-catalog"
-msgstr "Catálogo de plugins"
-
-#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint
-msgid "btn-reload-plugin-catalog"
-msgstr "Recarregar"
-
-#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint
-msgid "status-plugin-catalog-idle"
-msgstr "Ainda não recarregado"
-
-#: crates/adapter-gui/ui/components/chain_di_loop_button.slint
-msgid "di-loop-button-label"
-msgstr "Loop DI"
-
-#: crates/adapter-gui/ui/components/chain_di_loop_button.slint
-msgid "di-loop-play-label"
-msgstr "Tocar loop DI"
-
-#: crates/adapter-gui/ui/components/chain_di_loop_button.slint
-msgid "di-loop-stop-label"
-msgstr "Parar loop DI"
-
+#: crates/adapter-gui/ui/pages/settings.slint:201
+msgctxt "SettingsPage"
 msgid "title-section-integrations"
 msgstr "Integrações"
 
+#: crates/adapter-gui/ui/pages/settings.slint:216
+msgctxt "SettingsPage"
+msgid "nav-group-project"
+msgstr "PROJETO"
+
+#: crates/adapter-gui/ui/pages/settings.slint:227
+msgctxt "SettingsPage"
+msgid "title-section-project-meta"
+msgstr "Metadados"
+
+#: crates/adapter-gui/ui/pages/settings.slint:335
+msgctxt "SettingsPage"
+msgid "btn-save-audio-settings"
+msgstr "Aplicar"
+
+#: crates/adapter-gui/ui/pages/settings.slint:339
+msgctxt "SettingsPage"
+msgid "btn-close"
+msgstr "Fechar"
+
+#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint:27
+msgctxt "SectionProjectMeta"
+msgid "label-name"
+msgstr "Nome"
+
+#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint:58
+msgctxt "SectionProjectMeta"
+msgid "label-file"
+msgstr "Arquivo"
+
+#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint:66
+msgctxt "SectionProjectMeta"
+msgid "placeholder-project-unsaved"
+msgstr "(não salvo)"
+
+#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint:83
+msgctxt "SectionProjectMeta"
+msgid "btn-save-project"
+msgstr "Salvar projeto"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_audio.slint:95
+msgctxt "AudioDeviceRow"
+msgid "label-hz"
+msgstr "Hz"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_audio.slint:118
+msgctxt "AudioDeviceRow"
+msgid "label-buffer"
+msgstr "Buffer"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_audio.slint:141
+msgctxt "AudioDeviceRow"
+msgid "label-bits"
+msgstr "Bits"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:39
+msgctxt "SectionSystemIntegrations"
 msgid "label-midi-enabled"
 msgstr "Controle MIDI"
 
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:45
+msgctxt "SectionSystemIntegrations"
 msgid "desc-midi-enabled"
 msgstr "Liga o adaptador MIDI/BLE-MIDI para pedais controlarem o OpenRig"
 
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:93
+msgctxt "SectionSystemIntegrations"
 msgid "label-mcp-enabled"
 msgstr "Servidor MCP"
 
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:99
+msgctxt "SectionSystemIntegrations"
 msgid "desc-mcp-enabled"
 msgstr "Expõe o servidor MCP em 127.0.0.1:4123 para agentes"
 
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:134
+msgctxt "SectionSystemIntegrations"
 msgid "hint-restart-to-apply"
 msgstr "Vale a partir do próximo início."
+
+#: crates/adapter-gui/ui/pages/settings/section_system_language.slint:25
+msgctxt "SectionSystemLanguage"
+msgid "label-language"
+msgstr "Idioma"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:49
+msgctxt "SectionSystemPaths"
+msgid "label-presets-path"
+msgstr "Pasta de presets"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:57
+msgctxt "SectionSystemPaths"
+msgid "placeholder-default-path"
+msgstr "(padrão)"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:66
+msgctxt "SectionSystemPaths"
+msgid "btn-choose-path"
+msgstr "Escolher…"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:70
+msgctxt "SectionSystemPaths"
+msgid "btn-reset-path"
+msgstr "Restaurar"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:81
+msgctxt "SectionSystemPaths"
+msgid "label-plugins-path"
+msgstr "Pasta de plugins"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:113
+msgctxt "SectionSystemPaths"
+msgid "label-evaluations-path"
+msgstr "Pasta de avaliações"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:145
+msgctxt "SectionSystemPaths"
+msgid "label-plugin-catalog"
+msgstr "Catálogo de plugins"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:153
+msgctxt "SectionSystemPaths"
+msgid "status-plugin-catalog-idle"
+msgstr "Ainda não recarregado"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:162
+msgctxt "SectionSystemPaths"
+msgid "btn-reload-plugin-catalog"
+msgstr "Recarregar"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:73
+msgctxt "SpectrumCard"
+msgid "—"
+msgstr "—"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:127
+msgctxt "SpectrumCard"
+msgid "20"
+msgstr "20"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:133
+msgctxt "SpectrumCard"
+msgid "100"
+msgstr "100"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:139
+msgctxt "SpectrumCard"
+msgid "1k"
+msgstr "1k"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:145
+msgctxt "SpectrumCard"
+msgid "10k"
+msgstr "10k"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:151
+msgctxt "SpectrumCard"
+msgid "20k"
+msgstr "20k"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:199
+msgctxt "SpectrumPanel"
+msgid "label-spectrum"
+msgstr "SPECTRUM"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:241
+msgctxt "SpectrumPanel"
+msgid "status-no-active-outputs"
+msgstr "NO ACTIVE OUTPUTS"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:251
+msgctxt "SpectrumPanel"
+msgid "status-spectrum-empty-help"
+msgstr "Ligue o espectro e habilite uma chain com saída configurada."
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:279
+msgctxt "SpectrumWindow"
+msgid "title-window-spectrum"
+msgstr "OpenRig · Spectrum"
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:54
+msgctxt "MuteSwitch"
+msgid "label-mute"
+msgstr "MUTE"
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:316
+msgctxt "TunerPanel"
+msgid "label-tuner"
+msgstr "TUNER"
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:368
+msgctxt "TunerPanel"
+msgid "status-no-active-inputs"
+msgstr "NO ACTIVE INPUTS"
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:378
+msgctxt "TunerPanel"
+msgid "status-tuner-empty-help"
+msgstr "Habilite uma chain com entrada configurada para ver os tuners aqui."
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:406
+msgctxt "TunerWindow"
+msgid "title-window-tuner"
+msgstr "OpenRig · Tuner"
+
+#: crates/adapter-gui/ui/secondary_windows_block.slint:30
+msgctxt "BlockEditorWindow"
+msgid "title-window-block-editor"
+msgstr "OpenRig · Block"
+
+#: crates/adapter-gui/ui/secondary_windows_block.slint:231
+msgctxt "CompactChainViewWindow"
+msgid "title-window-chain-view"
+msgstr "OpenRig · Chain"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:60
+msgctxt "ProjectSettingsWindow"
+msgid "title-window-project-settings"
+msgstr "OpenRig · Configurar projeto"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:159
+msgctxt "ChainEditorWindow"
+msgid "title-window-chain-editor"
+msgstr "OpenRig · Configurar chain"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:192
+msgctxt "ChainEditorWindow"
+msgid "title-section-input"
+msgstr "Entrada"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:210
+msgctxt "ChainEditorWindow"
+msgid "title-section-output"
+msgstr "Saída"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:240
+msgctxt "ChainInputWindow"
+msgid "title-window-chain-input"
+msgstr "OpenRig · Entrada da chain"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:250
+msgctxt "ChainInputWindow"
+msgid "title-section-input"
+msgstr "Entrada"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:280
+msgctxt "ChainOutputWindow"
+msgid "title-window-chain-output"
+msgstr "OpenRig · Saída da chain"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:290
+msgctxt "ChainOutputWindow"
+msgid "title-section-output"
+msgstr "Saída"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:321
+msgctxt "ChainInputGroupsWindow"
+msgid "title-window-chain-inputs"
+msgstr "OpenRig · Entradas da chain"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:331
+msgctxt "ChainInputGroupsWindow"
+msgid "title-section-inputs"
+msgstr "Entradas"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:332
+msgctxt "ChainInputGroupsWindow"
+msgid "btn-add-input-row"
+msgstr "+ Adicionar entrada"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:362
+msgctxt "ChainOutputGroupsWindow"
+msgid "title-window-chain-outputs"
+msgstr "OpenRig · Saídas da chain"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:372
+msgctxt "ChainOutputGroupsWindow"
+msgid "title-section-outputs"
+msgstr "Saídas"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:373
+msgctxt "ChainOutputGroupsWindow"
+msgid "btn-add-output-row"
+msgstr "+ Adicionar saída"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:418
+msgctxt "ChainInsertWindow"
+msgid "title-window-chain-insert"
+msgstr "OpenRig · Configurar Insert"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:428
+msgctxt "ChainInsertWindow"
+msgid "title-section-configure-insert"
+msgstr "Configurar Insert"
+
+#: crates/adapter-gui/ui/touch_main.slint:667
+msgctxt "TouchMain"
+msgid "⌨"
+msgstr "⌨"

--- a/crates/adapter-gui/translations/zh_CN/LC_MESSAGES/adapter-gui.po
+++ b/crates/adapter-gui/translations/zh_CN/LC_MESSAGES/adapter-gui.po
@@ -12,571 +12,939 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #: crates/adapter-gui/ui/blocks/header.slint:13
+msgctxt "Header"
 msgid "OpenRig"
 msgstr "OpenRig"
 
 #: crates/adapter-gui/ui/components/block_panel_parameter_item.slint:274
+msgctxt "BlockPanelParameterItem"
 msgid "btn-load-file"
 msgstr "Load"
 
 #: crates/adapter-gui/ui/components/block_stream_mini_display.slint:23
+msgctxt "BlockStreamMiniDisplay"
 msgid "–"
 msgstr "–"
 
 #: crates/adapter-gui/ui/components/block_value_widgets.slint:128
+msgctxt "BlockValueStepper"
 msgid "−"
 msgstr "−"
 
 #: crates/adapter-gui/ui/components/block_value_widgets.slint:194
+msgctxt "BlockValueStepper"
 msgid "+"
 msgstr "+"
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:87
-msgid "Preset selector"
-msgstr ""
+#: crates/adapter-gui/ui/components/chain_di_loop_button.slint:61
+msgctxt "ChainDiLoopButton"
+msgid "di-loop-button-label"
+msgstr "DI 循环"
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:170
+#: crates/adapter-gui/ui/components/chain_di_loop_button.slint:138
+msgctxt "ChainDiLoopButton"
+msgid "di-loop-stop-label"
+msgstr "停止 DI 循环"
+
+#: crates/adapter-gui/ui/components/chain_di_loop_button.slint:138
+msgctxt "ChainDiLoopButton"
+msgid "di-loop-play-label"
+msgstr "播放 DI 循环"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:77
+msgctxt "SceneBtn"
 msgid "Scene {}"
 msgstr ""
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:192
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:99
+msgctxt "SceneBar"
 msgid "Add scene"
 msgstr ""
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:201
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:108
+msgctxt "SceneBar"
 msgid "Remove last scene"
 msgstr ""
 
-#: crates/adapter-gui/ui/components/chain_title_preset.slint:258
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:183
+msgctxt "ChainTitlePreset"
+msgid "tooltip-open-preset"
+msgstr "打开预设"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:193
+msgctxt "ChainTitlePreset"
+msgid "tooltip-save-preset"
+msgstr "保存预设"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:203
+msgctxt "ChainTitlePreset"
 msgid "Add preset"
 msgstr ""
 
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:213
+msgctxt "ChainTitlePreset"
+msgid "Rename preset"
+msgstr "重命名预设"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:224
+msgctxt "ChainTitlePreset"
+msgid "Remove preset"
+msgstr "删除预设"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:316
+msgctxt "ChainTitlePreset"
+msgid "Cancel"
+msgstr "取消"
+
+#: crates/adapter-gui/ui/components/chain_title_preset.slint:337
+msgctxt "ChainTitlePreset"
+msgid "OK"
+msgstr "确定"
+
 #: crates/adapter-gui/ui/components/chain_volume_button.slint:37
+msgctxt "ChainVolumeButton"
 msgid "Volume"
 msgstr ""
 
+#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:29
+msgctxt "ConfirmDeleteChainDialog"
+msgid "title-dialog-delete-chain"
+msgstr "删除链"
+
+#. text directly.
+#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:39
+msgctxt "ConfirmDeleteChainDialog"
+msgid "Excluir a chain \"{}\"?"
+msgstr "删除链 \"{}\"?"
+
+#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:58
+msgctxt "ConfirmDeleteChainDialog"
+msgid "btn-cancel"
+msgstr "取消"
+
+#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:75
+msgctxt "ConfirmDeleteChainDialog"
+msgid "btn-delete"
+msgstr "删除"
+
 #: crates/adapter-gui/ui/components/confirm_delete_dialog.slint:27
+msgctxt "ConfirmDeleteBlockDialog"
 msgid "title-dialog-delete-block"
 msgstr "删除块"
 
 #. pt-BR source string with the placeholder.
 #: crates/adapter-gui/ui/components/confirm_delete_dialog.slint:36
+msgctxt "ConfirmDeleteBlockDialog"
 msgid "Excluir \"{}\"?"
 msgstr "删除 \"{}\" 吗？"
 
 #: crates/adapter-gui/ui/components/confirm_delete_dialog.slint:55
+msgctxt "ConfirmDeleteBlockDialog"
 msgid "btn-cancel"
 msgstr "取消"
 
 #: crates/adapter-gui/ui/components/confirm_delete_dialog.slint:72
+msgctxt "ConfirmDeleteBlockDialog"
 msgid "btn-delete"
 msgstr "删除"
 
-#: crates/adapter-gui/ui/components/language_selector.slint:56
-msgid "accessible-language-selector"
-msgstr "语言选择器"
-
-#: crates/adapter-gui/ui/components/model_select_with_search.slint:93
-msgid "▼"
-msgstr "▼"
-
-#: crates/adapter-gui/ui/components/model_select_with_search.slint:175
-msgid "placeholder-search-models"
-msgstr "搜索模型..."
-
-#: crates/adapter-gui/ui/components/preset_select.slint:170
-msgid "status-no-presets-found"
-msgstr "未找到预设"
-
-#: crates/adapter-gui/ui/components/model_select_with_search.slint:209
-msgid "status-no-models-found"
-msgstr "未找到模型"
-
-#: crates/adapter-gui/ui/components/preset_picker_overlay.slint:32
-msgid "btn-load-preset"
-msgstr "加载预设"
-
-#: crates/adapter-gui/ui/pages/block_editor_panel.slint:122
-msgid "tooltip-delete"
-msgstr "删除"
-
-#: crates/adapter-gui/ui/pages/block_panel_editor.slint:36
-msgid "btn-add"
-msgstr "添加"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:195
-msgid "instrument-guitar"
-msgstr "吉他"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:196
-msgid "instrument-acoustic-guitar"
-msgstr "木吉他"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:197
-msgid "instrument-bass"
-msgstr "贝斯"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:198
-msgid "instrument-voice"
-msgstr "人声"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:199
-msgid "instrument-keyboard"
-msgstr "键盘"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:200
-msgid "instrument-drums"
-msgstr "鼓"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:201
-msgid "instrument-other"
-msgstr "其他"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:221
-msgid "title-new-chain"
-msgstr "新建链"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:221
-msgid "title-configure-chain"
-msgstr "配置链"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:240
-msgid "label-name"
-msgstr "名称"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:267
-msgid "label-instrument"
-msgstr "乐器"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:345
-msgid "title-section-inputs"
-msgstr "输入"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:371
-msgid "btn-add-input"
-msgstr "+ 添加输入"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:390
-msgid "title-section-outputs"
-msgstr "输出"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:416
-msgid "btn-add-output"
-msgstr "+ 添加输出"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:450
-msgid "btn-create-chain"
-msgstr "创建链"
-
-#: crates/adapter-gui/ui/pages/chain_editor.slint:450
-msgid "btn-save-chain"
-msgstr "保存链"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:66
-msgid "✓"
-msgstr "✓"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:140
-msgid "label-device"
-msgstr "设备"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:170
-msgid "label-mode"
-msgstr "模式"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:229
-msgid "label-channels"
-msgstr "通道"
-
-#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:275
-msgid "btn-ok"
-msgstr "确定"
-
-#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:99
-msgid "title-section-configure-insert"
-msgstr "配置Insert"
-
-#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:214
-msgid "label-send"
-msgstr "发送"
-
-#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:344
-msgid "label-return"
-msgstr "返回"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:140
-msgid "tooltip-expand-blocks"
-msgstr "展开块"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:148
-msgid "tooltip-measure-latency"
-msgstr "测量延迟（发出哔声）"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:177
-msgid "tooltip-configure"
-msgstr "配置"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:185
-msgid "tooltip-open-preset"
-msgstr "打开预设"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:193
-msgid "tooltip-save-preset"
-msgstr "保存预设"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:472
-msgid "label-lat"
-msgstr "LAT"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:521
-msgid "label-input"
-msgstr "输入"
-
-#: crates/adapter-gui/ui/pages/chain_row.slint:567
-msgid "label-output"
-msgstr "输出"
-
-#: crates/adapter-gui/ui/pages/compact_block_row.slint:493
-msgid "btn-open-plugin"
-msgstr "打开插件"
-
-#: crates/adapter-gui/ui/pages/compact_chain_view.slint:83
-msgid "label-in"
-msgstr "IN"
-
-#: crates/adapter-gui/ui/pages/compact_chain_view.slint:111
-msgid "label-out"
-msgstr "OUT"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:87
-msgid "·"
-msgstr "·"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:123
-msgid "label-description"
-msgstr "Description"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:142
-msgid "label-license"
-msgstr "License:"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:169
-msgid "↗"
-msgstr "↗"
-
-#: crates/adapter-gui/ui/pages/plugin_info_window.slint:175
-msgid "btn-open-homepage"
-msgstr "Open Homepage"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:136
-msgid "tooltip-back"
-msgstr "返回"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:144
-msgid "tooltip-spectrum"
-msgstr "Spectrum"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:152
-msgid "tooltip-tuner"
-msgstr "Tuner"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:160
-msgid "tooltip-project-settings"
-msgstr "项目"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:169
-msgid "tooltip-save"
-msgstr "保存"
-
-#: crates/adapter-gui/ui/pages/project_chains.slint:177
-msgid "tooltip-new-chain"
-msgstr "新建 链"
-
-#: crates/adapter-gui/ui/pages/project_launcher.slint:185
-msgid "placeholder-search-projects"
-msgstr "搜索项目"
-
-#: crates/adapter-gui/ui/pages/project_launcher.slint:288
-msgid "tooltip-open-project"
-msgstr "打开项目"
-
-#: crates/adapter-gui/ui/pages/project_launcher.slint:295
-msgid "btn-new-project"
-msgstr "新建项目"
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:147
-msgid "label-hz"
-msgstr "Hz"
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:170
-msgid "label-buffer"
-msgstr "Buffer"
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:193
-msgid "label-bits"
-msgstr "Bits"
-
-#: crates/adapter-gui/ui/pages/project_settings.slint:271
-msgid "title-section-audio-devices"
-msgstr "音频设备"
-
-#: crates/adapter-gui/ui/pages/project_setup.slint:55
-msgid "placeholder-project-name-example"
-msgstr "例如: 现场吉他"
-
-#: crates/adapter-gui/ui/pages/project_setup.slint:151
-msgid "title-new-project"
-msgstr "新建项目"
-
-#: crates/adapter-gui/ui/pages/project_setup.slint:164
-msgid "label-project-name"
-msgstr "项目名称"
-
-#: crates/adapter-gui/ui/pages/project_setup.slint:211
-msgid "btn-create-project"
-msgstr "创建项目"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:73
-msgid "—"
-msgstr "—"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:127
-msgid "20"
-msgstr "20"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:133
-msgid "100"
-msgstr "100"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:139
-msgid "1k"
-msgstr "1k"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:145
-msgid "10k"
-msgstr "10k"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:151
-msgid "20k"
-msgstr "20k"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:199
-msgid "label-spectrum"
-msgstr "SPECTRUM"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:241
-msgid "status-no-active-outputs"
-msgstr "NO ACTIVE OUTPUTS"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:251
-msgid "status-spectrum-empty-help"
-msgstr "打开频谱并启用带有配置输出的链。"
-
-#: crates/adapter-gui/ui/pages/spectrum_window.slint:279
-msgid "title-window-spectrum"
-msgstr "OpenRig · Spectrum"
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:54
-msgid "label-mute"
-msgstr "MUTE"
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:316
-msgid "label-tuner"
-msgstr "TUNER"
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:368
-msgid "status-no-active-inputs"
-msgstr "NO ACTIVE INPUTS"
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:378
-msgid "status-tuner-empty-help"
-msgstr "启用带有配置输入的链以在此处查看调音器。"
-
-#: crates/adapter-gui/ui/pages/tuner_window.slint:406
-msgid "title-window-tuner"
-msgstr "OpenRig · Tuner"
-
-#: crates/adapter-gui/ui/secondary_windows_block.slint:28
-msgid "title-window-block-editor"
-msgstr "OpenRig · Block"
-
-#: crates/adapter-gui/ui/secondary_windows_block.slint:195
-msgid "title-window-chain-view"
-msgstr "OpenRig · 链"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:23
-msgid "title-window-project-settings"
-msgstr "OpenRig · 配置项目"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:96
-msgid "title-window-chain-editor"
-msgstr "OpenRig · 配置链"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:129
-msgid "title-section-input"
-msgstr "输入"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:147
-msgid "title-section-output"
-msgstr "输出"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:177
-msgid "title-window-chain-input"
-msgstr "OpenRig · 链输入"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:217
-msgid "title-window-chain-output"
-msgstr "OpenRig · 链输出"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:258
-msgid "title-window-chain-inputs"
-msgstr "OpenRig · 链输入"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:269
-msgid "btn-add-input-row"
-msgstr "+ 添加输入"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:299
-msgid "title-window-chain-outputs"
-msgstr "OpenRig · 链输出"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:310
-msgid "btn-add-output-row"
-msgstr "+ 添加输出"
-
-#: crates/adapter-gui/ui/secondary_windows_chain.slint:355
-msgid "title-window-chain-insert"
-msgstr "OpenRig · 配置Insert"
-
-#: crates/adapter-gui/ui/touch_main.slint:586
-msgid "⌨"
-msgstr "⌨"
-
-#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:27
-msgid "title-dialog-delete-chain"
-msgstr "删除链"
-
-#: crates/adapter-gui/ui/components/confirm_delete_chain_dialog.slint:37
-msgid "Excluir a chain \"{}\"?"
-msgstr "删除链 \"{}\"?"
-
-#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:31
+#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:30
+msgctxt "ConfirmDeleteRecentProjectDialog"
 msgid "title-dialog-delete-recent-project"
 msgstr "从最近移除"
 
-#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:41
+#. Literal pt-BR source string with `{}` placeholder.
+#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:38
+msgctxt "ConfirmDeleteRecentProjectDialog"
 msgid "Remover o projeto \"{}\" dos recentes?"
 msgstr "从最近列表中移除项目 \"{}\"?"
 
-#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:75
+#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:57
+msgctxt "ConfirmDeleteRecentProjectDialog"
+msgid "btn-cancel"
+msgstr "取消"
+
+#: crates/adapter-gui/ui/components/confirm_delete_recent_project_dialog.slint:74
+msgctxt "ConfirmDeleteRecentProjectDialog"
 msgid "btn-remove"
 msgstr "移除"
 
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "tab-system"
-msgstr ""
+#: crates/adapter-gui/ui/components/language_selector.slint:56
+msgctxt "LanguageSelector"
+msgid "accessible-language-selector"
+msgstr "语言选择器"
 
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "tab-project"
-msgstr ""
+#: crates/adapter-gui/ui/components/model_select_with_search.slint:96
+msgctxt "ModelSelectWithSearch"
+msgid "▼"
+msgstr "▼"
 
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "btn-close"
-msgstr ""
+#: crates/adapter-gui/ui/components/model_select_with_search.slint:178
+msgctxt "ModelSelectWithSearch"
+msgid "placeholder-search-models"
+msgstr "搜索模型..."
 
-#: crates/adapter-gui/ui/components/settings_section.slint
-msgid "badge-system"
-msgstr ""
+#: crates/adapter-gui/ui/components/model_select_with_search.slint:212
+msgctxt "ModelSelectWithSearch"
+msgid "status-no-models-found"
+msgstr "未找到模型"
 
-#: crates/adapter-gui/ui/components/settings_section.slint
-msgid "badge-project"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_system_audio.slint
-msgid "title-section-audio-interface"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_system_language.slint
-msgid "title-section-language"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_system_midi_devices.slint
-msgid "title-section-midi-devices"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint
-msgid "title-section-project-meta"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint
-msgid "label-file"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_project_midi_mapping.slint
-msgid "title-section-midi-mapping"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_project_midi_mapping.slint
-msgid "btn-add-midi-binding"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_project_midi_mapping.slint
-msgid "empty-midi-mapping-explain"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings/section_project_midi_mapping.slint
-msgid "placeholder-midi-listen"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "nav-group-system"
-msgstr ""
-
-#: crates/adapter-gui/ui/pages/settings.slint
-msgid "nav-group-project"
-msgstr ""
+#: crates/adapter-gui/ui/components/preset_picker_overlay.slint:34
+msgctxt "PresetPickerOverlay"
+msgid "btn-load-preset"
+msgstr "加载预设"
 
 #: crates/adapter-gui/ui/components/preset_picker_overlay.slint:40
+msgctxt "PresetPickerOverlay"
 msgid "preset-search-placeholder"
 msgstr "搜索预设…"
 
+#: crates/adapter-gui/ui/components/preset_picker_overlay.slint:106
+msgctxt "PresetPickerOverlay"
+msgid "btn-cancel"
+msgstr "取消"
+
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:38
+msgctxt "PresetSaveOverlay"
 msgid "title-dialog-save-preset"
 msgstr "保存预设"
 
+#: crates/adapter-gui/ui/components/preset_save_overlay.slint:63
+msgctxt "PresetSaveOverlay"
+msgid "btn-cancel"
+msgstr "取消"
+
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:82
+msgctxt "PresetSaveOverlay"
 msgid "btn-save"
 msgstr "保存"
 
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:119
+msgctxt "PresetOverwriteOverlay"
 msgid "title-dialog-overwrite-preset"
 msgstr "覆盖预设？"
 
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:126
+msgctxt "PresetOverwriteOverlay"
 msgid "msg-overwrite-preset"
 msgstr "已存在名为 \"{}\" 的预设。是否覆盖？"
 
+#: crates/adapter-gui/ui/components/preset_save_overlay.slint:145
+msgctxt "PresetOverwriteOverlay"
+msgid "btn-cancel"
+msgstr "取消"
+
 #: crates/adapter-gui/ui/components/preset_save_overlay.slint:162
+msgctxt "PresetOverwriteOverlay"
 msgid "btn-overwrite"
 msgstr "覆盖"
 
-msgid "btn-save-audio-settings"
+#: crates/adapter-gui/ui/components/preset_select.slint:72
+msgctxt "PresetSelect"
+msgid "Preset selector"
 msgstr ""
 
+#: crates/adapter-gui/ui/components/preset_select.slint:137
+msgctxt "PresetSelect"
+msgid "preset-search-placeholder"
+msgstr "搜索预设…"
+
+#: crates/adapter-gui/ui/components/preset_select.slint:170
+msgctxt "PresetSelect"
+msgid "status-no-presets-found"
+msgstr "未找到预设"
+
+#: crates/adapter-gui/ui/pages/block_editor_panel.slint:122
+msgctxt "BlockEditorPanel"
+msgid "tooltip-delete"
+msgstr "删除"
+
+#: crates/adapter-gui/ui/pages/block_editor_panel.slint:243
+msgctxt "BlockEditorPanel"
+msgid "–"
+msgstr "–"
+
+#: crates/adapter-gui/ui/pages/block_panel_editor.slint:37
+msgctxt "BlockPanelEditor"
+msgid "btn-add"
+msgstr "添加"
+
+#: crates/adapter-gui/ui/pages/block_panel_editor.slint:323
+msgctxt "BlockPanelEditor"
+msgid "–"
+msgstr "–"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:195
+msgctxt "ChainEditorPage"
+msgid "instrument-guitar"
+msgstr "吉他"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:196
+msgctxt "ChainEditorPage"
+msgid "instrument-acoustic-guitar"
+msgstr "木吉他"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:197
+msgctxt "ChainEditorPage"
+msgid "instrument-bass"
+msgstr "贝斯"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:198
+msgctxt "ChainEditorPage"
+msgid "instrument-voice"
+msgstr "人声"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:199
+msgctxt "ChainEditorPage"
+msgid "instrument-keyboard"
+msgstr "键盘"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:200
+msgctxt "ChainEditorPage"
+msgid "instrument-drums"
+msgstr "鼓"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:201
+msgctxt "ChainEditorPage"
+msgid "instrument-other"
+msgstr "其他"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:221
+msgctxt "ChainEditorPage"
+msgid "title-new-chain"
+msgstr "新建链"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:221
+msgctxt "ChainEditorPage"
+msgid "title-configure-chain"
+msgstr "配置链"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:240
+msgctxt "ChainEditorPage"
+msgid "label-name"
+msgstr "名称"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:267
+msgctxt "ChainEditorPage"
+msgid "label-instrument"
+msgstr "乐器"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:345
+msgctxt "ChainEditorPage"
+msgid "title-section-inputs"
+msgstr "输入"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:371
+msgctxt "ChainEditorPage"
+msgid "btn-add-input"
+msgstr "+ 添加输入"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:390
+msgctxt "ChainEditorPage"
+msgid "title-section-outputs"
+msgstr "输出"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:416
+msgctxt "ChainEditorPage"
+msgid "btn-add-output"
+msgstr "+ 添加输出"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:443
+msgctxt "ChainEditorPage"
+msgid "btn-cancel"
+msgstr "取消"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:450
+msgctxt "ChainEditorPage"
+msgid "btn-create-chain"
+msgstr "创建链"
+
+#: crates/adapter-gui/ui/pages/chain_editor.slint:450
+msgctxt "ChainEditorPage"
+msgid "btn-save-chain"
+msgstr "保存链"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:66
+msgctxt "ChannelRow"
+msgid "✓"
+msgstr "✓"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:140
+msgctxt "ChainEndpointEditorPage"
+msgid "label-device"
+msgstr "设备"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:170
+msgctxt "ChainEndpointEditorPage"
+msgid "label-mode"
+msgstr "模式"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:229
+msgctxt "ChainEndpointEditorPage"
+msgid "label-channels"
+msgstr "通道"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:268
+msgctxt "ChainEndpointEditorPage"
+msgid "btn-cancel"
+msgstr "取消"
+
+#: crates/adapter-gui/ui/pages/chain_endpoint_editor.slint:275
+msgctxt "ChainEndpointEditorPage"
+msgid "btn-ok"
+msgstr "确定"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:99
+msgctxt "ChainInsertEditorPage"
+msgid "title-section-configure-insert"
+msgstr "配置Insert"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:214
+msgctxt "ChainInsertEditorPage"
+msgid "label-send"
+msgstr "发送"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:225
+msgctxt "ChainInsertEditorPage"
+msgid "label-device"
+msgstr "设备"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:247
+msgctxt "ChainInsertEditorPage"
+msgid "label-mode"
+msgstr "模式"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:299
+msgctxt "ChainInsertEditorPage"
+msgid "label-channels"
+msgstr "通道"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:344
+msgctxt "ChainInsertEditorPage"
+msgid "label-return"
+msgstr "返回"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:469
+msgctxt "ChainInsertEditorPage"
+msgid "btn-cancel"
+msgstr "取消"
+
+#: crates/adapter-gui/ui/pages/chain_insert_editor.slint:476
+msgctxt "ChainInsertEditorPage"
+msgid "btn-ok"
+msgstr "确定"
+
+#: crates/adapter-gui/ui/pages/chain_io_groups.slint:304
+msgctxt "ChainIoGroupsPage"
+msgid "btn-cancel"
+msgstr "取消"
+
+#: crates/adapter-gui/ui/pages/chain_io_groups.slint:311
+msgctxt "ChainIoGroupsPage"
+msgid "btn-ok"
+msgstr "确定"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:246
+msgctxt "ChainRow"
+msgid "tooltip-expand-blocks"
+msgstr "展开块"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:254
+msgctxt "ChainRow"
+msgid "tooltip-measure-latency"
+msgstr "测量延迟（发出哔声）"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:283
+msgctxt "ChainRow"
+msgid "tooltip-configure"
+msgstr "配置"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:291
+msgctxt "ChainRow"
+msgid "tooltip-delete"
+msgstr "删除"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:564
+msgctxt "ChainRow"
+msgid "label-lat"
+msgstr "LAT"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:613
+msgctxt "ChainRow"
+msgid "label-input"
+msgstr "输入"
+
+#: crates/adapter-gui/ui/pages/chain_row.slint:659
+msgctxt "ChainRow"
+msgid "label-output"
+msgstr "输出"
+
+#: crates/adapter-gui/ui/pages/compact_block_row.slint:415
+msgctxt "CompactBlockRow"
+msgid "▼"
+msgstr "▼"
+
+#: crates/adapter-gui/ui/pages/compact_block_row.slint:493
+msgctxt "CompactBlockRow"
+msgid "btn-open-plugin"
+msgstr "打开插件"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:160
+msgctxt "CompactChainViewPage"
+msgid "tooltip-measure-latency"
+msgstr "测量延迟（发出哔声）"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:187
+msgctxt "CompactChainViewPage"
+msgid "label-lat"
+msgstr "LAT"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:216
+msgctxt "CompactChainViewPage"
+msgid "tooltip-configure"
+msgstr "配置"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:230
+msgctxt "CompactChainViewPage"
+msgid "label-in"
+msgstr "IN"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:251
+msgctxt "CompactChainViewPage"
+msgid "label-out"
+msgstr "OUT"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:267
+msgctxt "CompactChainViewPage"
+msgid "tooltip-delete"
+msgstr "删除"
+
+#: crates/adapter-gui/ui/pages/compact_chain_view.slint:313
+msgctxt "CompactChainViewPage"
+msgid "+"
+msgstr "+"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:87
+msgctxt "PluginInfoPanel"
+msgid "·"
+msgstr "·"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:125
+msgctxt "PluginInfoPanel"
+msgid "label-description"
+msgstr "Description"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:144
+msgctxt "PluginInfoPanel"
+msgid "label-license"
+msgstr "License:"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:171
+msgctxt "PluginInfoPanel"
+msgid "↗"
+msgstr "↗"
+
+#: crates/adapter-gui/ui/pages/plugin_info_window.slint:177
+msgctxt "PluginInfoPanel"
+msgid "btn-open-homepage"
+msgstr "Open Homepage"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:145
+msgctxt "ProjectChainsPage"
+msgid "tooltip-back"
+msgstr "返回"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:153
+msgctxt "ProjectChainsPage"
+msgid "tooltip-spectrum"
+msgstr "Spectrum"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:161
+msgctxt "ProjectChainsPage"
+msgid "tooltip-tuner"
+msgstr "Tuner"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:169
+msgctxt "ProjectChainsPage"
+msgid "tooltip-project-settings"
+msgstr "项目"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:178
+msgctxt "ProjectChainsPage"
+msgid "tooltip-save"
+msgstr "保存"
+
+#: crates/adapter-gui/ui/pages/project_chains.slint:186
+msgctxt "ProjectChainsPage"
+msgid "tooltip-new-chain"
+msgstr "新建 链"
+
+#: crates/adapter-gui/ui/pages/project_launcher.slint:184
+msgctxt "SearchField"
+msgid "placeholder-search-projects"
+msgstr "搜索项目"
+
+#: crates/adapter-gui/ui/pages/project_launcher.slint:287
+msgctxt "ProjectLauncherPage"
+msgid "tooltip-open-project"
+msgstr "打开项目"
+
+#: crates/adapter-gui/ui/pages/project_launcher.slint:294
+msgctxt "ProjectLauncherPage"
+msgid "btn-new-project"
+msgstr "新建项目"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:55
+msgctxt "NameInput"
+msgid "placeholder-project-name-example"
+msgstr "例如: 现场吉他"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:151
+msgctxt "ProjectSetupPage"
+msgid "title-new-project"
+msgstr "新建项目"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:164
+msgctxt "ProjectSetupPage"
+msgid "label-project-name"
+msgstr "项目名称"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:204
+msgctxt "ProjectSetupPage"
+msgid "btn-cancel"
+msgstr "取消"
+
+#: crates/adapter-gui/ui/pages/project_setup.slint:211
+msgctxt "ProjectSetupPage"
+msgid "btn-create-project"
+msgstr "创建项目"
+
+#: crates/adapter-gui/ui/pages/settings.slint:170
+msgctxt "SettingsPage"
+msgid "nav-group-system"
+msgstr "系统"
+
+#: crates/adapter-gui/ui/pages/settings.slint:181
+msgctxt "SettingsPage"
+msgid "title-section-audio-interface"
+msgstr "音频接口"
+
+#: crates/adapter-gui/ui/pages/settings.slint:186
+msgctxt "SettingsPage"
+msgid "title-section-language"
+msgstr "语言"
+
+#: crates/adapter-gui/ui/pages/settings.slint:191
+msgctxt "SettingsPage"
+msgid "title-section-midi-devices"
+msgstr "MIDI 设备"
+
+#: crates/adapter-gui/ui/pages/settings.slint:196
+msgctxt "SettingsPage"
+msgid "title-section-paths"
+msgstr "路径"
+
+#: crates/adapter-gui/ui/pages/settings.slint:201
+msgctxt "SettingsPage"
 msgid "title-section-integrations"
 msgstr "集成"
 
+#: crates/adapter-gui/ui/pages/settings.slint:216
+msgctxt "SettingsPage"
+msgid "nav-group-project"
+msgstr "项目"
+
+#: crates/adapter-gui/ui/pages/settings.slint:227
+msgctxt "SettingsPage"
+msgid "title-section-project-meta"
+msgstr "元数据"
+
+#: crates/adapter-gui/ui/pages/settings.slint:335
+msgctxt "SettingsPage"
+msgid "btn-save-audio-settings"
+msgstr "应用"
+
+#: crates/adapter-gui/ui/pages/settings.slint:339
+msgctxt "SettingsPage"
+msgid "btn-close"
+msgstr "关闭"
+
+#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint:27
+msgctxt "SectionProjectMeta"
+msgid "label-name"
+msgstr "名称"
+
+#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint:58
+msgctxt "SectionProjectMeta"
+msgid "label-file"
+msgstr "文件"
+
+#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint:66
+msgctxt "SectionProjectMeta"
+msgid "placeholder-project-unsaved"
+msgstr "(未保存)"
+
+#: crates/adapter-gui/ui/pages/settings/section_project_meta.slint:83
+msgctxt "SectionProjectMeta"
+msgid "btn-save-project"
+msgstr "保存项目"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_audio.slint:95
+msgctxt "AudioDeviceRow"
+msgid "label-hz"
+msgstr "Hz"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_audio.slint:118
+msgctxt "AudioDeviceRow"
+msgid "label-buffer"
+msgstr "Buffer"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_audio.slint:141
+msgctxt "AudioDeviceRow"
+msgid "label-bits"
+msgstr "Bits"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:39
+msgctxt "SectionSystemIntegrations"
 msgid "label-midi-enabled"
 msgstr "MIDI 控制"
 
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:45
+msgctxt "SectionSystemIntegrations"
 msgid "desc-midi-enabled"
 msgstr "启用 MIDI/BLE-MIDI 适配器，让踏板控制 OpenRig"
 
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:93
+msgctxt "SectionSystemIntegrations"
 msgid "label-mcp-enabled"
 msgstr "MCP 服务器"
 
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:99
+msgctxt "SectionSystemIntegrations"
 msgid "desc-mcp-enabled"
 msgstr "在 127.0.0.1:4123 上为代理开放 MCP 服务器"
 
+#: crates/adapter-gui/ui/pages/settings/section_system_integrations.slint:134
+msgctxt "SectionSystemIntegrations"
 msgid "hint-restart-to-apply"
 msgstr "将在下次启动时生效。"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_language.slint:25
+msgctxt "SectionSystemLanguage"
+msgid "label-language"
+msgstr "语言"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:49
+msgctxt "SectionSystemPaths"
+msgid "label-presets-path"
+msgstr "预设文件夹"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:57
+msgctxt "SectionSystemPaths"
+msgid "placeholder-default-path"
+msgstr "(默认)"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:66
+msgctxt "SectionSystemPaths"
+msgid "btn-choose-path"
+msgstr "选择…"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:70
+msgctxt "SectionSystemPaths"
+msgid "btn-reset-path"
+msgstr "重置"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:81
+msgctxt "SectionSystemPaths"
+msgid "label-plugins-path"
+msgstr "插件文件夹"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:113
+msgctxt "SectionSystemPaths"
+msgid "label-evaluations-path"
+msgstr "评估文件夹"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:145
+msgctxt "SectionSystemPaths"
+msgid "label-plugin-catalog"
+msgstr "插件目录"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:153
+msgctxt "SectionSystemPaths"
+msgid "status-plugin-catalog-idle"
+msgstr "尚未重新加载"
+
+#: crates/adapter-gui/ui/pages/settings/section_system_paths.slint:162
+msgctxt "SectionSystemPaths"
+msgid "btn-reload-plugin-catalog"
+msgstr "重新加载"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:73
+msgctxt "SpectrumCard"
+msgid "—"
+msgstr "—"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:127
+msgctxt "SpectrumCard"
+msgid "20"
+msgstr "20"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:133
+msgctxt "SpectrumCard"
+msgid "100"
+msgstr "100"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:139
+msgctxt "SpectrumCard"
+msgid "1k"
+msgstr "1k"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:145
+msgctxt "SpectrumCard"
+msgid "10k"
+msgstr "10k"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:151
+msgctxt "SpectrumCard"
+msgid "20k"
+msgstr "20k"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:199
+msgctxt "SpectrumPanel"
+msgid "label-spectrum"
+msgstr "SPECTRUM"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:241
+msgctxt "SpectrumPanel"
+msgid "status-no-active-outputs"
+msgstr "NO ACTIVE OUTPUTS"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:251
+msgctxt "SpectrumPanel"
+msgid "status-spectrum-empty-help"
+msgstr "打开频谱并启用带有配置输出的链。"
+
+#: crates/adapter-gui/ui/pages/spectrum_window.slint:279
+msgctxt "SpectrumWindow"
+msgid "title-window-spectrum"
+msgstr "OpenRig · Spectrum"
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:54
+msgctxt "MuteSwitch"
+msgid "label-mute"
+msgstr "MUTE"
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:316
+msgctxt "TunerPanel"
+msgid "label-tuner"
+msgstr "TUNER"
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:368
+msgctxt "TunerPanel"
+msgid "status-no-active-inputs"
+msgstr "NO ACTIVE INPUTS"
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:378
+msgctxt "TunerPanel"
+msgid "status-tuner-empty-help"
+msgstr "启用带有配置输入的链以在此处查看调音器。"
+
+#: crates/adapter-gui/ui/pages/tuner_window.slint:406
+msgctxt "TunerWindow"
+msgid "title-window-tuner"
+msgstr "OpenRig · Tuner"
+
+#: crates/adapter-gui/ui/secondary_windows_block.slint:30
+msgctxt "BlockEditorWindow"
+msgid "title-window-block-editor"
+msgstr "OpenRig · Block"
+
+#: crates/adapter-gui/ui/secondary_windows_block.slint:231
+msgctxt "CompactChainViewWindow"
+msgid "title-window-chain-view"
+msgstr "OpenRig · 链"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:60
+msgctxt "ProjectSettingsWindow"
+msgid "title-window-project-settings"
+msgstr "OpenRig · 配置项目"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:159
+msgctxt "ChainEditorWindow"
+msgid "title-window-chain-editor"
+msgstr "OpenRig · 配置链"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:192
+msgctxt "ChainEditorWindow"
+msgid "title-section-input"
+msgstr "输入"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:210
+msgctxt "ChainEditorWindow"
+msgid "title-section-output"
+msgstr "输出"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:240
+msgctxt "ChainInputWindow"
+msgid "title-window-chain-input"
+msgstr "OpenRig · 链输入"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:250
+msgctxt "ChainInputWindow"
+msgid "title-section-input"
+msgstr "输入"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:280
+msgctxt "ChainOutputWindow"
+msgid "title-window-chain-output"
+msgstr "OpenRig · 链输出"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:290
+msgctxt "ChainOutputWindow"
+msgid "title-section-output"
+msgstr "输出"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:321
+msgctxt "ChainInputGroupsWindow"
+msgid "title-window-chain-inputs"
+msgstr "OpenRig · 链输入"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:331
+msgctxt "ChainInputGroupsWindow"
+msgid "title-section-inputs"
+msgstr "输入"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:332
+msgctxt "ChainInputGroupsWindow"
+msgid "btn-add-input-row"
+msgstr "+ 添加输入"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:362
+msgctxt "ChainOutputGroupsWindow"
+msgid "title-window-chain-outputs"
+msgstr "OpenRig · 链输出"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:372
+msgctxt "ChainOutputGroupsWindow"
+msgid "title-section-outputs"
+msgstr "输出"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:373
+msgctxt "ChainOutputGroupsWindow"
+msgid "btn-add-output-row"
+msgstr "+ 添加输出"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:418
+msgctxt "ChainInsertWindow"
+msgid "title-window-chain-insert"
+msgstr "OpenRig · 配置Insert"
+
+#: crates/adapter-gui/ui/secondary_windows_chain.slint:428
+msgctxt "ChainInsertWindow"
+msgid "title-section-configure-insert"
+msgstr "配置Insert"
+
+#: crates/adapter-gui/ui/touch_main.slint:667
+msgctxt "TouchMain"
+msgid "⌨"
+msgstr "⌨"

--- a/scripts/po_reconcile.py
+++ b/scripts/po_reconcile.py
@@ -44,9 +44,13 @@ def main(path: str) -> None:
         if mid and mid.group(1) and re.search(r'^msgstr ""$', blk, re.M):
             repl = active.get(mid.group(1)) or obsolete.get(mid.group(1))
             if repl:
-                escaped = repl.replace("\\", "\\\\").replace('"', '\\"')
+                # `repl` is the raw on-disk form captured between the msgstr
+                # quotes — already gettext-escaped. Insert it verbatim; a
+                # re-escape would turn `\"` into the invalid `\\"` (issue #714).
+                # Use a replacement function so re.sub does not interpret
+                # backslashes in `repl` as group references.
                 blk = re.sub(
-                    r'^msgstr ""$', f'msgstr "{escaped}"', blk, flags=re.M
+                    r'^msgstr ""$', lambda _: f'msgstr "{repl}"', blk, flags=re.M
                 )
         out.append(blk)
 

--- a/scripts/test_po_reconcile.py
+++ b/scripts/test_po_reconcile.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Tests for po_reconcile.py — translation recovery across key/context renames.
+
+Run: pytest scripts/test_po_reconcile.py
+"""
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).parent / "po_reconcile.py"
+
+
+def _run(po: Path) -> None:
+    subprocess.run([sys.executable, str(SCRIPT), str(po)], check=True)
+
+
+def test_recovers_plain_translation(tmp_path):
+    # A renamed key: active entry empty, obsolete entry holds the translation.
+    po = tmp_path / "x.po"
+    po.write_text(
+        'msgid ""\n'
+        'msgstr ""\n'
+        '"Content-Type: text/plain; charset=UTF-8\\n"\n'
+        "\n"
+        "#: x.slint:1\n"
+        'msgctxt "Dialog"\n'
+        'msgid "label-close"\n'
+        'msgstr ""\n'
+        "\n"
+        '#~ msgid "label-close"\n'
+        '#~ msgstr "Fechar"\n',
+        encoding="utf-8",
+    )
+    _run(po)
+    out = po.read_text(encoding="utf-8")
+    assert 'msgstr "Fechar"' in out
+    assert "#~" not in out  # obsolete dropped
+
+
+def test_recovers_quoted_translation_without_double_escaping(tmp_path):
+    # The translation (and msgid) contain escaped quotes. Reconcile must copy
+    # the already-escaped on-disk form verbatim — re-escaping it produces the
+    # invalid `\\"` sequence msgfmt rejects (the bug behind issue #714).
+    po = tmp_path / "x.po"
+    po.write_text(
+        'msgid ""\n'
+        'msgstr ""\n'
+        '"Content-Type: text/plain; charset=UTF-8\\n"\n'
+        "\n"
+        "#: x.slint:1\n"
+        'msgctxt "ConfirmDeleteBlockDialog"\n'
+        'msgid "Excluir \\"{}\\"?"\n'
+        'msgstr ""\n'
+        "\n"
+        '#~ msgid "Excluir \\"{}\\"?"\n'
+        '#~ msgstr "\\"{}\\" löschen?"\n',
+        encoding="utf-8",
+    )
+    _run(po)
+    out = po.read_text(encoding="utf-8")
+    assert '\\\\"' not in out, f"double-escaped quote produced:\n{out}"
+    assert 'msgstr "\\"{}\\" löschen?"' in out
+    # Must compile cleanly under gettext.
+    subprocess.run(
+        ["msgfmt", "--check", "-o", "/dev/null", str(po)], check=True
+    )


### PR DESCRIPTION
Closes #714.

## Problem
The Slint gettext catalogs drifted from source: `adapter-gui.pot` had 150 entries while `slint-tr-extractor` over the current `.slint` yields 188 — 35 new `@tr(...)` strings (new Settings sections, nav groups, save/overwrite-preset dialogs, DI-loop button) were never extracted, plus 1 obsolete key (`title-section-audio-devices`). Same drift class as #446. The rust-i18n `locales/*.yml` side was already in sync.

## What changed
- `crates/adapter-gui/translations/adapter-gui.pot` — refreshed 150 → 188; dropped obsolete `title-section-audio-devices`.
- 9 × `translations/<lang>/LC_MESSAGES/adapter-gui.po` — 35 newly-extracted strings translated in all shipped languages (de/en/es/fr/hi/ja/ko/pt/zh); audio jargon stays English per `docs/i18n.md`. Filled 3 pre-existing symbolic keys that leaked their raw key when empty.
- `scripts/po_reconcile.py` — fixed the double-escape (`\"` → invalid `\\"`) that corrupted catalogs on every refresh (the real reason the script was never run and the catalogs rotted).
- `scripts/test_po_reconcile.py` — new RED-first test (plain + quoted recovery, `msgfmt`-validated output).

## Verification
- `pytest scripts/test_po_reconcile.py` → 2 passed.
- `scripts/extract-translations.sh --check` → ✓ catalogs in sync, idempotent (CI `--check` guard stays green).
- `cargo build -p adapter-gui` → exit 0; `.mo` catalogs compile and load.

## Out of scope
Pre-existing empty skeleton entries in de/fr/hi/ja/ko/zh that predate this drift (they passthrough to English).

🤖 Generated with [Claude Code](https://claude.com/claude-code)