### PR TITLE
feat(#733): IR convolution reverb backend (dry/wet over shared IR engine)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,9 +966,12 @@ dependencies = [
  "anyhow",
  "block-core",
  "domain",
+ "hound",
+ "ir",
  "log",
  "lv2",
  "plugin-loader",
+ "serde_yaml",
  "vst3-host",
 ]
 

--- a/crates/block-reverb/Cargo.toml
+++ b/crates/block-reverb/Cargo.toml
@@ -6,8 +6,11 @@ edition.workspace = true
 anyhow.workspace = true
 block-core = { path = "../block-core" }
 plugin-loader = { path = "../plugin-loader" }
+ir = { path = "../ir" }
 lv2 = { path = "../lv2" }
 vst3-host = { path = "../vst3" }
 log.workspace = true
 [dev-dependencies]
 domain = { path = "../domain" }
+hound = "3.5"
+serde_yaml = "0.9"

--- a/crates/block-reverb/src/ir_reverb.rs
+++ b/crates/block-reverb/src/ir_reverb.rs
@@ -1,0 +1,226 @@
+//! IR (convolution) reverb backend.
+//!
+//! Wraps a wet impulse-response convolution (from `crates/ir`) with a
+//! dry/wet mixer, an optional pre-delay on the wet path, and a wet level
+//! trim. Unlike a cab block (100% wet, spectral-peak normalised), a reverb
+//! blends the dry signal with a long diffuse tail, so the wet path stays
+//! gain-passive and the mix is the primary control.
+//!
+//! Issue: #733
+
+use anyhow::Result;
+use block_core::param::{float_parameter, ParameterSet, ParameterSpec, ParameterUnit};
+use block_core::{AudioChannelLayout, BlockProcessor, MonoProcessor, StereoProcessor};
+use plugin_loader::LoadedPackage;
+
+/// Wet fraction (`%`) default — a tasteful blend, dry-dominant.
+const DEFAULT_MIX_PCT: f32 = 30.0;
+/// Pre-delay (ms) default — none.
+const DEFAULT_PRE_DELAY_MS: f32 = 0.0;
+/// Wet level trim (dB) default — unity.
+const DEFAULT_LEVEL_DB: f32 = 0.0;
+
+/// Parameter schema shared by every IR-backed reverb block. Single source for
+/// the editor knobs (see `project::block::dispatch`) and the processor
+/// defaults below — both read the same keys/defaults, so they never drift.
+///
+/// These are processing controls layered on top of any capture-grid axes the
+/// manifest declares (the IR file selectors); they are not capture selectors.
+pub fn ir_reverb_parameter_specs() -> Vec<ParameterSpec> {
+    vec![
+        float_parameter(
+            "mix",
+            "Mix",
+            None,
+            Some(DEFAULT_MIX_PCT),
+            0.0,
+            100.0,
+            1.0,
+            ParameterUnit::Percent,
+        ),
+        float_parameter(
+            "pre_delay_ms",
+            "Pre-Delay",
+            None,
+            Some(DEFAULT_PRE_DELAY_MS),
+            0.0,
+            200.0,
+            1.0,
+            ParameterUnit::Milliseconds,
+        ),
+        float_parameter(
+            "level",
+            "Wet Level",
+            None,
+            Some(DEFAULT_LEVEL_DB),
+            -24.0,
+            24.0,
+            0.1,
+            ParameterUnit::Decibels,
+        ),
+    ]
+}
+
+/// Build an IR-convolution reverb processor from a `type: reverb` +
+/// `backend: ir` package: the gain-passive wet convolution (reused from
+/// `crates/ir`) wrapped in a dry/wet mixer with a pre-delay on the wet path
+/// and a wet level trim.
+pub fn build_ir_reverb_from_package(
+    package: &LoadedPackage,
+    params: &ParameterSet,
+    sample_rate: f32,
+    layout: AudioChannelLayout,
+) -> Result<BlockProcessor> {
+    let (wet, _audit_db) =
+        ir::from_package::build_convolution_from_package(package, params, sample_rate, layout)?;
+
+    let mix = params.get_f32("mix").unwrap_or(DEFAULT_MIX_PCT) / 100.0;
+    let level_db = params.get_f32("level").unwrap_or(DEFAULT_LEVEL_DB);
+    let wet_gain = 10.0_f32.powf(level_db / 20.0);
+    let pre_delay_ms = params
+        .get_f32("pre_delay_ms")
+        .unwrap_or(DEFAULT_PRE_DELAY_MS)
+        .max(0.0);
+    let pre_delay_frames = (pre_delay_ms / 1000.0 * sample_rate).round() as usize;
+
+    Ok(match wet {
+        BlockProcessor::Stereo(wet) => BlockProcessor::Stereo(Box::new(DryWetStereo::new(
+            wet,
+            mix,
+            wet_gain,
+            PreDelayStereo::new(pre_delay_frames),
+        ))),
+        BlockProcessor::Mono(wet) => BlockProcessor::Mono(Box::new(DryWetMono::new(
+            wet,
+            mix,
+            wet_gain,
+            PreDelayMono::new(pre_delay_frames),
+        ))),
+    })
+}
+
+/// Fixed-length pre-delay ring buffer on the stereo wet path. A length of 0
+/// is a pass-through (no allocation walk, returns the input frame).
+pub(crate) struct PreDelayStereo {
+    buffer: Vec<[f32; 2]>,
+    index: usize,
+}
+
+impl PreDelayStereo {
+    pub(crate) fn new(frames: usize) -> Self {
+        Self {
+            buffer: vec![[0.0; 2]; frames],
+            index: 0,
+        }
+    }
+
+    fn process(&mut self, input: [f32; 2]) -> [f32; 2] {
+        if self.buffer.is_empty() {
+            return input;
+        }
+        let out = self.buffer[self.index];
+        self.buffer[self.index] = input;
+        self.index = (self.index + 1) % self.buffer.len();
+        out
+    }
+}
+
+/// Blends a dry stereo signal with a wet convolution tail. `mix` is the wet
+/// fraction in `0.0..=1.0`; `wet_gain` is a linear trim on the wet path; the
+/// wet input is fed through `pre_delay` first.
+pub(crate) struct DryWetStereo {
+    wet: Box<dyn StereoProcessor>,
+    mix: f32,
+    wet_gain: f32,
+    pre_delay: PreDelayStereo,
+}
+
+impl DryWetStereo {
+    pub(crate) fn new(
+        wet: Box<dyn StereoProcessor>,
+        mix: f32,
+        wet_gain: f32,
+        pre_delay: PreDelayStereo,
+    ) -> Self {
+        Self {
+            wet,
+            mix: mix.clamp(0.0, 1.0),
+            wet_gain,
+            pre_delay,
+        }
+    }
+}
+
+impl StereoProcessor for DryWetStereo {
+    fn process_frame(&mut self, input: [f32; 2]) -> [f32; 2] {
+        let delayed = self.pre_delay.process(input);
+        let wet = self.wet.process_frame(delayed);
+        let dry = 1.0 - self.mix;
+        let wet_l = self.mix * self.wet_gain * wet[0];
+        let wet_r = self.mix * self.wet_gain * wet[1];
+        [dry.mul_add(input[0], wet_l), dry.mul_add(input[1], wet_r)]
+    }
+}
+
+/// Fixed-length pre-delay ring buffer on the mono wet path. Length 0 is a
+/// pass-through.
+pub(crate) struct PreDelayMono {
+    buffer: Vec<f32>,
+    index: usize,
+}
+
+impl PreDelayMono {
+    pub(crate) fn new(frames: usize) -> Self {
+        Self {
+            buffer: vec![0.0; frames],
+            index: 0,
+        }
+    }
+
+    fn process(&mut self, input: f32) -> f32 {
+        if self.buffer.is_empty() {
+            return input;
+        }
+        let out = self.buffer[self.index];
+        self.buffer[self.index] = input;
+        self.index = (self.index + 1) % self.buffer.len();
+        out
+    }
+}
+
+/// Mono counterpart of [`DryWetStereo`].
+pub(crate) struct DryWetMono {
+    wet: Box<dyn MonoProcessor>,
+    mix: f32,
+    wet_gain: f32,
+    pre_delay: PreDelayMono,
+}
+
+impl DryWetMono {
+    pub(crate) fn new(
+        wet: Box<dyn MonoProcessor>,
+        mix: f32,
+        wet_gain: f32,
+        pre_delay: PreDelayMono,
+    ) -> Self {
+        Self {
+            wet,
+            mix: mix.clamp(0.0, 1.0),
+            wet_gain,
+            pre_delay,
+        }
+    }
+}
+
+impl MonoProcessor for DryWetMono {
+    fn process_sample(&mut self, input: f32) -> f32 {
+        let delayed = self.pre_delay.process(input);
+        let wet = self.wet.process_sample(delayed);
+        let dry = 1.0 - self.mix;
+        dry.mul_add(input, self.mix * self.wet_gain * wet)
+    }
+}
+
+#[cfg(test)]
+#[path = "ir_reverb_tests.rs"]
+mod tests;

