### PR TITLE
fix(#871): a disabled Input/Output block opens no stream and claims no route

### DIFF
--- a/crates/engine/src/runtime_effective_io_tests.rs
+++ b/crates/engine/src/runtime_effective_io_tests.rs
@@ -138,7 +138,7 @@ fn build_output_routing_state_mono_single_channel() {
         mode: ChainOutputMode::Mono,
         channels: vec![0],
     };
-    let state = build_output_routing_state(&output, DEFAULT_ELASTIC_TARGET, 0);
+    let state = build_output_routing_state(&output, DEFAULT_ELASTIC_TARGET, 0, 48_000.0);
     assert_eq!(state.output_channels, vec![0]);
 }
 
@@ -150,7 +150,7 @@ fn build_output_routing_state_stereo_two_channels() {
         mode: ChainOutputMode::Stereo,
         channels: vec![0, 1],
     };
-    let state = build_output_routing_state(&output, DEFAULT_ELASTIC_TARGET, 0);
+    let state = build_output_routing_state(&output, DEFAULT_ELASTIC_TARGET, 0, 48_000.0);
     assert_eq!(state.output_channels, vec![0, 1]);
 }
 
@@ -162,7 +162,7 @@ fn build_output_routing_state_mono_mode_with_two_channels_uses_mono() {
         mode: ChainOutputMode::Mono,
         channels: vec![0, 1],
     };
-    let _state = build_output_routing_state(&output, DEFAULT_ELASTIC_TARGET, 0);
+    let _state = build_output_routing_state(&output, DEFAULT_ELASTIC_TARGET, 0, 48_000.0);
     // Mono mode with 2 channels: layout should be Mono per the logic
     // Just verifying it doesn't panic and runs correctly
 }

