### PR TITLE
chore(#803): upgrade NeuralAmpModelerCore v0.5.3 → v0.5.4

### DIFF
--- a/deps/DEPS.md
+++ b/deps/DEPS.md
@@ -7,7 +7,7 @@ Use `./scripts/add-dep.sh` to add new ones.
 
 | Name | Repository | Pinned Hash | Build System | Plugins |
 |------|-----------|-------------|--------------|---------|
-| NeuralAmpModelerCore | https://github.com/sdatkinson/NeuralAmpModelerCore | `263640f` | CMake (via `cpp/`) | nam_wrapper (NAM inference + tone stack) |
+| NeuralAmpModelerCore | https://github.com/sdatkinson/NeuralAmpModelerCore | `1f42f88` (v0.5.4) | CMake (via `cpp/`) | nam_wrapper (NAM inference + tone stack) |
 | dragonfly-reverb | https://github.com/michaelwillis/dragonfly-reverb | `b3c15af` | DPF/Make | Hall, Plate, Room, EarlyReflections reverbs |
 | zam-plugins | https://github.com/zamaudio/zam-plugins | `6a7fd03` | DPF/Make | ZamComp, ZamDelay, ZamEQ2, ZamTube, ZamGate |
 | mod-utilities | https://github.com/mod-audio/mod-utilities | `b8a9d45` | Make | MOD gain, mixers, CV, switchboxes |


### PR DESCRIPTION
Bump submodule v0.5.3→v0.5.4 (Eigen 5.0.1, Reset() prewarms by default). Wrapper unchanged. cargo test --workspace --lib: 3074 passed. Closes #803