--- a/crates/block-reverb/src/ir_reverb_tests.rs
+++ b/crates/block-reverb/src/ir_reverb_tests.rs
@@ -1,0 +1,240 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use block_core::param::ParameterSet;
+use block_core::{AudioChannelLayout, BlockProcessor, StereoProcessor};
+use domain::value_objects::ParameterValue;
+use plugin_loader::manifest::PluginManifest;
+use plugin_loader::LoadedPackage;
+
+use super::{build_ir_reverb_from_package, DryWetStereo, PreDelayStereo};
+
+/// A wet stand-in that ignores its input and emits a fixed frame, so a test
+/// can prove the dry/wet blend without needing a real IR convolution.
+struct ConstWet(f32);
+
+impl StereoProcessor for ConstWet {
+    fn process_frame(&mut self, _input: [f32; 2]) -> [f32; 2] {
+        [self.0, self.0]
+    }
+}
+
+/// Identity wet: returns its input untouched, so mix=1 with unit gain and no
+/// pre-delay should reproduce the input exactly.
+struct IdentityWet;
+
+impl StereoProcessor for IdentityWet {
+    fn process_frame(&mut self, input: [f32; 2]) -> [f32; 2] {
+        input
+    }
+}
+
+#[test]
+fn mix_zero_passes_dry_only() {
+    let mut rev = DryWetStereo::new(Box::new(ConstWet(9.0)), 0.0, 1.0, PreDelayStereo::new(0));
+    let out = rev.process_frame([0.3, -0.4]);
+    assert!(
+        (out[0] - 0.3).abs() < 1e-6 && (out[1] - (-0.4)).abs() < 1e-6,
+        "mix=0 must be dry-only, got {out:?}"
+    );
+}
+
+#[test]
+fn mix_one_passes_wet_only() {
+    let mut rev = DryWetStereo::new(Box::new(IdentityWet), 1.0, 1.0, PreDelayStereo::new(0));
+    let out = rev.process_frame([0.25, 0.5]);
+    assert!(
+        (out[0] - 0.25).abs() < 1e-6 && (out[1] - 0.5).abs() < 1e-6,
+        "mix=1 with identity wet must reproduce input, got {out:?}"
+    );
+}
+
+#[test]
+fn mix_one_suppresses_dry() {
+    // Wet emits a constant; at mix=1 the dry input must not leak through.
+    let mut rev = DryWetStereo::new(Box::new(ConstWet(0.0)), 1.0, 1.0, PreDelayStereo::new(0));
+    let out = rev.process_frame([0.8, 0.8]);
+    assert!(
+        out[0].abs() < 1e-6 && out[1].abs() < 1e-6,
+        "mix=1 with silent wet must suppress dry, got {out:?}"
+    );
+}
+
+#[test]
+fn stereo_width_preserved_through_dry_path() {
+    // Distinct L/R must stay distinct (no auto-pan / no mono collapse).
+    let mut rev = DryWetStereo::new(Box::new(ConstWet(0.0)), 0.3, 1.0, PreDelayStereo::new(0));
+    let out = rev.process_frame([0.6, -0.2]);
+    assert!(out[0] != out[1], "L/R collapsed: {out:?}");
+    assert!(
+        (out[0] - 0.7 * 0.6).abs() < 1e-6,
+        "left dry scale wrong: {out:?}"
+    );
+    assert!(
+        (out[1] - 0.7 * -0.2).abs() < 1e-6,
+        "right dry scale wrong: {out:?}"
+    );
+}
+
+#[test]
+fn wet_gain_scales_wet_path() {
+    let mut rev = DryWetStereo::new(Box::new(ConstWet(0.5)), 1.0, 0.5, PreDelayStereo::new(0));
+    let out = rev.process_frame([0.0, 0.0]);
+    assert!(
+        (out[0] - 0.25).abs() < 1e-6 && (out[1] - 0.25).abs() < 1e-6,
+        "wet gain 0.5 on wet 0.5 must yield 0.25, got {out:?}"
+    );
+}
+
+// --- package-loading path (build_ir_reverb_from_package) ----------------
+
+const SR: f32 = 48_000.0;
+
+/// Write an impulse IR WAV (`channels`-wide, impulse of `gain` at sample 0,
+/// then `len-1` zeros) and return its path.
+fn write_impulse_ir(name: &str, channels: u16, gain: f32, len: usize) -> PathBuf {
+    let path = std::env::temp_dir().join(name);
+    let spec = hound::WavSpec {
+        channels,
+        sample_rate: 48_000,
+        bits_per_sample: 32,
+        sample_format: hound::SampleFormat::Float,
+    };
+    let mut writer = hound::WavWriter::create(&path, spec).expect("create IR wav");
+    for frame in 0..len {
+        let sample = if frame == 0 { gain } else { 0.0 };
+        for _ in 0..channels {
+            writer.write_sample(sample).expect("write sample");
+        }
+    }
+    writer.finalize().expect("finalize IR wav");
+    path
+}
+
+/// Build a `type: reverb` + `backend: ir` package whose single capture points
+/// at `wav_path` (whose parent becomes the package root).
+fn reverb_ir_package(wav_path: &Path) -> LoadedPackage {
+    let file_name = wav_path.file_name().unwrap().to_str().unwrap();
+    let yaml = format!(
+        "manifest_version: 1\n\
+         id: test_reverb_ir\n\
+         display_name: Test Reverb IR\n\
+         type: reverb\n\
+         backend: ir\n\
+         captures:\n\
+         \x20 - file: {file_name}\n"
+    );
+    let manifest: PluginManifest = serde_yaml::from_str(&yaml).expect("parse reverb-ir manifest");
+    LoadedPackage {
+        root: wav_path.parent().unwrap().to_path_buf(),
+        manifest,
+    }
+}
+
+fn params(pairs: &[(&str, f32)]) -> ParameterSet {
+    let mut set = ParameterSet::default();
+    for (k, v) in pairs {
+        set.insert(*k, ParameterValue::Float(*v));
+    }
+    set
+}
+
+#[test]
+fn reverb_ir_manifest_with_type_reverb_and_backend_ir_loads() {
+    // Guards the loader question: type: reverb + backend: ir must build.
+    let wav = write_impulse_ir("openrig_rev_load.wav", 2, 1.0, 128);
+    let pkg = reverb_ir_package(&wav);
+    let p = params(&[("mix", 30.0)]);
+    let built = build_ir_reverb_from_package(&pkg, &p, SR, AudioChannelLayout::Stereo);
+    fs::remove_file(&wav).ok();
+    assert!(built.is_ok(), "reverb-ir build failed: {:?}", built.err());
+    assert!(matches!(built.unwrap(), BlockProcessor::Stereo(_)));
+}
+
+#[test]
+fn stereo_reverb_ir_convolves_true_stereo_not_downmixed() {
+    // Feed L=impulse, R=silent. A true-stereo convolution keeps the wet
+    // energy on L only; a mono-collapse would mirror it onto R.
+    let wav = write_impulse_ir("openrig_rev_stereo.wav", 2, 1.0, 128);
+    let pkg = reverb_ir_package(&wav);
+    let p = params(&[("mix", 100.0)]);
+    let BlockProcessor::Stereo(mut proc) =
+        build_ir_reverb_from_package(&pkg, &p, SR, AudioChannelLayout::Stereo).unwrap()
+    else {
+        panic!("expected stereo processor");
+    };
+    fs::remove_file(&wav).ok();
+
+    let mut energy_l = 0.0f32;
+    let mut energy_r = 0.0f32;
+    for frame in 0..256 {
+        let input = if frame == 0 { [1.0, 0.0] } else { [0.0, 0.0] };
+        let out = proc.process_frame(input);
+        energy_l += out[0].abs();
+        energy_r += out[1].abs();
+    }
+    assert!(energy_l > 0.5, "left wet tail missing: {energy_l}");
+    assert!(
+        energy_r < 1e-3,
+        "right channel leaked (downmix): {energy_r}"
+    );
+}
+
+#[test]
+fn mix_zero_passes_dry_through_package_path() {
+    let wav = write_impulse_ir("openrig_rev_dry.wav", 2, 1.0, 128);
+    let pkg = reverb_ir_package(&wav);
+    let p = params(&[("mix", 0.0)]);
+    let BlockProcessor::Stereo(mut proc) =
+        build_ir_reverb_from_package(&pkg, &p, SR, AudioChannelLayout::Stereo).unwrap()
+    else {
+        panic!("expected stereo processor");
+    };
+    fs::remove_file(&wav).ok();
+    let out = proc.process_frame([0.6, -0.3]);
+    assert!(
+        (out[0] - 0.6).abs() < 1e-6 && (out[1] - (-0.3)).abs() < 1e-6,
+        "mix=0 must pass dry, got {out:?}"
+    );
+}
+
+#[test]
+fn mono_ir_in_mono_layout_produces_wet_tail() {
+    let wav = write_impulse_ir("openrig_rev_mono.wav", 1, 1.0, 128);
+    let pkg = reverb_ir_package(&wav);
+    let p = params(&[("mix", 100.0)]);
+    let BlockProcessor::Mono(mut proc) =
+        build_ir_reverb_from_package(&pkg, &p, SR, AudioChannelLayout::Mono).unwrap()
+    else {
+        panic!("expected mono processor");
+    };
+    fs::remove_file(&wav).ok();
+    let mut energy = 0.0f32;
+    for frame in 0..256 {
+        let input = if frame == 0 { 1.0 } else { 0.0 };
+        energy += proc.process_sample(input).abs();
+    }
+    assert!(energy > 0.5, "mono wet tail missing: {energy}");
+}
+
+#[test]
+fn pre_delay_shifts_wet_in_time() {
+    // Identity wet + 2-sample pre-delay: an impulse on the wet path must
+    // appear 2 frames later. mix=1 isolates the wet path.
+    let mut rev = DryWetStereo::new(Box::new(IdentityWet), 1.0, 1.0, PreDelayStereo::new(2));
+    let f0 = rev.process_frame([1.0, 1.0]);
+    let f1 = rev.process_frame([0.0, 0.0]);
+    let f2 = rev.process_frame([0.0, 0.0]);
+    assert!(
+        f0[0].abs() < 1e-6,
+        "frame 0 should be delayed silence, got {f0:?}"
+    );
+    assert!(
+        f1[0].abs() < 1e-6,
+        "frame 1 should be delayed silence, got {f1:?}"
+    );
+    assert!(
+        (f2[0] - 1.0).abs() < 1e-6,
+        "impulse should land at frame 2, got {f2:?}"
+    );
+}

