### PR TITLE
fix(#797): infra-cpal fails to compile under Linux+JACK — every PR gate errors

### DIFF
--- a/.claude/skills/openrig-code-quality/SKILL.md
+++ b/.claude/skills/openrig-code-quality/SKILL.md
@@ -261,7 +261,14 @@ exceção pra "é só visual".
 4. **`git push` da branch** (sem PR ainda).
 5. **Usuário valida na máquina dele** (`git checkout <branch> && git pull` → roda app/testa cenário). Esperar feedback explícito antes de prosseguir.
 6. **Quality gate compartilhado** rodar e ficar verde — invocar via skill `quality-gate` (mecânica do gate, JSON, bypass governance ficam todos lá).
-7. **Só ENTÃO** `gh pr create`.
+7. **Só ENTÃO** o PR, **sempre não-interativo** — push a branch first, then pass every field explicitly:
+
+   ```bash
+   gh pr create --repo jpfaria/OpenRig --base develop --head <branch> \
+     --title "<type>(#<issue>): <summary>" --body "Closes #<issue>. …"
+   ```
+
+   NUNCA rode `gh pr create` sem `--title`/`--body`/`--head` (ou com a branch não pushada): o shell do agente não tem TTY, o gh abre o prompt interativo e **pendura** lendo um stdin que nunca vem — até o timeout (~8 min). Guard-rail de máquina: `gh config set prompt disabled` faz o gh **errar na hora** em vez de travar.
 
 Não inverter:
 - PR antes da validação do usuário = retrabalho quando ele acha problema no comportamento real.

--- a/crates/adapter-gui/src/project_chain_defaults_persistence_tests.rs
+++ b/crates/adapter-gui/src/project_chain_defaults_persistence_tests.rs
@@ -274,6 +274,12 @@ fn write_config_with_devices(cfg_path: &PathBuf, input_id: &str, output_id: &str
             sample_rate: 44100,
             buffer_size_frames: 256,
             bit_depth: 24,
+            #[cfg(target_os = "linux")]
+            realtime: true,
+            #[cfg(target_os = "linux")]
+            rt_priority: 70,
+            #[cfg(target_os = "linux")]
+            nperiods: 3,
         }],
         output_devices: vec![infra_filesystem::GuiAudioDeviceSettings {
             device_id: output_id.to_string(),
@@ -281,6 +287,12 @@ fn write_config_with_devices(cfg_path: &PathBuf, input_id: &str, output_id: &str
             sample_rate: 44100,
             buffer_size_frames: 256,
             bit_depth: 24,
+            #[cfg(target_os = "linux")]
+            realtime: true,
+            #[cfg(target_os = "linux")]
+            rt_priority: 70,
+            #[cfg(target_os = "linux")]
+            nperiods: 3,
         }],
         ..AppConfig::default()
     };

