### PR TITLE
fix(#804): main-folder-guard blocks git worktree

### DIFF
--- a/.claude/hooks/main-folder-guard.sh
+++ b/.claude/hooks/main-folder-guard.sh
@@ -61,6 +61,16 @@ case "$tool" in
     esac ;;
   Bash)
     cmd="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')"
+    # `git worktree` is FORBIDDEN everywhere — no .solvers/ or cwd exemption. A
+    # worktree shares the parent .git (registers in the main repo's
+    # .git/worktrees and creates the branch there), so the user's own
+    # `git checkout <branch>` in the main folder aborts with "already used by
+    # worktree at …". Isolation is clone-only (each .solvers/issue-N is its own
+    # `git clone` with an independent .git). This check runs BEFORE any allow
+    # path below, including the .solvers-cwd early-allow (issue #804).
+    if printf '%s' "$cmd" | grep -qE '(^|[^[:alnum:]_])git[[:space:]]+(-C[[:space:]]+[^[:space:]]+[[:space:]]+)?worktree([^[:alnum:]_]|$)'; then
+      deny "LEI ZERO (OpenRig): 'git worktree' is FORBIDDEN. A worktree shares the main repo's .git and locks the branch, breaking the user's checkout. Isolate with 'git clone' into .solvers/issue-N instead (independent .git). (CLAUDE.md LEI ZERO)"
+    fi
     # Working dir already inside an isolated clone → allow (covers bare VCS like
     # `git commit` run after a cd, which carries no .solvers/ token; issue #751).
     case "$PWD" in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,8 @@ Pedalboard/rig virtual para guitarra em Rust + Slint. Cross-platform: macOS, Win
 
 **O agente trabalha SOMENTE em `.solvers/issue-N/`** — um clone isolado da branch. Edita ali, commita ali, dá push dali. A entrega termina no push; o usuário puxa a branch na pasta dele por conta própria.
 
+**A única primitiva de isolamento é `git clone` — `git worktree` é PROIBIDO, sempre, mesmo mirando `.solvers/`.** Um worktree compartilha o `.git` do repo principal: registra em `.git/worktrees` e cria a branch no repo principal, então o `git checkout <branch>` do usuário na pasta dele ABORTA com `'<branch>' is already used by worktree at …`. Um clone de verdade tem `.git` como DIRETÓRIO próprio (não um arquivo `.git` apontando de volta) — confira `.solvers/issue-N/.git` ser um dir antes de trabalhar. O guard `main-folder-guard.sh` agora BLOQUEIA `git worktree` (issue #804); mesmo assim: clone, nunca worktree.
+
 **Why:** o usuário roda vários agents em paralelo, cada um na sua branch, e usa a pasta principal pra rodar/testar o app. Um agent mexendo lá sobrescreve trabalho não-commitado do usuário e de outros agents, corrompe o estado de git da pasta e quebra a confiança — já aconteceu repetidas vezes. Regra escrita não basta: depende do agent lembrar.
 
 **How to apply:** se a tua sessão não está enraizada em `.solvers/issue-N/`, você está no lugar errado — clone a branch pra lá e trabalhe lá. Guard determinístico: o hook `main-folder-guard.sh` (PreToolUse) BLOQUEIA `Edit`/`Write`/`git` de qualquer sessão cuja raiz não esteja sob `.solvers/`. O bloqueio não depende do agent obedecer — a harness força.

--- a/scripts/tests/main-folder-guard_test.sh
+++ b/scripts/tests/main-folder-guard_test.sh
@@ -44,6 +44,13 @@ allow "harmless ls from main cwd"     "{\"tool_name\":\"Bash\",\"tool_input\":{\
 allow "Bash references sibling -plugins" "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"ls $TMP/OpenRig-plugins/plugins/source\"}}" "$MAIN"
 allow "Edit into sibling -plugins"    "{\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"$TMP/OpenRig-plugins/x.yaml\"}}" "$MAIN"
 deny  "cd into main then mutate"      "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"cd $MAIN && rm x\"}}"             "$MAIN"
+# worktree is FORBIDDEN everywhere: it shares the parent .git and locks the branch,
+# so the user's `git checkout <branch>` in the main folder aborts. Isolation is
+# clone-only. The .solvers/ target must NOT buy it an exemption (issue #804).
+deny  "worktree add targeting .solvers"  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"$VC worktree add -b bugfix/x $MAIN/.solvers/issue-3 origin/develop\"}}" "$MAIN"
+deny  "worktree add from .solvers cwd"    "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"$VC worktree add ../issue-9 develop\"}}"                              "$MAIN/.solvers/issue-1"
+# The word "worktree" inside a commit message is NOT a worktree command.
+allow "commit msg mentioning worktree"    "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"$VC commit -m 'drop worktree note'\"}}"                                "$MAIN/.solvers/issue-1"
 
 echo ""
 if [ "$FAILURES" -gt 0 ]; then echo "$FAILURES failure(s)" >&2; exit 1; fi


### PR DESCRIPTION
Guard now denies any git worktree subcommand before every allow path. 3 new guard tests green. Closes #804