### PR TITLE
copy(#834): stop tying OpenRig to a laptop

### DIFF
--- a/site/i18n/en/gear.json
+++ b/site/i18n/en/gear.json
@@ -62,7 +62,7 @@
   "gig.c2.h3": "Switch without a click",
   "gig.c2.p": "Change amp, add a pedal or load a preset while you're playing. No gap, no pop, no dead bar.",
   "gig.c3.h3": "No amp head, no pedalboard",
-  "gig.c3.p": "You already have an audio interface to plug the guitar into. Everything after it — amp, cab, pedals — runs on the laptop.",
+  "gig.c3.p": "You already have an audio interface to plug the guitar into. Everything after it — amp, cab, pedals — runs on the computer.",
   "app.eyebrow": "Inside",
   "app.h2": "Everything<br>in one view.",
   "app.lede": "Instruments on the left, gear in the middle, outputs on the right. That's the whole app.",

--- a/site/i18n/en/shell.json
+++ b/site/i18n/en/shell.json
@@ -12,7 +12,7 @@
   "nav.download": "Download",
   "hero.eyebrow": "Free · Open source · Mac",
   "hero.h1": "All that's left<br>is plugging in<br><em>your guitar.</em>",
-  "hero.lede": "{gear} amps, cabs and pedals running on the laptop you already own. Free, with no latency you can feel.",
+  "hero.lede": "{gear} amps, cabs and pedals, running on the computer you already have. Free, with no latency you can feel.",
   "hero.cta1": "Download for Mac",
   "hero.cta2": "See the rig",
   "hero.note": "Free forever. No account, no cloud, no subscription.",

--- a/site/i18n/es-ES/gear.json
+++ b/site/i18n/es-ES/gear.json
@@ -62,7 +62,7 @@
   "gig.c2.h3": "Cambios sin chasquido",
   "gig.c2.p": "Cambia de ampli, pon un pedal o carga un preset mientras tocas. Sin cortes, sin chasquidos, sin compases perdidos.",
   "gig.c3.h3": "Sin cabezal, sin pedalera",
-  "gig.c3.p": "Ya tienes la interfaz de audio para enchufar la guitarra. De ahí en adelante — ampli, pantalla, pedales — todo corre en el portátil.",
+  "gig.c3.p": "Ya tienes la interfaz de audio para enchufar la guitarra. De ahí en adelante — ampli, pantalla, pedales — todo corre en el ordenador.",
   "app.eyebrow": "Por dentro",
   "app.h2": "Todo en<br>una sola vista.",
   "app.lede": "Instrumentos a la izquierda, equipo en el medio, salidas a la derecha. Esa es toda la app.",

--- a/site/i18n/es-ES/shell.json
+++ b/site/i18n/es-ES/shell.json
@@ -12,7 +12,7 @@
   "nav.download": "Descargar",
   "hero.eyebrow": "Gratis · Código abierto · Mac",
   "hero.h1": "Solo falta<br>que enchufes<br><em>la guitarra.</em>",
-  "hero.lede": "{gear} amplis, bafles y pedales corriendo en el portátil que ya tienes. Gratis, sin latencia que puedas sentir.",
+  "hero.lede": "{gear} amplis, bafles y pedales corriendo en el ordenador que ya tienes. Gratis, sin latencia que puedas sentir.",
   "hero.cta1": "Descargar para Mac",
   "hero.cta2": "Ver el rig",
   "hero.note": "Gratis para siempre. Sin cuenta, sin nube, sin suscripción.",

--- a/site/i18n/pt-BR/gear.json
+++ b/site/i18n/pt-BR/gear.json
@@ -62,7 +62,7 @@
   "gig.c2.h3": "Troca sem estalo",
   "gig.c2.p": "Troca de amp, coloca um pedal ou carrega um preset tocando. Sem buraco, sem estalo, sem compasso perdido.",
   "gig.c3.h3": "Sem cabeçote, sem pedaleira",
-  "gig.c3.p": "Você já tem a interface de áudio pra plugar a guitarra. Do plug em diante — amp, caixa, pedais — roda tudo no notebook.",
+  "gig.c3.p": "Você já tem a interface de áudio pra plugar a guitarra. Do plug em diante — amp, caixa, pedais — roda tudo no computador.",
   "app.eyebrow": "Por dentro",
   "app.h2": "Tudo em<br>uma tela só.",
   "app.lede": "Instrumentos na esquerda, equipamento no meio, saídas na direita. É o app inteiro.",

--- a/site/i18n/pt-BR/shell.json
+++ b/site/i18n/pt-BR/shell.json
@@ -12,7 +12,7 @@
   "nav.download": "Baixar",
   "hero.eyebrow": "Grátis · Código aberto · Mac",
   "hero.h1": "Só falta<br>você plugar<br><em>a guitarra.</em>",
-  "hero.lede": "{gear} amps, caixas e pedais rodando no notebook que você já tem. De graça, sem latência que você sinta.",
+  "hero.lede": "{gear} amps, caixas e pedais rodando no computador que você já tem. De graça, sem latência que você sinta.",
   "hero.cta1": "Baixar para Mac",
   "hero.cta2": "Ver o rig",
   "hero.note": "Grátis pra sempre. Sem conta, sem nuvem, sem assinatura.",

--- a/site/index.html
+++ b/site/index.html
@@ -69,7 +69,7 @@
   <div class="wrap">
     <p class="eyebrow" data-i18n="hero.eyebrow">Free · Open source · Mac</p>
     <h1 data-i18n="hero.h1">All that's left<br>is plugging in<br><em>your guitar.</em></h1>
-    <p class="lede" data-i18n="hero.lede">{gear} amps, cabs and pedals running on the laptop you already own. Free, with no latency you can feel.</p>
+    <p class="lede" data-i18n="hero.lede">{gear} amps, cabs and pedals, running on the computer you already have. Free, with no latency you can feel.</p>
     <div class="hero-cta">
       <a class="btn btn-primary btn-lg" href="#download" data-i18n="hero.cta1">Download for Mac</a>
       <a class="btn btn-ghost btn-lg" href="#rig" data-i18n="hero.cta2">See the rig</a>

--- a/site/sections/gig.html
+++ b/site/sections/gig.html
@@ -10,7 +10,7 @@
     <div class="cards">
       <div class="card rv"><div class="n">01</div><h3 data-i18n="gig.c1.h3">No latency you can feel</h3><p data-i18n="gig.c1.p">The signal goes in and comes back out fast enough that your hands never notice the computer in between.</p></div>
       <div class="card rv"><div class="n">02</div><h3 data-i18n="gig.c2.h3">Silent switching</h3><p data-i18n="gig.c2.p">Swap an amp, add a pedal, change a preset while you're playing. No gaps, no pops, no dead bars.</p></div>
-      <div class="card rv"><div class="n">03</div><h3 data-i18n="gig.c3.h3">No amp head, no pedalboard</h3><p data-i18n="gig.c3.p">You already have an audio interface to plug the guitar into. Everything after it — amp, cab, pedals — runs on the laptop.</p></div>
+      <div class="card rv"><div class="n">03</div><h3 data-i18n="gig.c3.h3">No amp head, no pedalboard</h3><p data-i18n="gig.c3.p">You already have an audio interface to plug the guitar into. Everything after it — amp, cab, pedals — runs on the computer.</p></div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
It runs on a Mac, on a PC, on a small board — naming the machine in the copy shrinks it to one. Hero lede and the gig card now say "the computer you already have", in all three languages plus the English markup fallbacks.