### PR TITLE
fix(#834): drop the unsourced single-board claim

### DIFF
--- a/site/i18n/en.json
+++ b/site/i18n/en.json
@@ -87,8 +87,8 @@
   "gig.c1.p": "The signal goes in and comes back out fast enough that your hands never notice the computer in between.",
   "gig.c2.h3": "Silent switching",
   "gig.c2.p": "Swap an amp, add a pedal, change a preset while you're playing. No gaps, no pops, no dead bars.",
-  "gig.c3.h3": "Runs on modest hardware",
-  "gig.c3.p": "A laptop is plenty. It also runs on a small board you can screw to a pedalboard and forget about.",
+  "gig.c3.h3": "No hardware to buy",
+  "gig.c3.p": "The laptop you already own is the rig. Nothing extra to buy, nothing extra to carry to the gig.",
 
   "features.eyebrow": "Everything you need",
   "features.h2": "More than<br>a rig.",

--- a/site/i18n/es-ES.json
+++ b/site/i18n/es-ES.json
@@ -87,8 +87,8 @@
   "gig.c1.p": "La señal entra y vuelve lo bastante rápido para que tus manos nunca noten el ordenador de por medio.",
   "gig.c2.h3": "Cambios silenciosos",
   "gig.c2.p": "Cambia un ampli, añade un pedal, cambia de preset mientras tocas. Sin cortes, sin chasquidos, sin compases perdidos.",
-  "gig.c3.h3": "Funciona en hardware modesto",
-  "gig.c3.p": "Un portátil es más que suficiente. También corre en una placa pequeña que atornillas al pedalboard y te olvidas de ella.",
+  "gig.c3.h3": "Sin hardware que comprar",
+  "gig.c3.p": "El portátil que ya tienes es el rig. Nada más que comprar, nada más que cargar al show.",
 
   "features.eyebrow": "Todo lo que necesitas",
   "features.h2": "Más que<br>un rig.",

--- a/site/i18n/pt-BR.json
+++ b/site/i18n/pt-BR.json
@@ -87,8 +87,8 @@
   "gig.c1.p": "O sinal entra e volta rápido o suficiente pra suas mãos nunca perceberem o computador no meio do caminho.",
   "gig.c2.h3": "Troca silenciosa",
   "gig.c2.p": "Troca de amp, adiciona um pedal, muda de preset enquanto toca. Sem buraco, sem estalo, sem compasso perdido.",
-  "gig.c3.h3": "Roda em hardware modesto",
-  "gig.c3.p": "Um laptop já basta. Também roda numa placa pequena que você aparafusa no pedalboard e esquece que existe.",
+  "gig.c3.h3": "Sem hardware pra comprar",
+  "gig.c3.p": "O laptop que você já tem é o rig. Nada a mais pra comprar, nada a mais pra carregar pro show.",
 
   "features.eyebrow": "Tudo que você precisa",
   "features.h2": "Mais do que<br>um rig.",

--- a/site/sections/gig.html
+++ b/site/sections/gig.html
@@ -10,7 +10,7 @@
     <div class="cards">
       <div class="card rv"><div class="n">01</div><h3 data-i18n="gig.c1.h3">No latency you can feel</h3><p data-i18n="gig.c1.p">The signal goes in and comes back out fast enough that your hands never notice the computer in between.</p></div>
       <div class="card rv"><div class="n">02</div><h3 data-i18n="gig.c2.h3">Silent switching</h3><p data-i18n="gig.c2.p">Swap an amp, add a pedal, change a preset while you're playing. No gaps, no pops, no dead bars.</p></div>
-      <div class="card rv"><div class="n">03</div><h3 data-i18n="gig.c3.h3">Runs on modest hardware</h3><p data-i18n="gig.c3.p">A laptop is plenty. It also runs on a small board you can screw to a pedalboard and forget about.</p></div>
+      <div class="card rv"><div class="n">03</div><h3 data-i18n="gig.c3.h3">No hardware to buy</h3><p data-i18n="gig.c3.p">The laptop you already own is the rig. Nothing extra to buy, nothing extra to carry to the gig.</p></div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
Refs #834. The gig card claimed OpenRig runs on a small board screwed to a pedalboard — embellishment, and it contradicts the site's own roadmap (Linux builds under "next up", #479 open).