### PR TITLE
fix(#726): stop adapter-gui build.rs self-invalidating every build

### DIFF
--- a/crates/adapter-gui/build.rs
+++ b/crates/adapter-gui/build.rs
@@ -1,6 +1,12 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+// Shared with the crate (and unit-tested there) — see issue #726. Included by
+// path because a build script is its own compilation unit and can't reach the
+// crate's modules.
+#[path = "src/mo_freshness.rs"]
+mod mo_freshness;
+
 fn main() {
     // with_bundled_translations embeds the .po files directly into the
     // compiled binary at compile time. This sidesteps every runtime path
@@ -119,6 +125,18 @@ fn compile_po(po: &Path, mo_dir: &Path, lang: &str) {
         return;
     }
     let mo = mo_dir.join("adapter-gui.mo");
+    // #726: only (re)compile when the .mo is missing or older than its .po.
+    // Rewriting an up-to-date .mo bumps translations/ (tracked via
+    // rerun-if-changed), which makes Cargo re-run this build script and relink
+    // adapter-gui (~30s) on every build. The freshness rule is unit-tested in
+    // mo_freshness.rs.
+    let po_mtime = std::fs::metadata(po).and_then(|m| m.modified()).ok();
+    let mo_mtime = std::fs::metadata(&mo).and_then(|m| m.modified()).ok();
+    if let Some(po_mtime) = po_mtime {
+        if !mo_freshness::mo_is_stale(po_mtime, mo_mtime) {
+            return;
+        }
+    }
     let status = Command::new("msgfmt").arg("-o").arg(&mo).arg(po).status();
     if let Ok(s) = status {
         if !s.success() {

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -137,6 +137,7 @@ mod meter_wiring_row_update_tests;
 mod midi_adapter_wiring;
 pub mod midi_profile_wiring;
 pub use midi_profile_wiring::start_midi_profiles;
+pub mod mo_freshness;
 mod model_search;
 mod model_search_wiring;
 mod preset_search;

--- a/crates/adapter-gui/src/mo_freshness.rs
+++ b/crates/adapter-gui/src/mo_freshness.rs
@@ -1,0 +1,26 @@
+//! Freshness check for build.rs gettext `.mo` compilation (issue #726).
+//!
+//! `build.rs` writes the compiled `.mo` catalogs in-source under
+//! `translations/<lang>/LC_MESSAGES/` (the path the packaging scripts read)
+//! while also tracking `translations/` via `cargo:rerun-if-changed`.
+//! Rewriting an up-to-date `.mo` bumps the directory mtime, which makes Cargo
+//! treat the build script as stale and recompile + relink `adapter-gui` on
+//! every build (~30s). Gating the rewrite on this freshness check breaks the
+//! self-invalidation loop while keeping the in-source `.mo` packaging needs.
+//!
+//! Kept as a pure function of the two mtimes so it is trivially testable
+//! without touching the filesystem (see `tests/mo_freshness_idempotence.rs`);
+//! `build.rs` reads the metadata and feeds the timestamps in.
+
+use std::time::SystemTime;
+
+/// Returns `true` when the `.mo` must be (re)compiled: either it does not
+/// exist yet (`mo_mtime` is `None`), or its source `.po` is strictly newer.
+/// Equal mtimes count as up to date — no rewrite — so a clean tree stops
+/// touching `translations/` and Cargo stops re-running the build script.
+pub fn mo_is_stale(po_mtime: SystemTime, mo_mtime: Option<SystemTime>) -> bool {
+    match mo_mtime {
+        None => true,
+        Some(mo_mtime) => po_mtime > mo_mtime,
+    }
+}

--- a/crates/adapter-gui/tests/mo_freshness_idempotence.rs
+++ b/crates/adapter-gui/tests/mo_freshness_idempotence.rs
@@ -1,0 +1,41 @@
+// Issue #726 — the build.rs translation step rewrote the `.mo` catalogs on
+// every build even when the `.po` had not changed. Because build.rs also
+// tracks `translations/` via `cargo:rerun-if-changed`, the rewrite bumped the
+// dir mtime, Cargo declared the build script stale, and `adapter-gui` was
+// recompiled + relinked (~30s) on EVERY run. The fix gates the rewrite on a
+// freshness check: only (re)compile a `.mo` when it is missing or its source
+// `.po` is newer. These tests pin that freshness decision.
+
+use std::time::{Duration, SystemTime};
+
+use adapter_gui::mo_freshness::mo_is_stale;
+
+#[test]
+fn recompiles_when_mo_absent() {
+    // No compiled catalog yet → must compile.
+    assert!(mo_is_stale(SystemTime::UNIX_EPOCH, None));
+}
+
+#[test]
+fn recompiles_when_po_is_newer_than_mo() {
+    let mo = SystemTime::UNIX_EPOCH;
+    let po = mo + Duration::from_secs(10);
+    // Source edited after the last compile → must recompile.
+    assert!(mo_is_stale(po, Some(mo)));
+}
+
+#[test]
+fn skips_when_mo_is_newer_than_po() {
+    let po = SystemTime::UNIX_EPOCH;
+    let mo = po + Duration::from_secs(10);
+    // Already compiled and up to date → must NOT rewrite (this is the bug fix:
+    // rewriting here is what bumped translations/ and self-invalidated).
+    assert!(!mo_is_stale(po, Some(mo)));
+}
+
+#[test]
+fn skips_when_mo_equals_po() {
+    let t = SystemTime::UNIX_EPOCH + Duration::from_secs(5);
+    // Equal mtime → up to date, no rewrite.
+    assert!(!mo_is_stale(t, Some(t)));
+}


### PR DESCRIPTION
Closes #726.

## Problem
`adapter-gui` recompiled + relinked on **every** `cargo build`/run (~25–37s, almost all single-thread link), even with no source change. Root cause (proven via Cargo's fingerprint log): `build.rs` rewrites the in-source `.mo` catalogs under `translations/<lang>/LC_MESSAGES/` every build, while `translations/` is tracked via `cargo:rerun-if-changed` — a self-invalidation loop.

## Fix
Gate the `.mo` write on an mtime freshness check: only (re)compile when the `.mo` is missing or its `.po` is newer. The rule is a pure function `mo_freshness::mo_is_stale`, shared with `build.rs` via `#[path]` and unit-tested red-first.

## Verification
- Consecutive no-op `cargo build --bin adapter-gui`: **0.35–0.67s**, no `Compiling adapter-gui` (was 25–37s).
- `touch`ing a `.po` still regenerates its `.mo`.
- In-source `.mo` packaging path (macOS/Linux/Windows) unchanged.
- New tests: 4/4 pass (red-first verified: `unresolved import` → green).

## Base note
Targets `feature/issue-716` per request. The full `cargo test -p adapter-gui --lib` does not compile on this base due to two **pre-existing** #716 tests (`spectrum_session_tests`, `tuner_session_tests`: `InputBlock` missing `endpoint`/`io`) — untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)