### PR TITLE
fix(#723): audio analysis reads the live sample rate, never a hardcoded 48000

### DIFF
--- a/.claude/skills/openrig-code-quality/SKILL.md
+++ b/.claude/skills/openrig-code-quality/SKILL.md
@@ -460,6 +460,37 @@ Bug de áudio/real-time cuja causa não salta da leitura do código: **após a P
 
 ---
 
+## LEI — PROIBIDO marretar sample rate (ou qualquer valor dependente de device)
+
+**Nenhum caminho de áudio/análise pode assumir uma taxa de amostragem fixa.** Cada interface roda na taxa que for melhor pra ela (44.1k, 48k, 96k…). Todo cálculo que depende da taxa — pitch (tuner), bins de FFT→Hz (spectrum), latência, período, resample de loop (DI), timing — **tem que usar a taxa REAL que o stream negociou**, nunca um literal.
+
+**A fonte de verdade da taxa viva:**
+- `ProjectRuntimeController::sample_rate()` — a taxa que os streams realmente abriram (espelhada de `resolved.sample_rate`).
+- `LocalDispatcher::engine_sr()` — a mesma taxa, sincronizada via `attach_engine_sr` (caminho do #669).
+- `adapter_gui::sample_rate::resolve_input_sample_rate(project, device_id, live)` — helper único: setting salvo do device (autoritativo, o stream é forçado a ele ou falha) → senão a taxa viva. **Use este nos consumidores de análise (tuner/spectrum/latency).** NUNCA reimplemente a resolução com `unwrap_or(48_000)`.
+
+**A marreta quase nunca é um literal solto — é o FALLBACK.** O erro recorrente é `…device_settings…find(device)…map(|d| d.sample_rate).unwrap_or(48_000)`: quando o device não tem setting salvo, marreta 48000 enquanto o stream roda a 44.1k → tudo lê ~1.47 semitom acima (#723: E vira F; #669: loop de DI em câmera lenta). Variante igualmente errada: `.device_settings.iter().next()` (primeiro device) em vez do device DAQUELA chain/input.
+
+**Why:** taxa hardcoded é bug silencioso e dependente de hardware — passa na máquina do dev (48k), quebra na do usuário (44.1k). "Em macOS/Windows mudou o som" = regressão (red flag do CLAUDE.md). É a mesma doença que já mordeu tuner, spectrum, latency probe (#723) e o DI loop (#669).
+
+**How to apply:** precisa de uma taxa? Pergunte "de onde vem a taxa VIVA deste stream?" — `controller.sample_rate()` / `dispatcher.engine_sr()` / `resolve_input_sample_rate`. Uma vez que existe stream, a taxa viva SEMPRE existe; "preciso de algum valor de fallback" é falso pra caminho vivo. Exceções legítimas (não são marreta): default pré-device sobrescrito na ativação (estado inicial do controller, init de catálogo VST3), defaults de render/CLI que o usuário sobrescreve, fallback Linux/JACK de device não-configurado atrás de `cfg`, e compensação de design que USA a variável real (`scale = sample_rate / 44_100.0`).
+
+| Desculpa | Realidade |
+|---|---|
+| "Preciso de ALGUM valor pro detector rodar" | Caminho vivo sempre tem taxa viva: `controller.sample_rate()`/`engine_sr()`. O fallback marretado é o bug. |
+| "48000 é o default do projeto, é seguro" | Default pré-device ≠ taxa de um stream vivo. Num caminho de análise, 48000 fixo detona quem roda a 44.1k. |
+| "`unwrap_or(default_sample_rate())` resolve" | Continua marreta no caminho vivo. A taxa autoritativa é a do stream, não uma constante. |
+| "É só o primeiro device (`.next()`)" | Tem que ser o device DAQUELA chain/input. Primeiro device é outro stream/taxa. |
+| "É cosmético (beep/curva), não afeta som" | Mesmo assim é marreta: extraia helper que recebe a taxa real. Sem 48000 plantado. |
+
+**Red flags — PARAR:**
+- `unwrap_or(48_000)` / `unwrap_or(44_100)` em código que lê samples vivos ou calcula Hz/latência/período.
+- Um literal `48_000`/`44_100` num `.rs` de produção fora de: const default pré-device, `cfg(linux)` JACK, ou ratio de design com a variável real.
+- Re-derivar a taxa por conta própria em vez de chamar `resolve_input_sample_rate` / `controller.sample_rate()`.
+- `device_settings.iter().next()` pra achar "a taxa".
+
+---
+
 ## Audio runtime / DSP facts (hard-won — verify before touching these areas)
 
 - **`ChainRuntimeState` locks (#580):** the audio thread takes `processing.try_lock()` in `process_input_f32` and emits a SILENT buffer on failure. Any accessor the GUI calls repeatedly (meter timer at 30 Hz, spectrum, tuner) must NEVER take `processing.lock()` — mirror the value as an atomic (`AtomicUsize` etc.) updated at the rare write sites (`build_chain_runtime_state` + the rebuild path in `runtime_graph.rs`). Symptom of a violation is buffer-size dependent (32–64 glitches, 256+ absorbs); offline single-threaded tests pass while production clicks. Pinned by `crates/engine/src/stream_count_contention_tests.rs`.

--- a/crates/adapter-gui/src/block_choose_type_callback.rs
+++ b/crates/adapter-gui/src/block_choose_type_callback.rs
@@ -28,7 +28,9 @@ use crate::audio_devices::{
     refresh_input_devices, refresh_output_devices, replace_channel_options,
 };
 use crate::block_editor::{block_parameter_items_for_model, build_knob_overlays};
-use crate::eq::{build_curve_editor_points, build_multi_slider_points, compute_eq_curves};
+use crate::eq::{
+    build_curve_editor_points, build_multi_slider_points, compute_eq_curves, eq_viz_sample_rate,
+};
 use crate::helpers::{show_child_window, sync_block_editor_window, use_inline_block_editor};
 use crate::io_groups::{apply_chain_input_window_state, apply_chain_output_window_state};
 use crate::project_ops::sync_project_dirty;
@@ -336,6 +338,7 @@ pub(crate) fn wire(
             &model.effect_type,
             &model.model_id,
             &ParameterSet::default(),
+            eq_viz_sample_rate(&project_runtime),
         );
         eq_band_curves.set_vec(
             eq_bands

--- a/crates/adapter-gui/src/block_editor_window_lifecycle.rs
+++ b/crates/adapter-gui/src/block_editor_window_lifecycle.rs
@@ -37,7 +37,9 @@ use crate::block_editor::{
     block_parameter_items_for_model, build_knob_overlays, build_params_from_items,
     persist_block_editor_draft, schedule_block_editor_persist_for_block_win,
 };
-use crate::eq::{build_curve_editor_points, build_multi_slider_points, compute_eq_curves};
+use crate::eq::{
+    build_curve_editor_points, build_multi_slider_points, compute_eq_curves, eq_viz_sample_rate,
+};
 use crate::helpers::show_child_window;
 use crate::plugin_info;
 use crate::project_ops::sync_project_dirty;
@@ -216,8 +218,12 @@ pub(crate) fn wire(
                 &model.model_id,
                 &default_params,
             ));
-            let (eq_total, eq_bands) =
-                compute_eq_curves(&model.effect_type, &model.model_id, &default_params);
+            let (eq_total, eq_bands) = compute_eq_curves(
+                &model.effect_type,
+                &model.model_id,
+                &default_params,
+                eq_viz_sample_rate(&project_runtime),
+            );
             win_eq_band_curves.set_vec(
                 eq_bands
                     .into_iter()

--- a/crates/adapter-gui/src/block_editor_window_params.rs
+++ b/crates/adapter-gui/src/block_editor_window_params.rs
@@ -32,7 +32,7 @@ use crate::block_editor::{
     schedule_block_editor_persist_for_block_win, set_block_parameter_bool,
     set_block_parameter_number, set_block_parameter_option, set_block_parameter_text,
 };
-use crate::eq::compute_eq_curves;
+use crate::eq::{compute_eq_curves, eq_viz_sample_rate};
 use crate::state::{BlockEditorDraft, ProjectSession};
 use crate::{
     AppWindow, BlockEditorWindow, BlockKnobOverlay, BlockParameterItem, CurveEditorPoint,
@@ -119,8 +119,12 @@ pub(crate) fn wire(
             // would reset the TouchArea pressed state and break drag interactions).
             if let Some(draft) = win_draft.borrow().as_ref() {
                 let params = build_params_from_items(&win_param_items);
-                let (eq_total, eq_bands) =
-                    compute_eq_curves(&draft.effect_type, &draft.model_id, &params);
+                let (eq_total, eq_bands) = compute_eq_curves(
+                    &draft.effect_type,
+                    &draft.model_id,
+                    &params,
+                    eq_viz_sample_rate(&project_runtime),
+                );
                 win_eq_band_curves.set_vec(
                     eq_bands
                         .into_iter()

--- a/crates/adapter-gui/src/block_editor_window_setup.rs
+++ b/crates/adapter-gui/src/block_editor_window_setup.rs
@@ -29,7 +29,9 @@ use infra_cpal::{AudioDeviceDescriptor, ProjectRuntimeController};
 use project::param::ParameterSet;
 
 use crate::block_editor::{block_parameter_items_for_editor, build_knob_overlays};
-use crate::eq::{build_curve_editor_points, build_multi_slider_points, compute_eq_curves};
+use crate::eq::{
+    build_curve_editor_points, build_multi_slider_points, compute_eq_curves, eq_viz_sample_rate,
+};
 use crate::project_view::{
     block_model_index_from_items, block_model_picker_items, block_model_picker_labels,
     block_type_index, block_type_picker_items,
@@ -152,8 +154,12 @@ pub(crate) fn create_and_wire(
         &model_id,
         &editor_data.params,
     )));
-    let (win_eq_total, win_eq_bands) =
-        compute_eq_curves(&effect_type, &model_id, &editor_data.params);
+    let (win_eq_total, win_eq_bands) = compute_eq_curves(
+        &effect_type,
+        &model_id,
+        &editor_data.params,
+        eq_viz_sample_rate(&project_runtime),
+    );
     let win_eq_band_curves = Rc::new(VecModel::from(
         win_eq_bands
             .into_iter()

--- a/crates/adapter-gui/src/block_insert_callbacks.rs
+++ b/crates/adapter-gui/src/block_insert_callbacks.rs
@@ -25,7 +25,9 @@ use project::param::ParameterSet;
 use crate::block_editor::{
     block_parameter_items_for_model, build_knob_overlays, schedule_block_editor_persist,
 };
-use crate::eq::{build_curve_editor_points, build_multi_slider_points, compute_eq_curves};
+use crate::eq::{
+    build_curve_editor_points, build_multi_slider_points, compute_eq_curves, eq_viz_sample_rate,
+};
 use crate::helpers::{sync_block_editor_window, use_inline_block_editor};
 use crate::project_view::{block_model_picker_items, block_type_picker_items, set_selected_block};
 use crate::state::{BlockEditorDraft, ProjectSession, SelectedBlock};
@@ -216,6 +218,7 @@ pub(crate) fn wire(
                 &model.effect_type,
                 &model.model_id,
                 &ParameterSet::default(),
+                eq_viz_sample_rate(&project_runtime),
             );
             eq_band_curves.set_vec(
                 eq_bands

--- a/crates/adapter-gui/src/block_parameter_wiring.rs
+++ b/crates/adapter-gui/src/block_parameter_wiring.rs
@@ -33,7 +33,7 @@ use crate::block_editor::{
     set_block_parameter_bool, set_block_parameter_number, set_block_parameter_option,
     set_block_parameter_text,
 };
-use crate::eq::compute_eq_curves;
+use crate::eq::{compute_eq_curves, eq_viz_sample_rate};
 use crate::helpers::log_gui_message;
 use crate::project_ops::sync_project_dirty;
 use crate::project_view::{
@@ -365,8 +365,12 @@ pub(crate) fn wire(
             }
             if let Some(draft) = block_editor_draft.borrow().as_ref() {
                 let params = build_params_from_items(&block_parameter_items);
-                let (eq_total, eq_bands) =
-                    compute_eq_curves(&draft.effect_type, &draft.model_id, &params);
+                let (eq_total, eq_bands) = compute_eq_curves(
+                    &draft.effect_type,
+                    &draft.model_id,
+                    &params,
+                    eq_viz_sample_rate(&project_runtime),
+                );
                 eq_band_curves.set_vec(
                     eq_bands
                         .into_iter()

--- a/crates/adapter-gui/src/eq.rs
+++ b/crates/adapter-gui/src/eq.rs
@@ -1,4 +1,8 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
 use crate::{CurveEditorPoint, MultiSliderPoint};
+use infra_cpal::ProjectRuntimeController;
 use project::block::schema_for_block_model;
 use project::param::{CurveEditorRole, ParameterDomain, ParameterSet, ParameterWidget};
 
@@ -161,8 +165,26 @@ pub(crate) fn build_curve_editor_points(
 
 /// Number of frequency points for EQ curve rendering (20Hz–20kHz).
 pub(crate) const EQ_CURVE_POINTS: usize = 200;
-/// Sample rate assumed for EQ visualization.
-pub(crate) const EQ_VIZ_SAMPLE_RATE: f32 = 48_000.0;
+/// Reference rate used to draw the EQ curve only when NO live stream exists
+/// yet (the block editor can be open with audio stopped — the curve is then
+/// purely illustrative). Once a stream is running the curve is drawn at the
+/// real device rate via [`eq_viz_sample_rate`] so it matches the audible
+/// filter near Nyquist (issue #723). This is the sanctioned pre-device
+/// fallback, NOT an assumption baked into the live path.
+pub(crate) const EQ_VIZ_REFERENCE_SAMPLE_RATE: f32 = 48_000.0;
+
+/// The sample rate to draw EQ curves at: the live device rate when a runtime
+/// is active, else the reference (no audio running). Single source of truth so
+/// no call site re-bakes a fixed rate (issue #723).
+pub(crate) fn eq_viz_sample_rate(
+    project_runtime: &Rc<RefCell<Option<ProjectRuntimeController>>>,
+) -> f32 {
+    project_runtime
+        .borrow()
+        .as_ref()
+        .map(|c| c.sample_rate() as f32)
+        .unwrap_or(EQ_VIZ_REFERENCE_SAMPLE_RATE)
+}
 /// SVG viewbox width (must match Slint CurveEditorControl viewbox).
 pub(crate) const EQ_SVG_W: f32 = 1000.0;
 /// SVG viewbox height.
@@ -233,6 +255,7 @@ pub(crate) fn compute_eq_curves(
     effect_type: &str,
     model_id: &str,
     params: &ParameterSet,
+    sample_rate: f32,
 ) -> (String, Vec<String>) {
     let Ok(schema) = schema_for_block_model(effect_type, model_id) else {
         return (String::new(), Vec::new());
@@ -283,11 +306,11 @@ pub(crate) fn compute_eq_curves(
 
         let kind = biquad_kind_for_group(group);
         let filter =
-            block_core::BiquadFilter::new(kind, freq_hz, gain_db, q.max(0.01), EQ_VIZ_SAMPLE_RATE);
+            block_core::BiquadFilter::new(kind, freq_hz, gain_db, q.max(0.01), sample_rate);
 
         let band_dbs: Vec<f32> = freqs
             .iter()
-            .map(|&f| filter.magnitude_db(f, EQ_VIZ_SAMPLE_RATE))
+            .map(|&f| filter.magnitude_db(f, sample_rate))
             .collect();
 
         // Accumulate linear magnitudes for total curve

--- a/crates/adapter-gui/src/eq_tests.rs
+++ b/crates/adapter-gui/src/eq_tests.rs
@@ -1,5 +1,26 @@
 use super::*;
 
+// --- compute_eq_curves: sample-rate dependence (#723) ---
+
+#[test]
+fn compute_eq_curves_reflects_the_device_sample_rate() {
+    use domain::value_objects::ParameterValue;
+    use project::param::ParameterSet;
+    // Boost the high shelf so the near-Nyquist response — where bilinear
+    // warping differs most between rates — is non-flat.
+    let mut params = ParameterSet::default();
+    params.insert("high_gain", ParameterValue::Float(12.0));
+
+    let at_44100 = compute_eq_curves("filter", "eq_three_band_basic", &params, 44_100.0);
+    let at_96000 = compute_eq_curves("filter", "eq_three_band_basic", &params, 96_000.0);
+
+    assert!(!at_44100.1.is_empty(), "model must yield EQ band curves");
+    assert_ne!(
+        at_44100, at_96000,
+        "EQ curve must be drawn at the real device rate (issue #723), not a hardcoded 48k"
+    );
+}
+
 // --- db_to_linear / linear_to_db ---
 
 #[test]

--- a/crates/adapter-gui/src/latency_probe.rs
+++ b/crates/adapter-gui/src/latency_probe.rs
@@ -48,9 +48,28 @@ pub fn install_handler(
         let Some(chain) = proj.chains.get(index as usize) else {
             return;
         };
-        let device = proj.device_settings.first();
-        let sample_rate = device.map(|d| d.sample_rate as f32).unwrap_or(48_000.0);
-        let buffer_frames = device.map(|d| d.buffer_size_frames as usize).unwrap_or(256);
+        // Issue #723: never assume 48 kHz — a probe at the wrong rate skews
+        // the latency estimate. Prefer the chain input's saved device setting;
+        // otherwise fall back to the live engine rate the dispatcher synced
+        // from the running stream, not a hardcoded constant.
+        let chain_device = chain.blocks.iter().find_map(|b| match &b.kind {
+            project::block::AudioBlockKind::Input(input) => input
+                .entries
+                .first()
+                .and_then(|entry| {
+                    proj.device_settings
+                        .iter()
+                        .find(|d| d.device_id == entry.device_id)
+                }),
+            _ => None,
+        });
+        let live_sr = session.dispatcher.engine_sr();
+        let sample_rate = chain_device
+            .map(|d| d.sample_rate as f32)
+            .unwrap_or(live_sr as f32);
+        let buffer_frames = chain_device
+            .map(|d| d.buffer_size_frames as usize)
+            .unwrap_or(256);
         let ms = engine::probe::measure_chain_dsp_latency_ms(chain, sample_rate, buffer_frames);
         let expiry = Instant::now() + Duration::from_secs(10);
         probe_windows.borrow_mut().insert(index as usize, expiry);

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -88,6 +88,7 @@ pub use settings::audio::apply_audio_override;
 pub use settings::paths::{
     apply_evaluations_override, apply_plugins_override, apply_presets_override,
 };
+mod sample_rate;
 pub mod spectrum_close;
 mod spectrum_session;
 mod spectrum_wiring;

--- a/crates/adapter-gui/src/sample_rate.rs
+++ b/crates/adapter-gui/src/sample_rate.rs
@@ -1,0 +1,38 @@
+//! Single source of truth for resolving the sample rate a live-analysis
+//! consumer (tuner, spectrum, latency probe) must use for an input.
+//!
+//! The detectors are rate-agnostic *as long as they are told the true rate*.
+//! Issue #723: every consumer used to fall back to a hardcoded 48000 when an
+//! input had no saved per-device setting. On a device whose default rate is
+//! 44100 that biased pitch/spectrum readings by `48000/44100 ≈ +1.47`
+//! semitones (a played E displayed as F) and skewed latency estimates. The
+//! DI loop suffered the same class of bug (#669) before it learned to
+//! resample to the device's live rate. Each interface can run at whatever
+//! rate suits it; nothing downstream may assume a fixed rate.
+
+use domain::ids::DeviceId;
+use project::project::Project;
+
+/// Resolve the sample rate to use for an input on `device_id`.
+///
+/// The project's per-device setting is authoritative when present — the live
+/// stream is forced to that exact rate or fails to build, so it can never
+/// disagree. When no setting exists the input inherits `live_sample_rate`:
+/// the rate the controller actually negotiated with the device, NEVER a
+/// hardcoded guess.
+pub(crate) fn resolve_input_sample_rate(
+    project: &Project,
+    device_id: &DeviceId,
+    live_sample_rate: u32,
+) -> usize {
+    project
+        .device_settings
+        .iter()
+        .find(|d| &d.device_id == device_id)
+        .map(|d| d.sample_rate)
+        .unwrap_or(live_sample_rate) as usize
+}
+
+#[cfg(test)]
+#[path = "sample_rate_tests.rs"]
+mod tests;

--- a/crates/adapter-gui/src/sample_rate_tests.rs
+++ b/crates/adapter-gui/src/sample_rate_tests.rs
@@ -1,0 +1,54 @@
+use super::*;
+use domain::ids::DeviceId;
+use project::device::DeviceSettings;
+
+fn device_settings(device: &str, sample_rate: u32) -> DeviceSettings {
+    DeviceSettings {
+        device_id: DeviceId(device.into()),
+        sample_rate,
+        buffer_size_frames: 256,
+        bit_depth: 32,
+        #[cfg(target_os = "linux")]
+        realtime: true,
+        #[cfg(target_os = "linux")]
+        rt_priority: 70,
+        #[cfg(target_os = "linux")]
+        nperiods: 3,
+    }
+}
+
+fn empty_project() -> Project {
+    Project {
+        name: None,
+        device_settings: Vec::new(),
+        chains: Vec::new(),
+        midi: None,
+    }
+}
+
+#[test]
+fn resolve_input_sample_rate_uses_device_setting_when_present() {
+    let mut project = empty_project();
+    project.device_settings = vec![device_settings("dev:1", 44_100)];
+
+    // The configured rate is authoritative — the live fallback is ignored.
+    assert_eq!(
+        resolve_input_sample_rate(&project, &DeviceId("dev:1".into()), 96_000),
+        44_100,
+    );
+}
+
+#[test]
+fn resolve_input_sample_rate_falls_back_to_live_rate_not_48000() {
+    // No device_settings entry: the input must inherit the sample rate the
+    // stream actually negotiated, NOT a hardcoded 48000. Issue #723: a
+    // 48000-assumed / 44100-live mismatch biases YIN by ~1.47 semitones, so
+    // a played E is shown as F.
+    let project = empty_project();
+    assert!(project.device_settings.is_empty());
+
+    assert_eq!(
+        resolve_input_sample_rate(&project, &DeviceId("dev:1".into()), 44_100),
+        44_100,
+    );
+}

--- a/crates/adapter-gui/src/select_chain_block_callback.rs
+++ b/crates/adapter-gui/src/select_chain_block_callback.rs
@@ -38,7 +38,9 @@ use crate::block_editor::{
 };
 use crate::block_editor_window_setup;
 use crate::chain_editor::{chain_draft_from_chain, insert_mode_to_index};
-use crate::eq::{build_curve_editor_points, build_multi_slider_points, compute_eq_curves};
+use crate::eq::{
+    build_curve_editor_points, build_multi_slider_points, compute_eq_curves, eq_viz_sample_rate,
+};
 use crate::helpers::{set_status_error, show_child_window, use_inline_block_editor};
 use crate::io_groups::build_io_group_items;
 use crate::project_view::{
@@ -300,7 +302,7 @@ pub(crate) fn wire(
         block_parameter_items.set_vec(block_parameter_items_for_editor(&editor_data));
         multi_slider_points.set_vec(build_multi_slider_points(&editor_data.effect_type, &editor_data.model_id, &editor_data.params));
         curve_editor_points.set_vec(build_curve_editor_points(&editor_data.effect_type, &editor_data.model_id, &editor_data.params));
-        let (eq_total, eq_bands) = compute_eq_curves(&editor_data.effect_type, &editor_data.model_id, &editor_data.params);
+        let (eq_total, eq_bands) = compute_eq_curves(&editor_data.effect_type, &editor_data.model_id, &editor_data.params, eq_viz_sample_rate(&project_runtime));
         eq_band_curves.set_vec(eq_bands.into_iter().map(SharedString::from).collect::<Vec<_>>());
         window.set_eq_total_curve(eq_total.into());
         set_selected_block(&window, selected_block.borrow().as_ref(), Some(&chain));

--- a/crates/adapter-gui/src/spectrum_session.rs
+++ b/crates/adapter-gui/src/spectrum_session.rs
@@ -141,6 +141,10 @@ impl SpectrumSession {
             Rc::new(VecModel::from(Vec::<SpectrumRow>::new()));
         let mut row_states: Vec<RowState> = Vec::new();
 
+        // The rate the live streams actually run at — authoritative fallback
+        // for inputs without a saved per-device setting (issue #723).
+        let live_sample_rate = controller.sample_rate();
+
         for chain in &project.chains {
             if !chain.enabled {
                 continue;
@@ -192,16 +196,16 @@ impl SpectrumSession {
                 .blocks
                 .iter()
                 .find_map(|b| match &b.kind {
-                    AudioBlockKind::Input(input) => input.entries.first().and_then(|entry| {
-                        project
-                            .device_settings
-                            .iter()
-                            .find(|d| d.device_id == entry.device_id)
-                            .map(|d| d.sample_rate as usize)
+                    AudioBlockKind::Input(input) => input.entries.first().map(|entry| {
+                        crate::sample_rate::resolve_input_sample_rate(
+                            project,
+                            &entry.device_id,
+                            live_sample_rate,
+                        )
                     }),
                     _ => None,
                 })
-                .unwrap_or(48_000);
+                .unwrap_or(live_sample_rate as usize);
 
             for stream_index in 0..stream_count {
                 let device_label = entry_labels

--- a/crates/adapter-gui/src/tuner_session.rs
+++ b/crates/adapter-gui/src/tuner_session.rs
@@ -109,6 +109,10 @@ impl TunerSession {
         let rows_model: Rc<VecModel<TunerRow>> = Rc::new(VecModel::from(Vec::<TunerRow>::new()));
         let mut row_states: Vec<RowState> = Vec::new();
 
+        // The rate the live streams actually run at — authoritative fallback
+        // for inputs without a saved per-device setting (issue #723).
+        let live_sample_rate = controller.sample_rate();
+
         for chain in &project.chains {
             if !chain.enabled {
                 continue;
@@ -118,16 +122,16 @@ impl TunerSession {
                 .blocks
                 .iter()
                 .find_map(|b| match &b.kind {
-                    AudioBlockKind::Input(input) => input.entries.first().and_then(|entry| {
-                        project
-                            .device_settings
-                            .iter()
-                            .find(|d| d.device_id == entry.device_id)
-                            .map(|d| d.sample_rate)
+                    AudioBlockKind::Input(input) => input.entries.first().map(|entry| {
+                        crate::sample_rate::resolve_input_sample_rate(
+                            project,
+                            &entry.device_id,
+                            live_sample_rate,
+                        )
                     }),
                     _ => None,
                 })
-                .unwrap_or(48_000) as usize;
+                .unwrap_or(live_sample_rate as usize);
 
             let mut input_index = 0_usize;
             for block in &chain.blocks {

--- a/crates/application/src/local_dispatcher.rs
+++ b/crates/application/src/local_dispatcher.rs
@@ -222,6 +222,13 @@ impl LocalDispatcher {
         rebuilt
     }
 
+    /// The sample rate the live engine is currently running at, as last
+    /// synced via [`Self::attach_engine_sr`]. Authoritative fallback for any
+    /// consumer that would otherwise assume a fixed rate (issue #723).
+    pub fn engine_sr(&self) -> u32 {
+        *self.engine_sr.borrow()
+    }
+
     /// #614: retrieve the pre-loaded DI loop arc for `chain`, if any.
     ///
     /// The adapter-gui wiring (Task 6) calls this from the

--- a/crates/engine/src/probe.rs
+++ b/crates/engine/src/probe.rs
@@ -21,8 +21,8 @@
 
 use crate::runtime::{
     build_chain_runtime_state, process_input_f32, DEFAULT_ELASTIC_TARGET, PROBE_BEEP_FRAMES,
-    PROBE_BEEP_FREQ,
 };
+use crate::runtime_probe::write_probe_beep;
 use project::chain::Chain;
 use std::sync::Arc;
 
@@ -54,15 +54,8 @@ pub fn measure_chain_dsp_latency_ms(chain: &Chain, sample_rate: f32, buffer_fram
 
     let mut data = vec![0.0_f32; buffer_frames * PROBE_BUFFER_CHANNELS];
     let beep_frames = PROBE_BEEP_FRAMES.min(buffer_frames);
-    let nominal_sr = 48_000.0_f32;
-    for f in 0..beep_frames {
-        let t = f as f32 / nominal_sr;
-        let envelope = (std::f32::consts::PI * f as f32 / beep_frames as f32).sin();
-        let sample = (2.0 * std::f32::consts::PI * PROBE_BEEP_FREQ * t).sin() * 0.95 * envelope;
-        for ch in 0..PROBE_BUFFER_CHANNELS {
-            data[f * PROBE_BUFFER_CHANNELS + ch] = sample;
-        }
-    }
+    // Synthesize at the real measured rate (issue #723), not a hardcoded 48 kHz.
+    write_probe_beep(&mut data, PROBE_BUFFER_CHANNELS, sample_rate, beep_frames);
 
     // Diagnostic: log the chain shape and elapsed time so the user can
     // sanity-check that the probe is exercising every enabled block, not

--- a/crates/engine/src/runtime.rs
+++ b/crates/engine/src/runtime.rs
@@ -47,7 +47,7 @@ pub(crate) use crate::runtime_state::SelectRuntimeState;
 // runtime_probe.rs. Re-exports below preserve `crate::runtime::PROBE_*`
 // paths in runtime_graph.rs and probe.rs.
 use crate::runtime_probe::{PROBE_ARMED, PROBE_DETECT_THRESHOLD, PROBE_FIRED};
-pub(crate) use crate::runtime_probe::{PROBE_BEEP_FRAMES, PROBE_BEEP_FREQ, PROBE_IDLE};
+pub(crate) use crate::runtime_probe::{PROBE_BEEP_FRAMES, PROBE_IDLE};
 
 // Slice 3: graph + block builders. External callers keep using
 // `engine::runtime::*` paths via these re-exports.
@@ -127,18 +127,15 @@ pub fn process_input_f32(
             .store(injected_at, Ordering::Relaxed);
         let mut buf = data.to_vec();
         let beep_frames = PROBE_BEEP_FRAMES.min(num_frames);
-        // The audible pitch of the beep is approximate — we use the
-        // nominal 48 kHz for the sine step. The measurement itself
-        // does not depend on the beep's frequency.
-        let sr = 48_000.0_f32;
-        for f in 0..beep_frames {
-            let t = f as f32 / sr;
-            let envelope = (std::f32::consts::PI * f as f32 / beep_frames as f32).sin();
-            let sample = (2.0 * std::f32::consts::PI * PROBE_BEEP_FREQ * t).sin() * 0.95 * envelope;
-            for ch in 0..input_total_channels {
-                buf[f * input_total_channels + ch] = sample;
-            }
-        }
+        // Synthesize the beep at the runtime's REAL rate (issue #723), not a
+        // hardcoded 48 kHz. The measurement is timing-based, but the audible
+        // pitch should still be a true 1 kHz on any device rate.
+        crate::runtime_probe::write_probe_beep(
+            &mut buf,
+            input_total_channels,
+            runtime.sample_rate,
+            beep_frames,
+        );
         Some(buf)
     } else {
         None

--- a/crates/engine/src/runtime_graph.rs
+++ b/crates/engine/src/runtime_graph.rs
@@ -487,6 +487,9 @@ fn assemble_chain_runtime_state(
         // Issue #670 — audio-thread deadline accounting, zeroed at build.
         xrun_count: AtomicU64::new(0),
         peak_load_ppm: AtomicU64::new(0),
+        // Issue #723 — remember the real build rate so the live probe beep
+        // is synthesized at the device rate, never a hardcoded 48000.
+        sample_rate,
     })
 }
 

--- a/crates/engine/src/runtime_probe.rs
+++ b/crates/engine/src/runtime_probe.rs
@@ -42,6 +42,33 @@ pub(crate) const PROBE_BEEP_FREQ: f32 = 1000.0;
 /// floor so background hum does not false-trigger detection.
 pub(crate) const PROBE_DETECT_THRESHOLD: f32 = 0.05;
 
+/// Synthesize the latency-probe beep into `buf` (interleaved, `channels`
+/// wide) for the first `beep_frames` frames: a `PROBE_BEEP_FREQ` sine with a
+/// raised-cosine envelope, copied to every channel.
+///
+/// `sample_rate` MUST be the rate the stream actually runs at — the sine step
+/// is `f / sample_rate`. Issue #723: this used to be hardcoded to 48000 in
+/// both call sites (`process_input_f32` and `probe.rs`), so on a 44.1 kHz
+/// device the beep played at the wrong pitch. Shared here so neither caller
+/// can drift back to a fixed rate. Pure math, no allocation — safe to call
+/// from the audio thread.
+pub(crate) fn write_probe_beep(
+    buf: &mut [f32],
+    channels: usize,
+    sample_rate: f32,
+    beep_frames: usize,
+) {
+    use std::f32::consts::PI;
+    for f in 0..beep_frames {
+        let t = f as f32 / sample_rate;
+        let envelope = (PI * f as f32 / beep_frames as f32).sin();
+        let sample = (2.0 * PI * PROBE_BEEP_FREQ * t).sin() * 0.95 * envelope;
+        for ch in 0..channels {
+            buf[f * channels + ch] = sample;
+        }
+    }
+}
+
 impl ChainRuntimeState {
     /// Arm the latency probe. The next input callback will inject a short
     /// beep into the signal path, and the first output callback to see it

--- a/crates/engine/src/runtime_state.rs
+++ b/crates/engine/src/runtime_state.rs
@@ -389,9 +389,20 @@ pub struct ChainRuntimeState {
     /// [`crate::runtime_load`].
     pub(crate) xrun_count: AtomicU64,
     pub(crate) peak_load_ppm: AtomicU64,
+    /// The sample rate (Hz) this runtime was built at — the rate its streams
+    /// actually run at. Set once at construction, never mutated, so a plain
+    /// `f32` read is safe from the audio thread. Issue #723: the live probe
+    /// beep in `process_input_f32` reads this instead of assuming 48000, so
+    /// the 1 kHz tone is synthesized at the true device rate.
+    pub(crate) sample_rate: f32,
 }
 
 impl ChainRuntimeState {
+    /// The sample rate (Hz) this runtime runs at, captured at build time.
+    pub fn sample_rate(&self) -> f32 {
+        self.sample_rate
+    }
+
     /// Issue #703: the cpal input-stream index that feeds this runtime,
     /// when it is a per-entry isolated runtime. Two entries reading the
     /// same physical device are two runtimes with the SAME index — the

--- a/crates/engine/src/runtime_tests.rs
+++ b/crates/engine/src/runtime_tests.rs
@@ -3127,3 +3127,43 @@ fn processor_scratch_dual_mono_creates_dual_mono_scratch() {
     let scratch = processor_scratch(&proc);
     assert!(matches!(scratch, ProcessorScratch::DualMono { .. }));
 }
+
+// ── #723: no hardcoded sample rate in the latency-probe beep ──────────────
+
+#[test]
+fn chain_runtime_state_reports_its_build_sample_rate() {
+    // The live probe beep (process_input_f32) must synthesize at the real
+    // device rate, so the runtime has to remember the rate it was built at —
+    // never assume 48000 (issue #723).
+    let chain = tuner_track("chain:0", Vec::new());
+    let rt = build_chain_runtime_state(&chain, 44_100.0, &[DEFAULT_ELASTIC_TARGET])
+        .expect("runtime state should build");
+    assert_eq!(rt.sample_rate(), 44_100.0);
+}
+
+#[test]
+fn write_probe_beep_depends_on_the_passed_sample_rate() {
+    // The probe beep is a 1 kHz sine. Its sample at frame f is
+    // sin(2π·freq·f/sr)·0.95·envelope, so feeding 44100 vs 48000 must produce
+    // different audio — proving the rate is honored, not hardcoded.
+    use crate::runtime_probe::{write_probe_beep, PROBE_BEEP_FREQ};
+    let frames = 64usize;
+    let channels = 2usize;
+    let mut at_44100 = vec![0.0f32; frames * channels];
+    let mut at_48000 = vec![0.0f32; frames * channels];
+    write_probe_beep(&mut at_44100, channels, 44_100.0, frames);
+    write_probe_beep(&mut at_48000, channels, 48_000.0, frames);
+    assert_ne!(
+        at_44100, at_48000,
+        "beep must depend on the passed sample rate"
+    );
+
+    let f = 20usize;
+    let sr = 44_100.0f32;
+    let env = (std::f32::consts::PI * f as f32 / frames as f32).sin();
+    let expected =
+        (2.0 * std::f32::consts::PI * PROBE_BEEP_FREQ * (f as f32 / sr)).sin() * 0.95 * env;
+    assert!((at_44100[f * channels] - expected).abs() < 1e-5);
+    // Both channels carry the same mono beep.
+    assert_eq!(at_44100[f * channels], at_44100[f * channels + 1]);
+}


### PR DESCRIPTION
Closes #723.

## Problem
The Tuner displayed ~1.5 semitones sharp — a played **E** showed **F**. Root cause: consumers derived the sample rate from `device_settings` with a hardcoded **48000** fallback, while the live cpal stream opens at the device's negotiated rate (often 44100). YIN then computed `freq = 48000/tau` over 44100-rate samples → `48000/44100 ≈ +1.47` semitones. Same class of bug as the DI loop slow-motion at 44.1k (#669).

The audit found the same hardcoded-48000 assumption in **spectrum**, the **latency probe**, the **latency-probe beep**, and the **EQ curve visualization**.

## Fix — one rule: never assume a fixed rate, use the live negotiated one
- **Tuner / Spectrum:** new single source of truth `resolve_input_sample_rate(project, device_id, live)` — saved per-device setting when present, else the live `controller.sample_rate()`.
- **Latency probe:** keys the device by the chain input, falls back to the dispatcher's live `engine_sr()`; new `LocalDispatcher::engine_sr()` getter.
- **Probe beep:** shared `write_probe_beep(buf, channels, sample_rate, frames)` fed the real rate; `ChainRuntimeState` now remembers its build `sample_rate` (immutable, audio-thread-safe).
- **EQ curve:** `compute_eq_curves(..., sample_rate)`; the 7 block-editor call sites resolve it via `eq_viz_sample_rate(&project_runtime)` (live rate, else a clearly-named reference for editor-open-with-audio-stopped).
- **Skill LAW:** added "PROIBIDO marretar sample rate" to `openrig-code-quality` so the pattern is caught in review (sources of truth, `unwrap_or(48_000)`/`.next()` failure modes, rationalization table). RED→GREEN verified with subagents.

## Tests (TDD red-first)
`resolve_input_sample_rate_*`, `write_probe_beep_depends_on_the_passed_sample_rate`, `chain_runtime_state_reports_its_build_sample_rate`, `compute_eq_curves_reflects_the_device_sample_rate`. Engine 591 green; adapter-gui new tests green.

## Pre-existing failures (NOT from this PR)
`i18n::tests::preset_picker_overlay_tr_keys_are_translated_in_pt_br` and `settings_screen_tr_keys_are_translated_in_pt_br` fail on `develop` too — `btn-load-preset` has a `msgctxt` but is looked up context-free. This branch touches zero `.slint`/`.po` files (`git diff --name-only develop...HEAD`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)