--- a/crates/block-reverb/src/lib.rs
+++ b/crates/block-reverb/src/lib.rs
@@ -1,6 +1,9 @@
 //! Reverb implementations.
+mod ir_reverb;
 pub mod model_visual;
 mod registry;
+
+pub use ir_reverb::ir_reverb_parameter_specs;
 
 use anyhow::Result;
 use block_core::param::{ModelParameterSchema, ParameterSet};
@@ -78,6 +81,15 @@ pub fn build_reverb_processor_for_layout(
         return (definition.build)(params, sample_rate, layout);
     }
     if let Some(package) = plugin_loader::registry::find(model) {
+        // IR-backed reverb packages convolve a reverb impulse response and
+        // blend it with the dry signal (issue #733) — distinct from a cab
+        // block (100% wet). Everything else uses the package's own builder.
+        if matches!(
+            package.manifest.backend,
+            plugin_loader::manifest::Backend::Ir { .. }
+        ) {
+            return ir_reverb::build_ir_reverb_from_package(package, params, sample_rate, layout);
+        }
         return package.build_processor(params, sample_rate, layout);
     }
     anyhow::bail!("unsupported reverb model '{}'", model)

--- a/crates/ir/src/from_package.rs
+++ b/crates/ir/src/from_package.rs
@@ -18,19 +18,56 @@ use plugin_loader::LoadedPackage;
 use crate::{build_mono_ir_processor_from_wav, build_stereo_ir_processor_from_wav, IrAsset};
 
 /// Build a [`BlockProcessor`] from a disk-backed IR package.
