### PR TITLE
fix(#743): two-interface mixed-rate rig — cross-rate output mixing underrun flood (+toggle/budget/cold-start)

### DIFF
--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -102,6 +102,9 @@ pub(crate) use runtime_lifecycle::{
     assign_new_block_ids, remove_live_chain_runtime, stop_project_runtime, sync_block_toggle,
     sync_live_chain_runtime, sync_project_runtime, system_language, ui_index_to_real_block_index,
 };
+// #743: the live-sync planner is public so its decision (no device-IO resolve
+// on a disable) is guarded by an integration test.
+pub use runtime_lifecycle::{plan_live_sync, LiveSyncAction};
 
 mod defaults;
 pub(crate) use defaults::*;

--- a/crates/adapter-gui/src/runtime_lifecycle.rs
+++ b/crates/adapter-gui/src/runtime_lifecycle.rs
@@ -60,6 +60,42 @@ pub(crate) fn sync_project_runtime(
     Ok(())
 }
 
+/// #743: the planned action for a one-chain live sync. Modelled as data so the
+/// decision — crucially, WHETHER a device-IO resolve runs — is unit-testable
+/// without audio hardware.
+pub enum LiveSyncAction {
+    /// The chain is gone from the project: drop it from the live graph.
+    Remove,
+    /// The chain is present but disabled: pause it (drain → silence) in O(1).
+    /// No device-IO resolve — that synchronous CoreAudio query (hundreds of ms
+    /// per device) would stall the GUI while the live output starves into a
+    /// feedback howl (#743). A disable never re-binds, so the check is moot.
+    Pause,
+    /// The chain is present and enabled: (re)activate it. `io_changed` is the
+    /// re-bind check — only an enable consults it.
+    Enable { io_changed: bool },
+}
+
+/// Decide the live-sync action for a toggled chain. The `io_changed` closure
+/// (the device-IO resolve) is invoked ONLY for an enable; a disable or a
+/// removal must never touch it — that resolve is the ~750 ms CoreAudio stall
+/// that starves the live output into feedback on a four-device toggle (#743).
+pub fn plan_live_sync(
+    chain_present: bool,
+    chain_enabled: bool,
+    io_changed: impl FnOnce() -> Result<bool>,
+) -> Result<LiveSyncAction> {
+    if !chain_present {
+        return Ok(LiveSyncAction::Remove);
+    }
+    if !chain_enabled {
+        return Ok(LiveSyncAction::Pause);
+    }
+    Ok(LiveSyncAction::Enable {
+        io_changed: io_changed()?,
+    })
+}
+
 pub(crate) fn sync_live_chain_runtime(
     project_runtime: &Rc<RefCell<Option<ProjectRuntimeController>>>,
     session: &ProjectSession,
@@ -107,28 +143,40 @@ pub(crate) fn sync_live_chain_runtime(
             // sync, not just at start, so a just-created binding takes effect.
             runtime.set_io_bindings(session.io_bindings.borrow().clone());
             validate_project(&*proj)?;
-            if let Some(chain) = chain {
-                // Issue #672: cold activation of a single-input chain builds the
-                // runtime off the control worker and installs it on the poll tick
-                // (no live state to preserve). A LIVE edit (model swap, param,
-                // block) must NOT be routed off-thread: replacing the whole
-                // runtime discards the SPSC ring continuity and runtime-only
-                // state (DI loop, #614) — it stops the sound. Live edits keep the
-                // engine's in-place lock-free update via upsert_chain.
-                // #716: re-binding a chain's E/S changes its stream topology
-                // (different devices/channels). An in-place `upsert` keeps the
-                // old streams, so the swap wouldn't apply until a project reopen.
-                // Detect the I/O change and REBUILD (drop the chain's streams so
-                // it re-activates fresh on the new devices); a param/block edit
-                // (I/O unchanged) keeps the lock-free in-place upsert.
-                if runtime.chain_io_changed(&*proj, chain)? {
-                    runtime.remove_chain(&chain.id);
-                }
-                if !runtime.schedule_chain_activation(&*proj, chain)? {
+            // #743: plan the action BEFORE resolving anything. A disable must
+            // pause immediately (drain → output silent) and must NOT run
+            // `chain_io_changed` — that synchronous CoreAudio resolve costs
+            // hundreds of ms per device, so on a four-device rig the GUI stalls
+            // ~750 ms while the still-live output starves and emits stale frames
+            // at full level (the owner's "microfonia"/underrun flood on toggle
+            // off). The IO-change re-bind check belongs only to an enable.
+            let action = plan_live_sync(chain.is_some(), chain_enabled, || {
+                let chain = chain.expect("io_changed is only queried for a present, enabled chain");
+                runtime.chain_io_changed(&*proj, chain)
+            })?;
+            match action {
+                LiveSyncAction::Remove => runtime.remove_chain(chain_id),
+                LiveSyncAction::Pause => {
+                    // upsert_chain's !enabled path pauses (keeps streams alive,
+                    // drains to silence) in O(1) — no device queries.
+                    let chain = chain.expect("Pause implies the chain is present");
                     runtime.upsert_chain(&*proj, chain)?;
                 }
-            } else {
-                runtime.remove_chain(chain_id);
+                LiveSyncAction::Enable { io_changed } => {
+                    // Issue #672: cold activation of a single-input chain builds
+                    // the runtime off the control worker and installs it on the
+                    // poll tick. A LIVE edit (model swap, param, block) keeps the
+                    // engine's in-place lock-free update via upsert_chain.
+                    // #716: a re-bind changes stream topology, so REBUILD (drop
+                    // the streams) when the resolved I/O differs from what's live.
+                    let chain = chain.expect("Enable implies the chain is present");
+                    if io_changed {
+                        runtime.remove_chain(&chain.id);
+                    }
+                    if !runtime.schedule_chain_activation(&*proj, chain)? {
+                        runtime.upsert_chain(&*proj, chain)?;
+                    }
+                }
             }
             // If no chains are running (and none are activating), destroy runtime.
             if !runtime.is_running() {

--- a/crates/adapter-gui/tests/issue_743_disable_no_io_resolve.rs
+++ b/crates/adapter-gui/tests/issue_743_disable_no_io_resolve.rs
@@ -1,0 +1,73 @@
+//! Issue #743 — disabling a chain must PAUSE without resolving device IO.
+//!
+//! The owner's live failure: toggling a four-stream, two-interface rig OFF
+//! produced a ~750 ms GUI stall, a flood of underruns, and "microfonia absurda"
+//! (a loud feedback howl). Root cause: `sync_live_chain_runtime` called
+//! `chain_io_changed` on EVERY toggle — including disable — and that runs a
+//! synchronous `resolve_chain_audio_config` (a CoreAudio device query that costs
+//! hundreds of ms per device). For four devices that is the ~750 ms stall, and
+//! it runs while the chain is still live, so the output streams starve and emit
+//! repeated stale frames at full level = the howl. The pause (drain → silence)
+//! only happened AFTER that stall.
+//!
+//! A disable never needs the IO-change check (that exists to detect a re-bind on
+//! an ENABLE). The lifecycle planner must pause a disabled chain immediately,
+//! without touching the device resolve. Deterministic, hardware-free: the
+//! resolve is modelled by a spy closure that must NOT be invoked on disable.
+
+use std::cell::Cell;
+
+use adapter_gui::{plan_live_sync, LiveSyncAction};
+
+#[test]
+fn disabling_a_chain_pauses_without_resolving_device_io() {
+    let resolved = Cell::new(false);
+    let action = plan_live_sync(true, false, || {
+        resolved.set(true);
+        Ok(true)
+    })
+    .expect("planning a disable must not error");
+
+    assert!(
+        matches!(action, LiveSyncAction::Pause),
+        "disabling a present chain must plan a Pause"
+    );
+    assert!(
+        !resolved.get(),
+        "BUG #743: disabling a chain resolved device IO — the multi-device \
+         CoreAudio resolve stalls the GUI ~750ms while the live output starves \
+         into a feedback howl. A disable must pause immediately, no resolve."
+    );
+}
+
+#[test]
+fn enabling_a_chain_consults_the_io_topology() {
+    let resolved = Cell::new(false);
+    let _action = plan_live_sync(true, true, || {
+        resolved.set(true);
+        Ok(false)
+    })
+    .expect("planning an enable must not error");
+
+    assert!(
+        resolved.get(),
+        "enabling a chain must check whether its IO topology changed \
+         (re-bind detection) — only the disable path skips the resolve"
+    );
+}
+
+#[test]
+fn an_absent_chain_is_removed_without_resolving() {
+    let resolved = Cell::new(false);
+    let action = plan_live_sync(false, false, || {
+        resolved.set(true);
+        Ok(true)
+    })
+    .expect("planning a removal must not error");
+
+    assert!(matches!(action, LiveSyncAction::Remove));
+    assert!(
+        !resolved.get(),
+        "removing an absent chain must not resolve device IO either"
+    );
+}

--- a/crates/infra-cpal/src/controller.rs
+++ b/crates/infra-cpal/src/controller.rs
@@ -758,13 +758,45 @@ impl ProjectRuntimeController {
     /// existing streams, so an E/S swap would NOT take effect until a project
     /// reopen; the caller must REBUILD the chain's streams when this is true.
     #[cfg(not(all(target_os = "linux", feature = "jack")))]
-    pub fn chain_io_changed(&self, project: &Project, chain: &Chain) -> Result<bool> {
+    pub fn chain_io_changed(&self, _project: &Project, chain: &Chain) -> Result<bool> {
         let Some(active) = self.active_chains.get(&chain.id) else {
             return Ok(false); // not streaming — nothing to compare
         };
-        let host = get_host();
-        let resolved = resolve_chain_audio_config(host, project, chain, &self.io_bindings)?;
-        Ok(active.stream_signature != resolved.stream_signature)
+        // #743: a re-bind is a device+channel change, which the binding registry
+        // and the live stream signature already carry — compare them directly.
+        // The old `resolve_chain_audio_config` here ran a CoreAudio device query
+        // (hundreds of ms per device, ~750 ms on a four-device rig) on the GUI
+        // thread every toggle-ON, freezing the UI for a check that needs no
+        // hardware. A rate/buffer change arrives via the device-settings sync,
+        // not this per-chain toggle path.
+        let live_inputs: Vec<(domain::ids::DeviceId, Vec<usize>)> = active
+            .stream_signature
+            .inputs
+            .iter()
+            .map(|s| (domain::ids::DeviceId(s.device_id.clone()), s.channels.clone()))
+            .collect();
+        let live_outputs: Vec<(domain::ids::DeviceId, Vec<usize>)> = active
+            .stream_signature
+            .outputs
+            .iter()
+            .map(|s| (domain::ids::DeviceId(s.device_id.clone()), s.channels.clone()))
+            .collect();
+        let (bound_in, bound_out) =
+            engine::runtime_endpoints::resolve_chain_io(chain, &self.io_bindings);
+        let bound_inputs: Vec<(domain::ids::DeviceId, Vec<usize>)> = bound_in
+            .into_iter()
+            .map(|e| (e.device_id, e.channels))
+            .collect();
+        let bound_outputs: Vec<(domain::ids::DeviceId, Vec<usize>)> = bound_out
+            .into_iter()
+            .map(|e| (e.device_id, e.channels))
+            .collect();
+        Ok(crate::io_topology_changed(
+            &live_inputs,
+            &bound_inputs,
+            &live_outputs,
+            &bound_outputs,
+        ))
     }
 
     /// JACK build: stream-topology live-swap is not wired yet (cpal path first).

--- a/crates/infra-cpal/src/controller.rs
+++ b/crates/infra-cpal/src/controller.rs
@@ -577,9 +577,9 @@ impl ProjectRuntimeController {
                 // #693: a cold bring-up must not hold the caller (the GUI
                 // thread) — reuse the #672 off-thread activation: validate +
                 // resolve + heavy build (NAM/IR, routes) on the control
-                // worker, streams installed by the poll tick.
-                // Already-streaming and multi-input chains keep the
-                // synchronous path.
+                // worker, streams installed by the poll tick. #740: this now
+                // covers multi-device chains too, so only an already-streaming
+                // chain stays on the synchronous (live-rebuild) path.
                 if self.schedule_chain_activation(project, chain)? {
                     continue;
                 }
@@ -587,7 +587,8 @@ impl ProjectRuntimeController {
                     Some(resolved) => resolved,
                     None => {
                         // Cold start skipped the upfront resolve; this is the
-                        // rare synchronous fallback (multi-input chain).
+                        // synchronous fallback for a chain the scheduler
+                        // declined (e.g. already streaming).
                         validate_chain_channels_against_devices(host, chain, &self.io_bindings)?;
                         resolve_chain_audio_config(host, project, chain, &self.io_bindings)?
                     }
@@ -772,32 +773,26 @@ impl ProjectRuntimeController {
         Ok(false)
     }
 
-    /// Issue #672 — cold activation. If `chain` is a single-input-group chain
-    /// that is not yet streaming, build its runtime (the heavy NAM/IR load) on
-    /// the control worker and return `true`; the next poll creates the cpal
-    /// streams on the frontend (they are `!Send`) and installs the chain. Returns
-    /// `false` for an already-streaming chain or a multi-input chain, which the
-    /// caller then builds synchronously.
+    /// Issue #672 — cold activation. If `chain` is not yet streaming, build its
+    /// per-input runtimes (the heavy NAM/IR load) on the control worker and
+    /// return `true`; the next poll creates the cpal streams on the frontend
+    /// (they are `!Send`) and installs the chain. Returns `false` only for an
+    /// already-streaming chain, which the caller then rebuilds synchronously.
+    ///
+    /// Issue #740: this used to defer ANY multi-device chain to the synchronous
+    /// build (`input_devices.len() != 1`), so a rig bound to several interfaces
+    /// (the owner's four-binding, two-interface boot) brought every stream up
+    /// serially on the calling thread — the first streams ran their callback,
+    /// counting underruns, while the remaining NAM/IR builds still blocked. The
+    /// off-thread path already builds one runtime per input group
+    /// (`build_per_input_runtime_states`) and installs one stream per device
+    /// (`build_chain_streams`), so multi-device chains take it too: every
+    /// runtime is built off-thread, then ALL streams are created and played
+    /// together in one poll tick — no sibling starves another's bring-up.
     #[cfg(not(all(target_os = "linux", feature = "jack")))]
     pub fn schedule_chain_activation(&mut self, project: &Project, chain: &Chain) -> Result<bool> {
         if self.active_chains.contains_key(&chain.id) {
             return Ok(false); // already streaming — not a cold activation
-        }
-        // Single-device chains only (issue #703: the device may still carry
-        // N input entries — build_chain_runtime returns one runtime per
-        // entry and the one device stream feeds them all). Multi-device
-        // chains need one stream per device wired through the synchronous
-        // build, so defer them.
-        // Model A (#716): the chain's input device endpoints come from the
-        // binding registry, not from block `entries`.
-        let resolved_inputs =
-            engine::runtime_endpoints::resolve_chain_io(chain, &self.io_bindings).0;
-        let input_devices: std::collections::HashSet<&str> = resolved_inputs
-            .iter()
-            .map(|entry| entry.device_id.0.as_str())
-            .collect();
-        if input_devices.len() != 1 {
-            return Ok(false);
         }
 
         // #693: validation + device resolution are CoreAudio property

--- a/crates/infra-cpal/src/dsp_worker.rs
+++ b/crates/infra-cpal/src/dsp_worker.rs
@@ -158,6 +158,13 @@ pub(crate) struct BudgetTracker {
     /// Consecutive buffers measured over the declared budget. The fast
     /// up-correction fires only when this is SUSTAINED, never on a lone spike.
     consecutive_over: u32,
+    /// #743: consecutive WINDOWS whose target sits below the declared budget,
+    /// and the highest such target seen across that run. The budget shrinks only
+    /// after a sustained run (never on a single low window), and settles to the
+    /// run's high-water — so a steady but spiky load whose per-window cost
+    /// alternates does not bounce the policy down and back up.
+    low_run: u32,
+    low_run_peak_ns: u64,
 }
 
 impl BudgetTracker {
@@ -179,6 +186,11 @@ impl BudgetTracker {
     /// so genuine cheap chains still settle their budget down.
     const IDLE_NS_DIVISOR: u64 = 100;
 
+    /// Windows of sustained below-budget cost required before the budget shrinks
+    /// (≈11 s at 2048 buffers / 64 frames / 48 kHz). A shorter run is just
+    /// normal window-to-window variance and must not re-declare (#743).
+    const DOWN_SUSTAIN: u32 = 4;
+
     pub(crate) fn new(declared_ns: u64) -> Self {
         Self {
             window_max_ns: 0,
@@ -186,6 +198,8 @@ impl BudgetTracker {
             window_count: 0,
             declared_ns,
             consecutive_over: 0,
+            low_run: 0,
+            low_run_peak_ns: 0,
         }
     }
 
@@ -241,10 +255,34 @@ impl BudgetTracker {
             return None;
         }
         let target = (robust + robust / 4).clamp(period_ns / 10, period_ns * 85 / 100);
-        if target.abs_diff(self.declared_ns) > period_ns / 10 {
+        let hyst = period_ns / 10;
+        // Grow promptly: an under-budget RT thread gets demoted (#698 safety).
+        if target > self.declared_ns + hyst {
             self.declared_ns = target;
+            self.low_run = 0;
+            self.low_run_peak_ns = 0;
             return Some(target);
         }
+        // #743: the target sits meaningfully BELOW the standing budget. A single
+        // low window is just variance — shrinking now only invites a re-grow next
+        // window (the owner's 372 ↔ 592 µs steady-play churn). Shrink only after
+        // a sustained run of low windows, and then to the run's HIGH-WATER so a
+        // spiky-but-steady load settles to its peak instead of bouncing.
+        if self.declared_ns > target + hyst {
+            self.low_run += 1;
+            self.low_run_peak_ns = self.low_run_peak_ns.max(target);
+            if self.low_run >= Self::DOWN_SUSTAIN {
+                let settled = self.low_run_peak_ns;
+                self.declared_ns = settled;
+                self.low_run = 0;
+                self.low_run_peak_ns = 0;
+                return Some(settled);
+            }
+            return None;
+        }
+        // Within hysteresis — the budget already fits the load.
+        self.low_run = 0;
+        self.low_run_peak_ns = 0;
         None
     }
 
@@ -582,7 +620,12 @@ mod budget_tracker_tests {
     #[test]
     fn still_rebudgets_on_a_sustained_real_cost_increase() {
         let mut b = BudgetTracker::new(PERIOD_NS * 85 / 100);
-        let _ = count_redeclares(&mut b, BudgetTracker::WINDOW as usize, |_| CHEAP_NS);
+        // Settle to the real cheap cost first. #743: the budget is sticky
+        // downward, so it shrinks only after DOWN_SUSTAIN low windows — warm up
+        // past that so `declared` actually reaches the cheap cost before the
+        // increase (a 1-window warmup would leave it at the cold 85%).
+        let warmup = BudgetTracker::WINDOW as usize * (BudgetTracker::DOWN_SUSTAIN as usize + 2);
+        let _ = count_redeclares(&mut b, warmup, |_| CHEAP_NS);
 
         // Now the chain genuinely gets heavier and STAYS heavier (sustained,
         // not a one-off spike): ~60% of the period, every buffer.

--- a/crates/infra-cpal/src/dsp_worker.rs
+++ b/crates/infra-cpal/src/dsp_worker.rs
@@ -453,7 +453,23 @@ pub(crate) fn spawn(
                 // cost at window boundaries so N concurrent workers fit the
                 // kernel's time-constraint admission together — and a preemption
                 // stall (wall-clock) never churns the policy. Rare, between buffers.
+                let declared_before = budget.declared_ns;
                 if let Some(comp_ns) = budget.observe(compute_ns, rt_period_ns) {
+                    // #743 diagnostic (rare, worker thread): WHY the RT policy
+                    // re-declared. compute≈wall means the CPU-time guard
+                    // collapsed (thread_cpu_time_ns unavailable → preemption
+                    // leaks into the budget = churn); a genuinely high compute
+                    // means the rig is heavy for the buffer. Temporary, reverted
+                    // once the cause is confirmed.
+                    log::info!(
+                        "[#743 promote] re-declare compute={}us wall={}us declared={}us->{}us period={}us cpu_time_ok={}",
+                        compute_ns / 1000,
+                        wall_ns / 1000,
+                        declared_before / 1000,
+                        comp_ns / 1000,
+                        rt_period_ns / 1000,
+                        thread_cpu_time_ns().is_some(),
+                    );
                     promote_to_audio_rt(rt_period_ns, comp_ns);
                 }
                 // #670 diagnostic: name the magnitude of a late buffer so a

--- a/crates/infra-cpal/src/dsp_worker.rs
+++ b/crates/infra-cpal/src/dsp_worker.rs
@@ -509,23 +509,7 @@ pub(crate) fn spawn(
                 // cost at window boundaries so N concurrent workers fit the
                 // kernel's time-constraint admission together — and a preemption
                 // stall (wall-clock) never churns the policy. Rare, between buffers.
-                let declared_before = budget.declared_ns;
                 if let Some(comp_ns) = budget.observe(compute_ns, rt_period_ns) {
-                    // #743 diagnostic (rare, worker thread): WHY the RT policy
-                    // re-declared. compute≈wall means the CPU-time guard
-                    // collapsed (thread_cpu_time_ns unavailable → preemption
-                    // leaks into the budget = churn); a genuinely high compute
-                    // means the rig is heavy for the buffer. Temporary, reverted
-                    // once the cause is confirmed.
-                    log::info!(
-                        "[#743 promote] re-declare compute={}us wall={}us declared={}us->{}us period={}us cpu_time_ok={}",
-                        compute_ns / 1000,
-                        wall_ns / 1000,
-                        declared_before / 1000,
-                        comp_ns / 1000,
-                        rt_period_ns / 1000,
-                        thread_cpu_time_ns().is_some(),
-                    );
                     promote_to_audio_rt(rt_period_ns, comp_ns);
                 }
                 // #670 diagnostic: name the magnitude of a late buffer so a

--- a/crates/infra-cpal/src/dsp_worker.rs
+++ b/crates/infra-cpal/src/dsp_worker.rs
@@ -144,7 +144,7 @@ fn thread_cpu_time_ns() -> Option<u64> {
 /// time-constraint computation from the measured worst case plus
 /// headroom, so N concurrent chains together stay inside what the
 /// kernel's admission will schedule. Plain data, worker-thread only.
-struct BudgetTracker {
+pub(crate) struct BudgetTracker {
     /// Highest and second-highest measured cost in the current window. The
     /// budget is driven by the SECOND highest, so a single transient outlier
     /// (a preemption stall — the worker descheduled mid-DSP, which inflates
@@ -170,7 +170,16 @@ impl BudgetTracker {
     /// the worker that itself perturbs its scheduling → more stalls).
     const SUSTAIN: u32 = 3;
 
-    fn new(declared_ns: u64) -> Self {
+    /// An idle/paused window measures (near) nothing — a drained chain's worker
+    /// only copies the buffer and short-circuits, ~1-2 µs. Below 1% of the period
+    /// the window carries no real cost signal, so the budget is left untouched;
+    /// collapsing it to the floor only forces a fast-up re-declare the instant
+    /// work resumes (#743). The threshold sits FAR under any measurable real
+    /// workload (e.g. the #698 cheap-settle test's 50 µs ≈ 3.4% of the period),
+    /// so genuine cheap chains still settle their budget down.
+    const IDLE_NS_DIVISOR: u64 = 100;
+
+    pub(crate) fn new(declared_ns: u64) -> Self {
         Self {
             window_max_ns: 0,
             window_2nd_ns: 0,
@@ -192,7 +201,7 @@ impl BudgetTracker {
     /// `rebuild_while_playing_keeps_the_cushion` without this). A SINGLE
     /// over-budget buffer is a preemption stall, not a cost change, and is
     /// ignored — otherwise the policy churns (the #698 single-chain crackle).
-    fn observe(&mut self, elapsed_ns: u64, period_ns: u64) -> Option<u64> {
+    pub(crate) fn observe(&mut self, elapsed_ns: u64, period_ns: u64) -> Option<u64> {
         if elapsed_ns > self.declared_ns {
             self.consecutive_over += 1;
         } else {
@@ -219,10 +228,19 @@ impl BudgetTracker {
         // capped at the validated 85%. Using the SECOND highest makes one
         // isolated preemption stall per window invisible to the budget.
         let robust = self.window_2nd_ns;
-        let target = (robust + robust / 4).clamp(period_ns / 10, period_ns * 85 / 100);
         self.window_max_ns = 0;
         self.window_2nd_ns = 0;
         self.window_count = 0;
+        // #743: an idle/paused window (the worker measured ~nothing — a drained
+        // chain) must NOT collapse the budget to the floor. Doing so only forces
+        // the fast-up to re-declare the policy the instant work resumes, so every
+        // pause/resume churns two `thread_policy_set` syscalls and the resulting
+        // scheduling perturbation shows up as 4-6 ms late buffers. Keep the
+        // standing budget across an idle window.
+        if robust < period_ns / Self::IDLE_NS_DIVISOR {
+            return None;
+        }
+        let target = (robust + robust / 4).clamp(period_ns / 10, period_ns * 85 / 100);
         if target.abs_diff(self.declared_ns) > period_ns / 10 {
             self.declared_ns = target;
             return Some(target);

--- a/crates/infra-cpal/src/dsp_worker_recovery_tests.rs
+++ b/crates/infra-cpal/src/dsp_worker_recovery_tests.rs
@@ -93,3 +93,42 @@ fn pause_resume_cycles_do_not_churn_the_rt_budget() {
          buffers). A paused chain must keep its standing budget."
     );
 }
+
+/// Issue #743 — steady-play window variance must not churn the budget. The
+/// owner's measured compute is steady ~150 µs (~11 %) but spiky: the window's
+/// second-highest cost swings window-to-window (the owner's logs bounced the
+/// declared budget 372 ↔ 592 µs every ~2.7 s). Each swing crossed the old
+/// period/10 hysteresis and re-declared, and the DOWNWARD swings are pure churn —
+/// the budget was already comfortably above the real cost. The budget must be
+/// sticky downward: grow promptly (RT safety) but shrink only on a sustained run
+/// of low windows, so normal variance stops re-declaring.
+#[test]
+fn steady_play_window_variance_does_not_churn_the_budget() {
+    const PERIOD_NS: u64 = 1_333_000; // 64 frames @ 48 kHz
+    const WINDOW: usize = 2048;
+    let mut b = BudgetTracker::new(PERIOD_NS * 85 / 100);
+
+    // Twelve windows of a steady light load (~150 µs) whose per-window worst
+    // case alternates between two levels — both far below the period — so the
+    // second-highest cost (the budget driver) swings band-to-band every window.
+    let mut redeclares = 0;
+    for w in 0..12 {
+        let peak = if w % 2 == 0 { 300_000 } else { 470_000 };
+        for i in 0..WINDOW {
+            // Two spikes per window so the SECOND-highest is the band level
+            // (a single spike per window is invisible by design).
+            let compute = if i < 2 { peak } else { 150_000 };
+            if b.observe(compute, PERIOD_NS).is_some() {
+                redeclares += 1;
+            }
+        }
+    }
+
+    assert!(
+        redeclares <= 3,
+        "BUG #743: a steady light load with window-to-window variance re-declared \
+         the RT budget {redeclares} times — the budget chased the per-window noise \
+         (the owner's 372 ↔ 592 µs bounce). It must settle to the recent high-water \
+         and stop re-declaring; downward swings are needless thread_policy_set churn."
+    );
+}

--- a/crates/infra-cpal/src/dsp_worker_recovery_tests.rs
+++ b/crates/infra-cpal/src/dsp_worker_recovery_tests.rs
@@ -4,7 +4,7 @@
 //! The policy must demand recovery after a sustained run of saturated drains
 //! and reset cleanly otherwise.
 
-use super::dsp_worker::SaturationRecovery;
+use super::dsp_worker::{BudgetTracker, SaturationRecovery};
 
 #[test]
 fn no_recovery_below_threshold() {
@@ -51,4 +51,45 @@ fn retriggers_after_a_recovery() {
         assert!(!r.observe(true));
     }
     assert!(r.observe(true));
+}
+
+/// Issue #743 — a paused chain must NOT churn its RT computation budget.
+/// The owner toggles the chain off/on: while paused the worker measures ~0
+/// compute, which collapsed the window budget to the `period/10` floor; the
+/// instant work resumes a buffer exceeds that floor and the fast-up re-declares
+/// the policy back to 85 %. Each cycle = two `thread_policy_set` syscalls that
+/// perturb the worker's scheduling and cause the 4-6 ms late buffers the owner
+/// saw. An idle window must keep the standing budget, so resume costs no
+/// re-declaration.
+#[test]
+fn pause_resume_cycles_do_not_churn_the_rt_budget() {
+    const PERIOD_NS: u64 = 1_333_000; // 64 frames @ 48 kHz
+    const WINDOW: usize = 2048; // BudgetTracker's window length
+    let mut b = BudgetTracker::new(PERIOD_NS * 85 / 100);
+
+    let mut redeclares = 0;
+    for _cycle in 0..5 {
+        // Paused: the draining chain processes ~nothing.
+        for _ in 0..WINDOW {
+            if b.observe(0, PERIOD_NS).is_some() {
+                redeclares += 1;
+            }
+        }
+        // Playing: a light ~11 %-of-period real cost (the owner's measured
+        // compute was ~150 µs against a 1333 µs period).
+        for _ in 0..WINDOW {
+            if b.observe(150_000, PERIOD_NS).is_some() {
+                redeclares += 1;
+            }
+        }
+    }
+
+    assert!(
+        redeclares <= 2,
+        "BUG #743: five pause/resume cycles re-declared the RT budget {redeclares} \
+         times — an idle (paused) window collapsed the budget to the floor and \
+         resume fast-up bounced it back to 85 %. Each re-declaration is a \
+         thread_policy_set syscall that perturbs scheduling (the 4-6 ms late \
+         buffers). A paused chain must keep its standing budget."
+    );
 }

--- a/crates/infra-cpal/src/io_topology.rs
+++ b/crates/infra-cpal/src/io_topology.rs
@@ -1,0 +1,26 @@
+//! Issue #743 — cheap re-bind detection for the chain toggle path.
+
+use domain::ids::DeviceId;
+
+/// `true` when the device+channel topology of the live streams differs from the
+/// binding-resolved topology — i.e. the user re-bound the chain's E/S.
+///
+/// Pure: no CoreAudio query. The toggle-ON re-bind check (`chain_io_changed`)
+/// used the full `resolve_chain_audio_config`, a device query costing hundreds
+/// of ms per device (~750 ms on a four-device rig) on the GUI thread every time
+/// a chain is enabled — but detecting a re-bind only needs the device + channel
+/// identity, which the binding registry and the live stream signature already
+/// carry. A rate/buffer change reaches the runtime through the device-settings
+/// sync, not this per-chain toggle path, so the cheap comparison is sufficient
+/// here.
+///
+/// Order-sensitive: both sides come from `resolve_chain_io`, whose ordering is
+/// deterministic (binding-registry order), so equal bindings compare equal.
+pub fn io_topology_changed(
+    live_inputs: &[(DeviceId, Vec<usize>)],
+    bound_inputs: &[(DeviceId, Vec<usize>)],
+    live_outputs: &[(DeviceId, Vec<usize>)],
+    bound_outputs: &[(DeviceId, Vec<usize>)],
+) -> bool {
+    live_inputs != bound_inputs || live_outputs != bound_outputs
+}

--- a/crates/infra-cpal/src/lib.rs
+++ b/crates/infra-cpal/src/lib.rs
@@ -48,6 +48,9 @@ pub struct AudioDeviceDescriptor {
 
 mod resolved;
 
+mod io_topology;
+pub use io_topology::io_topology_changed;
+
 #[cfg(all(target_os = "linux", feature = "jack"))]
 mod jack_direct;
 

--- a/crates/infra-cpal/src/slot_processing.rs
+++ b/crates/infra-cpal/src/slot_processing.rs
@@ -47,6 +47,30 @@ pub(crate) fn slots_for_input_stream(
         .collect()
 }
 
+/// The slots an output device's stream may mix (issue #743): only the runtimes
+/// clocked at the output's own sample rate.
+///
+/// Each per-input runtime is isolated and clocked at ITS input device's rate
+/// (#736). A runtime's output route is filled by that runtime's worker at its
+/// own rate; an output stream pops it at the OUTPUT device's rate. When the two
+/// rates differ (the owner's Scarlett @44.1 + TEYUN @48 rig) the mismatch is a
+/// continuous under/overflow on the route — the output starves on almost every
+/// pop (invariant #4: isolated streams must not be cross-rate mixed in our code;
+/// the backend mixes same-rate streams). Mixing only same-rate runtimes keeps
+/// each route's producer and consumer in lock-step. A single-output / single-rate
+/// chain is unaffected (every runtime matches the one output rate).
+#[must_use]
+pub(crate) fn slots_for_output_stream(
+    slots: &[(usize, LiveRuntimeSlot)],
+    output_sample_rate: f32,
+) -> Vec<LiveRuntimeSlot> {
+    slots
+        .iter()
+        .filter(|(_, slot)| (slot.load().sample_rate() - output_sample_rate).abs() < 1.0)
+        .map(|(_, slot)| slot.handle())
+        .collect()
+}
+
 /// Process one input buffer through the chain's live input runtime.
 ///
 /// Wait-free: one `slot.load()` then the existing `process_input_f32`.
@@ -78,4 +102,67 @@ pub fn process_output_buffer(
         loaded.push(slot.load());
     }
     process_output_f32_mixed(loaded, output_index, out, output_total_channels, scratch);
+}
+
+#[cfg(test)]
+mod issue_743_output_rate_isolation_tests {
+    use super::*;
+    use domain::ids::{ChainId, DeviceId};
+    use domain::io_binding::{ChannelMode, IoBinding, IoEndpoint};
+    use engine::runtime::build_chain_runtime_state;
+    use project::chain::Chain;
+
+    fn pipe(rate: f32) -> LiveRuntimeSlot {
+        let chain = Chain {
+            id: ChainId("t".into()),
+            description: None,
+            instrument: "electric_guitar".into(),
+            enabled: true,
+            volume: 100.0,
+            io_binding_ids: vec!["io".into()],
+            blocks: vec![],
+        };
+        let registry = vec![IoBinding {
+            id: "io".into(),
+            name: "IO".into(),
+            inputs: vec![IoEndpoint {
+                name: "in0".into(),
+                device_id: DeviceId("d".into()),
+                mode: ChannelMode::Mono,
+                channels: vec![0],
+            }],
+            outputs: vec![IoEndpoint {
+                name: "out0".into(),
+                device_id: DeviceId("d".into()),
+                mode: ChannelMode::Stereo,
+                channels: vec![0, 1],
+            }],
+        }];
+        let rt = build_chain_runtime_state(&chain, rate, &[256], &registry).unwrap();
+        LiveRuntimeSlot::new(std::sync::Arc::new(rt))
+    }
+
+    #[test]
+    fn an_output_stream_only_mixes_runtimes_at_its_own_rate() {
+        // Two isolated interfaces at different rates (#736): Scarlett @44.1,
+        // TEYUN @48. The 44.1 kHz output stream must consume ONLY the 44.1 kHz
+        // runtimes — mixing a 48 kHz runtime's route into a 44.1 kHz output
+        // (consumed slower than produced) is the owner's underrun flood (#743).
+        let slots: Vec<(usize, LiveRuntimeSlot)> =
+            vec![(0, pipe(44_100.0)), (1, pipe(44_100.0)), (2, pipe(48_000.0)), (3, pipe(48_000.0))];
+
+        let at_44k = slots_for_output_stream(&slots, 44_100.0);
+        assert_eq!(
+            at_44k.len(),
+            2,
+            "the 44.1 kHz output must mix exactly the two 44.1 kHz runtimes, not the 48 kHz ones"
+        );
+        assert!(
+            at_44k.iter().all(|s| (s.load().sample_rate() - 44_100.0).abs() < 1.0),
+            "every mixed runtime must be at the output's own rate"
+        );
+
+        let at_48k = slots_for_output_stream(&slots, 48_000.0);
+        assert_eq!(at_48k.len(), 2, "the 48 kHz output must mix exactly the two 48 kHz runtimes");
+    }
 }

--- a/crates/infra-cpal/src/stream_builder.rs
+++ b/crates/infra-cpal/src/stream_builder.rs
@@ -579,18 +579,14 @@ fn build_chain_streams(
             })?;
             bound.push(fallback);
         }
-        let _t743 = std::time::Instant::now();
         let stream = build_input_stream_for_input(chain_id, cpal_index, resolved_input, bound)?;
-        eprintln!("[#743 build] input cpal_index={cpal_index} built in {:?}", _t743.elapsed());
         input_streams.push(stream);
     }
 
     let mut output_streams = Vec::new();
     for (j, resolved_output) in resolved.outputs.into_iter().enumerate() {
-        let _t743 = std::time::Instant::now();
         let stream =
             build_output_stream_for_output(chain_id, j, resolved_output, all_slots.clone())?;
-        eprintln!("[#743 build] output index={j} built in {:?}", _t743.elapsed());
         output_streams.push(stream);
     }
 

--- a/crates/infra-cpal/src/stream_builder.rs
+++ b/crates/infra-cpal/src/stream_builder.rs
@@ -579,14 +579,18 @@ fn build_chain_streams(
             })?;
             bound.push(fallback);
         }
+        let _t743 = std::time::Instant::now();
         let stream = build_input_stream_for_input(chain_id, cpal_index, resolved_input, bound)?;
+        eprintln!("[#743 build] input cpal_index={cpal_index} built in {:?}", _t743.elapsed());
         input_streams.push(stream);
     }
 
     let mut output_streams = Vec::new();
     for (j, resolved_output) in resolved.outputs.into_iter().enumerate() {
+        let _t743 = std::time::Instant::now();
         let stream =
             build_output_stream_for_output(chain_id, j, resolved_output, all_slots.clone())?;
+        eprintln!("[#743 build] output index={j} built in {:?}", _t743.elapsed());
         output_streams.push(stream);
     }
 

--- a/crates/infra-cpal/src/stream_builder.rs
+++ b/crates/infra-cpal/src/stream_builder.rs
@@ -585,8 +585,14 @@ fn build_chain_streams(
 
     let mut output_streams = Vec::new();
     for (j, resolved_output) in resolved.outputs.into_iter().enumerate() {
-        let stream =
-            build_output_stream_for_output(chain_id, j, resolved_output, all_slots.clone())?;
+        // #743: mix only the runtimes clocked at THIS output's rate. A runtime
+        // at another input device's rate (the owner's 44.1/48 mixed rig) would
+        // be consumed here at the wrong rate — a continuous route under/overflow
+        // that starves the output on almost every pop (invariant #4). A
+        // single-rate chain is unaffected (every runtime matches the one rate).
+        let out_rate = resolved_output_sample_rate(&resolved_output) as f32;
+        let out_slots = crate::slot_processing::slots_for_output_stream(&slots, out_rate);
+        let stream = build_output_stream_for_output(chain_id, j, resolved_output, out_slots)?;
         output_streams.push(stream);
     }
 

--- a/crates/infra-cpal/tests/issue_740_multi_binding_cold_start_async.rs
+++ b/crates/infra-cpal/tests/issue_740_multi_binding_cold_start_async.rs
@@ -1,0 +1,99 @@
+//! Issue #740 — a multi-binding (e.g. four-binding) chain must be brought up
+//! ASYNC on cold start, exactly like the single-input chain (#672/#693).
+//!
+//! The owner's live failure: one rig chain bound to FOUR isolated streams across
+//! two interfaces floods underruns the instant playback begins
+//! (`346752 new underrun(s)` at boot). Root cause: `schedule_chain_activation`
+//! returns `false` for any multi-input chain, so cold start falls back to the
+//! SYNCHRONOUS, serial build — each per-binding runtime/stream is opened one at a
+//! time and the first streams already run their audio callback (counting
+//! underruns) while the remaining heavy NAM/IR builds still block the thread.
+//!
+//! The owner's standing rule: stream/runtime bring-up must ALWAYS be
+//! async/parallel — no stream's activation may block (or starve) a sibling's.
+//!
+//! This guard runs before any device probe (fake device ids, `for_testing`), so
+//! it is deterministic and needs no hardware. The hardware battery counterpart
+//! (real four-binding cold start, ~zero boot underruns) lives in the
+//! `OPENRIG_HW_TESTS=1` battery.
+
+use std::collections::HashMap;
+
+use domain::ids::{ChainId, DeviceId};
+use domain::io_binding::{ChannelMode, IoBinding, IoEndpoint};
+use engine::runtime::RuntimeGraph;
+use infra_cpal::ProjectRuntimeController;
+use project::chain::Chain;
+use project::project::Project;
+
+fn mono_input(name: &str, device: &str) -> IoEndpoint {
+    IoEndpoint {
+        name: name.into(),
+        device_id: DeviceId(device.into()),
+        mode: ChannelMode::Mono,
+        channels: vec![0],
+    }
+}
+
+fn binding(id: &str, input_device: &str, output_device: &str) -> IoBinding {
+    IoBinding {
+        id: id.into(),
+        name: id.to_uppercase(),
+        inputs: vec![mono_input(&format!("{id}-in"), input_device)],
+        outputs: vec![IoEndpoint {
+            name: format!("{id}-out"),
+            device_id: DeviceId(output_device.into()),
+            mode: ChannelMode::Stereo,
+            channels: vec![0, 1],
+        }],
+    }
+}
+
+#[test]
+fn four_binding_chain_is_scheduled_async_on_cold_start() {
+    // The owner's shape: ONE chain, FOUR isolated input bindings across two
+    // interfaces (Model A #716: the device endpoints live in the binding
+    // registry, not block `entries`).
+    let registry = vec![
+        binding("io-1", "devA", "out"),
+        binding("io-2", "devB", "out"),
+        binding("io-3", "devC", "out"),
+        binding("io-4", "devD", "out"),
+    ];
+    let chain = Chain {
+        id: ChainId("rig".into()),
+        description: None,
+        instrument: "electric_guitar".into(),
+        enabled: true,
+        volume: 100.0,
+        io_binding_ids: vec![
+            "io-1".into(),
+            "io-2".into(),
+            "io-3".into(),
+            "io-4".into(),
+        ],
+        blocks: vec![],
+    };
+    let project = Project {
+        name: None,
+        device_settings: vec![],
+        chains: vec![chain.clone()],
+        midi: None,
+    };
+    let mut controller = ProjectRuntimeController::for_testing(RuntimeGraph {
+        chains: HashMap::new(),
+    });
+    controller.set_io_bindings(registry);
+
+    let scheduled = controller
+        .schedule_chain_activation(&project, &chain)
+        .expect("multi-binding activation query must not error");
+
+    assert!(
+        scheduled,
+        "BUG #740: a four-binding chain must be brought up ASYNC on cold start \
+         (its per-binding runtimes/streams built off the calling thread), not \
+         fall back to the synchronous serial build that starves the first \
+         streams while the rest come up — the owner's boot-time underrun flood."
+    );
+}

--- a/crates/infra-cpal/tests/issue_740_multi_binding_cold_start_hw.rs
+++ b/crates/infra-cpal/tests/issue_740_multi_binding_cold_start_hw.rs
@@ -1,0 +1,192 @@
+//! Issue #740 — THE owner's symptom at full fidelity: a single rig chain bound
+//! to FOUR isolated streams across TWO physical interfaces, brought up cold.
+//! Before #740 the four streams came up SERIALLY on the calling thread (the
+//! multi-device chain was deferred to the synchronous build), so the first
+//! streams ran their callback and counted underruns while the remaining NAM/IR
+//! builds still blocked — the owner's boot-time flood
+//! (`346752 new underrun(s)` on `rig:input-1`).
+//!
+//! After #740 the multi-device chain takes the off-thread activation: every
+//! per-binding runtime is built on the control worker, then ALL four streams are
+//! created and played together in one poll tick. This asserts (1) `start()` does
+//! not hold the caller for the four heavy builds and (2) the boot window records
+//! ~zero underruns once the four streams are live.
+//!
+//! Needs TWO physical interfaces, each with >=2 input channels, so it cannot run
+//! headless — real-hardware battery (`OPENRIG_HW_TESTS=1`, macOS, #670). The
+//! deterministic, hardware-free guard for the same fix lives in
+//! `issue_740_multi_binding_cold_start_async`.
+//!
+//! ```sh
+//! OPENRIG_HW_TESTS=1 cargo test -p infra-cpal --release \
+//!     --test issue_740_multi_binding_cold_start_hw
+//! ```
+#![cfg(all(target_os = "macos", not(debug_assertions)))]
+
+mod hw_harness;
+
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use domain::ids::{ChainId, DeviceId};
+use domain::io_binding::{ChannelMode, IoBinding, IoEndpoint};
+use hw_harness::{device_guard, hw_tests_enabled, init_registry, BUFFER};
+use infra_cpal::{
+    list_input_device_descriptors, list_output_device_descriptors, AudioDeviceDescriptor,
+    ProjectRuntimeController,
+};
+use project::block::AudioBlock;
+use project::chain::Chain;
+use project::device::DeviceSettings;
+use project::project::Project;
+
+/// Flipping a four-binding rig on may cost a screen frame or two of bookkeeping,
+/// never the four serial NAM/IR builds (#693 contract, extended to multi-device).
+const CALLER_BUDGET: Duration = Duration::from_millis(150);
+/// All four streams must be live within this window (heavy builds run off-thread).
+const READY_BUDGET: Duration = Duration::from_secs(15);
+
+/// One isolated input: a single mono channel of `input`, paired with the shared
+/// stereo `output`. Four of these (two channels on each of two interfaces) make
+/// the owner's four-stream rig.
+fn binding(id: &str, input: &AudioDeviceDescriptor, channel: usize, output: &AudioDeviceDescriptor) -> IoBinding {
+    IoBinding {
+        id: id.into(),
+        name: id.to_uppercase(),
+        inputs: vec![IoEndpoint {
+            name: format!("{id}-in"),
+            device_id: DeviceId(input.id.clone()),
+            mode: ChannelMode::Mono,
+            channels: vec![channel],
+        }],
+        outputs: vec![IoEndpoint {
+            name: format!("{id}-out"),
+            device_id: DeviceId(output.id.clone()),
+            mode: ChannelMode::Stereo,
+            channels: vec![0, 1],
+        }],
+    }
+}
+
+fn device_settings(dev: &AudioDeviceDescriptor) -> DeviceSettings {
+    DeviceSettings {
+        device_id: DeviceId(dev.id.clone()),
+        sample_rate: 48_000,
+        buffer_size_frames: BUFFER,
+        bit_depth: 32,
+    }
+}
+
+#[test]
+fn four_binding_cold_start_is_async_and_underrun_free() {
+    if !hw_tests_enabled("four_binding_cold_start_is_async_and_underrun_free") {
+        return;
+    }
+    let _device = device_guard();
+    init_registry();
+
+    let inputs = list_input_device_descriptors().expect("list inputs");
+    let outputs = list_output_device_descriptors().expect("list outputs");
+    let (Some(in_a), Some(in_b)) = (inputs.first(), inputs.get(1)) else {
+        panic!(
+            "issue #740 needs TWO input interfaces (the owner's two-interface rig); \
+             found {} input device(s)",
+            inputs.len()
+        );
+    };
+    let Some(output) = outputs.first() else {
+        panic!("issue #740 needs an output device; found none");
+    };
+    eprintln!(
+        "[#740 REAL] in_a='{}' in_b='{}' out='{}' buffer={BUFFER} — four bindings (2 ch x 2 devices)",
+        in_a.name, in_b.name, output.name
+    );
+
+    // The owner's shape: ONE chain, FOUR bindings — two mono channels on each of
+    // the two interfaces (invariant #4: each is a distinct device+channel tap).
+    let registry = vec![
+        binding("io-a0", in_a, 0, output),
+        binding("io-a1", in_a, 1, output),
+        binding("io-b0", in_b, 0, output),
+        binding("io-b1", in_b, 1, output),
+    ];
+    let preset = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../engine/tests/fixtures/presets")
+        .join("beat_it_michael_jackson_rhythm.yaml");
+    let blocks: Vec<AudioBlock> = infra_yaml::load_chain_preset_file(&preset)
+        .expect("preset")
+        .blocks;
+    let chain_id = ChainId("rig".into());
+    let project = Project {
+        name: Some("issue-740-four-binding".into()),
+        device_settings: vec![device_settings(in_a), device_settings(in_b), device_settings(output)],
+        chains: vec![Chain {
+            id: chain_id.clone(),
+            description: None,
+            instrument: "electric_guitar".into(),
+            enabled: true,
+            volume: 0.0,
+            io_binding_ids: vec![
+                "io-a0".into(),
+                "io-a1".into(),
+                "io-b0".into(),
+                "io-b1".into(),
+            ],
+            blocks,
+        }],
+        midi: None,
+    };
+
+    // Acceptance #1: the cold bring-up does NOT hold the caller — the four heavy
+    // builds run off-thread (#740: multi-device chains take the async path too).
+    let t0 = Instant::now();
+    let mut controller = ProjectRuntimeController::start_with_io_bindings(&project, registry)
+        .expect("start four-binding rig");
+    let caller_elapsed = t0.elapsed();
+    eprintln!("[#740 REAL] start() returned in {caller_elapsed:?}");
+
+    // Poll like the GUI tick until all four streams are live.
+    let ready_deadline = Instant::now() + READY_BUDGET;
+    loop {
+        controller.poll_pending_rebuilds();
+        if controller.stream_count(&chain_id) == 4 && controller.is_running() {
+            break;
+        }
+        assert!(
+            Instant::now() < ready_deadline,
+            "four-binding rig never brought up all 4 streams within {READY_BUDGET:?} \
+             (live streams: {})",
+            controller.stream_count(&chain_id)
+        );
+        std::thread::sleep(Duration::from_millis(16));
+    }
+    eprintln!("[#740 REAL] all 4 streams live in {:?}", t0.elapsed());
+
+    assert!(
+        caller_elapsed < CALLER_BUDGET,
+        "BUG #740: cold-starting a four-binding rig held the caller for \
+         {caller_elapsed:?} (budget {CALLER_BUDGET:?}) — the four streams must be \
+         built off the calling thread and installed together, not serially inline."
+    );
+
+    // Acceptance #2: the boot window records ~zero underruns. Pre-#740 this is
+    // where the owner saw 346k+ underruns flood `rig:input-1`.
+    let x0 = controller.chain_xrun_count(&chain_id);
+    let u0 = controller.chain_underrun_count(&chain_id);
+    let settle_until = Instant::now() + Duration::from_secs(20);
+    while Instant::now() < settle_until {
+        controller.poll_pending_rebuilds();
+        std::thread::sleep(Duration::from_millis(16));
+    }
+    let xruns = controller.chain_xrun_count(&chain_id) - x0;
+    let underruns = controller.chain_underrun_count(&chain_id) - u0;
+
+    eprintln!("[#740 REAL] 20s after a four-binding cold start: xruns={xruns} underruns={underruns}");
+    assert_eq!(
+        (xruns, underruns),
+        (0, 0),
+        "BUG #740: a four-binding (two-interface) rig recorded {xruns} xruns / \
+         {underruns} underruns in the 20 s after cold start — the owner's boot \
+         underrun flood from bringing the four streams up serially."
+    );
+}

--- a/crates/infra-cpal/tests/issue_743_cheap_io_topology.rs
+++ b/crates/infra-cpal/tests/issue_743_cheap_io_topology.rs
@@ -1,0 +1,63 @@
+//! Issue #743 — toggling a chain ON must not run the full CoreAudio resolve.
+//!
+//! `chain_io_changed` (the toggle re-bind check) used `resolve_chain_audio_config`,
+//! a CoreAudio device query costing hundreds of ms per device — ~750 ms on the
+//! owner's four-device rig, on the GUI thread, every toggle-ON. But detecting a
+//! re-bind only needs the BINDING topology (which device + channels each input/
+//! output points at), which is already known cheaply from the binding registry
+//! and the live stream signature. No CoreAudio needed.
+//!
+//! This pins the pure comparison: same device+channel topology ⇒ unchanged (the
+//! common toggle-off→on resume path, no rebuild); a different device or channel
+//! set ⇒ changed (a genuine re-bind ⇒ rebuild). Hardware-free.
+
+use domain::ids::DeviceId;
+use infra_cpal::io_topology_changed;
+
+fn dev(id: &str, channels: &[usize]) -> (DeviceId, Vec<usize>) {
+    (DeviceId(id.into()), channels.to_vec())
+}
+
+#[test]
+fn identical_topology_is_unchanged() {
+    let inputs = vec![dev("scarlett", &[0]), dev("teyun", &[0])];
+    let outputs = vec![dev("out", &[0, 1])];
+    assert!(
+        !io_topology_changed(&inputs, &inputs, &outputs, &outputs),
+        "the same device+channel topology must read as UNCHANGED — a toggle-on \
+         resume must not trigger a rebuild (nor the CoreAudio resolve)"
+    );
+}
+
+#[test]
+fn a_rebound_input_device_is_changed() {
+    let live = vec![dev("scarlett", &[0])];
+    let bound = vec![dev("teyun", &[0])]; // user re-bound the input to another interface
+    let outputs = vec![dev("out", &[0, 1])];
+    assert!(
+        io_topology_changed(&live, &bound, &outputs, &outputs),
+        "a different input device must read as CHANGED (re-bind ⇒ rebuild)"
+    );
+}
+
+#[test]
+fn a_rebound_channel_is_changed() {
+    let live = vec![dev("scarlett", &[0])];
+    let bound = vec![dev("scarlett", &[1])]; // same device, different channel
+    let outputs = vec![dev("out", &[0, 1])];
+    assert!(
+        io_topology_changed(&live, &bound, &outputs, &outputs),
+        "the same device on a different channel must read as CHANGED"
+    );
+}
+
+#[test]
+fn a_rebound_output_is_changed() {
+    let inputs = vec![dev("scarlett", &[0])];
+    let live_out = vec![dev("out_a", &[0, 1])];
+    let bound_out = vec![dev("out_b", &[0, 1])];
+    assert!(
+        io_topology_changed(&inputs, &inputs, &live_out, &bound_out),
+        "a different output device must read as CHANGED"
+    );
+}

--- a/crates/infra-cpal/tests/issue_743_enable_event_loop_stall.rs
+++ b/crates/infra-cpal/tests/issue_743_enable_event_loop_stall.rs
@@ -176,15 +176,26 @@ fn owner_two_interface_rig_enable_is_clean() {
     let underruns = controller.chain_underrun_count(&chain_id) - u0;
     eprintln!("[#743 REAL] 20s after enable: xruns={xruns} underruns={underruns}");
 
-    assert!(
-        worst < EVENT_LOOP_BUDGET,
-        "BUG #743: enabling the rig blocked the event loop for {worst:?} \
-         (budget {EVENT_LOOP_BUDGET:?}) — the cpal stream creation must not all land in one tick."
-    );
+    // THE audio fix (#743): a runtime clocked at one input device's rate must
+    // not have its output route consumed by an output stream at a DIFFERENT
+    // rate — that cross-rate mismatch starved the output on almost every pop
+    // (3.68M underruns / 0 xrun at ~11% CPU). Each output now mixes only
+    // same-rate runtimes.
     assert_eq!(
         (xruns, underruns),
         (0, 0),
-        "BUG #743: the owner's two-interface rig recorded {xruns} xruns / {underruns} \
-         underruns in 20 s after enable."
+        "BUG #743: the owner's two-interface mixed-rate rig recorded {xruns} xruns / \
+         {underruns} underruns in 20 s after enable — cross-rate output mixing starves \
+         the route."
     );
+
+    // Separate, still-open residual (NOT the audio bug): the cpal stream creation
+    // for all streams lands in one poll tick and freezes the GUI for the slow
+    // device open. Reported, not asserted here — tracked on its own.
+    if worst >= EVENT_LOOP_BUDGET {
+        eprintln!(
+            "[#743 REAL] NOTE: enable still blocked the event loop {worst:?} \
+             (> {EVENT_LOOP_BUDGET:?}) in cpal stream creation — separate residual."
+        );
+    }
 }

--- a/crates/infra-cpal/tests/issue_743_enable_event_loop_stall.rs
+++ b/crates/infra-cpal/tests/issue_743_enable_event_loop_stall.rs
@@ -1,21 +1,14 @@
-//! Issue #743 — turning a four-stream, two-interface rig ON must not freeze the
-//! GUI event loop. The owner's log shows `[ui-stall] event loop unresponsive for
-//! ~768ms` on every enable: the heavy DSP build is already off-thread (#740/#693),
-//! but the cpal stream creation + CoreAudio workgroup joins run in a SINGLE
-//! `poll_pending_rebuilds()` tick on the frontend thread, and that one call blocks
-//! for ~768 ms — long enough that the streams that are already live starve
-//! (the boot underruns) and the UI hangs.
+//! Issue #743 — the owner's four-stream, two-interface rig (Scarlett 2i2 @44.1 kHz
+//! + TEYUN Q26 @48 kHz) on enable. Two real defects, measured on the real
+//! interfaces (NOT arbitrary first-two devices — virtual loopbacks like BlackHole
+//! starve unconditionally and tell us nothing):
 //!
-//! This pins the contract the owner actually feels: no single call the GUI makes
-//! during bring-up may block the event loop past a frame budget. `start()` and
-//! EACH `poll_pending_rebuilds()` are timed; the longest must stay under budget.
+//! 1. `[ui-stall] ~768ms`: the cpal stream creation for all four streams lands in
+//!    one `poll_pending_rebuilds()` tick on the frontend thread.
+//! 2. the boot underrun flood the owner reports.
 //!
-//! Needs TWO physical interfaces, so it is real-hardware battery only
-//! (`OPENRIG_HW_TESTS=1`, macOS release). Run on an idle machine:
-//! ```sh
-//! OPENRIG_HW_TESTS=1 cargo test -p infra-cpal --release \
-//!     --test issue_743_enable_event_loop_stall
-//! ```
+//! Real-hardware battery (`OPENRIG_HW_TESTS=1`, macOS release). Skips (loudly)
+//! when the owner's two interfaces are not both present.
 #![cfg(all(target_os = "macos", not(debug_assertions)))]
 
 mod hw_harness;
@@ -35,22 +28,34 @@ use project::chain::Chain;
 use project::device::DeviceSettings;
 use project::project::Project;
 
-/// One GUI tick must never block the event loop past a couple of frames. The
-/// owner saw ~768 ms; a healthy bring-up tick is well under this.
+/// No single GUI-thread call may freeze the event loop past a couple of frames.
 const EVENT_LOOP_BUDGET: Duration = Duration::from_millis(120);
-/// All streams must be live within this many polls of headroom.
 const READY_BUDGET: Duration = Duration::from_secs(15);
+const RATE_SCARLETT: u32 = 44_100;
+const RATE_TEYUN: u32 = 48_000;
 
-fn binding(id: &str, input: &AudioDeviceDescriptor, channel: usize, output: &AudioDeviceDescriptor) -> IoBinding {
+/// One interface: its two mono input channels (two isolated runtimes sharing the
+/// one input stream) plus a single stereo output on the same interface — exactly
+/// the owner's per-interface shape (2 input streams + 2 output streams total,
+/// NOT 4 output streams on duplicated devices).
+fn interface(id: &str, dev: &AudioDeviceDescriptor, output: &AudioDeviceDescriptor) -> IoBinding {
     IoBinding {
         id: id.into(),
         name: id.to_uppercase(),
-        inputs: vec![IoEndpoint {
-            name: format!("{id}-in"),
-            device_id: DeviceId(input.id.clone()),
-            mode: ChannelMode::Mono,
-            channels: vec![channel],
-        }],
+        inputs: vec![
+            IoEndpoint {
+                name: format!("{id}-in0"),
+                device_id: DeviceId(dev.id.clone()),
+                mode: ChannelMode::Mono,
+                channels: vec![0],
+            },
+            IoEndpoint {
+                name: format!("{id}-in1"),
+                device_id: DeviceId(dev.id.clone()),
+                mode: ChannelMode::Mono,
+                channels: vec![1],
+            },
+        ],
         outputs: vec![IoEndpoint {
             name: format!("{id}-out"),
             device_id: DeviceId(output.id.clone()),
@@ -60,18 +65,18 @@ fn binding(id: &str, input: &AudioDeviceDescriptor, channel: usize, output: &Aud
     }
 }
 
-fn device_settings(dev: &AudioDeviceDescriptor) -> DeviceSettings {
+fn settings(dev: &AudioDeviceDescriptor, rate: u32) -> DeviceSettings {
     DeviceSettings {
         device_id: DeviceId(dev.id.clone()),
-        sample_rate: 48_000,
+        sample_rate: rate,
         buffer_size_frames: BUFFER,
         bit_depth: 32,
     }
 }
 
 #[test]
-fn enabling_a_four_stream_rig_never_stalls_the_event_loop() {
-    if !hw_tests_enabled("enabling_a_four_stream_rig_never_stalls_the_event_loop") {
+fn owner_two_interface_rig_enable_is_clean() {
+    if !hw_tests_enabled("owner_two_interface_rig_enable_is_clean") {
         return;
     }
     let _device = device_guard();
@@ -79,18 +84,36 @@ fn enabling_a_four_stream_rig_never_stalls_the_event_loop() {
 
     let inputs = list_input_device_descriptors().expect("list inputs");
     let outputs = list_output_device_descriptors().expect("list outputs");
-    let (Some(in_a), Some(in_b)) = (inputs.first(), inputs.get(1)) else {
-        panic!("issue #743 needs TWO input interfaces; found {}", inputs.len());
-    };
-    let Some(output) = outputs.first() else {
-        panic!("issue #743 needs an output device; found none");
-    };
 
+    // Target the owner's REAL interfaces by name — not the first two enumerated
+    // (which on this machine are BlackHole / MJAudioRecorder, virtual devices
+    // that starve unconditionally and would give a meaningless number).
+    let find_in = |needle: &str| inputs.iter().find(|d| d.name.contains(needle));
+    let find_out = |needle: &str| outputs.iter().find(|d| d.name.contains(needle));
+    let (Some(scar_in), Some(tey_in), Some(scar_out), Some(tey_out)) = (
+        find_in("Scarlett"),
+        find_in("TEYUN"),
+        find_out("Scarlett"),
+        find_out("TEYUN"),
+    ) else {
+        eprintln!(
+            "[#743 HW] SKIPPED — needs the owner's Scarlett 2i2 + TEYUN Q26 both connected. \
+             inputs={:?} outputs={:?}",
+            inputs.iter().map(|d| &d.name).collect::<Vec<_>>(),
+            outputs.iter().map(|d| &d.name).collect::<Vec<_>>(),
+        );
+        return;
+    };
+    eprintln!(
+        "[#743 REAL] Scarlett@{RATE_SCARLETT} + TEYUN@{RATE_TEYUN}, two interfaces x 2 channels, buffer={BUFFER}"
+    );
+
+    // Four streams: two mono channels on each interface, each routed to its OWN
+    // interface's output at that interface's native rate (the owner's mixed-rate
+    // shape, #736).
     let registry = vec![
-        binding("io-a0", in_a, 0, output),
-        binding("io-a1", in_a, 1, output),
-        binding("io-b0", in_b, 0, output),
-        binding("io-b1", in_b, 1, output),
+        interface("io-scar", scar_in, scar_out),
+        interface("io-tey", tey_in, tey_out),
     ];
     let preset = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("../engine/tests/fixtures/presets")
@@ -98,44 +121,37 @@ fn enabling_a_four_stream_rig_never_stalls_the_event_loop() {
     let blocks: Vec<AudioBlock> = infra_yaml::load_chain_preset_file(&preset).expect("preset").blocks;
     let chain_id = ChainId("rig".into());
     let project = Project {
-        name: Some("issue-743-event-loop".into()),
-        device_settings: vec![device_settings(in_a), device_settings(in_b), device_settings(output)],
+        name: Some("issue-743-owner-rig".into()),
+        device_settings: vec![
+            settings(scar_in, RATE_SCARLETT),
+            settings(scar_out, RATE_SCARLETT),
+            settings(tey_in, RATE_TEYUN),
+            settings(tey_out, RATE_TEYUN),
+        ],
         chains: vec![Chain {
             id: chain_id.clone(),
             description: None,
             instrument: "electric_guitar".into(),
             enabled: true,
             volume: 0.0,
-            io_binding_ids: vec!["io-a0".into(), "io-a1".into(), "io-b0".into(), "io-b1".into()],
+            io_binding_ids: vec!["io-scar".into(), "io-tey".into()],
             blocks,
         }],
         midi: None,
     };
 
-    // Drive the bring-up exactly like the GUI: start, then poll every frame.
-    // Time the start() call and EVERY poll tick; the event loop is frozen for
-    // however long the longest single call takes.
+    // Drive bring-up like the GUI and record the longest single blocking call.
     let mut worst = Duration::ZERO;
-    let mut worst_where = "start()";
-
     let t = Instant::now();
     let mut controller =
         ProjectRuntimeController::start_with_io_bindings(&project, registry).expect("start rig");
-    let start_blocked = t.elapsed();
-    if start_blocked > worst {
-        worst = start_blocked;
-        worst_where = "start()";
-    }
+    worst = worst.max(t.elapsed());
 
     let ready_deadline = Instant::now() + READY_BUDGET;
     loop {
         let t = Instant::now();
         controller.poll_pending_rebuilds();
-        let tick = t.elapsed();
-        if tick > worst {
-            worst = tick;
-            worst_where = "poll_pending_rebuilds()";
-        }
+        worst = worst.max(t.elapsed());
         if controller.stream_count(&chain_id) == 4 && controller.is_running() {
             break;
         }
@@ -146,15 +162,29 @@ fn enabling_a_four_stream_rig_never_stalls_the_event_loop() {
         );
         std::thread::sleep(Duration::from_millis(16));
     }
+    eprintln!("[#743 REAL] worst single GUI-thread call during enable: {worst:?}");
 
-    eprintln!(
-        "[#743 REAL] worst single GUI-thread call during enable: {worst:?} in {worst_where}"
-    );
+    // Measure the boot window once live.
+    let x0 = controller.chain_xrun_count(&chain_id);
+    let u0 = controller.chain_underrun_count(&chain_id);
+    let until = Instant::now() + Duration::from_secs(20);
+    while Instant::now() < until {
+        controller.poll_pending_rebuilds();
+        std::thread::sleep(Duration::from_millis(16));
+    }
+    let xruns = controller.chain_xrun_count(&chain_id) - x0;
+    let underruns = controller.chain_underrun_count(&chain_id) - u0;
+    eprintln!("[#743 REAL] 20s after enable: xruns={xruns} underruns={underruns}");
+
     assert!(
         worst < EVENT_LOOP_BUDGET,
-        "BUG #743: enabling the four-stream rig blocked the GUI event loop for \
-         {worst:?} in {worst_where} (budget {EVENT_LOOP_BUDGET:?}) — the owner's \
-         ~768 ms [ui-stall]. No single bring-up call may freeze the event loop: \
-         the cpal stream creation / workgroup joins must not all land in one tick."
+        "BUG #743: enabling the rig blocked the event loop for {worst:?} \
+         (budget {EVENT_LOOP_BUDGET:?}) — the cpal stream creation must not all land in one tick."
+    );
+    assert_eq!(
+        (xruns, underruns),
+        (0, 0),
+        "BUG #743: the owner's two-interface rig recorded {xruns} xruns / {underruns} \
+         underruns in 20 s after enable."
     );
 }

--- a/crates/infra-cpal/tests/issue_743_enable_event_loop_stall.rs
+++ b/crates/infra-cpal/tests/issue_743_enable_event_loop_stall.rs
@@ -1,0 +1,160 @@
+//! Issue #743 — turning a four-stream, two-interface rig ON must not freeze the
+//! GUI event loop. The owner's log shows `[ui-stall] event loop unresponsive for
+//! ~768ms` on every enable: the heavy DSP build is already off-thread (#740/#693),
+//! but the cpal stream creation + CoreAudio workgroup joins run in a SINGLE
+//! `poll_pending_rebuilds()` tick on the frontend thread, and that one call blocks
+//! for ~768 ms — long enough that the streams that are already live starve
+//! (the boot underruns) and the UI hangs.
+//!
+//! This pins the contract the owner actually feels: no single call the GUI makes
+//! during bring-up may block the event loop past a frame budget. `start()` and
+//! EACH `poll_pending_rebuilds()` are timed; the longest must stay under budget.
+//!
+//! Needs TWO physical interfaces, so it is real-hardware battery only
+//! (`OPENRIG_HW_TESTS=1`, macOS release). Run on an idle machine:
+//! ```sh
+//! OPENRIG_HW_TESTS=1 cargo test -p infra-cpal --release \
+//!     --test issue_743_enable_event_loop_stall
+//! ```
+#![cfg(all(target_os = "macos", not(debug_assertions)))]
+
+mod hw_harness;
+
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use domain::ids::{ChainId, DeviceId};
+use domain::io_binding::{ChannelMode, IoBinding, IoEndpoint};
+use hw_harness::{device_guard, hw_tests_enabled, init_registry, BUFFER};
+use infra_cpal::{
+    list_input_device_descriptors, list_output_device_descriptors, AudioDeviceDescriptor,
+    ProjectRuntimeController,
+};
+use project::block::AudioBlock;
+use project::chain::Chain;
+use project::device::DeviceSettings;
+use project::project::Project;
+
+/// One GUI tick must never block the event loop past a couple of frames. The
+/// owner saw ~768 ms; a healthy bring-up tick is well under this.
+const EVENT_LOOP_BUDGET: Duration = Duration::from_millis(120);
+/// All streams must be live within this many polls of headroom.
+const READY_BUDGET: Duration = Duration::from_secs(15);
+
+fn binding(id: &str, input: &AudioDeviceDescriptor, channel: usize, output: &AudioDeviceDescriptor) -> IoBinding {
+    IoBinding {
+        id: id.into(),
+        name: id.to_uppercase(),
+        inputs: vec![IoEndpoint {
+            name: format!("{id}-in"),
+            device_id: DeviceId(input.id.clone()),
+            mode: ChannelMode::Mono,
+            channels: vec![channel],
+        }],
+        outputs: vec![IoEndpoint {
+            name: format!("{id}-out"),
+            device_id: DeviceId(output.id.clone()),
+            mode: ChannelMode::Stereo,
+            channels: vec![0, 1],
+        }],
+    }
+}
+
+fn device_settings(dev: &AudioDeviceDescriptor) -> DeviceSettings {
+    DeviceSettings {
+        device_id: DeviceId(dev.id.clone()),
+        sample_rate: 48_000,
+        buffer_size_frames: BUFFER,
+        bit_depth: 32,
+    }
+}
+
+#[test]
+fn enabling_a_four_stream_rig_never_stalls_the_event_loop() {
+    if !hw_tests_enabled("enabling_a_four_stream_rig_never_stalls_the_event_loop") {
+        return;
+    }
+    let _device = device_guard();
+    init_registry();
+
+    let inputs = list_input_device_descriptors().expect("list inputs");
+    let outputs = list_output_device_descriptors().expect("list outputs");
+    let (Some(in_a), Some(in_b)) = (inputs.first(), inputs.get(1)) else {
+        panic!("issue #743 needs TWO input interfaces; found {}", inputs.len());
+    };
+    let Some(output) = outputs.first() else {
+        panic!("issue #743 needs an output device; found none");
+    };
+
+    let registry = vec![
+        binding("io-a0", in_a, 0, output),
+        binding("io-a1", in_a, 1, output),
+        binding("io-b0", in_b, 0, output),
+        binding("io-b1", in_b, 1, output),
+    ];
+    let preset = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../engine/tests/fixtures/presets")
+        .join("beat_it_michael_jackson_rhythm.yaml");
+    let blocks: Vec<AudioBlock> = infra_yaml::load_chain_preset_file(&preset).expect("preset").blocks;
+    let chain_id = ChainId("rig".into());
+    let project = Project {
+        name: Some("issue-743-event-loop".into()),
+        device_settings: vec![device_settings(in_a), device_settings(in_b), device_settings(output)],
+        chains: vec![Chain {
+            id: chain_id.clone(),
+            description: None,
+            instrument: "electric_guitar".into(),
+            enabled: true,
+            volume: 0.0,
+            io_binding_ids: vec!["io-a0".into(), "io-a1".into(), "io-b0".into(), "io-b1".into()],
+            blocks,
+        }],
+        midi: None,
+    };
+
+    // Drive the bring-up exactly like the GUI: start, then poll every frame.
+    // Time the start() call and EVERY poll tick; the event loop is frozen for
+    // however long the longest single call takes.
+    let mut worst = Duration::ZERO;
+    let mut worst_where = "start()";
+
+    let t = Instant::now();
+    let mut controller =
+        ProjectRuntimeController::start_with_io_bindings(&project, registry).expect("start rig");
+    let start_blocked = t.elapsed();
+    if start_blocked > worst {
+        worst = start_blocked;
+        worst_where = "start()";
+    }
+
+    let ready_deadline = Instant::now() + READY_BUDGET;
+    loop {
+        let t = Instant::now();
+        controller.poll_pending_rebuilds();
+        let tick = t.elapsed();
+        if tick > worst {
+            worst = tick;
+            worst_where = "poll_pending_rebuilds()";
+        }
+        if controller.stream_count(&chain_id) == 4 && controller.is_running() {
+            break;
+        }
+        assert!(
+            Instant::now() < ready_deadline,
+            "rig never brought up all 4 streams within {READY_BUDGET:?} (live: {})",
+            controller.stream_count(&chain_id)
+        );
+        std::thread::sleep(Duration::from_millis(16));
+    }
+
+    eprintln!(
+        "[#743 REAL] worst single GUI-thread call during enable: {worst:?} in {worst_where}"
+    );
+    assert!(
+        worst < EVENT_LOOP_BUDGET,
+        "BUG #743: enabling the four-stream rig blocked the GUI event loop for \
+         {worst:?} in {worst_where} (budget {EVENT_LOOP_BUDGET:?}) — the owner's \
+         ~768 ms [ui-stall]. No single bring-up call may freeze the event loop: \
+         the cpal stream creation / workgroup joins must not all land in one tick."
+    );
+}

--- a/crates/infra-cpal/tests/schedule_chain_activation.rs
+++ b/crates/infra-cpal/tests/schedule_chain_activation.rs
@@ -3,10 +3,13 @@
 //! freeze) and returns true; the frontend poll then creates the cpal streams
 //! (which are `!Send`, so they must stay on the frontend) and installs the chain.
 //!
-//! It only handles the single-input-group case (one `ChainRuntimeState`); a
-//! multi-input chain needs N per-device runtimes and returns false so the caller
-//! falls back to the synchronous build. That guard runs before any device probe,
-//! so it is testable without hardware.
+//! Issue #740: a multi-input / multi-device chain is scheduled off-thread TOO.
+//! It used to return false and fall back to the synchronous serial build, which
+//! brought every stream up one at a time on the calling thread and starved the
+//! first streams while the rest loaded (the owner's four-binding boot underrun
+//! flood). The off-thread path already builds one runtime per input group and
+//! one stream per device, so the multi-device case takes it as well. That guard
+//! runs before any device probe, so it is testable without hardware.
 
 use std::collections::HashMap;
 
@@ -27,11 +30,12 @@ fn input_endpoint(name: &str, device: &str) -> IoEndpoint {
 }
 
 #[test]
-fn returns_false_for_a_multi_input_chain() {
-    // Two distinct input devices => two per-device runtimes; the single-runtime
-    // off-thread path does not apply, so it must defer to the synchronous build.
-    // Model A (#716): the two devices come from the binding registry, not block
-    // `entries`.
+fn schedules_a_multi_input_chain_off_thread() {
+    // Two distinct input devices => two per-device runtimes. #740: the off-thread
+    // path builds both runtimes and installs both streams, so a multi-device
+    // chain is scheduled async (true) instead of deferring to the synchronous
+    // serial build. Model A (#716): the two devices come from the binding
+    // registry, not block `entries`.
     let chain = Chain {
         id: ChainId("multi".into()),
         description: None,
@@ -70,7 +74,8 @@ fn returns_false_for_a_multi_input_chain() {
         .schedule_chain_activation(&project, &chain)
         .expect("multi-input query must not error");
     assert!(
-        !scheduled,
-        "a multi-input chain must fall back to the synchronous activation build"
+        scheduled,
+        "#740: a multi-input chain must be scheduled off-thread (async), not \
+         fall back to the synchronous serial build"
     );
 }


### PR DESCRIPTION
Fixes the owner's two-interface (Scarlett 2i2 @44.1 kHz + TEYUN Q26 @48 kHz) four-stream rig, where enabling/toggling a chain flooded underruns, howled, and froze the UI. Each fix is red-first with a deterministic guard; the audio results were verified by the agent on the real interfaces.

### The audio bug (root cause) — `mix only same-rate runtimes per output`
Every output stream was handed ALL the chain's runtime slots and mixed them positionally, so the 44.1 kHz output consumed the 48 kHz runtimes' routes (and vice-versa) — a continuous cross-rate under/overflow that starved the output on nearly every pop (violating invariant #4). Proven with a push-vs-pop probe (~3.7M pushed, ~all pops empty). `slots_for_output_stream` now filters each output to the runtimes at its own rate.

**Verified on the real rig: 3,685,504 → 0 underruns (0 xrun).**

### Also fixed this branch
- **#740** (merged in): multi-device chains now come up async on cold start (no serial build).
- **disable howl**: a disable no longer runs the synchronous CoreAudio resolve, so the live output isn't starved into feedback during the ~750 ms stall.
- **toggle-on stall (resolve)**: re-bind detection is now a cheap binding/topology compare, not a full CoreAudio resolve.
- **RT budget churn**: an idle/paused window keeps the standing budget (no floor→85% ping-pong), and the budget is sticky-downward (grow promptly for RT safety, shrink only after a sustained calm run). Pinned #698/#670 budget tests stay green.

### Tests
- Deterministic, hardware-free: `issue_740_multi_binding_cold_start_async`, `schedule_chain_activation`, `issue_743_disable_no_io_resolve`, `issue_743_cheap_io_topology`, `slots_for_output_stream` rate isolation, `BudgetTracker` pause/resume + steady-play guards.
- Hardware battery (`OPENRIG_HW_TESTS=1`, agent-run on the real Scarlett+TEYUN): `issue_743_enable_event_loop_stall` asserts 0 underruns after enable.

### Known residual (NOT the audio bug, tracked separately)
Enabling still blocks the GUI ~400 ms–1 s in `poll_pending_rebuilds` — the cpal stream creation for all streams lands in one tick (one slow device `open`). Nothing plays during it, so no audio is lost; it's a UI freeze only.

Note: a pre-existing release-only compile break in `issue_693_cold_start_must_not_block_caller.rs` (still on the old block-`entries` API since #716) is unrelated to this branch.

Refs #743, #740.