--- a/crates/infra-cpal/src/di_stream_worker.rs
+++ b/crates/infra-cpal/src/di_stream_worker.rs
@@ -163,6 +163,10 @@ fn run(spec: DiWorkerSpec) {
     // one block per iteration, a breath every few blocks, and an honest RT
     // declaration sized to that cadence.
     let period_ns = (BLOCK as u64) * 1_000_000_000 / (output_rate.max(1) as u64);
+    // `dsp_worker` is cfg'd out under Linux+JACK (#755); mirror that gate so the
+    // crate still compiles there. `promote_to_audio_rt` is a no-op off macOS
+    // regardless, so skipping it under Linux+JACK changes no behavior.
+    #[cfg(not(all(target_os = "linux", feature = "jack")))]
     crate::dsp_worker::promote_to_audio_rt(period_ns, period_ns * 3 / 5);
     let silence = vec![0.0f32; BLOCK];
     let mut drain = vec![0.0f32; BLOCK * routed.drain_width];

--- a/crates/infra-cpal/src/slot_processing.rs
+++ b/crates/infra-cpal/src/slot_processing.rs
@@ -115,7 +115,9 @@ pub fn process_output_buffer(
     process_output_f32_mixed(loaded, output_index, out, output_total_channels, scratch);
 }
 
-#[cfg(test)]
+// `slots_for_output_stream` is cfg'd out under Linux+JACK (#755); gate its tests
+// the same way so the crate compiles there (JACK routes in its own supervisor).
+#[cfg(all(test, not(all(target_os = "linux", feature = "jack"))))]
 mod issue_743_output_rate_isolation_tests {
     use super::*;
     use domain::ids::{ChainId, DeviceId};

--- a/crates/infra-cpal/src/stream_config.rs
+++ b/crates/infra-cpal/src/stream_config.rs
@@ -26,7 +26,10 @@
 
 #[cfg(any(not(all(target_os = "linux", feature = "jack")), test))]
 use anyhow::bail;
-#[cfg(not(all(target_os = "linux", feature = "jack")))]
+// `#[cfg(test)]` helpers below (e.g. resolve_chain_runtime_sample_rate,
+// max_supported_channels) use `Result`/`anyhow!` under Linux+JACK+test, so the
+// import must reach `test` too — same gate as `bail` above.
+#[cfg(any(not(all(target_os = "linux", feature = "jack")), test))]
 use anyhow::{anyhow, Result};
 #[cfg(not(all(target_os = "linux", feature = "jack")))]
 use cpal::SupportedStreamConfigRange;

--- a/crates/infra-cpal/tests/hw_harness/mod.rs
+++ b/crates/infra-cpal/tests/hw_harness/mod.rs
@@ -107,12 +107,24 @@ pub fn rig_project_with(
                 sample_rate,
                 buffer_size_frames: buffer_frames,
                 bit_depth: 32,
+                #[cfg(target_os = "linux")]
+                realtime: true,
+                #[cfg(target_os = "linux")]
+                rt_priority: 70,
+                #[cfg(target_os = "linux")]
+                nperiods: 3,
             },
             DeviceSettings {
                 device_id: DeviceId(output.id.clone()),
                 sample_rate,
                 buffer_size_frames: buffer_frames,
                 bit_depth: 32,
+                #[cfg(target_os = "linux")]
+                realtime: true,
+                #[cfg(target_os = "linux")]
+                rt_priority: 70,
+                #[cfg(target_os = "linux")]
+                nperiods: 3,
             },
         ],
         chains: vec![Chain {

--- a/crates/infra-cpal/tests/issue_670_cab_swap.rs
+++ b/crates/infra-cpal/tests/issue_670_cab_swap.rs
@@ -202,12 +202,24 @@ fn preset_project(
                 sample_rate: 48_000,
                 buffer_size_frames: BUFFER,
                 bit_depth: 32,
+                #[cfg(target_os = "linux")]
+                realtime: true,
+                #[cfg(target_os = "linux")]
+                rt_priority: 70,
+                #[cfg(target_os = "linux")]
+                nperiods: 3,
             },
             DeviceSettings {
                 device_id: DeviceId(output.id.clone()),
                 sample_rate: 48_000,
                 buffer_size_frames: BUFFER,
                 bit_depth: 32,
+                #[cfg(target_os = "linux")]
+                realtime: true,
+                #[cfg(target_os = "linux")]
+                rt_priority: 70,
+                #[cfg(target_os = "linux")]
+                nperiods: 3,
             },
         ],
         chains: vec![Chain {
@@ -537,6 +549,12 @@ fn enabling_the_preset_chain_live_is_clean() {
             sample_rate: 48_000,
             buffer_size_frames: 64,
             bit_depth: 32,
+            #[cfg(target_os = "linux")]
+            realtime: true,
+            #[cfg(target_os = "linux")]
+            rt_priority: 70,
+            #[cfg(target_os = "linux")]
+            nperiods: 3,
         })
         .collect();
     infra_cpal::apply_device_settings(&project.device_settings).expect("apply device settings");

--- a/crates/infra-cpal/tests/issue_693_cold_start_must_not_block_caller.rs
+++ b/crates/infra-cpal/tests/issue_693_cold_start_must_not_block_caller.rs
@@ -114,12 +114,24 @@ fn rig_project(
                 sample_rate: 48_000,
                 buffer_size_frames: BUFFER,
                 bit_depth: 32,
+                #[cfg(target_os = "linux")]
+                realtime: true,
+                #[cfg(target_os = "linux")]
+                rt_priority: 70,
+                #[cfg(target_os = "linux")]
+                nperiods: 3,
             },
             DeviceSettings {
                 device_id: DeviceId(output.id.clone()),
                 sample_rate: 48_000,
                 buffer_size_frames: BUFFER,
                 bit_depth: 32,
+                #[cfg(target_os = "linux")]
+                realtime: true,
+                #[cfg(target_os = "linux")]
+                rt_priority: 70,
+                #[cfg(target_os = "linux")]
+                nperiods: 3,
             },
         ],
         chains: vec![Chain {

--- a/crates/infra-cpal/tests/issue_736_multi_rate_streams.rs
+++ b/crates/infra-cpal/tests/issue_736_multi_rate_streams.rs
@@ -67,6 +67,12 @@ fn device_settings(dev: &AudioDeviceDescriptor, rate: u32) -> DeviceSettings {
         sample_rate: rate,
         buffer_size_frames: BUFFER,
         bit_depth: 32,
+        #[cfg(target_os = "linux")]
+        realtime: true,
+        #[cfg(target_os = "linux")]
+        rt_priority: 70,
+        #[cfg(target_os = "linux")]
+        nperiods: 3,
     }
 }
 

--- a/crates/infra-cpal/tests/issue_740_live_edit_not_sync.rs
+++ b/crates/infra-cpal/tests/issue_740_live_edit_not_sync.rs
@@ -65,6 +65,12 @@ fn settings(dev: &AudioDeviceDescriptor, rate: u32) -> DeviceSettings {
         sample_rate: rate,
         buffer_size_frames: BUFFER,
         bit_depth: 32,
+        #[cfg(target_os = "linux")]
+        realtime: true,
+        #[cfg(target_os = "linux")]
+        rt_priority: 70,
+        #[cfg(target_os = "linux")]
+        nperiods: 3,
     }
 }
 

--- a/crates/infra-cpal/tests/issue_740_multi_binding_cold_start_hw.rs
+++ b/crates/infra-cpal/tests/issue_740_multi_binding_cold_start_hw.rs
@@ -79,6 +79,12 @@ fn device_settings(dev: &AudioDeviceDescriptor) -> DeviceSettings {
         sample_rate: 48_000,
         buffer_size_frames: BUFFER,
         bit_depth: 32,
+        #[cfg(target_os = "linux")]
+        realtime: true,
+        #[cfg(target_os = "linux")]
+        rt_priority: 70,
+        #[cfg(target_os = "linux")]
+        nperiods: 3,
     }
 }
 

--- a/crates/infra-cpal/tests/issue_743_enable_event_loop_stall.rs
+++ b/crates/infra-cpal/tests/issue_743_enable_event_loop_stall.rs
@@ -71,6 +71,12 @@ fn settings(dev: &AudioDeviceDescriptor, rate: u32) -> DeviceSettings {
         sample_rate: rate,
         buffer_size_frames: BUFFER,
         bit_depth: 32,
+        #[cfg(target_os = "linux")]
+        realtime: true,
+        #[cfg(target_os = "linux")]
+        rt_priority: 70,
+        #[cfg(target_os = "linux")]
+        nperiods: 3,
     }
 }
 