+///
+/// This is the cab/body path: 100% wet convolution with the capture's
+/// audit-baseline output gain applied. For a reverb wet path that blends
+/// dry/wet itself, use [`build_convolution_from_package`] and apply the
+/// dry/wet mixer on top.
 pub fn build_from_package(
     package: &LoadedPackage,
     params: &ParameterSet,
     sample_rate: f32,
     layout: AudioChannelLayout,
 ) -> Result<BlockProcessor> {
+    let (processor, capture_audit_db) =
+        build_convolution_from_package(package, params, sample_rate, layout)?;
+    // Issue #491 + #514 + #655: post-convolution output gain (dB). A pure
+    // IR is gain-passive, but the perceived level varies a lot (cab/body
+    // shapers attenuate lows differently), so each capture ships an audit
+    // baseline (`capture.output_gain_db`, manifest-level as fallback).
+    // Since #655 the user-facing `output_db` knob is the absolute applied
+    // level and overrides the baseline when present; legacy presets without
+    // the param keep their audit loudness (volume invariant #10).
+    let user_output_db = params.get_f32("output_db");
+    let applied_db = resolve_output_db(
+        user_output_db,
+        capture_audit_db,
+        package.manifest.output_gain_db,
+    );
+    Ok(wrap_with_output_gain_db(processor, applied_db))
+}
+
+/// Build the raw, gain-passive convolution [`BlockProcessor`] for the IR
+/// capture matched by `params`, returning it alongside the matched capture's
+/// audit-baseline `output_gain_db` (so the cab path can wrap it).
+///
+/// Resolves the capture grid, loads the WAV, and matches the file's channel
+/// count to the requested layout (true-stereo for 2-channel, dual-mono wrap
+/// for a mono IR in a stereo chain). No output gain is applied — the caller
+/// owns the level strategy (cab: audit baseline; reverb #733: dry/wet mix).
+pub fn build_convolution_from_package(
+    package: &LoadedPackage,
+    params: &ParameterSet,
+    sample_rate: f32,
+    layout: AudioChannelLayout,
+) -> Result<(BlockProcessor, Option<f32>)> {
     let (parameters, captures) = match &package.manifest.backend {
         Backend::Ir {
             parameters,
             captures,
         } => (parameters, captures),
         _ => bail!(
-            "ir::build_from_package called with non-IR backend (model `{}`)",
+            "ir::build_convolution_from_package called with non-IR backend (model `{}`)",
             package.manifest.id
         ),
     };
@@ -69,20 +106,7 @@ pub fn build_from_package(
             package.manifest.id
         ),
     };
