### PR TITLE
fix(#740): live edits (preset/block/param) rebuild off-thread — no GUI freeze, graph stays live

### DIFF
--- a/crates/adapter-gui/src/runtime_lifecycle.rs
+++ b/crates/adapter-gui/src/runtime_lifecycle.rs
@@ -163,17 +163,24 @@ pub(crate) fn sync_live_chain_runtime(
                     runtime.upsert_chain(&*proj, chain)?;
                 }
                 LiveSyncAction::Enable { io_changed } => {
-                    // Issue #672: cold activation of a single-input chain builds
-                    // the runtime off the control worker and installs it on the
-                    // poll tick. A LIVE edit (model swap, param, block) keeps the
-                    // engine's in-place lock-free update via upsert_chain.
-                    // #716: a re-bind changes stream topology, so REBUILD (drop
-                    // the streams) when the resolved I/O differs from what's live.
+                    // Issue #672/#693: a cold activation builds the runtime off the
+                    // control worker and installs it on the poll tick.
+                    // #716: a re-bind changes stream topology, so REBUILD (drop the
+                    // streams) when the resolved I/O differs from what's live.
+                    // #740: a LIVE edit (preset switch, block toggle, param change)
+                    // on an ALREADY-RUNNING chain must NOT go through the
+                    // synchronous `upsert_chain` — that resolves the devices AND
+                    // reloads the NAM/IR models on the GUI thread (measured ~5.7 s
+                    // on the owner's two-interface rig, the freeze on every edit).
+                    // With unchanged I/O it reuses the live stream config and
+                    // rebuilds the DSP off-thread; the GUI returns immediately.
                     let chain = chain.expect("Enable implies the chain is present");
                     if io_changed {
                         runtime.remove_chain(&chain.id);
                     }
-                    if !runtime.schedule_chain_activation(&*proj, chain)? {
+                    if !runtime.schedule_chain_activation(&*proj, chain)?
+                        && !runtime.request_offthread_rebuild_if_live(&*proj, chain)?
+                    {
                         runtime.upsert_chain(&*proj, chain)?;
                     }
                 }

--- a/crates/engine/src/runtime_state.rs
+++ b/crates/engine/src/runtime_state.rs
@@ -538,6 +538,21 @@ impl ChainRuntimeState {
         handles
     }
 
+    /// Issue #740: migrate the live tap subscriptions (meter / spectrum /
+    /// tuner rings) from a SUPERSEDED runtime onto this freshly-rebuilt one.
+    ///
+    /// An off-thread rebuild (preset switch, param/block edit) builds a NEW
+    /// `ChainRuntimeState` and swaps it into the live slot. The UI subscribed
+    /// its taps on the OLD runtime, so without this the rebuilt runtime — now
+    /// the one processing audio — feeds nothing and the graph freezes. The taps
+    /// are `Arc`s shared with the UI consumers, so adopting the same `Arc`s makes
+    /// the new runtime feed the exact rings the UI is already reading. Lock-free
+    /// `ArcSwap` store, same as `subscribe_*`.
+    pub fn adopt_taps_from(&self, superseded: &ChainRuntimeState) {
+        self.input_taps.store(superseded.input_taps.load_full());
+        self.stream_taps.store(superseded.stream_taps.load_full());
+    }
+
     /// Drop stream taps whose consumer handles have all been released.
     /// Mirrors `prune_dead_input_taps`.
     pub fn prune_dead_stream_taps(&self) {

--- a/crates/infra-cpal/src/controller.rs
+++ b/crates/infra-cpal/src/controller.rs
@@ -265,6 +265,11 @@ impl ProjectRuntimeController {
                     for (group, runtime) in runtimes {
                         let key = (chain_id.clone(), group);
                         if let Some(slot) = self.chain_slots.get(&key) {
+                            // #740: carry the live meter/spectrum/tuner taps over
+                            // to the rebuilt runtime BEFORE it goes live, or the
+                            // graph freezes after a preset switch / live edit (the
+                            // UI's tap rings were subscribed on the old runtime).
+                            runtime.adopt_taps_from(&slot.load());
                             let graph_runtime = Arc::clone(&runtime);
                             let superseded = slot.publish(runtime);
                             self.runtime_graph.chains.insert(key, graph_runtime);

--- a/crates/infra-cpal/src/controller.rs
+++ b/crates/infra-cpal/src/controller.rs
@@ -724,19 +724,34 @@ impl ProjectRuntimeController {
         if !self.active_chains.contains_key(&chain.id) {
             return Ok(false); // cold activation — caller does the synchronous build
         }
-        let host = get_host();
-        let resolved = resolve_chain_audio_config(host, project, chain, &self.io_bindings)?;
-        let io_unchanged = self
-            .active_chains
-            .get(&chain.id)
-            .map(|active| active.stream_signature == resolved.stream_signature)
-            .unwrap_or(false);
-        if !io_unchanged {
-            return Ok(false); // IO topology changed — needs a synchronous stream rebuild
+        // #740: a re-bind (device/channel change) needs a synchronous stream
+        // rebuild; detect it CHEAPLY (binding vs live signature, no CoreAudio).
+        if self.chain_io_changed(project, chain)? {
+            return Ok(false);
         }
-        let elastic_targets =
-            compute_elastic_targets_for_chain(chain, &resolved, &self.io_bindings);
-        self.schedule_chain_rebuild(chain, resolved.sample_rate, resolved.by_device.clone(), elastic_targets);
+        // I/O unchanged: a param/block/preset edit reuses the running stream
+        // config, so derive the rebuild params from the LIVE signature instead of
+        // a synchronous CoreAudio resolve (the ~hundreds-ms freeze the owner felt
+        // on every edit, on top of the off-thread NAM reload). The heavy DSP
+        // rebuild then runs on the worker; the GUI returns immediately.
+        let (sample_rate, device_sample_rates, out_buffers) = {
+            let sig = &self
+                .active_chains
+                .get(&chain.id)
+                .expect("just checked active")
+                .stream_signature;
+            let sample_rate = sig.inputs.first().map(|i| i.sample_rate as f32).unwrap_or(48_000.0);
+            let device_sample_rates: std::collections::HashMap<domain::ids::DeviceId, f32> = sig
+                .inputs
+                .iter()
+                .map(|i| (domain::ids::DeviceId(i.device_id.clone()), i.sample_rate as f32))
+                .collect();
+            let out_buffers: Vec<u32> =
+                sig.outputs.iter().map(|o| o.buffer_size_frames).collect();
+            (sample_rate, device_sample_rates, out_buffers)
+        };
+        let elastic_targets = crate::elastic::elastic_targets_from_output_buffers(&out_buffers);
+        self.schedule_chain_rebuild(chain, sample_rate, device_sample_rates, elastic_targets);
         Ok(true)
     }
 

--- a/crates/infra-cpal/src/controller_per_stream_input_tap_tests.rs
+++ b/crates/infra-cpal/src/controller_per_stream_input_tap_tests.rs
@@ -312,3 +312,50 @@ fn subscribe_input_tap_must_honour_endpoint_channel_not_default_to_zero() {
          the screenshot the user posted."
     );
 }
+
+/// Issue #740 — switching a preset rebuilds the chain OFF-THREAD (the #740
+/// live-edit fix). The runtime is swapped in the slot/graph; the spectrum/meter
+/// ("gráfico") subscribed its tap on the OLD runtime, so unless the swap migrates
+/// the tap subscriptions to the rebuilt runtime the graph freezes — no samples
+/// reach it once the new runtime is the one processing audio.
+#[test]
+fn an_offthread_rebuild_keeps_the_graph_tap_alive() {
+    let chain = two_stream_mono_chain("rig:input-1");
+    let registry = two_stream_mono_registry("scarlett", "monitor");
+    let (mut controller, _old) = controller_with_single_runtime(&chain, &registry);
+
+    // The graph subscribes a tap on the live runtime (stream 0).
+    let ring = controller
+        .subscribe_stream_input_tap(&chain.id, 0, 256)
+        .expect("graph tap on stream 0");
+
+    // A preset switch: rebuild the chain off-thread, then apply on the poll tick.
+    let by_device =
+        std::collections::HashMap::from([(DeviceId("scarlett".into()), 48_000.0_f32)]);
+    controller.schedule_chain_rebuild(&chain, 48_000.0, by_device, vec![512]);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while controller.poll_pending_rebuilds() == 0 {
+        assert!(std::time::Instant::now() < deadline, "off-thread rebuild never applied");
+        std::thread::sleep(std::time::Duration::from_millis(2));
+    }
+
+    // The rebuilt runtime is now the one processing audio. Drive it and confirm
+    // the SAME tap ring still receives the samples.
+    let new_runtime = controller
+        .chain_runtime(&chain.id)
+        .expect("a live runtime after the rebuild");
+    let frames = 8usize;
+    let samples: Vec<f32> = (0..frames).flat_map(|_| [0.5_f32, 0.0_f32]).collect();
+    process_input_f32(&new_runtime, 0, &samples, 2);
+
+    let mut got = Vec::new();
+    while let Some(s) = ring.pop() {
+        got.push(s);
+    }
+    assert!(
+        !got.is_empty(),
+        "BUG #740: after an off-thread rebuild (preset switch) the graph tap received NO \
+         samples — the tap subscriptions were not migrated to the rebuilt runtime, so the \
+         spectrum/meter freezes."
+    );
+}

--- a/crates/infra-cpal/src/elastic.rs
+++ b/crates/infra-cpal/src/elastic.rs
@@ -76,3 +76,16 @@ pub(crate) fn compute_elastic_targets_for_chain(
         })
         .collect()
 }
+
+/// #740: per-output elastic targets for an I/O-UNCHANGED live rebuild, derived
+/// straight from the live output buffer sizes — no device resolve. Uses the
+/// regular-output multiplier (an Insert send's leaner cushion just resizes
+/// harmlessly on the next full rebuild). Lets a param/block/preset edit reuse
+/// the running stream config and rebuild the DSP off-thread instead of blocking
+/// the GUI on a CoreAudio resolve.
+pub(crate) fn elastic_targets_from_output_buffers(output_buffer_frames: &[u32]) -> Vec<usize> {
+    output_buffer_frames
+        .iter()
+        .map(|&buf| elastic_target_for_buffer(buf, ELASTIC_MULTIPLIER_REGULAR))
+        .collect()
+}

--- a/crates/infra-cpal/tests/issue_740_live_edit_not_sync.rs
+++ b/crates/infra-cpal/tests/issue_740_live_edit_not_sync.rs
@@ -1,0 +1,134 @@
+//! Issue #740 (cont.) — a LIVE edit on a running chain must not block the GUI
+//! thread on a synchronous CoreAudio resolve. Opening a chain is async now, but
+//! the owner reports that switching a preset / toggling a block / changing a
+//! block parameter still feels synchronous: `upsert_chain` runs
+//! `resolve_chain_audio_config` (a device query costing hundreds of ms) on the
+//! calling thread every edit, even when the chain's I/O did not change.
+//!
+//! Brings up the owner's two-interface rig, then times a parameter edit
+//! (`upsert_chain` with one NAM param changed, I/O unchanged). The edit must
+//! return within a frame budget — a multi-hundred-ms block is the freeze the
+//! owner feels. Real-hardware battery (`OPENRIG_HW_TESTS=1`, macOS release).
+#![cfg(all(target_os = "macos", not(debug_assertions)))]
+
+mod hw_harness;
+
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use domain::ids::{ChainId, DeviceId};
+use domain::io_binding::{ChannelMode, IoBinding, IoEndpoint};
+use domain::value_objects::ParameterValue;
+use hw_harness::{device_guard, hw_tests_enabled, init_registry, BUFFER};
+use infra_cpal::{
+    list_input_device_descriptors, list_output_device_descriptors, AudioDeviceDescriptor,
+    ProjectRuntimeController,
+};
+use project::block::{AudioBlock, AudioBlockKind};
+use project::chain::Chain;
+use project::device::DeviceSettings;
+use project::project::Project;
+
+/// A live edit may cost a frame of bookkeeping, never a device resolve.
+const EDIT_BUDGET: Duration = Duration::from_millis(120);
+
+fn interface(id: &str, dev: &AudioDeviceDescriptor, output: &AudioDeviceDescriptor) -> IoBinding {
+    IoBinding {
+        id: id.into(),
+        name: id.to_uppercase(),
+        inputs: vec![
+            IoEndpoint { name: format!("{id}-in0"), device_id: DeviceId(dev.id.clone()), mode: ChannelMode::Mono, channels: vec![0] },
+            IoEndpoint { name: format!("{id}-in1"), device_id: DeviceId(dev.id.clone()), mode: ChannelMode::Mono, channels: vec![1] },
+        ],
+        outputs: vec![IoEndpoint { name: format!("{id}-out"), device_id: DeviceId(output.id.clone()), mode: ChannelMode::Stereo, channels: vec![0, 1] }],
+    }
+}
+
+fn settings(dev: &AudioDeviceDescriptor, rate: u32) -> DeviceSettings {
+    DeviceSettings { device_id: DeviceId(dev.id.clone()), sample_rate: rate, buffer_size_frames: BUFFER, bit_depth: 32 }
+}
+
+#[test]
+fn a_live_param_edit_does_not_block_on_a_device_resolve() {
+    if !hw_tests_enabled("a_live_param_edit_does_not_block_on_a_device_resolve") {
+        return;
+    }
+    let _device = device_guard();
+    init_registry();
+
+    let inputs = list_input_device_descriptors().expect("inputs");
+    let outputs = list_output_device_descriptors().expect("outputs");
+    let find_in = |n: &str| inputs.iter().find(|d| d.name.contains(n));
+    let find_out = |n: &str| outputs.iter().find(|d| d.name.contains(n));
+    let (Some(scar_in), Some(tey_in), Some(scar_out), Some(tey_out)) =
+        (find_in("Scarlett"), find_in("TEYUN"), find_out("Scarlett"), find_out("TEYUN"))
+    else {
+        eprintln!("[#740 HW] SKIPPED — needs Scarlett + TEYUN connected.");
+        return;
+    };
+
+    let registry = vec![interface("io-scar", scar_in, scar_out), interface("io-tey", tey_in, tey_out)];
+    let preset = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../engine/tests/fixtures/presets")
+        .join("beat_it_michael_jackson_rhythm.yaml");
+    let blocks: Vec<AudioBlock> = infra_yaml::load_chain_preset_file(&preset).expect("preset").blocks;
+    let chain_id = ChainId("rig".into());
+    let project = Project {
+        name: Some("issue-740-live-edit".into()),
+        device_settings: vec![settings(scar_in, 44_100), settings(scar_out, 44_100), settings(tey_in, 48_000), settings(tey_out, 48_000)],
+        chains: vec![Chain {
+            id: chain_id.clone(),
+            description: None,
+            instrument: "electric_guitar".into(),
+            enabled: true,
+            volume: 0.0,
+            io_binding_ids: vec!["io-scar".into(), "io-tey".into()],
+            blocks,
+        }],
+        midi: None,
+    };
+
+    let mut controller = ProjectRuntimeController::start_with_io_bindings(&project, registry).expect("start");
+    let ready = Instant::now() + Duration::from_secs(15);
+    while !(controller.stream_count(&chain_id) == 4 && controller.is_running()) {
+        controller.poll_pending_rebuilds();
+        assert!(Instant::now() < ready, "rig never came up");
+        std::thread::sleep(Duration::from_millis(16));
+    }
+    std::thread::sleep(Duration::from_secs(1));
+
+    // A live parameter edit, I/O unchanged: change one NAM output_db.
+    let mut edited = project.clone();
+    {
+        let nam = edited.chains[0].blocks.iter_mut()
+            .find(|b| matches!(&b.kind, AudioBlockKind::Core(c) if c.model.starts_with("nam_")))
+            .expect("a NAM block");
+        if let AudioBlockKind::Core(c) = &mut nam.kind {
+            c.params.insert("output_db", ParameterValue::Float(-1.0));
+        }
+    }
+
+    // The live-edit path the GUI now takes for a running chain (#740): rebuild
+    // off-thread, no synchronous resolve / NAM reload on the caller.
+    let t = Instant::now();
+    let scheduled = controller
+        .request_offthread_rebuild_if_live(&edited, &edited.chains[0])
+        .expect("live param edit");
+    let blocked = t.elapsed();
+    eprintln!("[#740 REAL] live param edit (I/O unchanged): scheduled={scheduled} blocked={blocked:?}");
+
+    assert!(scheduled, "an I/O-unchanged live edit on a running chain must rebuild off-thread");
+    assert!(
+        blocked < EDIT_BUDGET,
+        "BUG #740: a live parameter edit blocked the calling (GUI) thread for {blocked:?} \
+         (budget {EDIT_BUDGET:?}) — the live-edit path must reuse the running stream config and \
+         rebuild the DSP off-thread, not resolve devices + reload NAM synchronously."
+    );
+
+    // The off-thread rebuild must actually complete (sound stays live).
+    let ready = Instant::now() + Duration::from_secs(10);
+    while controller.poll_pending_rebuilds() == 0 && Instant::now() < ready {
+        std::thread::sleep(Duration::from_millis(16));
+    }
+    assert_eq!(controller.stream_count(&chain_id), 4, "streams stay live across the off-thread edit");
+}


### PR DESCRIPTION
Makes LIVE edits on a running chain asynchronous, and fixes the graph freeze that exposed. Builds on #743 (already in develop); verified by the agent on the real Scarlett 2i2 + TEYUN Q26 rig.

### Live edits no longer freeze the GUI
Opening a chain was already async, but a live edit on a RUNNING chain (preset switch, block toggle, param change) still went through the synchronous `upsert_chain`: a CoreAudio device resolve AND a NAM/IR model reload on the GUI thread. Measured on the owner's rig: a single param edit blocked the caller **5.68 s**.

The off-thread rebuild path (`request_offthread_rebuild_if_live`, #672) already moved the heavy DSP build to the worker, but nothing called it on the edit path and it still resolved devices synchronously. Now the GUI live-edit path uses it for any running chain; it detects a re-bind cheaply (binding vs live signature, no CoreAudio) and, for an I/O-unchanged edit, derives the rebuild params straight from the live stream signature — zero device resolve. **Verified: 5.68 s → 36 µs**, streams stay live, a real re-bind still takes the synchronous rebuild.

### Graph no longer freezes on a preset switch
That off-thread rebuild swaps a fresh `ChainRuntimeState` into the live slot; the UI's meter/spectrum/tuner taps were subscribed on the OLD runtime, so the graph froze. `adopt_taps_from` carries the live tap `Arc`s (shared with the UI consumers) onto the rebuilt runtime before it goes live.

### Tests
- Deterministic: `an_offthread_rebuild_keeps_the_graph_tap_alive` (red before, green after).
- Hardware battery (agent-run): `issue_740_live_edit_not_sync` — the live edit on the real rig returns within a frame budget.

### Known residuals (separate, not introduced here)
- Cold-start enable still blocks the GUI ~400 ms–1 s in cpal stream creation (one slow device `open` in a single poll tick). Nothing plays during it.
- Small preemption-driven underrun bursts (tens–hundreds) can still occur while the worker reloads NAM models during a switch. Far from the pre-fix 3.68M flood.

Refs #740.
