### PR TITLE
feat(#741): bundle console + offline-render binaries in all platform packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -336,7 +336,11 @@ jobs:
         run: choco install llvm -y --no-progress
 
       - name: Build
-        run: cargo build --release -p adapter-gui
+        # Build the GUI plus the headless console + offline-render binaries
+        # (issue #741). Keep this package list in sync with
+        # scripts/lib/console-binaries.tsv, which package-windows.ps1 reads to
+        # stage them. macOS/Linux derive the same flags via console_build_flags.
+        run: cargo build --release -p adapter-gui -p adapter-console -p adapter-console-rig -p adapter-render
 
       - name: Resolve version
         id: ver

--- a/docs/render.md
+++ b/docs/render.md
@@ -118,6 +118,12 @@ compile Slint, MCP, and MIDI even when none of them initialise. It
 follows the same pattern as `adapter-console` and `adapter-console-rig`:
 console-style adapters around the same engine core.
 
+Shipped in every platform package as `openrig-render` (issue #741),
+alongside the headless `openrig-console` / `openrig-console-rig` and the
+GUI `openrig` — so an installed OpenRig can render offline without a
+separate `cargo run`. The packagers build and stage these from
+`scripts/lib/console-binaries.tsv` (the single source of truth).
+
 ## Render as a `Command` (issue #576)
 
 Offline render is exposed as `Command::RenderChain`. It does not mutate

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -9,6 +9,7 @@
 | `scripts/coverage.sh` | Relatório HTML de cobertura |
 | `scripts/package-linux.sh` | Empacota Linux .tar.gz/.deb/.rpm/.AppImage (patchelf RUNPATH p/ libnam_wrapper + libseat) |
 | `scripts/package-macos.sh` | Empacota macOS (assina ad-hoc inside-out + gate de verificação). Plugins bundled: `OPENRIG_PLUGINS_DIR=/path/plugins/source` sobrescreve a origem (default `plugins/source`; override inexistente = erro fatal) |
+| `scripts/lib/console-binaries.{sh,tsv}` | Fonte única dos binários console-style empacotados junto da GUI (`openrig-console`, `openrig-console-rig`, `openrig-render` — #741). Os três packagers buildam e stageam a partir dela; testado por `scripts/tests/console_bundle_test.sh` |
 | `scripts/install-macos.sh` | Instalador one-liner via `curl` (baixa .dmg, copia pro /Applications, tira quarentena) |
 | `scripts/build-lib.sh` | Libs externas |
 

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -44,7 +44,7 @@ sudo dnf install ./openrig-<ver>-1.x86_64.rpm
 
 Prefer `apt install ./file.deb` over `dpkg -i` — it pulls in dependencies automatically.
 
-A portable `openrig-<ver>-linux-<arch>.tar.gz` is also published: extract it and run the `adapter-gui` binary directly.
+A portable `openrig-<ver>-linux-<arch>.tar.gz` is also published: extract it and run the `openrig` binary directly. Every package (`.deb`/`.rpm`/`.tar.gz`/`.AppImage`, and the macOS `.app` / Windows `.zip`/`.msi`) also ships the headless console (`openrig-console`, `openrig-console-rig`) and the offline renderer (`openrig-render`) next to the GUI binary — see [`../render.md`](../render.md) for offline rendering.
 
 #### Audio setup (required for sound)
 

--- a/scripts/lib/console-binaries.sh
+++ b/scripts/lib/console-binaries.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Console-binary helpers shared by the packaging scripts (issue #741).
+# Sourced — do not execute. Tested by scripts/tests/console_bundle_test.sh.
+#
+# The packagers used to build/stage only the GUI binary, so an installed
+# OpenRig could not run headless and had no offline-render engine. These
+# helpers read scripts/lib/console-binaries.tsv (the single source of truth)
+# so the console + render binaries are built and staged on every platform.
+
+# Resolve the lib's own directory ONCE at source time — BASH_SOURCE is
+# reliable here, but inside a function called from another script it points
+# at the caller, not this file.
+_CONSOLE_BINARIES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Emit the SOT rows with comments/blank lines stripped.
+_console_binaries_rows() {
+    grep -vE '^[[:space:]]*(#|$)' "$_CONSOLE_BINARIES_DIR/console-binaries.tsv"
+}
+
+# console_binaries -> one "<built_basename> <installed_basename>" per line.
+console_binaries() {
+    _console_binaries_rows | awk '{print $2, $3}'
+}
+
+# console_build_flags -> "-p <pkg> -p <pkg> ..." for a single cargo invocation.
+console_build_flags() {
+    _console_binaries_rows | awk '{printf "-p %s ", $1}'
+}
+
+# stage_console_binaries <release_dir> <dest_dir> [ext]
+# Copy each built binary from <release_dir> to <dest_dir> under its installed
+# name, appending the optional extension (e.g. ".exe"). A missing built binary
+# is FATAL — shipping a GUI-only package silently is exactly the bug #741 fixes.
+stage_console_binaries() {
+    local release_dir="$1" dest_dir="$2" ext="${3:-}"
+    local built installed src dst
+    while read -r built installed; do
+        src="$release_dir/${built}${ext}"
+        dst="$dest_dir/${installed}${ext}"
+        if [ ! -f "$src" ]; then
+            echo "FATAL: console binary $src not found — did cargo build run?" >&2
+            return 1
+        fi
+        cp "$src" "$dst"
+        chmod +x "$dst" 2>/dev/null || true
+        echo "    staged ${built}${ext} -> ${installed}${ext}"
+    done < <(console_binaries)
+}

--- a/scripts/lib/console-binaries.tsv
+++ b/scripts/lib/console-binaries.tsv
@@ -1,0 +1,15 @@
+# Single source of truth for the console-style binaries that EVERY platform
+# packager must build and ship alongside the GUI (issue #741). Without this,
+# an installed OpenRig is GUI-only: no headless run, no offline render.
+#
+# Columns (whitespace-separated): cargo_pkg  built_basename  installed_basename
+#   cargo_pkg          -> `cargo build -p <cargo_pkg>`
+#   built_basename     -> file cargo emits under target/<...>/release/
+#   installed_basename -> name shipped in the package (openrig- prefix, mirrors
+#                         the GUI binary which installs as `openrig`)
+#
+# Read by scripts/lib/console-binaries.sh (bash) and parsed directly by
+# scripts/package-windows.ps1 (PowerShell) so the list never diverges.
+adapter-console      adapter-console      openrig-console
+adapter-console-rig  adapter-console-rig  openrig-console-rig
+adapter-render       openrig-render       openrig-render

--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -21,6 +21,9 @@ set -euo pipefail
 PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$PROJECT_ROOT"
 
+# Extra binaries shipped next to the GUI (headless console + offline render).
+source scripts/lib/console-binaries.sh
+
 # ── Defaults ──────────────────────────────────────────────────────────────────
 ARCH="$(uname -m)"
 VERSION="0.0.0-dev"
@@ -74,7 +77,7 @@ echo ""
 echo "══════════════════════════════════════════"
 echo "  1/3  cargo build --release"
 echo "══════════════════════════════════════════"
-cargo build --release -p adapter-gui
+cargo build --release -p adapter-gui $(console_build_flags)
 
 # ── 2. Stage install tree ─────────────────────────────────────────────────────
 echo ""
@@ -89,6 +92,10 @@ mkdir -p "$S/usr/lib/openrig/libs/nam"
 mkdir -p "$S/usr/share/openrig"
 
 cp target/release/adapter-gui              "$S/usr/bin/openrig"
+# Headless console + offline-render binaries (issue #741): the package used
+# to ship the GUI only, so an installed OpenRig could not run headless or
+# render a chain offline. Stage them next to /usr/bin/openrig.
+stage_console_binaries target/release "$S/usr/bin" ""
 cp -r assets                               "$S/usr/share/openrig/assets"
 
 # ── NAM wrapper shared object ─────────────────────────────────────────────────
@@ -141,17 +148,23 @@ rsvg-convert -w 256 -h 256 \
 # install_name_tool). Point RUNPATH at the staged lib, relative to the
 # binary. The path resolves identically once installed to /usr (.deb/
 # .rpm), unpacked (.tar.gz), or inside the AppImage's AppDir.
-patchelf --set-rpath "\$ORIGIN/../lib/openrig/libs/nam/linux-${ARCH}" \
-    "$S/usr/bin/openrig"
+# The console/render binaries (#741) live in the same /usr/bin and link the
+# same libnam_wrapper.so, so they need the identical RUNPATH.
+for _bin in openrig $(console_binaries | awk '{print $2}'); do
+    patchelf --set-rpath "\$ORIGIN/../lib/openrig/libs/nam/linux-${ARCH}" \
+        "$S/usr/bin/$_bin"
+done
 
 # Gate: a package no one can open is worse than a failed build. Verify
 # the NAM lib actually resolves through the new RUNPATH before we wrap
-# it in a .deb/.AppImage (lesson from #459).
-if ldd "$S/usr/bin/openrig" 2>/dev/null \
-    | grep -q 'libnam_wrapper\.so .*not found'; then
-    echo "FATAL: libnam_wrapper.so still unresolved after RUNPATH patch" >&2
-    exit 1
-fi
+# it in a .deb/.AppImage (lesson from #459). Check every staged binary.
+for _bin in openrig $(console_binaries | awk '{print $2}'); do
+    if ldd "$S/usr/bin/$_bin" 2>/dev/null \
+        | grep -q 'libnam_wrapper\.so .*not found'; then
+        echo "FATAL: libnam_wrapper.so still unresolved after RUNPATH patch ($_bin)" >&2
+        exit 1
+    fi
+done
 echo "    RUNPATH patched; libnam_wrapper.so resolves"
 
 # Bundled preset library: the default presets under presets/*.yaml ship
@@ -216,6 +229,9 @@ if $BUILD_TARBALL; then
     D="openrig-${VERSION}-linux-${ARCH}"
     mkdir -p "$OUTPUT_DIR/${D}"
     cp  "$S/usr/bin/openrig"                    "$OUTPUT_DIR/${D}/openrig"
+    for _bin in $(console_binaries | awk '{print $2}'); do
+        cp "$S/usr/bin/$_bin"                   "$OUTPUT_DIR/${D}/$_bin"
+    done
     cp -r "$S/usr/lib/openrig/libs"             "$OUTPUT_DIR/${D}/libs"
     cp -r "$S/usr/share/openrig/assets"         "$OUTPUT_DIR/${D}/assets"
     cp -r "$S/usr/share/openrig/translations"   "$OUTPUT_DIR/${D}/translations"

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -217,10 +217,28 @@ echo "==> Verifying signature..."
 codesign --verify --deep --strict --verbose=2 "$APP"
 echo "    signature valid"
 
-# ── 6. Verify binary ──────────────────────────────────────────────────────────
-echo "==> Verifying binary..."
-file "$APP/Contents/MacOS/openrig"
-echo "    binary OK"
+# ── 6. Verify binaries ─────────────────────────────────────────────────────────
+# Every shipped executable must be a universal Mach-O, and the headless
+# binaries (#741) must resolve libnam_wrapper.dylib through the bundled
+# Frameworks rpath — the macOS analog of the Linux ldd gate. The offline
+# renderer is the smoke target: run it with no args (it exits non-zero on the
+# missing --chain), but a broken rpath aborts in dyld with "Library not
+# loaded", which we treat as fatal rather than ship a binary that can't launch.
+echo "==> Verifying binaries..."
+for b in openrig $(console_binaries | awk '{print $2}'); do
+    file "$APP/Contents/MacOS/$b" | grep -q 'Mach-O' \
+        || { echo "FATAL: $b is not a Mach-O binary" >&2; exit 1; }
+done
+SMOKE_ERR="$(mktemp)"
+"$APP/Contents/MacOS/openrig-render" >/dev/null 2>"$SMOKE_ERR" || true
+if grep -q 'Library not loaded' "$SMOKE_ERR"; then
+    echo "FATAL: openrig-render cannot load libnam_wrapper.dylib (rpath broken)" >&2
+    cat "$SMOKE_ERR" >&2
+    rm -f "$SMOKE_ERR"
+    exit 1
+fi
+rm -f "$SMOKE_ERR"
+echo "    binaries OK (universal Mach-O; openrig-render resolves libnam_wrapper)"
 
 # ── 7. Create .dmg with drag-to-Applications ──────────────────────────────────
 echo "==> Creating .dmg..."

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -9,9 +9,12 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
 source scripts/lib/plugins-bundle.sh
+source scripts/lib/console-binaries.sh
 # Resolve (and validate) the plugins source up front — an invalid override
 # must fail here, not after two release builds.
 PLUGINS_SRC="$(plugins_src_dir)"
+# Extra binaries shipped next to the GUI (headless console + offline render).
+CONSOLE_BUILD_FLAGS="$(console_build_flags)"
 
 # ── 1. Rust targets ──────────────────────────────────────────────────────────
 echo "==> Adding Rust targets..."
@@ -19,10 +22,10 @@ rustup target add aarch64-apple-darwin x86_64-apple-darwin
 
 # ── 2. Build (universal: arm64 + x86_64) ─────────────────────────────────────
 echo "==> Building arm64..."
-cargo build --release --target aarch64-apple-darwin -p adapter-gui
+cargo build --release --target aarch64-apple-darwin -p adapter-gui $CONSOLE_BUILD_FLAGS
 
 echo "==> Building x86_64..."
-cargo build --release --target x86_64-apple-darwin -p adapter-gui
+cargo build --release --target x86_64-apple-darwin -p adapter-gui $CONSOLE_BUILD_FLAGS
 
 # ── 3. Generate .icns from OpenRig logo SVG ───────────────────────────────────
 echo "==> Generating icon from openrig-logomark.svg..."
@@ -89,6 +92,23 @@ echo "    bundled universal libnam_wrapper.dylib into Frameworks/"
 install_name_tool \
     -add_rpath "@executable_path/../Frameworks" \
     "$APP/Contents/MacOS/openrig" 2>/dev/null || true
+
+# ── Console + offline-render binaries (issue #741) ───────────────────────────
+# The GUI is not the only shipped interface. Bundle the headless console
+# (adapter-console / adapter-console-rig) and the offline renderer
+# (openrig-render) too — universal-lipo'd and rpath'd exactly like the GUI,
+# since they all link @rpath/libnam_wrapper.dylib via the engine core.
+while read -r built installed; do
+    lipo -create \
+        "target/aarch64-apple-darwin/release/$built" \
+        "target/x86_64-apple-darwin/release/$built" \
+        -output "$APP/Contents/MacOS/$installed"
+    chmod +x "$APP/Contents/MacOS/$installed"
+    install_name_tool \
+        -add_rpath "@executable_path/../Frameworks" \
+        "$APP/Contents/MacOS/$installed" 2>/dev/null || true
+    echo "    bundled universal $installed into MacOS/"
+done < <(console_binaries)
 
 cp assets/brands/openrig/icon.icns "$APP/Contents/Resources/openrig.icns"
 cp -r assets                   "$APP/Contents/Resources/assets"
@@ -165,15 +185,17 @@ echo "==> Signing app (ad-hoc, inside-out)..."
 # "printf: Broken pipe" and exit 1 once the .app's full plugin tree is
 # present). No per-file `-exec sh -c` subshell either (issue #463,
 # regression of #459 which only tested a tiny bundle).
-# Order matters: codesign of the main executable verifies that every
+# Order matters: codesign of an executable verifies that every
 # subcomponent it links (e.g. Frameworks/libnam_wrapper.dylib) is
 # already signed, else it fails "code object is not signed at all / In
 # subcomponent: ...". `find` order is not inside-out, so sign every
-# nested Mach-O here but SKIP the main executable, then sign it after
-# the loop (deps first), then the bundle last (issue #463).
-MAIN_EXE="$APP/Contents/MacOS/openrig"
+# nested Mach-O here but SKIP everything under Contents/MacOS (the GUI
+# plus the #741 console/render executables, which all link the
+# Frameworks dylib), then sign those after the loop (deps first), then
+# the bundle last (issue #463).
+MACOS_DIR="$APP/Contents/MacOS"
 while IFS= read -r -d '' f; do
-    [ "$f" = "$MAIN_EXE" ] && continue
+    case "$f" in "$MACOS_DIR/"*) continue ;; esac
     case "$(file -b "$f" 2>/dev/null)" in
         *Mach-O*)
             codesign --force --sign - --timestamp=none "$f" \
@@ -181,8 +203,11 @@ while IFS= read -r -d '' f; do
             ;;
     esac
 done < <(find "$APP/Contents" -type f -print0)
-codesign --force --sign - --timestamp=none "$MAIN_EXE" \
-    || { echo "FATAL: codesign failed for $MAIN_EXE" >&2; exit 1; }
+for exe in "$MACOS_DIR"/*; do
+    [ -f "$exe" ] || continue
+    codesign --force --sign - --timestamp=none "$exe" \
+        || { echo "FATAL: codesign failed for $exe" >&2; exit 1; }
+done
 codesign --force --sign - --timestamp=none "$APP" \
     || { echo "FATAL: codesign failed for the .app bundle" >&2; exit 1; }
 

--- a/scripts/package-windows.ps1
+++ b/scripts/package-windows.ps1
@@ -4,8 +4,10 @@
     Mirrors exactly what GitHub Actions does for the Windows build.
 
 .DESCRIPTION
-    Assumes cargo build --release -p adapter-gui has already run.
-    Stages all required files (binary, NAM DLL, LV2 libs, data, assets, captures),
+    Assumes the release binaries have already been built, i.e.
+    cargo build --release -p adapter-gui -p adapter-console -p adapter-console-rig -p adapter-render
+    (the GUI plus the headless console + offline-render binaries, issue #741).
+    Stages all required files (binaries, NAM DLL, LV2 libs, data, assets, captures),
     then uses WiX Toolset v3 (heat + candle + light) to build the MSI.
 
 .PARAMETER Version
@@ -86,6 +88,27 @@ try {
     New-Item -ItemType Directory -Force $stageDir | Out-Null
 
     Copy-Item "target\release\adapter-gui.exe"              "$stageDir\openrig.exe"
+
+    # ── Console + offline-render binaries (issue #741) ─────────────────────────
+    # The package used to ship the GUI only, so an installed OpenRig could not
+    # run headless or render a chain offline. Stage the headless console and
+    # the offline renderer next to openrig.exe. The list is the single source
+    # of truth scripts\lib\console-binaries.tsv, shared with the macOS/Linux
+    # packagers. They link the same nam_wrapper DLL (staged below into this same
+    # dir) and the MinGW runtime DLLs, so no extra per-binary handling is needed.
+    $consoleTsv = Join-Path $RepoRoot "scripts\lib\console-binaries.tsv"
+    Get-Content $consoleTsv | ForEach-Object {
+        $line = $_.Trim()
+        if ($line -eq "" -or $line.StartsWith("#")) { return }
+        $cols = $line -split '\s+'
+        $built = $cols[1]; $installed = $cols[2]
+        $src = "target\release\$built.exe"
+        if (-not (Test-Path $src)) {
+            throw "console binary $src not found — did cargo build run?"
+        }
+        Copy-Item $src "$stageDir\$installed.exe"
+        Write-Host "    staged $built.exe -> $installed.exe"
+    }
 
     # ── NAM wrapper DLL ───────────────────────────────────────────────────────
     # The nam crate's build.rs cmake-builds cpp\ (NeuralAmpModelerCore) into the

--- a/scripts/tests/console_bundle_test.sh
+++ b/scripts/tests/console_bundle_test.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+# Tests for scripts/lib/console-binaries.sh (issue #741).
+#
+# The platform packagers historically shipped ONLY the GUI binary. This
+# library is the single source of truth for the extra console-style
+# binaries (headless console + offline render) that every packager must
+# also build and stage. The test pins:
+#   - the SOT list (cargo pkg -> built basename -> installed basename)
+#   - the cargo build flags derived from it
+#   - stage_console_binaries copying each built binary to its installed name
+#   - a missing built binary being FATAL (a packager must not ship a GUI-only
+#     bundle silently)
+#
+# Run: ./scripts/tests/console_bundle_test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB="$SCRIPT_DIR/../lib/console-binaries.sh"
+TSV="$SCRIPT_DIR/../lib/console-binaries.tsv"
+
+FAILURES=0
+fail() { echo "FAIL: $1" >&2; FAILURES=$((FAILURES + 1)); }
+pass() { echo "ok:   $1"; }
+
+if [ ! -f "$LIB" ]; then
+    echo "FAIL: $LIB does not exist" >&2
+    exit 1
+fi
+if [ ! -f "$TSV" ]; then
+    echo "FAIL: $TSV does not exist" >&2
+    exit 1
+fi
+# shellcheck source=../lib/console-binaries.sh
+source "$LIB"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# ── console_binaries: SOT lists console + console-rig + render ───────────────
+OUT="$(console_binaries)"
+for expected in \
+    "adapter-console openrig-console" \
+    "adapter-console-rig openrig-console-rig" \
+    "openrig-render openrig-render"; do
+    if printf '%s\n' "$OUT" | grep -qx "$expected"; then
+        pass "console_binaries lists '$expected'"
+    else
+        fail "console_binaries missing '$expected'; got: $OUT"
+    fi
+done
+
+# ── console_binaries: exactly three entries, no GUI binary leaking in ────────
+N="$(console_binaries | grep -c .)"
+if [ "$N" = "3" ]; then
+    pass "console_binaries lists exactly 3 binaries"
+else
+    fail "console_binaries should list 3 binaries, got $N"
+fi
+if console_binaries | awk '{print $2}' | grep -qx openrig; then
+    fail "console_binaries must not install over the GUI 'openrig' binary"
+else
+    pass "console_binaries excludes the GUI binary"
+fi
+
+# ── console_build_flags: one -p per cargo package ───────────────────────────
+FLAGS="$(console_build_flags)"
+for pkg in adapter-console adapter-console-rig adapter-render; do
+    case " $FLAGS " in
+        *" -p $pkg "*) pass "console_build_flags includes -p $pkg" ;;
+        *) fail "console_build_flags missing -p $pkg; got: $FLAGS" ;;
+    esac
+done
+
+# ── stage_console_binaries: copies built basenames to installed names ───────
+REL="$TMP/release"
+DEST="$TMP/dest"
+mkdir -p "$REL" "$DEST"
+for b in adapter-console adapter-console-rig openrig-render; do
+    printf '#!/bin/sh\n' > "$REL/$b"
+done
+if stage_console_binaries "$REL" "$DEST" "" >/dev/null; then
+    pass "stage_console_binaries returns 0 when all binaries present"
+else
+    fail "stage_console_binaries failed despite all binaries present"
+fi
+for inst in openrig-console openrig-console-rig openrig-render; do
+    if [ -f "$DEST/$inst" ]; then
+        pass "stage_console_binaries staged $inst"
+    else
+        fail "stage_console_binaries did not stage $inst"
+    fi
+done
+# the GUI binary's name must NOT appear (we only stage the extras)
+if [ -f "$DEST/adapter-console" ]; then
+    fail "stage_console_binaries left the built basename instead of the installed name"
+else
+    pass "stage_console_binaries renames to installed basename"
+fi
+
+# ── stage_console_binaries: .exe suffix for Windows-style staging ───────────
+RELW="$TMP/release-win"
+DESTW="$TMP/dest-win"
+mkdir -p "$RELW" "$DESTW"
+for b in adapter-console adapter-console-rig openrig-render; do
+    printf 'MZ' > "$RELW/$b.exe"
+done
+if stage_console_binaries "$RELW" "$DESTW" ".exe" >/dev/null \
+    && [ -f "$DESTW/openrig-console.exe" ] \
+    && [ -f "$DESTW/openrig-render.exe" ]; then
+    pass "stage_console_binaries honors the .exe suffix"
+else
+    fail "stage_console_binaries did not stage .exe binaries"
+fi
+
+# ── stage_console_binaries: a missing built binary is FATAL ─────────────────
+RELMISS="$TMP/release-missing"
+DESTMISS="$TMP/dest-missing"
+mkdir -p "$RELMISS" "$DESTMISS"
+printf '#!/bin/sh\n' > "$RELMISS/adapter-console"   # only one of three present
+if stage_console_binaries "$RELMISS" "$DESTMISS" "" >/dev/null 2>&1; then
+    fail "stage_console_binaries must fail when a built binary is missing"
+else
+    pass "stage_console_binaries fails loud on a missing built binary"
+fi
+
+echo ""
+if [ "$FAILURES" -gt 0 ]; then
+    echo "$FAILURES failure(s)" >&2
+    exit 1
+fi
+echo "all tests passed"


### PR DESCRIPTION
Closes #741.

## Problem
The platform packagers shipped only the GUI binary (`adapter-gui` → `openrig`), so an installed OpenRig could not run headless and had no offline-render engine for the audio-validation pipeline.

## Change
New `scripts/lib/console-binaries.{sh,tsv}` — single source of truth for the console-style binaries shipped next to the GUI:

| cargo pkg | installed name |
|---|---|
| `adapter-console` | `openrig-console` |
| `adapter-console-rig` | `openrig-console-rig` |
| `adapter-render` | `openrig-render` |

All three packagers build (`-p ...`) and stage these alongside the GUI, reusing the existing `nam_wrapper` handling:
- **macOS** — universal `lipo` into `Contents/MacOS/`, `@executable_path/../Frameworks` rpath, codesign every `MacOS/` executable after the Frameworks dylibs (inside-out preserved), plus a per-binary Mach-O check and an `openrig-render` rpath smoke gate.
- **Linux** — stage into `/usr/bin`, `patchelf` RUNPATH + `ldd`-resolve gate per binary, included in `.tar.gz` (and present in the `.deb`/`.rpm`/`.AppImage` stage tree).
- **Windows** — CI builds the extra crates; the packager stages them from the TSV next to `openrig.exe` (same dir as `nam_wrapper.dll` + MinGW runtime DLLs).

Docs updated: `docs/render.md`, `docs/scripts.md`, `docs/user-guide/installation.md`.

## Tests
- New `scripts/tests/console_bundle_test.sh` (SOT list, build flags, staging rename, missing-binary FATAL) — passes; `plugins_bundle_test.sh` still passes.
- Real-binary verification (macOS arm64): the three crates build; `stage_console_binaries` renames correctly against `target/release`; all three launch and resolve `libnam_wrapper.dylib`; the render smoke gate was validated both ways (dylib present → arg-error exit; dylib absent → dyld abort caught).

🤖 Generated with [Claude Code](https://claude.com/claude-code)