-    // Issue #491 + #514 + #655: post-convolution output gain (dB). A pure
-    // IR is gain-passive, but the perceived level varies a lot (cab/body
-    // shapers attenuate lows differently), so each capture ships an audit
-    // baseline (`capture.output_gain_db`, manifest-level as fallback).
-    // Since #655 the user-facing `output_db` knob is the absolute applied
-    // level and overrides the baseline when present; legacy presets without
-    // the param keep their audit loudness (volume invariant #10).
-    let user_output_db = params.get_f32("output_db");
-    let applied_db = resolve_output_db(
-        user_output_db,
-        capture.output_gain_db,
-        package.manifest.output_gain_db,
-    );
-    Ok(wrap_with_output_gain_db(processor, applied_db))
+    Ok((processor, capture.output_gain_db))
 }
 
 /// Choose the audit-baseline dB to apply, preferring the per-capture

--- a/crates/project/src/block/dispatch.rs
+++ b/crates/project/src/block/dispatch.rs
@@ -154,6 +154,14 @@ pub(crate) fn synthesize_parameters_from_manifest(
             let axes = plugin_loader::grid_axes::effective_grid_axes(parameters, captures);
             let mut specs: Vec<block_core::param::ParameterSpec> =
                 axes.iter().map(grid_parameter_to_spec).collect();
+            // Issue #733: a `type: reverb` IR blends dry/wet rather than
+            // playing 100% wet at a calibrated level, so it exposes the
+            // reverb controls (mix / pre-delay / wet level) in place of the
+            // cab-style absolute Output knob.
+            if package.manifest.block_type == plugin_loader::manifest::BlockType::Reverb {
+                specs.extend(block_reverb::ir_reverb_parameter_specs());
+                return specs;
+            }
             // Issue #655: user-adjustable Output Level knob (mirrors NAM).
             // The default mirrors the engine baseline — the first capture's
             // audit (manifest-level fallback, 0 dB if neither) — so the knob

--- a/docs/blocks-catalog.md
+++ b/docs/blocks-catalog.md
@@ -30,7 +30,8 @@ Mass-import LV2 (issue #379, 2026-05-04): adicionou ~246 plugins LV2 ao catálog
 - **Preamp/Amp nativos**: input, gain, bass, middle, treble, presence, depth, sag, master, bright
 - **NAM preamp**: volume (50–70%), gain (10–100%) em steps
 - **Delay**: time_ms (1–2000), feedback (0–100%), mix (0–100%)
-- **Reverb**: room_size, damping, mix (0–100%)
+- **Reverb (native)**: room_size, damping, mix (0–100%)
+- **Reverb (IR convolution, `backend: ir` — #733)**: mix (0–100%, default 30%), pre_delay_ms (0–200), level (wet trim, −24..+24 dB). Convolves a reverb impulse response (same FFT engine as the IR cab) and blends it with the dry signal — distinct from a cab block (100% wet). True-stereo for 2-channel IRs; a mono IR is dual-mono wrapped in a stereo chain.
 - **Compressor**: threshold, ratio, attack_ms, release_ms, makeup_gain, mix
 - **Gate** (`gate_basic`): threshold (-96 a 0 dB), attack_ms (0.1–100), release_ms (1–500), **hold_ms** (0–2000, default 150 — evita cortar decay), **hysteresis_db** (0–20, default 6 — evita chattering)
 - **Three Band EQ** (`eq_three_band_basic`): `low_gain`/`mid_gain`/`high_gain` (-12/+12 dB), `low_freq`/`mid_freq`/`high_freq` (Hz), `mid_q` (0.1–6)
@@ -60,7 +61,7 @@ Mass-import LV2 (issue #379, 2026-05-04): adicionou ~246 plugins LV2 ao catálog
   and show a plain **NAM** badge (blue, same as A1). `NAM/A2` packages also
   expose a `slim` size knob in the block editor (#657) — see the NAM block
   plugin params above; A1 never does.
-- **IR** — Impulse Response (cabs, corpos). Uniformly-partitioned FFT convolution (`crates/ir`); partition size = 64 so per-callback cost is uniform with no periodic FFT spike — safe at 64-frame device buffers, ~1.3 ms added latency (#617). Exposes a user-adjustable **Output** knob (dB, −24..+24) mirroring NAM (#655): it is the absolute applied output level and defaults to the selected capture's `output_gain_db` audit baseline, re-seeding to the new capture's baseline when the user switches mic/position. Presets saved before the knob keep their audit loudness (the audio path resolves the per-capture baseline from the raw params; volume invariant #10).
+- **IR** — Impulse Response (cabs, corpos). Uniformly-partitioned FFT convolution (`crates/ir`); partition size = 64 so per-callback cost is uniform with no periodic FFT spike — safe at 64-frame device buffers, ~1.3 ms added latency (#617). For `type: cab`/`body` it is 100% wet and exposes a user-adjustable **Output** knob (dB, −24..+24) mirroring NAM (#655): the absolute applied output level, defaulting to the selected capture's `output_gain_db` audit baseline and re-seeding to the new capture's baseline when the user switches mic/position. Presets saved before the knob keep their audit loudness (the audio path resolves the per-capture baseline from the raw params; volume invariant #10). For `type: reverb` (#733) the **same convolution engine** drives the wet path but the block stays gain-passive and blends dry/wet via **mix** (+ **pre_delay_ms**, wet **level**) instead of normalising to a calibrated level — long diffuse reverb tails would be wrong under cab-style peak normalisation. Dispatch branches on the backend in `block_reverb::build_reverb_processor_for_layout`; the wet builder is shared via `ir::from_package::build_convolution_from_package`.
 - **LV2** — Plugins externos open-source
 
 ### Native cab voicing (#620)


### PR DESCRIPTION
Targets `feature/issue-716` (not develop) per request.

Wires `ReverbBackendKind::Ir` into the reverb dispatch: a `type: reverb` + `backend: ir` package convolves a reverb IR and blends dry/wet (mix / pre_delay_ms / level), distinct from a cab (100% wet). Wet path reuses the same FFT convolution engine as the IR cab via the extracted `ir::from_package::build_convolution_from_package`.

Tests (block-reverb `ir_reverb`): dry-only at mix=0, wet-only at mix=1, stereo width preserved (no downmix), mono dual-mono wrap, pre-delay time-shift, wet-gain scaling. `cargo test -p block-reverb -p ir -p project --lib` green.

Refs #733. Cross-repo items 5 + pack import (OpenRig-plugins) remain follow-up.