--- a/crates/infra-cpal/src/issue_871_disabled_io_routing_tests.rs
+++ b/crates/infra-cpal/src/issue_871_disabled_io_routing_tests.rs
@@ -1,0 +1,143 @@
+//! #871 — the routing consequence of a DISABLED mid `Input`/`Output` block.
+//!
+//! The owner's `GUITARRA - TONES` runs on the SCARLETT's input 1 and the
+//! TEYUN's input 1, and carries a mid `Input` bound to the SCARLETT's channel 1
+//! (physical input **2**) plus a mid `Output` bound to the TEYUN — both toggled
+//! OFF. Guitar plugged into the Scarlett's input 2 was audible, and it came out
+//! of the TEYUN: the disabled input still opened its stream and the mid-input
+//! pass still routed it to the chain's tail devices.
+
+use domain::ids::{BlockId, ChainId, DeviceId};
+use domain::io_binding::{ChannelMode, IoBinding, IoEndpoint};
+use engine::runtime_endpoints::resolve_chain_io;
+use project::block::{AudioBlock, AudioBlockKind, InputBlock, OutputBlock};
+use project::chain::Chain;
+
+use super::chain_resolve_io_map::output_devices_by_input_cpal;
+
+const SCARLETT: &str = "coreaudio:scarlett";
+const TEYUN: &str = "coreaudio:teyun";
+
+fn endpoint(name: &str, device: &str, channels: Vec<usize>) -> IoEndpoint {
+    IoEndpoint {
+        name: name.into(),
+        device_id: DeviceId(device.into()),
+        mode: ChannelMode::Mono,
+        channels,
+    }
+}
+
+fn stereo(name: &str, device: &str) -> IoEndpoint {
+    IoEndpoint {
+        name: name.into(),
+        device_id: DeviceId(device.into()),
+        mode: ChannelMode::Stereo,
+        channels: vec![0, 1],
+    }
+}
+
+/// The owner's registry: one E/S per input channel plus the "ALL" TEYUN E/S.
+fn registry() -> Vec<IoBinding> {
+    vec![
+        IoBinding {
+            id: "scarlett-1".into(),
+            name: "SCARLET - 1".into(),
+            inputs: vec![endpoint("In 1", SCARLETT, vec![0])],
+            outputs: vec![stereo("Out 1", SCARLETT)],
+        },
+        IoBinding {
+            id: "teyun-1".into(),
+            name: "TEYUN - 1".into(),
+            inputs: vec![endpoint("In 1", TEYUN, vec![0])],
+            outputs: vec![stereo("Out 1", TEYUN)],
+        },
+        IoBinding {
+            id: "scarlett-2".into(),
+            name: "SCARLET - 2".into(),
+            inputs: vec![endpoint("In 1", SCARLETT, vec![1])],
+            outputs: vec![stereo("Out 1", SCARLETT)],
+        },
+        IoBinding {
+            id: "teyun-all".into(),
+            name: "TEYUN - ALL".into(),
+            inputs: vec![endpoint("In 1", TEYUN, vec![0])],
+            outputs: vec![stereo("Out 1", TEYUN)],
+        },
+    ]
+}
+
+fn disabled_mid_input() -> AudioBlock {
+    AudioBlock {
+        id: BlockId("rig:tones:input:1".into()),
+        enabled: false,
+        kind: AudioBlockKind::Input(InputBlock {
+            model: "standard".into(),
+            io: "scarlett-2".into(),
+            endpoint: "In 1".into(),
+        }),
+    }
+}
+
+fn disabled_mid_output() -> AudioBlock {
+    AudioBlock {
+        id: BlockId("rig:tones:output:1".into()),
+        enabled: false,
+        kind: AudioBlockKind::Output(OutputBlock {
+            model: "standard".into(),
+            io: "teyun-all".into(),
+            endpoint: "Out 1".into(),
+        }),
+    }
+}
+
+fn owners_chain() -> Chain {
+    Chain {
+        id: ChainId("rig:tones".into()),
+        description: Some("GUITARRA - TONES".into()),
+        instrument: "electric_guitar".into(),
+        enabled: true,
+        volume: 100.0,
+        io_binding_ids: vec!["scarlett-1".into(), "teyun-1".into()],
+        blocks: vec![disabled_mid_input(), disabled_mid_output()],
+        di_output: None,
+        loopers: vec![],
+    }
+}
+
+#[test]
+fn a_disabled_mid_input_opens_no_stream() {
+    let (inputs, _) = resolve_chain_io(&owners_chain(), &registry());
+    assert_eq!(
+        inputs.len(),
+        2,
+        "only the two head inputs are live, not the disabled block's"
+    );
+    assert!(
+        !inputs
+            .iter()
+            .any(|i| i.device_id.0 == SCARLETT && i.channels == vec![1]),
+        "the Scarlett's channel 1 belongs to a disabled Input — no stream for it"
+    );
+}
+
+#[test]
+fn a_disabled_mid_output_claims_no_device_route() {
+    let chain = owners_chain();
+    let registry = registry();
+    let (inputs, _) = resolve_chain_io(&chain, &registry);
+    let by_cpal = output_devices_by_input_cpal(&chain, &registry, &inputs);
+
+    // cpal 0 = SCARLETT (head In 1), cpal 1 = TEYUN (head In 1).
+    assert_eq!(by_cpal.len(), 2, "two input devices → two cpal indices");
+    assert_eq!(
+        by_cpal[0],
+        vec![SCARLETT.to_string()],
+        "the Scarlett stream writes ONLY the Scarlett's output — the TEYUN route \
+         belongs to a DISABLED Output block (stream-isolation LAW)"
+    );
+    assert_eq!(
+        by_cpal[1],
+        vec![TEYUN.to_string()],
+        "the TEYUN stream writes ONLY the TEYUN's output"
+    );
+}