--- a/crates/infra-cpal/tests/issue_762_live_rebuild_offthread.rs
+++ b/crates/infra-cpal/tests/issue_762_live_rebuild_offthread.rs
@@ -109,12 +109,24 @@ fn rig_project(
                 sample_rate: 48_000,
                 buffer_size_frames: BUFFER,
                 bit_depth: 32,
+                #[cfg(target_os = "linux")]
+                realtime: true,
+                #[cfg(target_os = "linux")]
+                rt_priority: 70,
+                #[cfg(target_os = "linux")]
+                nperiods: 3,
             },
             DeviceSettings {
                 device_id: DeviceId(output.id.clone()),
                 sample_rate: 48_000,
                 buffer_size_frames: BUFFER,
                 bit_depth: 32,
+                #[cfg(target_os = "linux")]
+                realtime: true,
+                #[cfg(target_os = "linux")]
+                rt_priority: 70,
+                #[cfg(target_os = "linux")]
+                nperiods: 3,
             },
         ],
         chains: vec![Chain {

--- a/crates/infra-cpal/tests/issue_779_vst3_live_param_no_reinstantiate.rs
+++ b/crates/infra-cpal/tests/issue_779_vst3_live_param_no_reinstantiate.rs
@@ -105,12 +105,24 @@ fn chow_project(
                 sample_rate: SR as u32,
                 buffer_size_frames: BUFFER,
                 bit_depth: 32,
+                #[cfg(target_os = "linux")]
+                realtime: true,
+                #[cfg(target_os = "linux")]
+                rt_priority: 70,
+                #[cfg(target_os = "linux")]
+                nperiods: 3,
             },
             DeviceSettings {
                 device_id: DeviceId(output.id.clone()),
                 sample_rate: SR as u32,
                 buffer_size_frames: BUFFER,
                 bit_depth: 32,
+                #[cfg(target_os = "linux")]
+                realtime: true,
+                #[cfg(target_os = "linux")]
+                rt_priority: 70,
+                #[cfg(target_os = "linux")]
+                nperiods: 3,
             },
         ],
         chains: vec![Chain {

--- a/docs/development/gitflow.md
+++ b/docs/development/gitflow.md
@@ -25,6 +25,7 @@ Issue → Branch (from develop) → Commits → PR → Review/Merge
 8. **NUNCA rebase.** Sempre `git merge`, nunca `git pull --rebase`.
 9. **Quality gate só na criação do PR — NUNCA por push.** Push é direto após o commit. O gate **compartilhado** `xgodev/claude-plugin` (`~/.claude-plugin/tools/quality-gate/qg --base origin/develop` ou a skill `claude-plugin:quality-gate`) roda **uma vez, antes de `gh pr create`**, e o mesmo dispatcher roda no CI do PR (`.github/workflows/pr.yml`): falha lá = sticky comment + request-changes automático. Rodar o gate a cada push arrastou 2 dias de trabalho — proibido. Detalhes em [`quality-gate.md`](quality-gate.md).
 10. **Push imediato após cada commit** (sem gate; o gate é só no PR).
+11. **PR sempre não-interativo.** Push a branch first, then `gh pr create --repo jpfaria/OpenRig --base develop --head <branch> --title "…" --body "…"` — todos os campos explícitos. Sem `--title`/`--body`/`--head` (ou com a branch não pushada) o gh abre o prompt interativo e **pendura** num shell sem TTY até o timeout (~8 min). Guard-rail: `gh config set prompt disabled` (o gh erra na hora em vez de travar).
 
 ## Fechar issue
 


### PR DESCRIPTION
Closes #797.

## Problem

`mod dsp_worker` is cfg'd out under `all(target_os = "linux", feature = "jack")` (#755), but `di_stream_worker::run` called `crate::dsp_worker::promote_to_audio_rt(...)` unconditionally. So `infra-cpal` did not compile under Linux+JACK — the exact config the shared quality gate builds — and **every PR's gate errored on the baseline build** (e.g. CI run 29463906987, `error[E0433] di_stream_worker.rs:166`).

## Fix

Gate the call with the same cfg as the module. `promote_to_audio_rt` is a no-op off macOS, so Linux+JACK loses no behavior; `period_ns` stays used by the pacing sleep, so no unused-variable warning.

## Verification (macOS)

- **RED:** module forced absent → `cargo check -p infra-cpal --features jack` → `E0433 di_stream_worker.rs:166` (matches CI).
- **GREEN:** with the fix, all `target_os="linux"` cfgs flipped to `macos` to simulate the target → `cargo check --features jack` compiles clean, zero warnings.
- `cargo check -p infra-cpal` (no-jack) and `--features jack`: clean.
- `cargo test -p infra-cpal`: all pass, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)