### PR TITLE
chore(#755): cfg-gate infra-cpal non-jack items to eliminate warnings (no #[allow])

### DIFF
--- a/crates/infra-cpal/src/chain_resolve.rs
+++ b/crates/infra-cpal/src/chain_resolve.rs
@@ -35,6 +35,7 @@ use project::project::Project;
 
 #[cfg(not(all(target_os = "linux", feature = "jack")))]
 use engine::runtime_endpoints::{resolve_chain_io, resolve_chain_io_by_binding, InputEntry, OutputEntry};
+#[cfg(not(all(target_os = "linux", feature = "jack")))]
 use project::block::{AudioBlockKind, InsertBlock};
 #[cfg(not(all(target_os = "linux", feature = "jack")))]
 use project::chain::Chain;

--- a/crates/infra-cpal/src/elastic.rs
+++ b/crates/infra-cpal/src/elastic.rs
@@ -83,6 +83,7 @@ pub(crate) fn compute_elastic_targets_for_chain(
 /// harmlessly on the next full rebuild). Lets a param/block/preset edit reuse
 /// the running stream config and rebuild the DSP off-thread instead of blocking
 /// the GUI on a CoreAudio resolve.
+#[cfg(not(all(target_os = "linux", feature = "jack")))] // CPAL live-rebuild path only (#755)
 pub(crate) fn elastic_targets_from_output_buffers(output_buffer_frames: &[u32]) -> Vec<usize> {
     output_buffer_frames
         .iter()

--- a/crates/infra-cpal/src/lib.rs
+++ b/crates/infra-cpal/src/lib.rs
@@ -91,10 +91,16 @@ mod jack_chain_resolve;
 
 mod validation;
 
+// audio_workgroup (macOS RT-cluster join) and dsp_worker (CPAL per-input DSP
+// worker, #670) serve ONLY the CPAL audio path. On Linux+JACK that path is not
+// compiled (the JACK-direct backend bypasses CPAL), so gate these modules to
+// the same `cfg` as their callers to avoid dead-code warnings (#755).
+#[cfg(not(all(target_os = "linux", feature = "jack")))]
 mod audio_workgroup;
 mod callback_load_timing;
+#[cfg(not(all(target_os = "linux", feature = "jack")))]
 mod dsp_worker;
-#[cfg(test)]
+#[cfg(all(test, not(all(target_os = "linux", feature = "jack"))))]
 #[path = "dsp_worker_recovery_tests.rs"]
 mod dsp_worker_recovery_tests;
 mod stream_builder;

--- a/crates/infra-cpal/src/slot_processing.rs
+++ b/crates/infra-cpal/src/slot_processing.rs
@@ -35,6 +35,9 @@ pub fn build_chain_slots(
 /// one device, so the single callback fans out to all of them. Runtimes
 /// without a per-entry identity (legacy whole-chain shape) fall back to
 /// their group id, which historically WAS the cpal index.
+// Only the CPAL stream-builders call this; the JACK-direct path (Linux+JACK)
+// does not, so gate to its callers' cfg to stay warning-clean (#755).
+#[cfg(not(all(target_os = "linux", feature = "jack")))]
 #[must_use]
 pub(crate) fn slots_for_input_stream(
     slots: &[(usize, LiveRuntimeSlot)],
@@ -59,6 +62,7 @@ pub(crate) fn slots_for_input_stream(
 /// the backend mixes same-rate streams). Mixing only same-rate runtimes keeps
 /// each route's producer and consumer in lock-step. A single-output / single-rate
 /// chain is unaffected (every runtime matches the one output rate).
+#[cfg(not(all(target_os = "linux", feature = "jack")))]
 #[must_use]
 pub(crate) fn slots_for_output_stream(
     slots: &[(usize, LiveRuntimeSlot)],

--- a/crates/infra-cpal/src/stream_builder.rs
+++ b/crates/infra-cpal/src/stream_builder.rs
@@ -25,6 +25,7 @@
 #[cfg(not(all(target_os = "linux", feature = "jack")))]
 use anyhow::anyhow;
 use anyhow::Result;
+#[cfg(not(all(target_os = "linux", feature = "jack")))]
 use std::sync::Arc;
 
 #[cfg(not(all(target_os = "linux", feature = "jack")))]
@@ -35,6 +36,7 @@ use cpal::Stream;
 
 use domain::ids::ChainId;
 use domain::io_binding::IoBinding;
+#[cfg(not(all(target_os = "linux", feature = "jack")))]
 use engine::runtime::ChainRuntimeState;
 #[cfg(not(all(target_os = "linux", feature = "jack")))]
 use engine::runtime_endpoints::{resolve_chain_io, InputEntry, OutputEntry};


### PR DESCRIPTION
Closes #755.

## What

The Linux **release** build (which forces `infra-cpal` feature `jack` via `adapter-gui`) emitted **23 warnings** in `infra-cpal` (`dead_code` + `unused_imports`), violating the zero-warnings invariant.

## Root cause

On **Linux+JACK** the CPAL audio path is not compiled — the JACK-direct backend bypasses CPAL. So the CPAL-only items were dead in that config: the `dsp_worker` (per-input DSP worker, #670) and `audio_workgroup` (macOS RT-cluster join) modules, the `slot_processing` per-stream slot helpers, the `elastic` live-rebuild targets, and the `Arc` / `ChainRuntimeState` / `AudioBlockKind` / `InsertBlock` imports.

## Fix

Each dead item is **`cfg`-gated to the same `cfg(not(all(target_os = "linux", feature = "jack")))`** as its real callers — **no `#[allow(dead_code)]` / `#[allow(unused_imports)]` band-aids, no `cargo fix`** (which would strip items used under `--features jack` / on macOS and break those targets).

## Verification

Built clean (**0 warnings, no errors**) on all three configs:

- `cargo build -p infra-cpal` (macOS, non-jack)
- `cargo build -p infra-cpal --features jack` (Linux+JACK — was 23 warnings)
- `cargo build -p infra-cpal` (Linux, no jack)

`cargo test -p infra-cpal --lib`: 105 passed, 0 failed, 0 ignored (the `dsp_worker` budget/saturation tests still run on the non-jack configs).

Quality cleanup surfaced during the v0.1.0 release; not a release blocker.
