### PR TITLE
feat(#774): install-macos-local.sh — build from source and install into /Applications

### DIFF
--- a/.claude/skills/openrig-tooling/SKILL.md
+++ b/.claude/skills/openrig-tooling/SKILL.md
@@ -33,6 +33,7 @@ Not for: editing code (see `openrig-code-quality`), or UI design work (see
 | Goal | Command (from repo root) |
 |---|---|
 | macOS universal .dmg | `OPENRIG_PLUGINS_DIR=<plugins> ./scripts/package-macos.sh <ver>` |
+| macOS build + install to /Applications | `OPENRIG_PLUGINS_DIR=<plugins> ./scripts/install-macos-local.sh [ver]` (dev; builds via packager, quits+replaces+launches) |
 | Linux .deb (arm64+amd64) | `./scripts/build-deb-local.sh` (Docker Desktop running) |
 | Orange Pi SD image | `./scripts/build-orange-pi-image.sh --local-deb output/deb/openrig_*_arm64.deb` |
 | Headless Slint → PNG | `cargo run --manifest-path tools/slint-render/Cargo.toml --release -- <file.slint> <Component> <out.png> [w] [h]` |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -10,7 +10,8 @@
 | `scripts/package-linux.sh` | Empacota Linux .tar.gz/.deb/.rpm/.AppImage (patchelf RUNPATH p/ libnam_wrapper + libseat) |
 | `scripts/package-macos.sh` | Empacota macOS (assina ad-hoc inside-out + gate de verificação). Plugins bundled: `OPENRIG_PLUGINS_DIR=/path/plugins/source` sobrescreve a origem (default `plugins/source`; override inexistente = erro fatal) |
 | `scripts/lib/console-binaries.{sh,tsv}` | Fonte única dos binários console-style empacotados junto da GUI (`openrig-console`, `openrig-console-rig`, `openrig-render` — #741). Os três packagers buildam e stageam a partir dela; testado por `scripts/tests/console_bundle_test.sh` |
-| `scripts/install-macos.sh` | Instalador one-liner via `curl` (baixa .dmg, copia pro /Applications, tira quarentena) |
+| `scripts/install-macos.sh` | Instalador one-liner via `curl` (baixa .dmg de release, copia pro /Applications, tira quarentena) |
+| `scripts/install-macos-local.sh` | Dev: builda do checkout atual (via `package-macos.sh`) e instala em `/Applications` (mata instância aberta + abre). `OPENRIG_PLUGINS_DIR` repassado ao packager. `[version]` default `dev` (#774) |
 | `scripts/build-lib.sh` | Libs externas |
 
 ## Fluxo branch → .deb → Orange Pi

--- a/scripts/install-macos-local.sh
+++ b/scripts/install-macos-local.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# OpenRig macOS local dev installer — build from source and install into /Applications.
+#
+# Companion to package-macos.sh (which only emits a .dmg) and install-macos.sh
+# (which downloads a *released* .dmg via curl). This one is for the developer on
+# this machine: it builds a fresh universal bundle from the current checkout and
+# drops it straight into /Applications, replacing whatever is there.
+#
+# Usage: [OPENRIG_PLUGINS_DIR=/path/to/plugins/source] ./scripts/install-macos-local.sh [version]
+#   version defaults to "dev". OPENRIG_PLUGINS_DIR is forwarded to package-macos.sh
+#   (without it the installed app ships without plugins — a NOTE, not an error).
+#
+# Issue: #774
+set -euo pipefail
+
+VERSION="${1:-dev}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+APP_SRC="dist/OpenRig.app"
+APP_DEST="/Applications/OpenRig.app"
+
+if [ "$(uname -s)" != "Darwin" ]; then
+    echo "install-macos-local.sh is for macOS only (got $(uname -s))." >&2
+    exit 1
+fi
+
+# ── 1. Build the universal, ad-hoc-signed bundle (single source of truth) ─────
+# package-macos.sh produces dist/OpenRig.app (and a .dmg as a byproduct). We
+# reuse it wholesale so the installed app is byte-for-byte what a release ships,
+# rather than duplicating the bundle/sign logic here.
+echo "==> Building bundle via package-macos.sh (${VERSION})..."
+./scripts/package-macos.sh "$VERSION"
+
+if [ ! -d "$APP_SRC" ]; then
+    echo "FATAL: expected $APP_SRC after packaging, but it is missing." >&2
+    exit 1
+fi
+
+# ── 2. Quit any running instance so the replace doesn't hit a busy bundle ─────
+echo "==> Quitting any running OpenRig..."
+osascript -e 'tell application "OpenRig" to quit' 2>/dev/null || true
+# Give a graceful quit a moment; then force any stragglers (e.g. a hung GUI).
+for _ in 1 2 3 4 5; do
+    pgrep -x openrig >/dev/null 2>&1 || break
+    sleep 0.3
+done
+pkill -x openrig 2>/dev/null || true
+
+# ── 3. Replace the installed app ──────────────────────────────────────────────
+echo "==> Installing to ${APP_DEST}..."
+if [ -e "$APP_DEST" ] && ! rm -rf "$APP_DEST" 2>/dev/null; then
+    echo "FATAL: cannot remove $APP_DEST (permission?). Run as an admin user." >&2
+    exit 1
+fi
+if ! cp -R "$APP_SRC" "$APP_DEST" 2>/dev/null; then
+    echo "FATAL: cannot copy into /Applications (permission?). Run as an admin user." >&2
+    exit 1
+fi
+
+# A locally built bundle has no com.apple.quarantine, but strip it defensively
+# in case the tree was ever synced/downloaded — keeps Gatekeeper quiet.
+xattr -dr com.apple.quarantine "$APP_DEST" 2>/dev/null || true
+
+# ── 4. Launch it ──────────────────────────────────────────────────────────────
+echo "==> Launching OpenRig..."
+open -a OpenRig
+
+echo ""
+echo "==> Done: installed ${VERSION} to ${APP_DEST} and launched it."


### PR DESCRIPTION
Closes #774.

## What

New `scripts/install-macos-local.sh`: one command to build the current checkout and install OpenRig into `/Applications` on this Mac.

It reuses `scripts/package-macos.sh` wholesale (universal arm64+x86_64 bundle + ad-hoc inside-out signing — single source of truth), then:
1. quits any running OpenRig (graceful `osascript quit`, `pkill` fallback);
2. removes the previous `/Applications/OpenRig.app`;
3. copies the freshly built bundle in;
4. strips `com.apple.quarantine` defensively and launches it.

Forwards `OPENRIG_PLUGINS_DIR` to the packager; `[version]` defaults to `dev`.

## Why a new script

- `package-macos.sh` only emits a `.dmg`, no install.
- `install-macos.sh` (#459) downloads a *released* `.dmg` via curl for end users — different purpose, left untouched.

## Docs

`docs/scripts.md` + the `openrig-tooling` runbook quick-reference.

## Validation

`bash -n` clean. Not run end-to-end (it installs to `/Applications` and opens the GUI — the user's machine, the user's call); the build/bundle/sign path is fully delegated to the already-tested `package-macos.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)