### PR TITLE
chore: scope dev-rules plugin gate to crates/**/src/** via .dev-rules.json

### DIFF
--- a/.dev-rules.json
+++ b/.dev-rules.json
@@ -1,0 +1,5 @@
+{
+  "enabled": true,
+  "production_globs": ["crates/**/src/**"],
+  "test_globs": ["**/*_test*.rs", "**/tests/**", "**/*test*.rs"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,9 @@ crates/adapter-gui/translations/*/LC_MESSAGES/*.mo
 # private CC auto-memory — must never be versioned
 .claude/projects/
 
-# RED-FIRST unlock sentinel — ephemeral/local only, never versioned.
-# If committed, the guard sees it on every checkout and never blocks
-# production edits, so the TDD red-first gate is silently disabled.
+# dev-rules gate sentinels (.dev-rules/.red-first-unlocked, .mode-feature) --
+# ephemeral/local only, never versioned. If committed, the guard sees them on
+# every checkout and never blocks, silently disabling the gate. The bare
+# .red-first-unlocked line is kept for the pre-plugin sentinel path.
+.dev-rules/
 .red-first-unlocked


### PR DESCRIPTION
## O quê
Adiciona `.dev-rules.json` na raiz e ignora o diretório de sentinelas do gate.

## Por quê
O plugin `xgodev/dev-rules` passou a **embarcar** o hook genérico de RED-first (antes o OpenRig tinha uma cópia local Rust-specific em `.claude/hooks/`, que já foi removida). Sem config, o hook do plugin usa a heurística default de segmentos; este `.dev-rules.json` **escopa o gate exatamente ao que o hook local antigo cobria** (`crates/**/src/**`), de forma exclusiva.

## Mudanças
- `.dev-rules.json`:
  - `production_globs: ["crates/**/src/**"]` — só o source dos crates é gated (build.rs, `.slint`, assets, docs ficam livres).
  - `test_globs` Rust — arquivos de teste nunca bloqueiam (o RED sempre pode ser escrito).
- `.gitignore`: adiciona `.dev-rules/` (sentinelas `.red-first-unlocked` / `.mode-feature` são efêmeras, nunca versionadas).

## Verificação (hook do plugin, modo bug / sem sentinela)
- `crates/**/src/**` (ex. `crates/audio/src/block/mixer.rs`) -> **BLOCK**
- `crates/*/src/*_test.rs`, `crates/*/tests/**`, `crates/*/build.rs` -> allow
- `assets/**/*.slint`, `README.md` -> allow

## Requisito
Requer o plugin **`dev-rules >= 0.6.3`** — versões anteriores tinham um bug em que globs com `**` não casavam (`dr_glob_match` escapava a estrela), tornando este `.dev-rules.json` um no-op. Rode `/plugin update` para pegar a 0.6.3.

## Fora de escopo
- Remoção dos hooks locais e do wiring no `settings.json`: **já feito** no `develop`.
- Docs de planos históricos que citam o path antigo `.claude/.red-first-unlocked`: são registros datados, não a fonte viva; não tocados aqui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)