### PR TITLE
fix(#815): parameter tabs on block add — unify add/edit onto create_and_wire

### DIFF
--- a/crates/adapter-gui/src/block_choose_type_callback.rs
+++ b/crates/adapter-gui/src/block_choose_type_callback.rs
@@ -31,18 +31,21 @@ use crate::block_editor::{block_parameter_items_for_model, build_knob_overlays};
 use crate::eq::{
     build_curve_editor_points, build_multi_slider_points, compute_eq_curves, eq_viz_sample_rate,
 };
-use crate::helpers::{show_child_window, sync_block_editor_window, use_inline_block_editor};
+use crate::helpers::{show_child_window, use_inline_block_editor};
 use crate::project_ops::sync_project_dirty;
 use crate::project_view::{
     block_model_picker_items, block_model_picker_labels, block_type_picker_items,
     replace_project_chains,
 };
-use crate::state::{BlockEditorDraft, InsertDraft, ProjectSession};
+use crate::state::{
+    BlockEditorData, BlockEditorDraft, BlockWindow, InsertDraft, ProjectSession, SelectedBlock,
+};
 use crate::sync_live_chain_runtime;
 use crate::ui_state::block_drawer_state;
 use crate::{
-    AppWindow, BlockEditorWindow, BlockModelPickerItem, BlockParameterItem, ChainInsertWindow,
-    ChannelOptionItem, CurveEditorPoint, MultiSliderPoint, ProjectChainItem,
+    block_editor_window_setup, AppWindow, BlockModelPickerItem, BlockParameterItem,
+    ChainInsertWindow, ChannelOptionItem, CurveEditorPoint, MultiSliderPoint, PluginInfoWindow,
+    ProjectChainItem,
 };
 
 pub(crate) struct BlockChooseTypeCallbackCtx {
@@ -66,12 +69,16 @@ pub(crate) struct BlockChooseTypeCallbackCtx {
     pub chain_output_device_options: Rc<VecModel<SharedString>>,
     pub insert_send_channels: Rc<VecModel<ChannelOptionItem>>,
     pub insert_return_channels: Rc<VecModel<ChannelOptionItem>>,
+    // #815: the ADD detached editor is now built via `create_and_wire`, so this
+    // callback needs the same per-block window deps as the edit path.
+    pub selected_block: Rc<RefCell<Option<SelectedBlock>>>,
+    pub open_block_windows: Rc<RefCell<Vec<BlockWindow>>>,
+    pub plugin_info_window: Rc<RefCell<Option<PluginInfoWindow>>>,
     pub auto_save: bool,
 }
 
 pub(crate) fn wire(
     window: &AppWindow,
-    block_editor_window: &BlockEditorWindow,
     chain_insert_window: &ChainInsertWindow,
     ctx: BlockChooseTypeCallbackCtx,
 ) {
@@ -96,11 +103,13 @@ pub(crate) fn wire(
         chain_output_device_options,
         insert_send_channels,
         insert_return_channels,
+        selected_block,
+        open_block_windows,
+        plugin_info_window,
         auto_save,
     } = ctx;
 
     let weak_window = window.as_weak();
-    let weak_block_editor_window = block_editor_window.as_weak();
     let weak_insert_window = chain_insert_window.as_weak();
 
     window.on_choose_block_type(move |index| {
@@ -268,12 +277,70 @@ pub(crate) fn wire(
             window.set_block_knob_overlays(ModelRc::from(Rc::new(VecModel::from(overlays))));
             window.set_show_block_drawer(true);
         } else {
+            // #815: build the SAME per-block tabbed editor the edit path uses,
+            // in add-mode (block_index None). The window builds its own params,
+            // knob overlays and #780 parameter tabs from `editor_data`; the
+            // block is created only on save (persist inserts when index is None).
             window.set_show_block_drawer(false);
-            if let Some(block_editor_window) = weak_block_editor_window.upgrade() {
-                block_editor_window
-                    .set_block_knob_overlays(ModelRc::from(Rc::new(VecModel::from(overlays))));
-                sync_block_editor_window(&window, &block_editor_window);
-                show_child_window(window.window(), block_editor_window.window());
+            let (chain_index, before_index) = block_editor_draft
+                .borrow()
+                .as_ref()
+                .map(|d| (d.chain_index, d.before_index))
+                .unwrap_or((0, 0));
+            let editor_data = BlockEditorData {
+                effect_type: model.effect_type.to_string(),
+                model_id: model.model_id.to_string(),
+                params: seeded.clone(),
+                enabled: true,
+                is_select: false,
+                select_options: Vec::new(),
+                selected_select_option_block_id: None,
+            };
+            // Only one add-editor at a time — close any prior one (sentinel key).
+            {
+                let borrow = open_block_windows.borrow();
+                for bw in borrow.iter().filter(|bw| bw.block_index == usize::MAX) {
+                    let _ = bw.window.hide();
+                }
+            }
+            open_block_windows
+                .borrow_mut()
+                .retain(|bw| bw.block_index != usize::MAX);
+            let setup_ctx = block_editor_window_setup::BlockEditorWindowSetupCtx {
+                chain_index,
+                block_index: None,
+                before_index,
+                instrument: instrument.clone(),
+                effect_type: model.effect_type.to_string(),
+                model_id: model.model_id.to_string(),
+                enabled: true,
+                editor_data,
+                block_id: None,
+                project_session: project_session.clone(),
+                project_chains: project_chains.clone(),
+                project_runtime: project_runtime.clone(),
+                saved_project_snapshot: saved_project_snapshot.clone(),
+                project_dirty: project_dirty.clone(),
+                input_chain_devices: input_chain_devices.clone(),
+                output_chain_devices: output_chain_devices.clone(),
+                selected_block: selected_block.clone(),
+                open_block_windows: open_block_windows.clone(),
+                plugin_info_window: plugin_info_window.clone(),
+                auto_save,
+            };
+            match block_editor_window_setup::create_and_wire(window.as_weak(), setup_ctx) {
+                Ok((win, stream_timer)) => {
+                    show_child_window(window.window(), win.window());
+                    open_block_windows.borrow_mut().push(BlockWindow {
+                        chain_index,
+                        block_index: usize::MAX,
+                        window: win,
+                        stream_timer,
+                    });
+                }
+                Err(e) => {
+                    log::error!("[adapter-gui] add-block editor open: {e}");
+                }
             }
         }
     });

--- a/crates/adapter-gui/src/block_editor_window_setup.rs
+++ b/crates/adapter-gui/src/block_editor_window_setup.rs
@@ -45,13 +45,21 @@ use crate::{
 
 pub(crate) struct BlockEditorWindowSetupCtx {
     pub chain_index: usize,
-    pub block_index: usize,
+    /// `Some(index)` when editing an existing block; `None` when the editor is
+    /// opened for a block being ADDED to the chain (#815). Add-mode skips the
+    /// per-edit auto-persist and the utility stream timer; the block is created
+    /// only on save (`persist_block_editor_draft` inserts when this is `None`).
+    pub block_index: Option<usize>,
+    /// Chain position the new block will be inserted before (add-mode). For the
+    /// edit path this equals `block_index`.
+    pub before_index: usize,
     pub instrument: String,
     pub effect_type: String,
     pub model_id: String,
     pub enabled: bool,
     pub editor_data: BlockEditorData,
-    pub block_id: domain::ids::BlockId,
+    /// `None` in add-mode — there is no block in the chain yet.
+    pub block_id: Option<domain::ids::BlockId>,
     pub project_session: Rc<RefCell<Option<ProjectSession>>>,
     pub project_chains: Rc<VecModel<ProjectChainItem>>,
     pub project_runtime: Rc<RefCell<Option<ProjectRuntimeController>>>,
@@ -72,6 +80,7 @@ pub(crate) fn create_and_wire(
     let BlockEditorWindowSetupCtx {
         chain_index,
         block_index,
+        before_index,
         instrument,
         effect_type,
         model_id,
@@ -121,8 +130,8 @@ pub(crate) fn create_and_wire(
     ));
     let win_draft = Rc::new(RefCell::new(Some(BlockEditorDraft {
         chain_index,
-        block_index: Some(block_index),
-        before_index: block_index,
+        block_index,
+        before_index,
         instrument: instrument.clone(),
         effect_type: effect_type.clone(),
         model_id: model_id.clone(),
@@ -198,7 +207,19 @@ pub(crate) fn create_and_wire(
     win.set_eq_band_curves(ModelRc::from(win_eq_band_curves.clone()));
     win.set_block_drawer_selected_type_index(type_index);
     win.set_block_drawer_selected_model_index(model_index);
-    win.set_block_drawer_edit_mode(true);
+    // Add-mode (no block yet, #815) shows the "add" confirm label and hides the
+    // delete affordance; editing an existing block shows "save".
+    let is_edit = block_index.is_some();
+    win.set_block_drawer_edit_mode(is_edit);
+    win.set_block_drawer_confirm_label(
+        if is_edit {
+            rust_i18n::t!("btn-save")
+        } else {
+            rust_i18n::t!("btn-add")
+        }
+        .as_ref()
+        .into(),
+    );
     win.set_block_drawer_enabled(enabled);
     win.set_block_drawer_status_message("".into());
     // Set window title
@@ -215,16 +236,21 @@ pub(crate) fn create_and_wire(
     // Start the timer regardless of current enabled state: when the user enables
     // the block while the popup is open, stream data must appear without reopening.
     let mut block_stream_timer: Option<Rc<Timer>> = None;
+    // Add-mode (no block yet) has no runtime block to poll; the stream timer is
+    // an edit-only concern. `block_id` is `Some` exactly when `block_index` is.
     let is_utility = effect_type == block_core::EFFECT_TYPE_UTILITY;
-    log::info!(
-        "[block-editor-stream] block='{}' effect_type='{}' model='{}' enabled={} is_utility={}",
-        block_id.0,
-        effect_type,
-        model_id,
-        enabled,
-        is_utility
-    );
-    if is_utility {
+    if let Some(block_id) = block_id.as_ref() {
+        log::info!(
+            "[block-editor-stream] block='{}' effect_type='{}' model='{}' enabled={} is_utility={}",
+            block_id.0,
+            effect_type,
+            model_id,
+            enabled,
+            is_utility
+        );
+    }
+    if is_utility && block_id.is_some() {
+        let block_id = block_id.clone().expect("guarded by block_id.is_some()");
         log::info!(
             "[block-editor-stream] starting stream timer for block '{}'",
             block_id.0
@@ -329,7 +355,7 @@ pub(crate) fn create_and_wire(
             open_block_windows,
             plugin_info_window,
             chain_index,
-            block_index,
+            block_index: block_index.unwrap_or(before_index),
             auto_save,
         },
     );

--- a/crates/adapter-gui/src/desktop_app_block_wiring.rs
+++ b/crates/adapter-gui/src/desktop_app_block_wiring.rs
@@ -165,7 +165,6 @@ pub(crate) fn wire_all(deps: &BlockWiringDeps<'_>) {
     // --- on_choose_block_type (extracted to block_choose_type_callback) ---
     crate::block_choose_type_callback::wire(
         deps.window,
-        deps.block_editor_window,
         deps.chain_insert_window,
         crate::block_choose_type_callback::BlockChooseTypeCallbackCtx {
             block_editor_draft: deps.block_editor_draft.clone(),
@@ -188,6 +187,9 @@ pub(crate) fn wire_all(deps: &BlockWiringDeps<'_>) {
             chain_output_device_options: deps.chain_output_device_options.clone(),
             insert_send_channels: deps.insert_send_channels.clone(),
             insert_return_channels: deps.insert_return_channels.clone(),
+            selected_block: deps.selected_block.clone(),
+            open_block_windows: deps.open_block_windows.clone(),
+            plugin_info_window: deps.plugin_info_window.clone(),
             auto_save: deps.auto_save,
         },
     );

--- a/crates/adapter-gui/src/issue_815_add_block_tabs_tests.rs
+++ b/crates/adapter-gui/src/issue_815_add_block_tabs_tests.rs
@@ -80,3 +80,20 @@ fn adding_a_block_opens_the_tabbed_editor_in_add_mode() {
         "adding a block must NOT be in edit mode"
     );
 }
+
+/// The end-to-end add flow needs a fully wired `AppWindow`, which the codebase
+/// keeps out of tests, so we pin the routing by source (the `no_native_dialogs`
+/// convention): the ADD detached branch must build the editor via
+/// `create_and_wire`, NOT sync the retired persistent window.
+#[test]
+fn add_flow_uses_create_and_wire_not_the_persistent_window() {
+    let src = include_str!("block_choose_type_callback.rs");
+    assert!(
+        src.contains("create_and_wire"),
+        "the ADD detached branch must build the editor via create_and_wire"
+    );
+    assert!(
+        !src.contains("sync_block_editor_window"),
+        "the ADD flow must NOT sync the old persistent window anymore"
+    );
+}

--- a/crates/adapter-gui/src/issue_815_add_block_tabs_tests.rs
+++ b/crates/adapter-gui/src/issue_815_add_block_tabs_tests.rs
@@ -1,0 +1,82 @@
+//! #815 — a block ADDED to the chain must open the same tabbed editor as an
+//! edited block. The ADD flow now goes through `create_and_wire` in
+//! "new-block" mode (`block_index: None`): edit-mode off, "add" confirm label,
+//! and the #780 parameter tabs populated exactly like the edit path.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use slint::{ComponentHandle, Model, VecModel};
+
+use crate::block_editor_window_setup::{create_and_wire, BlockEditorWindowSetupCtx};
+use crate::project_ops::create_new_project_session;
+use crate::state::{BlockEditorData, ProjectSession};
+
+fn empty_session() -> Rc<RefCell<Option<ProjectSession>>> {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let session = create_new_project_session(&tmp.path().join("config.yaml"));
+    // The window setup only wires callbacks against the session; it never reads
+    // it during construction. Leak the tempdir so the session's paths stay valid
+    // for the lifetime of the test.
+    std::mem::forget(tmp);
+    Rc::new(RefCell::new(Some(session)))
+}
+
+fn new_block_ctx() -> BlockEditorWindowSetupCtx {
+    // The 8-band parametric EQ exposes 8 parameter groups ("Band 1".."Band 8"),
+    // so a correctly built editor must render more than one tab.
+    let seeded =
+        application::block_factory::default_params_for_model("filter", "eq_eight_band_parametric")
+            .unwrap_or_default();
+    BlockEditorWindowSetupCtx {
+        chain_index: 0,
+        block_index: None,
+        before_index: 0,
+        instrument: "electric_guitar".to_string(),
+        effect_type: "filter".to_string(),
+        model_id: "eq_eight_band_parametric".to_string(),
+        enabled: true,
+        editor_data: BlockEditorData {
+            effect_type: "filter".to_string(),
+            model_id: "eq_eight_band_parametric".to_string(),
+            params: seeded,
+            enabled: true,
+            is_select: false,
+            select_options: Vec::new(),
+            selected_select_option_block_id: None,
+        },
+        block_id: None,
+        project_session: empty_session(),
+        project_chains: Rc::new(VecModel::default()),
+        project_runtime: Rc::new(RefCell::new(None)),
+        saved_project_snapshot: Rc::new(RefCell::new(None)),
+        project_dirty: Rc::new(RefCell::new(false)),
+        input_chain_devices: Rc::new(RefCell::new(Vec::new())),
+        output_chain_devices: Rc::new(RefCell::new(Vec::new())),
+        selected_block: Rc::new(RefCell::new(None)),
+        open_block_windows: Rc::new(RefCell::new(Vec::new())),
+        plugin_info_window: Rc::new(RefCell::new(None)),
+        auto_save: false,
+    }
+}
+
+#[test]
+fn adding_a_block_opens_the_tabbed_editor_in_add_mode() {
+    i_slint_backend_testing::init_no_event_loop();
+    let weak = {
+        let w = crate::AppWindow::new().unwrap();
+        w.as_weak()
+    };
+    let (win, _timer) = create_and_wire(weak, new_block_ctx()).unwrap();
+
+    // The #780 parameter tabs must be built for a NEW block, just like edit.
+    assert!(
+        win.get_block_parameter_groups().row_count() > 1,
+        "a newly added 8-band EQ must show its parameter tabs"
+    );
+    // New block => add mode, not edit mode (no delete, confirm = add).
+    assert!(
+        !win.get_block_drawer_edit_mode(),
+        "adding a block must NOT be in edit mode"
+    );
+}

--- a/crates/adapter-gui/src/lib.rs
+++ b/crates/adapter-gui/src/lib.rs
@@ -143,6 +143,8 @@ pub mod graph_view_model;
 mod helpers;
 #[cfg(test)]
 mod issue_692_project_open_time_tests;
+#[cfg(test)]
+mod issue_815_add_block_tabs_tests;
 mod latency_probe;
 /// #693: non-blocking logger init shared by binaries and tests.
 pub mod logging;

--- a/crates/adapter-gui/src/select_chain_block_callback.rs
+++ b/crates/adapter-gui/src/select_chain_block_callback.rs
@@ -345,13 +345,14 @@ pub(crate) fn wire(
             // Build + wire a fresh BlockEditorWindow for this block
             let setup_ctx = block_editor_window_setup::BlockEditorWindowSetupCtx {
                 chain_index: ci,
-                block_index: bi,
+                block_index: Some(bi),
+                before_index: bi,
                 instrument: instrument.clone(),
                 effect_type: effect_type.clone(),
                 model_id: model_id.clone(),
                 enabled,
                 editor_data,
-                block_id: block_id_for_editor,
+                block_id: Some(block_id_for_editor),
                 project_session: project_session.clone(),
                 project_chains: project_chains.clone(),
                 project_runtime: project_runtime.clone(),

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,3 +34,15 @@ assets/amps/{brand}/{model}/component.yaml     ← caminhos de assets + svg_cx/c
 ## BlockEditorPanel
 
 Quando o bloco selecionado é `preamp`, o painel mostra `controls.svg` em vez de só sliders. Implementação em `crates/adapter-gui/ui/pages/project_chains.slint` (propriedades `is-preamp`, `selected-model-id`, ternary chain de `@image-url()` por compile-time). `amp` ainda não tem equivalente.
+
+### Detached editor: one wiring for add and edit (#815)
+
+Outside inline (fullscreen/touch) mode, the block editor opens as a detached
+`BlockEditorWindow` built per-block by `block_editor_window_setup::create_and_wire`.
+Both flows use it: editing an existing block passes `block_index: Some(i)`; adding
+a new block passes `block_index: None` (add-mode — no auto-persist, no stream
+timer, "add" confirm label, and the block is created only on save, where
+`persist_block_editor_draft` inserts when the index is `None`). Because both share
+this one setup, the #780 parameter tabs render identically on add and edit. Add
+previously went through a separate persistent-window wiring that never built the
+tabs — that path is being retired.

--- a/docs/superpowers/plans/2026-07-23-unify-block-editor-add-edit.md
+++ b/docs/superpowers/plans/2026-07-23-unify-block-editor-add-edit.md
@@ -1,0 +1,323 @@
+# Unify Block Editor Add/Edit Wiring Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the detached block editor use ONE wiring for both adding and editing a block, so a newly added block shows parameter tabs exactly like an edited one (issue #815).
+
+**Architecture:** Today the detached editor has two fully duplicated wirings: EDIT builds a fresh `BlockEditorWindow` via `block_editor_window_setup::create_and_wire` (tabs + tab-select + insert/overwrite save all wired), while ADD reuses a single persistent `BlockEditorWindow` created at startup and driven by a parallel, older set of wirings that never learned the #780 parameter tabs. We make `create_and_wire` handle the "new block" case (no `block_index` yet) and route ADD through it, then retire the persistent window and its duplicated wirings.
+
+**Tech Stack:** Rust, Slint, `i-slint-backend-testing` for headless window tests.
+
+## Global Constraints
+
+- Zero warnings (`cargo build` clean).
+- TDD red-first: no production change without a test that failed first; watch the assertion fail.
+- Repo content in English (code, comments, commits, docs). Chat/reasoning pt-BR.
+- Agent works ONLY under `.solvers/issue-815/`; never the main folder.
+- No `#[ignore]`. Behavior gate is `cargo test --workspace --lib`.
+- The save path already handles insert-vs-edit by `draft.block_index` (`Some` → `OverwriteBlock`, `None` → `InsertPrebuiltBlock`) in `persist_block_editor_draft` — do NOT duplicate that logic.
+- Stream isolation / audio invariants untouched — this is GUI wiring only.
+
+---
+
+## File Structure
+
+Phase 1 (fix the bug + unify onto `create_and_wire`):
+- `crates/adapter-gui/src/block_editor_window_setup.rs` — `create_and_wire` gains new-block mode.
+- `crates/adapter-gui/src/select_chain_block_callback.rs` — EDIT call site adapts to the new ctx shape.
+- `crates/adapter-gui/src/block_choose_type_callback.rs` — ADD (detached branch) routes through `create_and_wire`.
+- `crates/adapter-gui/src/issue_815_add_block_tabs_tests.rs` — new inline test module (behavioral + source-presence).
+- `crates/adapter-gui/src/lib.rs` — register the test module under `#[cfg(test)]`.
+
+Phase 2 (retire the persistent window + duplicated wirings):
+- `crates/adapter-gui/src/desktop_app.rs`, `desktop_app_block_models.rs`, `helpers.rs`, and the persistent-window wiring files (`block_editor_window_wiring.rs`, `block_parameter_wiring.rs`, `block_model_search_wiring.rs`, `block_picker_wiring.rs`, `block_insert_callbacks.rs`, `block_drawer_save_delete_wiring.rs`, `block_drawer_close_wiring.rs`, `block_delete_wiring.rs`, `back_to_launcher_wiring.rs`).
+
+---
+
+## Task 1: `create_and_wire` accepts an optional `block_index` (mechanical, behavior-preserving)
+
+**Files:**
+- Modify: `crates/adapter-gui/src/block_editor_window_setup.rs` (ctx struct + body)
+- Modify: `crates/adapter-gui/src/select_chain_block_callback.rs:346-378` (the one EDIT call site)
+
+**Interfaces:**
+- Produces: `BlockEditorWindowSetupCtx` with `block_index: Option<usize>`, `before_index: usize`, `block_id: Option<domain::ids::BlockId>` (was `block_index: usize`, `block_id: BlockId`).
+
+- [ ] **Step 1: Change the ctx fields.** In `block_editor_window_setup.rs` change
+  `pub block_index: usize,` → `pub block_index: Option<usize>,`, add `pub before_index: usize,`,
+  and `pub block_id: domain::ids::BlockId,` → `pub block_id: Option<domain::ids::BlockId>,`.
+
+- [ ] **Step 2: Adapt the body, KEEPING behavior identical for the edit case.** In `create_and_wire`:
+  - `win_draft`: `block_index: block_index` (already `Option`), `before_index: before_index`.
+  - Stream timer + `block_id` logging: guard with `if let Some(block_id) = &block_id { ... }` and only start the utility timer when `block_index.is_some()`.
+  - Leave `win.set_block_drawer_edit_mode(true);` UNCHANGED for now (Task 2 makes it conditional). This keeps the refactor behavior-preserving.
+  - The `block_editor_window_lifecycle::wire` / `block_editor_window_params::wire` ctxs take `block_index`/`before_index` — pass `block_index.unwrap_or(before_index)` where a bare `usize` is still required (lifecycle `chain_index`/`block_index` fields), preserving today's values for the edit path.
+
+- [ ] **Step 3: Update the EDIT call site** (`select_chain_block_callback.rs`): pass `block_index: Some(bi)`, `before_index: bi`, `block_id: Some(block_id_for_editor)`.
+
+- [ ] **Step 4: Build + existing tests green** (proves behavior-preserving):
+
+Run: `cargo test -p adapter-gui --lib`
+Expected: PASS, zero warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/adapter-gui/src/block_editor_window_setup.rs crates/adapter-gui/src/select_chain_block_callback.rs
+git commit -m "refactor(#815): create_and_wire takes Option<block_index> (edit path unchanged)"
+```
+
+---
+
+## Task 2: New-block mode drives edit-mode + confirm label (RED first)
+
+**Files:**
+- Create: `crates/adapter-gui/src/issue_815_add_block_tabs_tests.rs`
+- Modify: `crates/adapter-gui/src/lib.rs` (register test module)
+- Modify: `crates/adapter-gui/src/block_editor_window_setup.rs`
+
+**Interfaces:**
+- Consumes: `BlockEditorWindowSetupCtx` from Task 1.
+
+- [ ] **Step 1: Write the failing test.** New inline module. It builds a minimal ctx with an empty in-memory session and calls `create_and_wire` in new-block mode for the 8-band EQ (`filter` / `eq_eight_band_parametric`, which has 8 param groups). Assert new-block behavior.
+
+```rust
+//! #815 — a block ADDED to the chain must open the same tabbed editor as an
+//! edited block. The ADD flow now goes through `create_and_wire` in
+//! "new-block" mode (`block_index: None`): edit-mode off, "Adicionar" confirm
+//! label, and the #780 parameter tabs populated exactly like the edit path.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use slint::{Model, VecModel};
+
+use crate::block_editor_window_setup::{create_and_wire, BlockEditorWindowSetupCtx};
+use crate::project_ops::create_new_project_session;
+use crate::state::{BlockEditorData, ProjectSession};
+
+fn empty_session() -> Rc<RefCell<Option<ProjectSession>>> {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let session = create_new_project_session(&tmp.path().join("config.yaml"));
+    // keep tmp alive for the session's lifetime in-test
+    std::mem::forget(tmp);
+    Rc::new(RefCell::new(Some(session)))
+}
+
+fn new_block_ctx() -> BlockEditorWindowSetupCtx {
+    let seeded = application::block_factory::default_params_for_model(
+        "filter",
+        "eq_eight_band_parametric",
+    )
+    .unwrap_or_default();
+    BlockEditorWindowSetupCtx {
+        chain_index: 0,
+        block_index: None,
+        before_index: 0,
+        instrument: "electric_guitar".to_string(),
+        effect_type: "filter".to_string(),
+        model_id: "eq_eight_band_parametric".to_string(),
+        enabled: true,
+        editor_data: BlockEditorData {
+            effect_type: "filter".to_string(),
+            model_id: "eq_eight_band_parametric".to_string(),
+            params: seeded,
+            enabled: true,
+            is_select: false,
+            select_options: Vec::new(),
+            selected_select_option_block_id: None,
+        },
+        block_id: None,
+        project_session: empty_session(),
+        project_chains: Rc::new(VecModel::default()),
+        project_runtime: Rc::new(RefCell::new(None)),
+        saved_project_snapshot: Rc::new(RefCell::new(None)),
+        project_dirty: Rc::new(RefCell::new(false)),
+        input_chain_devices: Rc::new(RefCell::new(Vec::new())),
+        output_chain_devices: Rc::new(RefCell::new(Vec::new())),
+        selected_block: Rc::new(RefCell::new(None)),
+        open_block_windows: Rc::new(RefCell::new(Vec::new())),
+        plugin_info_window: Rc::new(RefCell::new(None)),
+        auto_save: false,
+    }
+}
+
+#[test]
+fn adding_a_block_opens_the_tabbed_editor_in_add_mode() {
+    i_slint_backend_testing::init_no_event_loop();
+    let weak = {
+        let w = crate::AppWindow::new().unwrap();
+        w.as_weak()
+    };
+    let (win, _timer) = create_and_wire(weak, new_block_ctx()).unwrap();
+
+    // The #780 parameter tabs must be built for a NEW block, just like edit.
+    assert!(
+        win.get_block_parameter_groups().row_count() > 1,
+        "a newly added 8-band EQ must show its parameter tabs"
+    );
+    // New block => add mode, not edit mode (no delete, confirm = Adicionar).
+    assert!(
+        !win.get_block_drawer_edit_mode(),
+        "adding a block must NOT be in edit mode"
+    );
+}
+```
+
+- [ ] **Step 2: Register the module.** In `lib.rs`, next to the other `#[cfg(test)] mod *_tests;` lines add:
+
+```rust
+#[cfg(test)]
+mod issue_815_add_block_tabs_tests;
+```
+
+- [ ] **Step 3: Run test to verify it fails behaviorally.**
+
+Run: `cargo test -p adapter-gui --lib adding_a_block_opens_the_tabbed_editor_in_add_mode -- --nocapture`
+Expected: FAIL on the `edit_mode` assertion (currently `create_and_wire` hardcodes edit-mode on). The tabs assertion already passes — that is the point: `create_and_wire` already builds tabs; only add-mode is missing.
+
+- [ ] **Step 4: Make it pass.** In `block_editor_window_setup.rs` replace the hardcoded
+  `win.set_block_drawer_edit_mode(true);` with add/edit-aware state:
+
+```rust
+let is_edit = block_index.is_some();
+win.set_block_drawer_edit_mode(is_edit);
+win.set_block_drawer_confirm_label(
+    if is_edit { rust_i18n::t!("btn-save") } else { rust_i18n::t!("btn-add") }
+        .as_ref()
+        .into(),
+);
+```
+
+- [ ] **Step 5: Run test to verify it passes + whole lib green.**
+
+Run: `cargo test -p adapter-gui --lib`
+Expected: PASS, zero warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/adapter-gui/src/block_editor_window_setup.rs crates/adapter-gui/src/issue_815_add_block_tabs_tests.rs crates/adapter-gui/src/lib.rs
+git commit -m "feat(#815): create_and_wire builds an add-mode tabbed editor for new blocks"
+```
+
+---
+
+## Task 3: Route the ADD (detached) flow through `create_and_wire`
+
+**Files:**
+- Modify: `crates/adapter-gui/src/block_choose_type_callback.rs` (detached branch + ctx)
+- Modify: `crates/adapter-gui/src/desktop_app.rs` (pass the extra deps into the choose-type ctx)
+- Modify: `crates/adapter-gui/src/issue_815_add_block_tabs_tests.rs` (add source-presence pin)
+
+**Interfaces:**
+- Consumes: `create_and_wire` new-block mode from Task 2.
+
+- [ ] **Step 1: Write the failing source-presence test** (pins the routing; the behavioral end-to-end needs a fully wired `AppWindow`, which the repo keeps out of tests, so we pin the wiring by source — the `no_native_dialogs.rs` convention):
+
+```rust
+#[test]
+fn add_flow_uses_create_and_wire_not_the_persistent_window() {
+    let src = include_str!("block_choose_type_callback.rs");
+    assert!(
+        src.contains("create_and_wire"),
+        "the ADD detached branch must build the editor via create_and_wire"
+    );
+    assert!(
+        !src.contains("sync_block_editor_window"),
+        "the ADD flow must NOT sync the old persistent window anymore"
+    );
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails.**
+
+Run: `cargo test -p adapter-gui --lib add_flow_uses_create_and_wire_not_the_persistent_window`
+Expected: FAIL (`block_choose_type_callback.rs` still calls `sync_block_editor_window` and never `create_and_wire`).
+
+- [ ] **Step 3: Rewire the detached branch.** In `block_choose_type_callback.rs`, replace the
+  `else { ... sync_block_editor_window ... show_child_window(block_editor_window) }` block (the non-inline path, ~lines 270-278) with a `create_and_wire` call mirroring the EDIT site: build `BlockEditorData` from the seeded `new_params`' source model, `block_index: None`, `before_index: draft.before_index`, register the returned window in `open_block_windows` (sentinel `block_index: usize::MAX`) so it stays alive, and `show_child_window`. Expand `BlockChooseTypeCallbackCtx` with the deps `create_and_wire` needs (`project_runtime`, `saved_project_snapshot`, `project_dirty`, `input_chain_devices`, `output_chain_devices`, `selected_block`, `open_block_windows`, `plugin_info_window`) and thread them from `desktop_app.rs`. Remove the now-unused `sync_block_editor_window` import.
+
+- [ ] **Step 4: Run test + whole lib green.**
+
+Run: `cargo test -p adapter-gui --lib`
+Expected: PASS, zero warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/adapter-gui/src/block_choose_type_callback.rs crates/adapter-gui/src/desktop_app.rs crates/adapter-gui/src/issue_815_add_block_tabs_tests.rs
+git commit -m "feat(#815): route the ADD detached flow through create_and_wire (tabs on add)"
+```
+
+---
+
+## Task 4: Retire the persistent block-editor window and its duplicated wirings
+
+> Mechanical cleanup once ADD no longer shows the persistent window. Do it in
+> one commit but verify after each file that the crate still builds.
+
+**Files:**
+- Modify: `crates/adapter-gui/src/desktop_app.rs` — remove the persistent `block_editor_window` creation (`desktop_app.rs:232`) and every `wire(...)` call that took it.
+- Modify: `crates/adapter-gui/src/desktop_app_block_models.rs` — drop the persistent-window seeding.
+- Modify: `crates/adapter-gui/src/helpers.rs` — delete `sync_block_editor_window`.
+- Remove the persistent-window wiring bodies (or the `&BlockEditorWindow` parameter and its uses) in: `block_editor_window_wiring.rs`, `block_parameter_wiring.rs`, `block_model_search_wiring.rs`, `block_picker_wiring.rs`, `block_insert_callbacks.rs`, `block_drawer_save_delete_wiring.rs`, `block_drawer_close_wiring.rs`, `block_delete_wiring.rs`, `back_to_launcher_wiring.rs`.
+
+- [ ] **Step 1: Write the failing guard test** (pins that the persistent window is gone):
+
+```rust
+#[test]
+fn no_persistent_block_editor_window_remains() {
+    let src = include_str!("desktop_app.rs");
+    let occurrences = src.matches("BlockEditorWindow::new").count();
+    assert_eq!(
+        occurrences, 0,
+        "the persistent BlockEditorWindow must be retired; editors are built per-block via create_and_wire"
+    );
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails.**
+
+Run: `cargo test -p adapter-gui --lib no_persistent_block_editor_window_remains`
+Expected: FAIL (`desktop_app.rs` still creates the persistent window).
+
+- [ ] **Step 3: Remove the persistent window + dead wirings.** Delete the creation and each dead `wire(&block_editor_window, ...)` call; where a whole wiring file only existed to drive the persistent window, delete the file and its `mod` line; where a file wired BOTH the main window and the persistent one, drop only the persistent-window parameter and its uses. Keep deleting until `cargo build -p adapter-gui` is clean with zero warnings (unused imports/params guide you).
+
+- [ ] **Step 4: Run guard test + whole lib green.**
+
+Run: `cargo test -p adapter-gui --lib`
+Expected: PASS, zero warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A crates/adapter-gui/src
+git commit -m "refactor(#815): retire the persistent block-editor window and its duplicated wirings"
+```
+
+---
+
+## Task 5: Docs
+
+**Files:**
+- Modify: `docs/architecture.md` (BlockEditorPanel / detached editor section) and/or `docs/screens.md` (Block Editor) — state that the detached block editor is built per-block via `create_and_wire` for BOTH add and edit, with #780 parameter tabs in both.
+
+- [ ] **Step 1:** Update the relevant doc paragraph to describe the single add/edit editor path.
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs
+git commit -m "docs(#815): document the unified add/edit block editor path"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Bug (no tabs on add) → Task 2 + Task 3. "Same slint for add/edit" → Tasks 3-4 (one wiring). "Retire persistent window" → Task 4. Docs → Task 5.
+- **Type consistency:** `block_index: Option<usize>`, `before_index: usize`, `block_id: Option<BlockId>` used consistently Task 1 → 3. `create_and_wire` return `(BlockEditorWindow, Option<Rc<Timer>>)` unchanged.
+- **Placeholder scan:** none — every code step shows the code or the exact deletion criterion (build-clean).
+- **Risk:** Task 4 is broad; its guard is "crate builds warning-free + full lib green + the source-presence pins from Tasks 3-4". Real-hardware battery not needed (no audio-thread change).
+</content>
+</invoke>


### PR DESCRIPTION
Closes #815.

## Problem
Adding a block to a chain showed its parameters as a flat list — no tabs — while editing an existing block showed them split into tabs.

## Root cause
Same `.slint` component, two different Rust wirings. EDIT builds a fresh `BlockEditorWindow` via `create_and_wire` (with #780 parameter tabs, tab-select, and insert/overwrite save). ADD reused a single *persistent* window driven by an older parallel wiring that never learned the tabs.

## Fix — unify onto `create_and_wire`
- `create_and_wire` now takes `block_index: Option<usize>`. Add-mode (`None`) skips the edit-only auto-persist and stream timer, shows the *add* confirm label, leaves edit-mode off, and still builds the parameter tabs. The block is created only on save (shared `persist_block_editor_draft` inserts when the index is `None`).
- The ADD detached flow (`on_choose_block_type`) now opens that same tabbed editor instead of syncing the persistent window.

## Tests (TDD, red-first)
- `adding_a_block_opens_the_tabbed_editor_in_add_mode` — behavioral; failed on the edit-mode assertion before the fix.
- `add_flow_uses_create_and_wire_not_the_persistent_window` — source-presence pin.
- `cargo test -p adapter-gui --lib` → 547 passed, 0 failed. `cargo build --workspace` clean, zero warnings.

## Follow-up (this branch)
Fully retire the now-dead persistent `BlockEditorWindow` and its duplicated wirings (~10 files) — deferred to keep this broad mechanical removal out of the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)