### PR TITLE
fix(gui): [ui-stall] watchdog ignores OS-parked idle/background pauses (#721)

### DIFF
--- a/crates/adapter-gui/src/desktop_app.rs
+++ b/crates/adapter-gui/src/desktop_app.rs
@@ -53,23 +53,51 @@ pub fn run_desktop_app(
     // heartbeat into the Slint event loop every 250 ms; if the loop stops
     // answering past ~600 ms a `[ui-stall]` warn names the freeze with its
     // duration — real-session stalls become self-reporting.
+    //
+    // #721: a large gap alone is ambiguous. A genuine freeze leaves the rest
+    // of the process (this thread included) running, so the watchdog keeps
+    // waking on schedule while the UI gap grows. An OS pause (macOS App Nap /
+    // display sleep / timer coalescing on an idle background app) parks the
+    // whole process, so this thread is frozen too and its own wake interval
+    // balloons in lockstep with the gap. `is_genuine_ui_stall` warns only in
+    // the former case, so idle/backgrounded pauses no longer cry wolf.
     {
+        use crate::ui_stall::is_genuine_ui_stall;
         use std::sync::atomic::{AtomicU64, Ordering};
         use std::sync::Arc;
+        use std::time::{Duration, Instant};
+
+        const TICK: Duration = Duration::from_millis(250);
+        const THRESHOLD: Duration = Duration::from_millis(600);
+
         let beat = Arc::new(AtomicU64::new(0));
         let beat_bg = Arc::clone(&beat);
         std::thread::Builder::new()
             .name("ui-watchdog".into())
             .spawn(move || {
-                let start = std::time::Instant::now();
+                let start = Instant::now();
                 let mut warned_at: u64 = 0;
+                let mut last_wake = Instant::now();
                 loop {
-                    std::thread::sleep(std::time::Duration::from_millis(250));
+                    std::thread::sleep(TICK);
+                    // How long this thread was actually away: ~TICK under
+                    // normal scheduling, but it balloons toward the UI gap when
+                    // the OS parked the whole process.
+                    let now = Instant::now();
+                    let wake_interval = now.duration_since(last_wake);
+                    last_wake = now;
+
                     let now_ms = start.elapsed().as_millis() as u64;
                     let seen = beat_bg.load(Ordering::Relaxed);
-                    let gap = now_ms.saturating_sub(seen);
-                    if seen > 0 && gap > 600 && seen != warned_at {
-                        log::warn!("[ui-stall] event loop unresponsive for ~{gap}ms");
+                    let gap = Duration::from_millis(now_ms.saturating_sub(seen));
+                    if seen > 0
+                        && seen != warned_at
+                        && is_genuine_ui_stall(gap, wake_interval, TICK, THRESHOLD)
+                    {
+                        log::warn!(
+                            "[ui-stall] event loop unresponsive for ~{}ms",
+                            gap.as_millis()
+                        );
                         warned_at = seen;
                     }
                     let beat_ui = Arc::clone(&beat_bg);

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -95,6 +95,7 @@ mod thumbnails;
 pub mod tuner_close;
 mod tuner_session;
 mod tuner_wiring;
+pub mod ui_stall;
 mod virtual_keyboard_wiring;
 mod vst3_editor_wiring;
 pub use bank_scene_render::{render as render_bank_scene, BankNavRow};

--- a/crates/adapter-gui/src/ui_stall.rs
+++ b/crates/adapter-gui/src/ui_stall.rs
@@ -1,0 +1,47 @@
+//! Decision logic for the `[ui-stall]` event-loop watchdog (#693, #721).
+//!
+//! The watchdog (in [`crate::desktop_app`]) runs on its own thread that wakes
+//! every `tick` (250 ms) and measures the gap since the Slint event loop last
+//! answered a posted heartbeat. A large gap was warned on directly — but that
+//! conflates two very different situations:
+//!
+//! * a **genuine freeze**: the UI thread is stuck, so it stops answering while
+//!   the rest of the process (this watchdog thread included) keeps running on
+//!   schedule; and
+//! * an **OS-induced pause**: macOS App Nap / display sleep / timer coalescing
+//!   parks the *whole process* while it sits idle in the background, so the UI
+//!   loop answers late through no fault of its own (#721).
+//!
+//! The distinguisher needs no per-thread CPU accounting or platform APIs: if
+//! only the event loop is frozen, this watchdog thread still wakes about every
+//! `tick`, so its own observed wake interval stays small while the UI gap grows.
+//! If the process was parked, the watchdog thread was frozen too, so its wake
+//! interval balloons in lockstep with the UI gap. A genuine stall is therefore
+//! "UI gap over threshold *and* the watchdog itself woke on time".
+
+use std::time::Duration;
+
+/// Whether a measured event-loop `ui_gap` is a genuine UI freeze rather than
+/// the OS parking the whole process while idle in the background.
+///
+/// * `ui_gap` — how long the event loop has gone without answering.
+/// * `watchdog_wake_interval` — how long this watchdog thread actually slept on
+///   its last iteration. ~`tick` under normal scheduling; balloons toward
+///   `ui_gap` when the OS parked the process.
+/// * `tick` — the watchdog's nominal wake period.
+/// * `threshold` — the gap above which a freeze is worth reporting.
+pub fn is_genuine_ui_stall(
+    ui_gap: Duration,
+    watchdog_wake_interval: Duration,
+    tick: Duration,
+    threshold: Duration,
+) -> bool {
+    if ui_gap < threshold {
+        return false;
+    }
+    // The watchdog thread was itself parked for far longer than its tick, in
+    // lockstep with the UI gap → the OS suspended the whole process; the event
+    // loop never actually froze. Allow a few ticks of ordinary scheduling
+    // jitter before deciding the thread "woke on time".
+    watchdog_wake_interval <= tick.saturating_mul(2)
+}

--- a/crates/adapter-gui/tests/issue_721_ui_stall_watchdog.rs
+++ b/crates/adapter-gui/tests/issue_721_ui_stall_watchdog.rs
@@ -1,0 +1,63 @@
+//! Regression for #721: the `[ui-stall]` watchdog cried wolf while the app
+//! was idle in the background.
+//!
+//! The watchdog runs on its own thread that wakes every ~250 ms and measures
+//! the gap since the Slint event loop last answered. macOS App Nap / display
+//! sleep / timer coalescing parks an idle background process, so a heartbeat
+//! lands ~800 ms late even though the UI thread never froze. The old watchdog
+//! warned on that wall-clock gap alone, indistinguishable from a real freeze.
+//!
+//! The fix: a genuine freeze leaves the rest of the process running, so the
+//! watchdog thread keeps waking on schedule while the UI gap grows. An OS pause
+//! freezes the watchdog thread too, so its own wake interval balloons in
+//! lockstep with the UI gap. `is_genuine_ui_stall` decides on that basis.
+
+use std::time::Duration;
+
+use adapter_gui::ui_stall::is_genuine_ui_stall;
+
+const TICK: Duration = Duration::from_millis(250);
+const THRESHOLD: Duration = Duration::from_millis(600);
+
+#[test]
+fn os_suspension_gap_is_not_a_stall() {
+    // The exact #721 symptom: ~800 ms UI gap while idle/backgrounded, but the
+    // watchdog thread was parked for the same ~800 ms — the whole process slept.
+    assert!(
+        !is_genuine_ui_stall(
+            Duration::from_millis(800),
+            Duration::from_millis(790),
+            TICK,
+            THRESHOLD,
+        ),
+        "a process-wide OS pause (watchdog parked in lockstep) must not be reported as a stall",
+    );
+}
+
+#[test]
+fn frozen_loop_with_live_watchdog_is_a_real_stall() {
+    // A genuine freeze: the UI loop is stuck, but the watchdog thread kept
+    // waking on schedule (~one tick), so it can see the loop is unresponsive.
+    assert!(
+        is_genuine_ui_stall(
+            Duration::from_millis(800),
+            Duration::from_millis(255),
+            TICK,
+            THRESHOLD,
+        ),
+        "a large UI gap while the watchdog woke on time is a genuine freeze",
+    );
+}
+
+#[test]
+fn gap_under_threshold_never_warns() {
+    assert!(
+        !is_genuine_ui_stall(
+            Duration::from_millis(120),
+            Duration::from_millis(250),
+            TICK,
+            THRESHOLD,
+        ),
+        "gaps below the warn threshold are normal scheduling jitter",
+    );
+}


### PR DESCRIPTION
Closes #721.

## Problem
The event-loop watchdog (`crates/adapter-gui/src/desktop_app.rs`, #693) warned on the raw wall-clock gap since the Slint loop last answered. While the app sits idle in the background, macOS App Nap / display sleep / timer coalescing parks the **whole process**, so a heartbeat lands ~800ms late through no fault of its own — indistinguishable from a real freeze by wall-clock alone. This fired spurious `[ui-stall] event loop unresponsive for ~800ms` warns while idle.

Evidence it was not a real stall: only `adapter_gui::desktop_app` fired, never the `application::publishing_dispatcher` `[ui-stall]` (a Command holding the dispatching thread), and the audio thread is isolated from the event loop (invariants 4 & 8) — no audio/latency impact.

## Fix
A genuine freeze leaves the rest of the process running, so the watchdog thread keeps waking on schedule (~its 250ms tick) while the UI gap grows. An OS pause freezes the watchdog thread too, so its own wake interval balloons in lockstep with the gap. New pure `is_genuine_ui_stall(ui_gap, watchdog_wake_interval, tick, threshold)` warns only when the gap is over threshold **and** the watchdog woke on time. No per-thread CPU accounting or platform APIs — cross-platform by construction.

## Changes
- `crates/adapter-gui/src/ui_stall.rs` — new pure decision function.
- `crates/adapter-gui/src/desktop_app.rs` — watchdog measures its own wake interval and defers to `is_genuine_ui_stall`.
- `crates/adapter-gui/src/lib.rs` — `pub mod ui_stall`.
- `crates/adapter-gui/tests/issue_721_ui_stall_watchdog.rs` — RED-first regression.

## Verification
- RED-first: test failed to compile (`unresolved import adapter_gui::ui_stall`) before the fix.
- `cargo test -p adapter-gui --test issue_721_ui_stall_watchdog` → 3 passed (OS-park suppressed, real freeze still warns, sub-threshold quiet).
- `cargo build -p adapter-gui` → clean, zero warnings.

## Out of scope
- The known boot-time `[ui-stall]` (~760ms device enumeration) — a genuine UI-thread stall, still reported.
- The `publishing_dispatcher` watchdog — separate, working as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)