### PR TITLE
fix(#812): VST3 manifest overlay is groups-only; min/max/default optional

### DIFF
--- a/crates/plugin-loader/src/manifest.rs
+++ b/crates/plugin-loader/src/manifest.rs
@@ -280,8 +280,8 @@ pub enum Backend {
 }
 
 /// One parameter of a VST3 plugin, with the bridge between OpenRig's
-/// schema-friendly value range (`min`..`max`, optional discrete `step`)
-/// and the VST3 host's normalized 0.0..1.0 value space.
+/// schema-friendly value range (optional `min`..`max`, optional discrete
+/// `step`) and the VST3 host's normalized 0.0..1.0 value space.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Vst3Parameter {
     /// Stable identifier under which the user's `ParameterSet` keys this
@@ -292,9 +292,15 @@ pub struct Vst3Parameter {
     /// VST3 numeric parameter ID, exposed by the plugin's
     /// `IEditController::getParameterCount()` enumeration.
     pub vst3_id: u32,
-    pub min: f64,
-    pub max: f64,
-    pub default: f64,
+    /// Optional value range / default. The overlay is groups-only by design
+    /// (#812): the live plugin's `IEditController` owns the real range and
+    /// default, so a manifest that names only `vst3_id` + `group` is valid.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub min: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default: Option<f64>,
     /// Optional step for discrete UI knobs (1.0 percent, 0.5 dB, etc).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub step: Option<f64>,

--- a/crates/plugin-loader/src/manifest_more_tests.rs
+++ b/crates/plugin-loader/src/manifest_more_tests.rs
@@ -326,3 +326,31 @@ parameters:
     assert!(!map.contains_key(&9));
     assert_eq!(map.len(), 3);
 }
+
+#[test]
+fn vst3_groups_only_overlay_parses_without_ranges() {
+    // #812: the VST3 overlay is groups-only by design — the live plugin's
+    // IEditController owns the real ranges/defaults, so a manifest that
+    // declares just `vst3_id` + `group` must deserialize. Requiring
+    // min/max/default broke every populated overlay in OpenRig-plugins and
+    // aborted the release bundle.
+    let yaml = r#"
+manifest_version: 1
+id: qdelay
+display_name: QDelay
+type: vst3
+backend: vst3
+bundle: QDelay.vst3
+parameters:
+  - name: p0
+    vst3_id: 0
+    group: Input EQ
+  - name: p1
+    vst3_id: 1
+    group: Saturation
+"#;
+    let manifest = parse(yaml);
+    let map = manifest.vst3_group_map();
+    assert_eq!(map.get(&0).map(String::as_str), Some("Input EQ"));
+    assert_eq!(map.get(&1).map(String::as_str), Some("Saturation"));
+}

--- a/crates/plugin-loader/src/validate.rs
+++ b/crates/plugin-loader/src/validate.rs
@@ -143,10 +143,14 @@ pub fn validate_manifest(manifest: &PluginManifest) -> Result<(), ValidationErro
                 if parameter.name.trim().is_empty() {
                     return Err(ValidationError::EmptyParameterName);
                 }
-                if parameter.max < parameter.min {
-                    return Err(ValidationError::Vst3InvalidRange {
-                        name: parameter.name.clone(),
-                    });
+                // Only a declared range can be inverted; a groups-only
+                // overlay declares none and takes the plugin's own (#812).
+                if let (Some(min), Some(max)) = (parameter.min, parameter.max) {
+                    if max < min {
+                        return Err(ValidationError::Vst3InvalidRange {
+                            name: parameter.name.clone(),
+                        });
+                    }
                 }
             }
             Ok(())

--- a/crates/project/src/block/dispatch.rs
+++ b/crates/project/src/block/dispatch.rs
@@ -128,9 +128,11 @@ pub(crate) fn synthesize_parameters_from_manifest(
                     &param.name,
                     param.display_name.as_deref().unwrap_or(&param.name),
                     None,
-                    Some(param.default as f32),
-                    param.min as f32,
-                    param.max as f32,
+                    param.default.map(|value| value as f32),
+                    // Undeclared range → the normalized 0..100 % convention
+                    // `vst3_schema` uses for live plugin parameters (#812).
+                    param.min.unwrap_or(0.0) as f32,
+                    param.max.unwrap_or(100.0) as f32,
                     param.step.unwrap_or(0.01) as f32,
                     block_core::param::ParameterUnit::None,
                 )

--- a/docs/blocks-catalog.md
+++ b/docs/blocks-catalog.md
@@ -71,7 +71,11 @@ Mass-import LV2 (issue #379, 2026-05-04): adicionou ~246 plugins LV2 ao catálog
   (`<plugins_root>/vst3/<id>/bundles/<Name>.vst3`, manifest `type: vst3` /
   `backend: vst3`) lands in the **same** VST3 block list as a user-installed
   one, with the same native editor and `Vst3Processor`. Parameters are read at
-  runtime from the plugin's `IEditController`, not from the manifest.
+  runtime from the plugin's `IEditController`, not from the manifest. The
+  manifest's optional `parameters:` overlay is **groups-only** (#812): each
+  entry names a `vst3_id` and the block-editor tab it belongs to; `min` / `max`
+  / `default` are optional and unused for grouping, since the live controller
+  owns the real ranges.
   Parameter changes made in the plugin's **native editor** are captured back
   into the block's params (`p{id}` percent) on save, via `CaptureRigEdits`
   (#780) — the controller's current non-default values are read through the


### PR DESCRIPTION
Closes #812.

## Problem

`Vst3Parameter` required `min` / `max` / `default`, but the documented VST3 **group overlay** (#780) declares only `vst3_id` + `group`. Every VST3 manifest in OpenRig-plugins shipping a populated overlay failed to deserialize (`missing field `min``), aborting `pack_plugins` — the same code path as the `Bundle plugins` release job — for 13 plugins.

## Fix

- `crates/plugin-loader/src/manifest.rs` — `min` / `max` / `default` become `Option<f64>` (`#[serde(default, skip_serializing_if)]`), matching the groups-only design: the live `IEditController` owns the real ranges and defaults.
- `crates/plugin-loader/src/validate.rs` — the inverted-range check only fires when both bounds are declared.
- `crates/project/src/block/dispatch.rs` — the legacy manifest-driven schema path falls back to the normalized `0..100 %` convention `vst3_schema` already uses; `default` passes through as an `Option`.
- `docs/blocks-catalog.md` — documents the overlay as groups-only.

## Verification

- **RED first**: `vst3_groups_only_overlay_parses_without_ranges` failed with `Error("missing field `min`", line: 2, column: 1)` before the change, green after.
- `cargo build --workspace` clean (zero warnings); `cargo test -p plugin-loader -p project` green.
- **End-to-end**: ran the real `pack_plugins` gate against the local `.vst3` bundles with this branch patched in — exit 0, all 13 previously-failing VST3 packages (`chow_tape_model`, `cloud_reverb`, `filtr`, `frequalizer`, `gate12`, `homecorrupter`, `master_me`, `qdelay`, `reevr`, `regrader`, `sirial`, `time12`, `vitottx`) now pack `ok`.

Unblocks OpenRig-plugins#121.

Note: the shared quality gate was run locally but wedged on a pre-existing hang in a **baseline** (`origin/develop`) test binary (`issue_693_config_writes_must_not_block_caller`), unrelated to this change; the CI dispatcher run on this PR is the authoritative one.