--- a/crates/infra-cpal/src/lib.rs
+++ b/crates/infra-cpal/src/lib.rs
@@ -102,6 +102,9 @@ mod issue_85_live_rebuild_rates_tests;
 #[cfg(test)]
 #[path = "issue_85_mid_output_device_tests.rs"]
 mod issue_85_mid_output_device_tests;
+#[cfg(all(test, not(all(target_os = "linux", feature = "jack"))))]
+#[path = "issue_871_disabled_io_routing_tests.rs"]
+mod issue_871_disabled_io_routing_tests;
 pub use chain_resolve::resolve_project_chain_sample_rates;
 
 #[cfg(all(target_os = "linux", feature = "jack"))]

--- a/crates/project/src/binding_discovery.rs
+++ b/crates/project/src/binding_discovery.rs
@@ -80,6 +80,12 @@ pub fn resolve_chain_ports(chain: &Chain, registry: &[IoBinding]) -> Vec<ChainPo
 
     // Mid Input/Output blocks reference one binding endpoint by io/endpoint.
     for (i, block) in chain.blocks.iter().enumerate() {
+        // #871: a disabled block is out of the signal path, so it owns no port —
+        // otherwise its stream still opens and its route still gets written (a
+        // disabled Input on the Scarlett's 2nd channel came out of the TEYUN).
+        if !block.enabled {
+            continue;
+        }
         let (direction, io, endpoint_name) = match &block.kind {
             AudioBlockKind::Input(b) => (PortDirection::Input, &b.io, &b.endpoint),
             AudioBlockKind::Output(b) => (PortDirection::Output, &b.io, &b.endpoint),

--- a/crates/project/tests/issue_871_disabled_io_block_has_no_port.rs
+++ b/crates/project/tests/issue_871_disabled_io_block_has_no_port.rs
@@ -1,0 +1,209 @@
+//! #871 — a DISABLED mid `Input`/`Output` block contributes no I/O port.
+//!
+//! A block toggled off is not part of the signal path, so it must not open a
+//! stream nor claim a device route. The owner's report: an `Input` block bound
+//! to the Scarlett's channel 1 (physical input 2) and an `Output` block bound
+//! to the TEYUN — BOTH disabled — still fed audio, and the Scarlett input came
+//! out of the TEYUN output (a stream-isolation violation on top of the leak).
+
+use domain::ids::{BlockId, ChainId, DeviceId};
+use domain::io_binding::{ChannelMode, IoBinding, IoEndpoint};
+use project::binding_discovery::{resolve_chain_ports, PortDirection};
+use project::block::{AudioBlock, AudioBlockKind, CoreBlock, InputBlock, OutputBlock};
+use project::chain::Chain;
+use project::param::ParameterSet;
+
+const SCARLETT: &str = "coreaudio:Focusrite:Scarlett 2i2";
+const TEYUN: &str = "coreaudio:TEYUN Q26";
+
+fn ep(name: &str, device: &str, ch: usize) -> IoEndpoint {
+    IoEndpoint {
+        name: name.into(),
+        device_id: DeviceId(device.into()),
+        mode: ChannelMode::Mono,
+        channels: vec![ch],
+    }
+}
+
+fn stereo_out(name: &str, device: &str) -> IoEndpoint {
+    IoEndpoint {
+        name: name.into(),
+        device_id: DeviceId(device.into()),
+        mode: ChannelMode::Stereo,
+        channels: vec![0, 1],
+    }
+}
+
+fn effect(id: &str) -> AudioBlock {
+    AudioBlock {
+        id: BlockId(id.into()),
+        enabled: true,
+        kind: AudioBlockKind::Core(CoreBlock {
+            effect_type: "gain".into(),
+            model: "volume".into(),
+            params: ParameterSet::default(),
+        }),
+    }
+}
+
+fn input_block(id: &str, enabled: bool, io: &str, endpoint: &str) -> AudioBlock {
+    AudioBlock {
+        id: BlockId(id.into()),
+        enabled,
+        kind: AudioBlockKind::Input(InputBlock {
+            model: "standard".into(),
+            io: io.into(),
+            endpoint: endpoint.into(),
+        }),
+    }
+}
+
+fn output_block(id: &str, enabled: bool, io: &str, endpoint: &str) -> AudioBlock {
+    AudioBlock {
+        id: BlockId(id.into()),
+        enabled,
+        kind: AudioBlockKind::Output(OutputBlock {
+            model: "standard".into(),
+            io: io.into(),
+            endpoint: endpoint.into(),
+        }),
+    }
+}
+
+fn chain_with(io_binding_ids: Vec<String>, blocks: Vec<AudioBlock>) -> Chain {
+    Chain {
+        id: ChainId("guitarra-tones".into()),
+        description: Some("GUITARRA - TONES".into()),
+        instrument: "electric_guitar".into(),
+        enabled: true,
+        volume: 100.0,
+        io_binding_ids,
+        blocks,
+        di_output: None,
+        loopers: vec![],
+    }
+}
+
+/// The owner's registry: the head bindings the chain selects (Scarlett in 1,
+/// TEYUN in 1) plus the two the disabled blocks reference.
+fn registry() -> Vec<IoBinding> {
+    vec![
+        IoBinding {
+            id: "io-4-d73c".into(),
+            name: "SCARLET - 1".into(),
+            inputs: vec![ep("In 1", SCARLETT, 0)],
+            outputs: vec![stereo_out("Out 1", SCARLETT)],
+        },
+        IoBinding {
+            id: "io-5-79a0".into(),
+            name: "TEYUN - 1".into(),
+            inputs: vec![ep("In 1", TEYUN, 0)],
+            outputs: vec![stereo_out("Out 1", TEYUN)],
+        },
+        IoBinding {
+            id: "io-3-47e6".into(),
+            name: "SCARLET - 2".into(),
+            inputs: vec![ep("In 1", SCARLETT, 1)],
+            outputs: vec![stereo_out("Out 1", SCARLETT)],
+        },
+        IoBinding {
+            id: "io-2-fb90".into(),
+            name: "TEYUN - ALL".into(),
+            inputs: vec![ep("In 1", TEYUN, 0), ep("In 2", TEYUN, 1)],
+            outputs: vec![stereo_out("Out 1", TEYUN)],
+        },
+    ]
+}
+
+#[test]
+fn disabled_mid_input_block_resolves_no_port() {
+    let chain = chain_with(
+        vec![],
+        vec![
+            effect("A"),
+            input_block("mid:in", false, "io-3-47e6", "In 1"),
+        ],
+    );
+    let ports = resolve_chain_ports(&chain, &registry());
+    assert!(
+        ports.is_empty(),
+        "a disabled Input block is out of the signal path — no port, no stream; got {:?}",
+        ports
+            .iter()
+            .map(|p| (p.direction, p.binding_id.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn disabled_mid_output_block_resolves_no_port() {
+    let chain = chain_with(
+        vec![],
+        vec![
+            effect("A"),
+            output_block("mid:out", false, "io-2-fb90", "Out 1"),
+        ],
+    );
+    let ports = resolve_chain_ports(&chain, &registry());
+    assert!(
+        ports.is_empty(),
+        "a disabled Output block claims no device route; got {:?}",
+        ports
+            .iter()
+            .map(|p| (p.direction, p.binding_id.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn enabled_mid_blocks_still_resolve() {
+    // The guard above must not silence the working case (#85 / #716).
+    let chain = chain_with(
+        vec![],
+        vec![
+            input_block("mid:in", true, "io-3-47e6", "In 1"),
+            output_block("mid:out", true, "io-2-fb90", "Out 1"),
+        ],
+    );
+    let ports = resolve_chain_ports(&chain, &registry());
+    assert_eq!(ports.len(), 2, "enabled mid blocks keep their ports");
+}
+
+#[test]
+fn owners_rig_does_not_open_the_scarletts_second_input() {
+    // GUITARRA - TONES: head = Scarlett in 1 + TEYUN in 1. The disabled mid
+    // Input (Scarlett channel 1 = physical input 2) and the disabled mid
+    // Output (TEYUN) must contribute nothing.
+    let chain = chain_with(
+        vec!["io-4-d73c".into(), "io-5-79a0".into()],
+        vec![
+            effect("comp"),
+            input_block("mid:in", false, "io-3-47e6", "In 1"),
+            effect("preamp"),
+            output_block("mid:out", false, "io-2-fb90", "Out 1"),
+            effect("reverb"),
+        ],
+    );
+    let ports = resolve_chain_ports(&chain, &registry());
+
+    let inputs: Vec<_> = ports
+        .iter()
+        .filter(|p| p.direction == PortDirection::Input)
+        .collect();
+    assert_eq!(
+        inputs.len(),
+        2,
+        "only the two head inputs (Scarlett in 1, TEYUN in 1) are live"
+    );
+    assert!(
+        !inputs
+            .iter()
+            .any(|p| p.endpoint.device_id.0 == SCARLETT && p.endpoint.channels == vec![1]),
+        "the Scarlett's channel 1 (physical input 2) belongs to a DISABLED block \
+         and must not be opened"
+    );
+    assert!(
+        !ports.iter().any(|p| p.from_block),
+        "no port comes from a disabled block"
+    );
+}

--- a/docs/audio-config.md
+++ b/docs/audio-config.md
@@ -308,6 +308,13 @@ and the chain's tail devices are added to each mid input's stream. Neither
 widens isolation — only this chain's own runtimes are involved. #716 still
 governs HEAD inputs: a TEYUN in never exits a SCARLET out.
 
+**A disabled port is no port at all (#871).** `resolve_chain_ports` skips a mid
+`Input`/`Output` block whose `enabled` is `false`, so it opens no stream and
+claims no device route. Until #871 the flag was ignored here: a disabled `Input`
+on the Scarlett's channel 1 still opened that channel, and the mid-input pass
+above still routed it to the chain's tail devices — the owner heard his 2nd
+Scarlett input come out of the TEYUN.
+
 **A DI loop plays on every pipeline this input feeds.** #699 fed the loop to
 segment 0 alone — right when the other segments were split-mono siblings summing
 into ONE route, wrong under this model, where each pipeline owns its own route:


### PR DESCRIPTION
Closes #871.

## Problem

`resolve_chain_ports` materialized a port for every mid `Input`/`Output` block regardless of `block.enabled`. A block toggled **off** still opened its device stream and still had its route written.

In the owner's rig (`GUITARRA - TONES`) a disabled `Input` bound to the Scarlett's channel 1 (physical input **2**) was audible, and the mid-input pass in `chain_resolve_io_map.rs` routed it to the chain's tail devices — so a Scarlett input came out of the **TEYUN**, violating stream isolation.

## Fix

A disabled mid `Input`/`Output` block contributes no port: no stream, no route. Head/tail ports derived from `io_binding_ids` are untouched, and #85 (mid output reaching its device) / #716 (binding-derived I/O) suites stay green.

## Red first

Both suites failed before the production change:

- `crates/project/tests/issue_871_disabled_io_block_has_no_port.rs` — `got [(Input, "io-3-47e6")]`, `got [(Output, "io-2-fb90")]`, owner's rig resolved `3` inputs instead of `2`.
- `crates/infra-cpal/src/issue_871_disabled_io_routing_tests.rs` — the Scarlett cpal index mapped to `[scarlett, teyun]`.

## Also

`crates/engine/src/runtime_effective_io_tests.rs` was already broken on `release/v0.3.0` (`build_output_routing_state` gained a `sample_rate` argument), so the engine suite could not compile at all. Fixed in the same commit to unblock verification.

## Tests

`cargo test --workspace` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)